### PR TITLE
fixes bug with HTTPbody parameters being encoded twice

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -113,7 +113,7 @@ public enum ParameterEncoding {
                     mutableURLRequest.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
                 }
 
-                mutableURLRequest.HTTPBody = (CFURLCreateStringByAddingPercentEscapes(nil, query(parameters!) as NSString, nil, nil, CFStringConvertNSStringEncodingToEncoding(NSUTF8StringEncoding)) as NSString).dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
+                mutableURLRequest.HTTPBody = query(parameters!).dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
             }
         case .JSON:
             let options = NSJSONWritingOptions.allZeros


### PR DESCRIPTION
apparently there was an issue when special symbols in the HTTP body were encoded twice, transforming string name@example.com into name%2540example.com
