### PR TITLE
Fix curl command output

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -1261,7 +1261,9 @@ extension Request: DebugPrintable {
         }
         
         if let HTTPBody = request.HTTPBody {
-            components.append("-d \"\(NSString(data: HTTPBody, encoding: NSUTF8StringEncoding))\"")
+            let escapedBody = NSString(data: HTTPBody, encoding: NSUTF8StringEncoding)
+                                .stringByReplacingOccurrencesOfString("\"", withString: "\\\"")
+            components.append("-d \"\(escapedBody)\"")
         }
 
         components.append("\"\(URL.absoluteString!)\"")


### PR DESCRIPTION
There were still some optionals that needed to be unwrapped, and quotes need to be escaped when posting JSON content.
