### PR TITLE
Added support of Default Headers for Uploads

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -635,26 +635,61 @@ extension Manager {
         if self.automaticallyStartsRequests {
             request.resume()
         }
+        
+        var mutableRequest: NSMutableURLRequest! = request.mutableCopy() as NSMutableURLRequest
+        
+        for (field, value) in self.defaultHeaders {
+            if mutableRequest.valueForHTTPHeaderField(field) == nil {
+                mutableRequest.setValue(value, forHTTPHeaderField: field)
+            }
+        }
 
-        return request
+        return mutableRequest
     }
 
     // MARK: File
 
     func upload(request: NSURLRequest, file: NSURL) -> Request {
-        return upload(.File(request, file))
+        
+        var mutableRequest: NSMutableURLRequest! = request.mutableCopy() as NSMutableURLRequest
+        
+        for (field, value) in self.defaultHeaders {
+            if mutableRequest.valueForHTTPHeaderField(field) == nil {
+                mutableRequest.setValue(value, forHTTPHeaderField: field)
+            }
+        }
+        
+        return upload(.File(mutableRequest, file))
     }
 
     // MARK: Data
 
     func upload(request: NSURLRequest, data: NSData) -> Request {
-        return upload(.Data(request, data))
+        
+        var mutableRequest: NSMutableURLRequest! = request.mutableCopy() as NSMutableURLRequest
+        
+        for (field, value) in self.defaultHeaders {
+            if mutableRequest.valueForHTTPHeaderField(field) == nil {
+                mutableRequest.setValue(value, forHTTPHeaderField: field)
+            }
+        }
+        
+        return upload(.Data(mutableRequest, data))
     }
 
     // MARK: Stream
 
     func upload(request: NSURLRequest, stream: NSInputStream) -> Request {
-        return upload(.Stream(request, stream))
+        
+        var mutableRequest: NSMutableURLRequest! = request.mutableCopy() as NSMutableURLRequest
+        
+        for (field, value) in self.defaultHeaders {
+            if mutableRequest.valueForHTTPHeaderField(field) == nil {
+                mutableRequest.setValue(value, forHTTPHeaderField: field)
+            }
+        }
+        
+        return upload(.Stream(mutableRequest, stream))
     }
 }
 


### PR DESCRIPTION
With this pull request it's able to add some custom headers to uploads. Same way like you can already add custom headers to other Alamofire Requests.

Examples for some custom headers...
1. Accept Header
   Manager.sharedInstance.defaultHeaders["Accept"] = "application/json"
2. Basic Auth Header
       let plainString = "username:password" as NSString
       let plainData = plainString.dataUsingEncoding(NSUTF8StringEncoding)
       let base64String = plainData?.base64EncodedStringWithOptions(NSDataBase64EncodingOptions.fromRaw(0)!)
       Manager.sharedInstance.defaultHeaders["Authorization"] = "Basic " + base64String!
