### PR TITLE
unwrap optional httpmethod in curl representation

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -795,7 +795,7 @@ extension Request: DebugPrintable {
         let URL = self.request.URL
 
         if self.request.HTTPMethod != "GET" {
-            components.append("-X \(self.request.HTTPMethod)")
+            components.append("-X \(self.request.HTTPMethod!)")
         }
 
         if let credentialStorage = self.session.configuration.URLCredentialStorage {


### PR DESCRIPTION
Otherwise you see Optional(POST) instead of POST
