### PR TITLE
Adds a queue options to run response processing in other queue

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -1337,8 +1337,8 @@ extension Request {
 
         :returns: The request.
     */
-    public func responseString(encoding: NSStringEncoding = NSUTF8StringEncoding, completionHandler: (NSURLRequest, NSHTTPURLResponse?, String?, NSError?) -> Void) -> Self  {
-        return response(serializer: Request.stringResponseSerializer(encoding: encoding), completionHandler: { request, response, string, error in
+    public func responseString(queue: dispatch_queue_t? = nil, encoding: NSStringEncoding = NSUTF8StringEncoding, completionHandler: (NSURLRequest, NSHTTPURLResponse?, String?, NSError?) -> Void) -> Self  {
+        return response(queue: queue, serializer: Request.stringResponseSerializer(encoding: encoding), completionHandler: { request, response, string, error in
             completionHandler(request, response, string as? String, error)
         })
     }
@@ -1435,8 +1435,8 @@ extension Request {
 
         :returns: The request.
     */
-    public func responsePropertyList(options: NSPropertyListReadOptions = 0, completionHandler: (NSURLRequest, NSHTTPURLResponse?, AnyObject?, NSError?) -> Void) -> Self {
-        return response(serializer: Request.propertyListResponseSerializer(options: options), completionHandler: { (request, response, plist, error) in
+    public func responsePropertyList(queue: dispatch_queue_t? = nil, options: NSPropertyListReadOptions = 0, completionHandler: (NSURLRequest, NSHTTPURLResponse?, AnyObject?, NSError?) -> Void) -> Self {
+        return response(queue: queue, serializer: Request.propertyListResponseSerializer(options: options), completionHandler: { (request, response, plist, error) in
             completionHandler(request, response, plist, error)
         })
     }


### PR DESCRIPTION
This allows to set a custom queue, for instance a background queue or a dedicated queue. If no queue is added, Alamofire will specify a queue (and default is main queue).

Usage:

``` Swift
Alamofire.request(.GET, "http://someurl.com")
.responseJSON() { request, response, json, error in
    // this will run in main queue
}

let backgroundQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)
Alamofire.request(.GET, "http://someurl.com")
.responseJSON(queue: backgroundQueue) { request, response, json, error in
    // this will run in a background queue
}
```
