### PR TITLE
Simplify prepareForSegue(_:_:)

### DIFF
--- a/Example/MasterViewController.swift
+++ b/Example/MasterViewController.swift
@@ -52,13 +52,10 @@ class MasterViewController: UITableViewController {
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
         if let detailViewController = segue.destinationViewController.topViewController as? DetailViewController {
             func requestForSegue(segue: UIStoryboardSegue) -> Request? {
-                switch segue.identifier {
-                    case "GET", "POST", "PUT", "DELETE":
-                        let method = Alamofire.Method.fromRaw(segue.identifier)!
-                        return Alamofire.request(method, HTTPBinRoute.Method(method))
-                    default:
-                        return nil
+                if let method = Method.fromRaw(segue.identifier) {
+                    return request(method, HTTPBinRoute.Method(method))
                 }
+                return nil
             }
 
             if let request = requestForSegue(segue) {


### PR DESCRIPTION
Since `Method.fromRaw()` returns an optional, it's safer, simpler & more future proof not to switch on string values in `prepareForSegue(_:_:)`
