### PR TITLE
Changed move data task type before download task during initialization o...

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -417,10 +417,10 @@ public struct Alamofire {
 
             if task is NSURLSessionUploadTask {
                 self.delegate = UploadTaskDelegate(task: task)
-            } else if task is NSURLSessionDownloadTask {
-                self.delegate = DownloadTaskDelegate(task: task)
             } else if task is NSURLSessionDataTask {
                 self.delegate = DataTaskDelegate(task: task)
+            } else if task is NSURLSessionDownloadTask {
+                self.delegate = DownloadTaskDelegate(task: task)
             } else {
                 self.delegate = TaskDelegate(task: task)
             }


### PR DESCRIPTION
...f Request object. This can fix #35 and #17. But I'm not very sure whether it will introduce new bug with download task under iOS 7 and OS X 10.9.

Looks like under iOS 7, `NSURLSessionDataTask` object is wrongly treated as `NSURLSessionDownloadTask`. While in `NSURLSessionDataDelegate`'s `URLSession(session: NSURLSession!, dataTask: NSURLSessionDataTask!, didReceiveData data: NSData!)` method, `dataTask` in this callback is actually a `NSURLSessionDownloadTask` object, and the unwrap result to an `NSURLSessionDataTask` object is `nil`, which lead to `nil` response data.

So I moved `NSURLSessionDataTask` above `NSURLSessionDownloadTask` and data task is correctly recognized. 

But I'm not very sure whether `NSURLSessionDownloadTask` object would be recognized as `NSURLSessionDataTask` under iOS 7 too. So this fix may be a new bug. 
