### PR TITLE
Made typealias for AF public

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -964,4 +964,4 @@ extension Alamofire {
     }
 }
 
-typealias AF = Alamofire
+public typealias AF = Alamofire


### PR DESCRIPTION
Without this, the typealias is confined to the target that the Alamofire.swift file is included in, so you couldn't use it in, say, unit tests or something. 
