### PR TITLE
Fix the URL written to the cURL debug string

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -833,7 +833,7 @@ extension Request: DebugPrintable {
 
         // TODO: -T arguments for files
 
-        components.append("\"\(URL.absoluteString)\"")
+        components.append("\"\(URL.absoluteString!)\"")
 
         return join(" \\\n\t", components)
     }


### PR DESCRIPTION
The URL was being output as `"Optional(http://domain.com)"` instead of `"http://domain.com"`.
