### PR TITLE
Fix code block formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ let destination =
 Alamofire.download(.GET,
                    "http://httpbin.org/stream/100",
                    destination: destination)
+```
 
 #### Downloading a File w/Progress
 


### PR DESCRIPTION
missed a closing ```
