### PR TITLE
Default to HTTP method GET for Alamofire.request()

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,19 +42,19 @@ _The infrastructure and best practices for distributing Swift libraries is curre
 ### GET Request
 
 ```swift
-Alamofire.request(.GET, "http://httpbin.org/get")
+Alamofire.request("http://httpbin.org/get")
 ```
 
 #### With Parameters
 
 ```swift
-Alamofire.request(.GET, "http://httpbin.org/get", parameters: ["foo": "bar"])
+Alamofire.request("http://httpbin.org/get", parameters: ["foo": "bar"])
 ```
 
 #### With Response Handling
 
 ```swift
-Alamofire.request(.GET, "http://httpbin.org/get", parameters: ["foo": "bar"])
+Alamofire.request("http://httpbin.org/get", parameters: ["foo": "bar"])
          .response { (request, response, data, error) in
                      println(request)
                      println(response)
@@ -65,7 +65,7 @@ Alamofire.request(.GET, "http://httpbin.org/get", parameters: ["foo": "bar"])
 #### With Response String Handling
 
 ```swift
-Alamofire.request(.GET, "http://httpbin.org/get", parameters: ["foo": "bar"])
+Alamofire.request("http://httpbin.org/get", parameters: ["foo": "bar"])
          .responseString { (request, response, string, error) in
                   println(string)
          }

--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -933,6 +933,10 @@ extension Alamofire {
     }
 
     // MARK: Request
+    
+    static func request(URL: String, parameters: [String: AnyObject]? = nil, encoding: ParameterEncoding = .URL) -> Request {
+            return request(.GET, URL, parameters: parameters, encoding: encoding)
+    }
 
     static func request(method: Method, _ URL: String, parameters: [String: AnyObject]? = nil, encoding: ParameterEncoding = .URL) -> Request {
         var mutableRequest = NSMutableURLRequest(URL: NSURL(string: URL))

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -26,6 +26,16 @@ import XCTest
 extension Alamofire {
     struct RequestTests {
         class RequestInitializationTestCase: XCTestCase {
+            func testRequestClassMethodWithURL() {
+                let URL = "http://httpbin.org/"
+                let request = Alamofire.request(URL)
+                
+                XCTAssertEqual(request.request.HTTPMethod!, Method.GET.toRaw(), "default request method should be GET")
+                XCTAssertNotNil(request.request, "request should not be nil")
+                XCTAssertEqual(request.request.URL!, NSURL(string: URL), "request URL should be equal")
+                XCTAssertNil(request.response, "response should be nil")
+            }
+            
             func testRequestClassMethodWithMethodAndURL() {
                 let URL = "http://httpbin.org/"
                 let request = Alamofire.request(.GET, URL)


### PR DESCRIPTION
This allows calling `Alamofire.request(URL)`. GET seems to be the most common request mode, so it makes sense to use it as a default. 

Implemented as a separate func because making `method` optional and unnamed would require re-ordering the params to avoid breaking existing implementations. I agree with having the request mode specified first anyway.

Also, added a test for it and updated the README.

Thanks for this great class!
