### PR TITLE
Rearrange else-if in Request.init to fix iOS 7 fatal error.

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -417,10 +417,10 @@ public struct Alamofire {
 
             if task is NSURLSessionUploadTask {
                 self.delegate = UploadTaskDelegate(task: task)
-            } else if task is NSURLSessionDownloadTask {
-                self.delegate = DownloadTaskDelegate(task: task)
             } else if task is NSURLSessionDataTask {
                 self.delegate = DataTaskDelegate(task: task)
+            } else if task is NSURLSessionDownloadTask {
+                self.delegate = DownloadTaskDelegate(task: task)
             } else {
                 self.delegate = TaskDelegate(task: task)
             }


### PR DESCRIPTION
See my comments on [Alamofire Issue 29](https://github.com/Alamofire/Alamofire/issues/29) [here](https://github.com/Alamofire/Alamofire/issues/29#issuecomment-51516437).
