### PR TITLE
Rework tests

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -735,10 +735,10 @@ extension Alamofire.Manager {
 }
 
 extension Alamofire.Request {
-    class func suggestedDownloadDestination(directory: NSSearchPathDirectory = .DocumentDirectory, domain: NSSearchPathDomainMask = .UserDomainMask) -> (NSURL, NSHTTPURLResponse) -> (NSURL) {
+    class func suggestedDownloadDestination(directory: NSSearchPathDirectory, domain: NSSearchPathDomainMask) -> (NSURL, NSHTTPURLResponse) -> (NSURL) {
 
         return { (temporaryURL, response) -> (NSURL) in
-            if let directoryURL = NSFileManager.defaultManager().URLsForDirectory(.DocumentDirectory, inDomains: .UserDomainMask)[0] as? NSURL {
+            if let directoryURL = NSFileManager.defaultManager().URLsForDirectory(directory, inDomains: domain)[0] as? NSURL {
                 return directoryURL.URLByAppendingPathComponent(response.suggestedFilename)
             }
 
@@ -884,8 +884,12 @@ extension Alamofire.Request {
     class func JSONResponseSerializer(options: NSJSONReadingOptions = .AllowFragments) -> (NSURLRequest, NSHTTPURLResponse?, NSData?, NSError?) -> (AnyObject?, NSError?) {
         return { (request, response, data, error) in
             var serializationError: NSError?
-            let JSON: AnyObject! = NSJSONSerialization.JSONObjectWithData(data, options: options, error: &serializationError)
-            return (JSON, serializationError)
+            if let d = data {
+                let JSON: AnyObject? = NSJSONSerialization.JSONObjectWithData(data, options: options, error: &serializationError)
+                return (JSON, serializationError)
+            } else {
+              return (nil, NSError(domain: "AlamofireError", code: 0, userInfo: [:]))
+            }
         }
     }
 

--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -20,258 +20,253 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import UIKit
 import XCTest
 
-extension Alamofire {
-    struct ParameterEncodingTests {
-        class URLParameterEncodingTestCase: XCTestCase {
-            let encoding: ParameterEncoding = .URL
-            var request: NSURLRequest!
+class URLParameterEncodingTestCase: XCTestCase {
+    let encoding: Alamofire.ParameterEncoding = .URL
+    var request: NSURLRequest!
 
-            override func setUp()  {
-                super.setUp()
+    override func setUp()  {
+        super.setUp()
 
-                let URL = NSURL(string: "http://example.com/")
-                self.request = NSURLRequest(URL: URL)
-            }
+        let URL = NSURL(string: "http://example.com/")
+        self.request = NSURLRequest(URL: URL)
+    }
 
-            // MARK: -
+    // MARK: -
 
-            func testURLParameterEncodeNilParameters() {
-                let (request, error) = self.encoding.encode(self.request, parameters: nil)
+    func testURLParameterEncodeNilParameters() {
+        let (request, error) = self.encoding.encode(self.request, parameters: nil)
 
-                XCTAssertNil(request.URL.query?, "query should be nil")
-            }
+        XCTAssertNil(request.URL.query?, "query should be nil")
+    }
 
-            func testURLParameterEncodeOneStringKeyStringValueParameter() {
-                let parameters = ["foo": "bar"]
-                let (request, error) = self.encoding.encode(self.request, parameters: parameters)
+    func testURLParameterEncodeOneStringKeyStringValueParameter() {
+        let parameters = ["foo": "bar"]
+        let (request, error) = self.encoding.encode(self.request, parameters: parameters)
 
-                XCTAssertEqual(request.URL.query!, "foo=bar", "query is incorrect")
-            }
+        XCTAssertEqual(request.URL.query!, "foo=bar", "query is incorrect")
+    }
 
-            func testURLParameterEncodeOneStringKeyStringValueParameterAppendedToQuery() {
-                var mutableRequest = self.request.mutableCopy() as NSMutableURLRequest
-                let URLComponents = NSURLComponents(URL: mutableRequest.URL, resolvingAgainstBaseURL: false)
-                URLComponents.query = "baz=qux"
-                mutableRequest.URL = URLComponents.URL
+    func testURLParameterEncodeOneStringKeyStringValueParameterAppendedToQuery() {
+        var mutableRequest = self.request.mutableCopy() as NSMutableURLRequest
+        let URLComponents = NSURLComponents(URL: mutableRequest.URL, resolvingAgainstBaseURL: false)
+        URLComponents.query = "baz=qux"
+        mutableRequest.URL = URLComponents.URL
 
-                let parameters = ["foo": "bar"]
-                let (request, error) = self.encoding.encode(mutableRequest, parameters: parameters)
+        let parameters = ["foo": "bar"]
+        let (request, error) = self.encoding.encode(mutableRequest, parameters: parameters)
 
-                XCTAssertEqual(request.URL.query!, "baz=qux&foo=bar", "query is incorrect")
-            }
+        XCTAssertEqual(request.URL.query!, "baz=qux&foo=bar", "query is incorrect")
+    }
 
-            func testURLParameterEncodeTwoStringKeyStringValueParameters() {
-                let parameters = ["foo": "bar", "baz": "qux"]
-                let (request, error) = self.encoding.encode(self.request, parameters: parameters)
+    func testURLParameterEncodeTwoStringKeyStringValueParameters() {
+        let parameters = ["foo": "bar", "baz": "qux"]
+        let (request, error) = self.encoding.encode(self.request, parameters: parameters)
 
-                XCTAssertEqual(request.URL.query!, "baz=qux&foo=bar", "query is incorrect")
-            }
+        XCTAssertEqual(request.URL.query!, "baz=qux&foo=bar", "query is incorrect")
+    }
 
-            func testURLParameterEncodeStringKeyIntegerValueParameter() {
-                let parameters = ["foo": 1]
-                let (request, error) = self.encoding.encode(self.request, parameters: parameters)
+    func testURLParameterEncodeStringKeyIntegerValueParameter() {
+        let parameters = ["foo": 1]
+        let (request, error) = self.encoding.encode(self.request, parameters: parameters)
 
-                XCTAssertEqual(request.URL.query!, "foo=1", "query is incorrect")
-            }
+        XCTAssertEqual(request.URL.query!, "foo=1", "query is incorrect")
+    }
 
-            func testURLParameterEncodeStringKeyDoubleValueParameter() {
-                let parameters = ["foo": 1.1]
-                let (request, error) = self.encoding.encode(self.request, parameters: parameters)
+    func testURLParameterEncodeStringKeyDoubleValueParameter() {
+        let parameters = ["foo": 1.1]
+        let (request, error) = self.encoding.encode(self.request, parameters: parameters)
 
-                XCTAssertEqual(request.URL.query!, "foo=1.1", "query is incorrect")
-            }
+        XCTAssertEqual(request.URL.query!, "foo=1.1", "query is incorrect")
+    }
 
-            func testURLParameterEncodeStringKeyBoolValueParameter() {
-                let parameters = ["foo": true]
-                let (request, error) = self.encoding.encode(self.request, parameters: parameters)
+    func testURLParameterEncodeStringKeyBoolValueParameter() {
+        let parameters = ["foo": true]
+        let (request, error) = self.encoding.encode(self.request, parameters: parameters)
 
-                XCTAssertEqual(request.URL.query!, "foo=1", "query is incorrect")
-            }
+        XCTAssertEqual(request.URL.query!, "foo=1", "query is incorrect")
+    }
 
-            func testURLParameterEncodeStringKeyArrayValueParameter() {
-                let parameters = ["foo": ["a", 1, true]]
-                let (request, error) = self.encoding.encode(self.request, parameters: parameters)
+    func testURLParameterEncodeStringKeyArrayValueParameter() {
+        let parameters = ["foo": ["a", 1, true]]
+        let (request, error) = self.encoding.encode(self.request, parameters: parameters)
 
-                XCTAssertEqual(request.URL.query!, "foo%5B%5D=a&foo%5B%5D=1&foo%5B%5D=1", "query is incorrect")
-            }
+        XCTAssertEqual(request.URL.query!, "foo%5B%5D=a&foo%5B%5D=1&foo%5B%5D=1", "query is incorrect")
+    }
 
-            func testURLParameterEncodeStringKeyDictionaryValueParameter() {
-                let parameters = ["foo": ["bar": 1]]
-                let (request, error) = self.encoding.encode(self.request, parameters: parameters)
+    func testURLParameterEncodeStringKeyDictionaryValueParameter() {
+        let parameters = ["foo": ["bar": 1]]
+        let (request, error) = self.encoding.encode(self.request, parameters: parameters)
 
-                XCTAssertEqual(request.URL.query!, "foo%5Bbar%5D=1", "query is incorrect")
-            }
+        XCTAssertEqual(request.URL.query!, "foo%5Bbar%5D=1", "query is incorrect")
+    }
 
-            func testURLParameterEncodeStringKeyNestedDictionaryValueParameter() {
-                let parameters = ["foo": ["bar": ["baz": 1]]]
-                let (request, error) = self.encoding.encode(self.request, parameters: parameters)
+    func testURLParameterEncodeStringKeyNestedDictionaryValueParameter() {
+        let parameters = ["foo": ["bar": ["baz": 1]]]
+        let (request, error) = self.encoding.encode(self.request, parameters: parameters)
 
-                XCTAssertEqual(request.URL.query!, "foo%5Bbar%5D%5Bbaz%5D=1", "query is incorrect")
-            }
+        XCTAssertEqual(request.URL.query!, "foo%5Bbar%5D%5Bbaz%5D=1", "query is incorrect")
+    }
 
-            func testURLParameterEncodeStringKeyNestedDictionaryArrayValueParameter() {
-                let parameters = ["foo": ["bar": ["baz": ["a", 1, true]]]]
-                let (request, error) = self.encoding.encode(self.request, parameters: parameters)
+    func testURLParameterEncodeStringKeyNestedDictionaryArrayValueParameter() {
+        let parameters = ["foo": ["bar": ["baz": ["a", 1, true]]]]
+        let (request, error) = self.encoding.encode(self.request, parameters: parameters)
 
-                XCTAssertEqual(request.URL.query!, "foo%5Bbar%5D%5Bbaz%5D%5B%5D=a&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1", "query is incorrect")
-            }
+        XCTAssertEqual(request.URL.query!, "foo%5Bbar%5D%5Bbaz%5D%5B%5D=a&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1", "query is incorrect")
+    }
 
-            func testURLParameterEncodeStringKeyPercentEncodedStringValueParameter() {
-                let parameters = ["percent": "%25"]
-                let (request, error) = self.encoding.encode(self.request, parameters: parameters)
+    func testURLParameterEncodeStringKeyPercentEncodedStringValueParameter() {
+        let parameters = ["percent": "%25"]
+        let (request, error) = self.encoding.encode(self.request, parameters: parameters)
 
-                XCTAssertEqual(request.URL.query!, "percent=%2525", "query is incorrect")
-            }
+        XCTAssertEqual(request.URL.query!, "percent=%2525", "query is incorrect")
+    }
 
-            func testURLParameterEncodeStringKeyNonLatinStringValueParameter() {
-                let parameters = [
-                    "french": "français",
-                    "japanese": "日本語",
-                    "arabic": "العربية",
-                    "emoji": "😃"
-                ]
-                let (request, error) = self.encoding.encode(self.request, parameters: parameters)
+    func testURLParameterEncodeStringKeyNonLatinStringValueParameter() {
+        let parameters = [
+            "french": "français",
+            "japanese": "日本語",
+            "arabic": "العربية",
+            "emoji": "😃"
+        ]
+        let (request, error) = self.encoding.encode(self.request, parameters: parameters)
 
-                XCTAssertEqual(request.URL.query!, "arabic=%D8%A7%D9%84%D8%B9%D8%B1%D8%A8%D9%8A%D8%A9&emoji=%F0%9F%98%83&french=fran%C3%A7ais&japanese=%E6%97%A5%E6%9C%AC%E8%AA%9E", "query is incorrect")
-            }
+        XCTAssertEqual(request.URL.query!, "arabic=%D8%A7%D9%84%D8%B9%D8%B1%D8%A8%D9%8A%D8%A9&emoji=%F0%9F%98%83&french=fran%C3%A7ais&japanese=%E6%97%A5%E6%9C%AC%E8%AA%9E", "query is incorrect")
+    }
 
-            func testURLParameterEncodeGETParametersInURL() {
-                var mutableRequest = self.request.mutableCopy() as NSMutableURLRequest!
-                mutableRequest.HTTPMethod = Method.GET.toRaw()
+    func testURLParameterEncodeGETParametersInURL() {
+        var mutableRequest = self.request.mutableCopy() as NSMutableURLRequest!
+        mutableRequest.HTTPMethod = Alamofire.Method.GET.toRaw()
 
-                let parameters = ["foo": 1, "bar": 2]
-                let (request, error) = self.encoding.encode(mutableRequest, parameters: parameters)
+        let parameters = ["foo": 1, "bar": 2]
+        let (request, error) = self.encoding.encode(mutableRequest, parameters: parameters)
 
-                XCTAssertEqual(request.URL.query!, "bar=2&foo=1", "query is incorrect")
-                XCTAssertNil(request.valueForHTTPHeaderField("Content-Type"), "Content-Type should be nil")
-                XCTAssertNil(request.HTTPBody, "HTTPBody should be nil")
-            }
+        XCTAssertEqual(request.URL.query!, "bar=2&foo=1", "query is incorrect")
+        XCTAssertNil(request.valueForHTTPHeaderField("Content-Type"), "Content-Type should be nil")
+        XCTAssertNil(request.HTTPBody, "HTTPBody should be nil")
+    }
 
-            func testURLParameterEncodePOSTParametersInHTTPBody() {
-                var mutableRequest = self.request.mutableCopy() as NSMutableURLRequest!
-                mutableRequest.HTTPMethod = Method.POST.toRaw()
+    func testURLParameterEncodePOSTParametersInHTTPBody() {
+        var mutableRequest = self.request.mutableCopy() as NSMutableURLRequest!
+        mutableRequest.HTTPMethod = Alamofire.Method.POST.toRaw()
 
-                let parameters = ["foo": 1, "bar": 2]
-                let (request, error) = self.encoding.encode(mutableRequest, parameters: parameters)
+        let parameters = ["foo": 1, "bar": 2]
+        let (request, error) = self.encoding.encode(mutableRequest, parameters: parameters)
 
-                XCTAssertEqual(NSString(data: request.HTTPBody, encoding: NSUTF8StringEncoding), "bar=2&foo=1", "HTTPBody is incorrect")
-                XCTAssertEqual(request.valueForHTTPHeaderField("Content-Type")!, "application/x-www-form-urlencoded", "Content-Type should be application/x-www-form-urlencoded")
-                XCTAssertNotNil(request.HTTPBody, "HTTPBody should not be nil")            }
-        }
+        XCTAssertEqual(NSString(data: request.HTTPBody, encoding: NSUTF8StringEncoding), "bar=2&foo=1", "HTTPBody is incorrect")
+        XCTAssertEqual(request.valueForHTTPHeaderField("Content-Type")!, "application/x-www-form-urlencoded", "Content-Type should be application/x-www-form-urlencoded")
+        XCTAssertNotNil(request.HTTPBody, "HTTPBody should not be nil")            }
+}
 
-        class JSONParameterEncodingTestCase: XCTestCase {
-            let encoding: ParameterEncoding = .JSON(options: nil)
-            var request: NSURLRequest!
+class JSONParameterEncodingTestCase: XCTestCase {
+    let encoding: Alamofire.ParameterEncoding = .JSON(options: nil)
+    var request: NSURLRequest!
 
-            override func setUp()  {
-                super.setUp()
+    override func setUp()  {
+        super.setUp()
 
-                let URL = NSURL(string: "http://example.com/")
-                self.request = NSURLRequest(URL: URL)
-            }
+        let URL = NSURL(string: "http://example.com/")
+        self.request = NSURLRequest(URL: URL)
+    }
 
-            // MARK: -
+    // MARK: -
 
-            func testJSONParameterEncodeNilParameters() {
-                let (request, error) = self.encoding.encode(self.request, parameters: nil)
+    func testJSONParameterEncodeNilParameters() {
+        let (request, error) = self.encoding.encode(self.request, parameters: nil)
 
-                XCTAssertNil(error, "error should be nil")
-                XCTAssertNil(request.URL.query?, "query should be nil")
-                XCTAssertNil(request.valueForHTTPHeaderField("Content-Type"), "Content-Type should be nil")
-                XCTAssertNil(request.HTTPBody, "HTTPBody should be nil")
-            }
+        XCTAssertNil(error, "error should be nil")
+        XCTAssertNil(request.URL.query?, "query should be nil")
+        XCTAssertNil(request.valueForHTTPHeaderField("Content-Type"), "Content-Type should be nil")
+        XCTAssertNil(request.HTTPBody, "HTTPBody should be nil")
+    }
 
-            func testJSONParameterEncodeComplexParameters() {
-                let parameters = [
-                    "foo": "bar",
-                    "baz": ["a", 1, true],
-                    "qux": ["a": 1,
-                            "b": [2, 2],
-                            "c": [3, 3, 3]
-                           ]
-                ]
+    func testJSONParameterEncodeComplexParameters() {
+        let parameters = [
+            "foo": "bar",
+            "baz": ["a", 1, true],
+            "qux": ["a": 1,
+                    "b": [2, 2],
+                    "c": [3, 3, 3]
+                   ]
+        ]
 
-                let (request, error) = self.encoding.encode(self.request, parameters: parameters)
+        let (request, error) = self.encoding.encode(self.request, parameters: parameters)
 
-                XCTAssertNil(error, "error should be nil")
-                XCTAssertNil(request.URL.query?, "query should be nil")
-                XCTAssertNotNil(request.valueForHTTPHeaderField("Content-Type"), "Content-Type should not be nil")
-                XCTAssert(request.valueForHTTPHeaderField("Content-Type")!.hasPrefix("application/json"), "Content-Type should be application/json")
-                XCTAssertNotNil(request.HTTPBody, "HTTPBody should not be nil")
+        XCTAssertNil(error, "error should be nil")
+        XCTAssertNil(request.URL.query?, "query should be nil")
+        XCTAssertNotNil(request.valueForHTTPHeaderField("Content-Type"), "Content-Type should not be nil")
+        XCTAssert(request.valueForHTTPHeaderField("Content-Type")!.hasPrefix("application/json"), "Content-Type should be application/json")
+        XCTAssertNotNil(request.HTTPBody, "HTTPBody should not be nil")
 
-                let JSON = NSJSONSerialization.JSONObjectWithData(request.HTTPBody, options: .AllowFragments, error: nil) as NSObject!
-                XCTAssertNotNil(JSON, "HTTPBody JSON is invalid")
-                XCTAssertEqual(JSON as NSObject, parameters as NSObject, "HTTPBody JSON does not equal parameters")
-            }
-        }
+        let JSON = NSJSONSerialization.JSONObjectWithData(request.HTTPBody, options: .AllowFragments, error: nil) as NSObject!
+        XCTAssertNotNil(JSON, "HTTPBody JSON is invalid")
+        XCTAssertEqual(JSON as NSObject, parameters as NSObject, "HTTPBody JSON does not equal parameters")
+    }
+}
 
-        class PropertyListParameterEncodingTestCase: XCTestCase {
-            let encoding: ParameterEncoding = .PropertyList(format: .XMLFormat_v1_0, options: 0)
-            var request: NSURLRequest!
+class PropertyListParameterEncodingTestCase: XCTestCase {
+    let encoding: Alamofire.ParameterEncoding = .PropertyList(format: .XMLFormat_v1_0, options: 0)
+    var request: NSURLRequest!
 
-            override func setUp()  {
-                super.setUp()
+    override func setUp()  {
+        super.setUp()
 
-                let URL = NSURL(string: "http://example.com/")
-                self.request = NSURLRequest(URL: URL)
-            }
+        let URL = NSURL(string: "http://example.com/")
+        self.request = NSURLRequest(URL: URL)
+    }
 
-            // MARK: -
+    // MARK: -
 
-            func testPropertyListParameterEncodeNilParameters() {
-                let (request, error) = self.encoding.encode(self.request, parameters: nil)
+    func testPropertyListParameterEncodeNilParameters() {
+        let (request, error) = self.encoding.encode(self.request, parameters: nil)
 
-                XCTAssertNil(error, "error should be nil")
-                XCTAssertNil(request.URL.query?, "query should be nil")
-                XCTAssertNil(request.valueForHTTPHeaderField("Content-Type"), "Content-Type should be nil")
-                XCTAssertNil(request.HTTPBody, "HTTPBody should be nil")
-            }
+        XCTAssertNil(error, "error should be nil")
+        XCTAssertNil(request.URL.query?, "query should be nil")
+        XCTAssertNil(request.valueForHTTPHeaderField("Content-Type"), "Content-Type should be nil")
+        XCTAssertNil(request.HTTPBody, "HTTPBody should be nil")
+    }
 
-            func testPropertyListParameterEncodeComplexParameters() {
-                let parameters = [
-                    "foo": "bar",
-                    "baz": ["a", 1, true],
-                    "qux": ["a": 1,
-                        "b": [2, 2],
-                        "c": [3, 3, 3]
-                    ]
-                ]
+    func testPropertyListParameterEncodeComplexParameters() {
+        let parameters = [
+            "foo": "bar",
+            "baz": ["a", 1, true],
+            "qux": ["a": 1,
+                "b": [2, 2],
+                "c": [3, 3, 3]
+            ]
+        ]
 
-                let (request, error) = self.encoding.encode(self.request, parameters: parameters)
+        let (request, error) = self.encoding.encode(self.request, parameters: parameters)
 
-                XCTAssertNil(error, "error should be nil")
-                XCTAssertNil(request.URL.query?, "query should be nil")
-                XCTAssertNotNil(request.valueForHTTPHeaderField("Content-Type"), "Content-Type should not be nil")
-                XCTAssert(request.valueForHTTPHeaderField("Content-Type")!.hasPrefix("application/x-plist"), "Content-Type should be application/x-plist")
-                XCTAssertNotNil(request.HTTPBody, "HTTPBody should not be nil")
+        XCTAssertNil(error, "error should be nil")
+        XCTAssertNil(request.URL.query?, "query should be nil")
+        XCTAssertNotNil(request.valueForHTTPHeaderField("Content-Type"), "Content-Type should not be nil")
+        XCTAssert(request.valueForHTTPHeaderField("Content-Type")!.hasPrefix("application/x-plist"), "Content-Type should be application/x-plist")
+        XCTAssertNotNil(request.HTTPBody, "HTTPBody should not be nil")
 
-                let plist = NSPropertyListSerialization.propertyListWithData(request.HTTPBody, options: 0, format: nil, error: nil) as NSObject
-                XCTAssertNotNil(plist, "HTTPBody JSON is invalid")
-                XCTAssertEqual(plist as NSObject, parameters as NSObject, "HTTPBody plist does not equal parameters")
-            }
+        let plist = NSPropertyListSerialization.propertyListWithData(request.HTTPBody, options: 0, format: nil, error: nil) as NSObject
+        XCTAssertNotNil(plist, "HTTPBody JSON is invalid")
+        XCTAssertEqual(plist as NSObject, parameters as NSObject, "HTTPBody plist does not equal parameters")
+    }
 
-            func testPropertyListParameterEncodeDateAndDataParameters() {
-                let parameters = [
-                    "date": NSDate(),
-                    "data": "data".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
-                ]
+    func testPropertyListParameterEncodeDateAndDataParameters() {
+        let parameters = [
+            "date": NSDate(),
+            "data": "data".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
+        ]
 
-                let (request, error) = self.encoding.encode(self.request, parameters: parameters)
+        let (request, error) = self.encoding.encode(self.request, parameters: parameters)
 
-                XCTAssertNil(error, "error should be nil")
-                XCTAssertNil(request.URL.query?, "query should be nil")
-                XCTAssertNotNil(request.valueForHTTPHeaderField("Content-Type"), "Content-Type should not be nil")
-                XCTAssert(request.valueForHTTPHeaderField("Content-Type")!.hasPrefix("application/x-plist"), "Content-Type should be application/x-plist")
-                XCTAssertNotNil(request.HTTPBody, "HTTPBody should not be nil")
+        XCTAssertNil(error, "error should be nil")
+        XCTAssertNil(request.URL.query?, "query should be nil")
+        XCTAssertNotNil(request.valueForHTTPHeaderField("Content-Type"), "Content-Type should not be nil")
+        XCTAssert(request.valueForHTTPHeaderField("Content-Type")!.hasPrefix("application/x-plist"), "Content-Type should be application/x-plist")
+        XCTAssertNotNil(request.HTTPBody, "HTTPBody should not be nil")
 
-                let plist = NSPropertyListSerialization.propertyListWithData(request.HTTPBody, options: 0, format: nil, error: nil) as NSObject!
-                XCTAssertNotNil(plist, "HTTPBody JSON is invalid")
-                XCTAssert(plist.valueForKey("date") is NSDate, "date is not NSDate")
-                XCTAssert(plist.valueForKey("data") is NSData, "data is not NSData")
-            }
-        }
+        let plist = NSPropertyListSerialization.propertyListWithData(request.HTTPBody, options: 0, format: nil, error: nil) as NSObject!
+        XCTAssertNotNil(plist, "HTTPBody JSON is invalid")
+        XCTAssert(plist.valueForKey("date") is NSDate, "date is not NSDate")
+        XCTAssert(plist.valueForKey("data") is NSData, "data is not NSData")
     }
 }

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -23,50 +23,46 @@
 import Foundation
 import XCTest
 
-extension Alamofire {
-    struct RequestTests {
-        class RequestInitializationTestCase: XCTestCase {
-            func testRequestClassMethodWithMethodAndURL() {
-                let URL = "http://httpbin.org/"
-                let request = Alamofire.request(.GET, URL)
+class RequestInitializationTestCase: XCTestCase {
+    func testRequestClassMethodWithMethodAndURL() {
+        let URL = "http://httpbin.org/"
+        let request = Alamofire.request(.GET, URL)
 
-                XCTAssertNotNil(request.request, "request should not be nil")
-                XCTAssertEqual(request.request.URL!, NSURL(string: URL), "request URL should be equal")
-                XCTAssertNil(request.response, "response should be nil")
-            }
+        XCTAssertNotNil(request.request, "request should not be nil")
+        XCTAssertEqual(request.request.URL!, NSURL(string: URL), "request URL should be equal")
+        XCTAssertNil(request.response, "response should be nil")
+    }
 
-            func testRequestClassMethodWithMethodAndURLAndParameters() {
-                let URL = "http://httpbin.org/get"
-                let request = Alamofire.request(.GET, URL, parameters: ["foo": "bar"])
+    func testRequestClassMethodWithMethodAndURLAndParameters() {
+        let URL = "http://httpbin.org/get"
+        let request = Alamofire.request(.GET, URL, parameters: ["foo": "bar"])
 
-                XCTAssertNotNil(request.request, "request should not be nil")
-                XCTAssertNotEqual(request.request.URL, NSURL(string: URL), "request URL should be equal")
-                XCTAssertEqual(request.request.URL.query!, "foo=bar", "query is incorrect")
-                XCTAssertNil(request.response, "response should be nil")
-            }
-        }
+        XCTAssertNotNil(request.request, "request should not be nil")
+        XCTAssertNotEqual(request.request.URL, NSURL(string: URL), "request URL should be equal")
+        XCTAssertEqual(request.request.URL.query!, "foo=bar", "query is incorrect")
+        XCTAssertNil(request.response, "response should be nil")
+    }
+}
 
-        class RequestResponseTestCase: XCTestCase {
-            func testRequestResponse() {
-                let URL = "http://httpbin.org/get"
-                let serializer = Alamofire.Request.stringResponseSerializer(encoding: NSUTF8StringEncoding)
+class RequestResponseTestCase: XCTestCase {
+    func testRequestResponse() {
+        let URL = "http://httpbin.org/get"
+        let serializer = Alamofire.Request.stringResponseSerializer(encoding: NSUTF8StringEncoding)
 
-                let expectation = expectationWithDescription("\(URL)")
+        let expectation = expectationWithDescription("\(URL)")
 
-                Alamofire.request(.GET, URL, parameters: ["foo": "bar"])
-                         .response(serializer: serializer){ (request, response, string, error) in
-                            expectation.fulfill()
+        Alamofire.request(.GET, URL, parameters: ["foo": "bar"])
+                 .response(serializer: serializer){ (request, response, string, error) in
+                    expectation.fulfill()
 
-                            XCTAssertNotNil(request, "request should not be nil")
-                            XCTAssertNotNil(response, "response should not be nil")
-                            XCTAssertNotNil(string, "string should not be nil")
-                            XCTAssertNil(error, "error should be nil")
-                         }
+                    XCTAssertNotNil(request, "request should not be nil")
+                    XCTAssertNotNil(response, "response should not be nil")
+                    XCTAssertNotNil(string, "string should not be nil")
+                    XCTAssertNil(error, "error should be nil")
+                 }
 
-                waitForExpectationsWithTimeout(10){ error in
-                    XCTAssertNil(error, "\(error)")
-                }
-            }
+        waitForExpectationsWithTimeout(10){ error in
+            XCTAssertNil(error, "\(error)")
         }
     }
 }

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -23,28 +23,26 @@
 import Foundation
 import XCTest
 
-extension Alamofire {
-    struct ResponseTests {
-        class JSONResponseTestCase: XCTestCase {
-            func testJSONResponse() {
-                let URL = "http://httpbin.org/get"
-                let expectation = expectationWithDescription("\(URL)")
+class JSONResponseTestCase: XCTestCase {
+    func testJSONResponse() {
+        let URL = "http://httpbin.org/get"
+        let expectation = expectationWithDescription("\(URL)")
 
-                Alamofire.request(.GET, URL, parameters: ["foo": "bar"])
-                         .responseJSON { (request, response, JSON, error) in
-                            expectation.fulfill()
-                            XCTAssertNotNil(request, "request should not be nil")
-                            XCTAssertNotNil(response, "response should not be nil")
-                            XCTAssertNotNil(JSON, "JSON should not be nil")
-                            XCTAssertNil(error, "error should be nil")
+        Alamofire.request(.GET, URL, parameters: ["foo": "bar"])
+                 .responseJSON { (request, response, JSON, error) in
+                    expectation.fulfill()
+                    XCTAssertNotNil(request, "request should not be nil")
+                    XCTAssertNotNil(response, "response should not be nil")
+                    XCTAssertNil(error, "error should be nil")
+                    if let j: AnyObject = JSON {
+                        XCTAssertEqual(j["args"] as NSObject, ["foo": "bar"], "args should be equal")
+                    } else {
+                        XCTFail("JSON should not be nil")
+                    }
+                 }
 
-                            XCTAssertEqual(JSON!["args"] as NSObject, ["foo": "bar"], "args should be equal")
-                         }
-
-                waitForExpectationsWithTimeout(10){ error in
-                    XCTAssertNil(error, "\(error)")
-                }
-            }
+        waitForExpectationsWithTimeout(10){ error in
+            XCTAssertNil(error, "\(error)")
         }
     }
 }

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -23,32 +23,27 @@
 import Foundation
 import XCTest
 
-extension Alamofire {
-    struct UploadTests {
-        class UploadResponseTestCase: XCTestCase {
-            func testDownloadRequest() {
-                let URL = "http://httpbin.org/post"
-                let data = "Lorem ipsum dolor sit amet".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
+class UploadResponseTestCase: XCTestCase {
+    func testDownloadRequest() {
+        let URL = "http://httpbin.org/post"
+        let data = "Lorem ipsum dolor sit amet".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
 
-                let expectation = expectationWithDescription(URL)
+        let expectation = expectationWithDescription(URL)
 
-                Alamofire.upload(.POST, URL, data: data!)
-                    .responseJSON {(request, response, JSON, error) in
-                        expectation.fulfill()
+        Alamofire.upload(.POST, URL, data: data!)
+            .responseJSON {(request, response, JSON, error) in
+                expectation.fulfill()
 
-                        XCTAssertNotNil(request, "request should not be nil")
-                        XCTAssertNotNil(response, "response should not be nil")
+                XCTAssertNotNil(request, "request should not be nil")
+                XCTAssertNotNil(response, "response should not be nil")
 
-                        XCTAssertNil(error, "error should be nil")
+                XCTAssertNil(error, "error should be nil")
 
-                        println(JSON)
-                    }
-
-                waitForExpectationsWithTimeout(10){ error in
-                    XCTAssertNil(error, "\(error)")
-                }
+                println(JSON)
             }
+
+        waitForExpectationsWithTimeout(10){ error in
+            XCTAssertNil(error, "\(error)")
         }
     }
 }
-


### PR DESCRIPTION
- Removed default arg of User's home directory
- Moved test `100.json` file to `Library/Caches` directory
- Pulled test classes out of extensions
- Fixed 100.json test
- Fixed bugs in empty data handling for JSON

You probably want to pick a better `NSError` domain.
