### PR TITLE
[Issue #141] Allow obtaining of resume data

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -677,10 +677,13 @@ public class Request {
     /**
         Cancels the request.
     */
-    public func cancel() {
+    public func cancel(_ completion: ((NSData?) -> Void)? = nil) {
         if let downloadDelegate = delegate as? DownloadTaskDelegate {
             downloadDelegate.downloadTask.cancelByProducingResumeData { (data) in
                 downloadDelegate.resumeData = data
+                if let handler = completion {
+                    handler(data);
+                }
             }
         } else {
             task.cancel()

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -105,4 +105,23 @@ class AlamofireDownloadResponseTestCase: XCTestCase {
             XCTAssertNil(error, "\(error)")
         }
     }
+
+    func testDownloadRequestCancellationWithResumeData() {
+        let numberOfLines = 100
+        let URL = "http://httpbin.org/stream/\(numberOfLines)"
+
+        let expectation = expectationWithDescription(URL)
+
+        let destination = Alamofire.Request.suggestedDownloadDestination(directory: searchPathDirectory, domain: searchPathDomain)
+
+        let download = Alamofire.download(.GET, URL, destination)
+        download.cancel { (resumeData) -> Void in
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(10) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+
+    }
 }


### PR DESCRIPTION
A fix for Issue #141

There are some inconsistencies with resume data closure parameter being exposed in non-download request. See issue thread for more detail.

The thing is that we have to be sure we will be OK with such interface for the first version at least, because if we decide to change it later, it will likely be a breaking change.