### PR TITLE
Changed Requirements to iOS 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Alamofire is an HTTP networking library written in Swift, from the [creator](htt
 
 ## Requirements
 
-- iOS 7.0+ / Mac OS X 10.9+
+- iOS 8.0+ / Mac OS X 10.9+
 - Xcode 6.0
 
 > For Xcode 6.1, use [the `xcode-6.1` branch](https://github.com/Alamofire/Alamofire/tree/xcode-6.1).


### PR DESCRIPTION
Since the dynamic embedded frameworks feature doesn't work with the deployment target set to iOS 7.x and Swift can't be compiled to a static library, the minimum iOS version to use should be changed to 8.0 with the current installation instructions.
