### PR TITLE
Allow Request to be initialized externally

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -521,7 +521,7 @@ public class Request {
     /// The progress of the request lifecycle.
     public var progress: NSProgress? { return delegate.progress }
 
-    private init(session: NSURLSession, task: NSURLSessionTask) {
+    public init(session: NSURLSession, task: NSURLSessionTask) {
         self.session = session
 
         switch task {


### PR DESCRIPTION
We are trying to use Alamofire in a project where we are unit testing. Unfortunately there are two things that make this difficult

1) Due to the nature of Swift, the way to stub out dependencies in a unit test is to inject them. However it is not possible to inject classes. A bit of Alamofire's magic is in its static `request` method, so using an `Alamofire.Manager` became painful. In order to inject Alamofire we have had to write a wrapper class as follows, that lets as treat Alamofire as an instance instead of a class:

``` swift
import Alamofire
class NetworkingManager {
    func request(method: Alamofire.Method, URLString: URLStringConvertible, parameters: [String: AnyObject]? = nil, encoding: ParameterEncoding = .URL ) -> Request {
        return Alamofire.request(method, URLString, parameters: parameters, encoding: encoding)
    }
}
```

This allows us to create `FakeNetworkingManager` which is a subclass of `NetworkingManager` and inject it into classes that consume it for unit tests.

2) When trying to create `FakeNetworkingManager` which overrides `request`, we need to return an `Alamofire.Request` object. However the initializer for `Request` is private. Since Swift's access control system is very strict, we could not find a way to implement an initializer such that we could create and return a `Request` object from our fake.

This PR is about making `Requests``s init method public, so we can return a FakeRequest in our tests and properly unit test our classes.

Thanks,
 Tim
