### PR TITLE
More descriptive errors for validation failures

### DIFF
--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -68,7 +68,7 @@ class AlamofireDownloadResponseTestCase: XCTestCase {
                 XCTAssertEqual(filteredContents.count, 1, "should have one file in Documents")
 
                 let file = filteredContents.first as NSURL
-                XCTAssertEqual(file.lastPathComponent, "\(numberOfLines)", "filename should be \(numberOfLines)")
+                XCTAssertEqual(file.lastPathComponent!, "\(numberOfLines)", "filename should be \(numberOfLines)")
 
                 if let data = NSData(contentsOfURL: file) {
                     XCTAssertGreaterThan(data.length, 0, "data length should be non-zero")

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -55,6 +55,7 @@ class AlamofireStatusCodeValidationTestCase: XCTestCase {
 
                 XCTAssertNotNil(error, "error should not be nil")
                 XCTAssertEqual(error!.domain, AlamofireErrorDomain, "error should be in Alamofire error domain")
+                XCTAssertEqual(error!.code, AlamofireErrorCodes.InvalidStatusCode.rawValue, "error should have invalid status code code")
         }
 
         waitForExpectationsWithTimeout(10) { (error) in
@@ -74,6 +75,7 @@ class AlamofireStatusCodeValidationTestCase: XCTestCase {
 
                 XCTAssertNotNil(error, "error should not be nil")
                 XCTAssertEqual(error!.domain, AlamofireErrorDomain, "error should be in Alamofire error domain")
+                XCTAssertEqual(error!.code, AlamofireErrorCodes.InvalidStatusCode.rawValue, "error should have invalid status code code")
         }
 
         waitForExpectationsWithTimeout(10) { (error) in
@@ -133,6 +135,7 @@ class AlamofireContentTypeValidationTestCase: XCTestCase {
 
                 XCTAssertNotNil(error, "error should not be nil")
                 XCTAssertEqual(error!.domain, AlamofireErrorDomain, "error should be in Alamofire error domain")
+                XCTAssertEqual(error!.code, AlamofireErrorCodes.UnacceptableContentType.rawValue, "error should have unacceptable content type code")
         }
 
         waitForExpectationsWithTimeout(10) { (error) in
@@ -152,6 +155,7 @@ class AlamofireContentTypeValidationTestCase: XCTestCase {
 
                 XCTAssertNotNil(error, "error should not be nil")
                 XCTAssertEqual(error!.domain, AlamofireErrorDomain, "error should be in Alamofire error domain")
+                XCTAssertEqual(error!.code, AlamofireErrorCodes.UnacceptableContentType.rawValue, "error should have unacceptable content type code")
         }
 
         waitForExpectationsWithTimeout(10) { (error) in
@@ -234,6 +238,7 @@ class AlamofireAutomaticValidationTestCase: XCTestCase {
 
                 XCTAssertNotNil(error, "error should not be nil")
                 XCTAssertEqual(error!.domain, AlamofireErrorDomain, "error should be in Alamofire error domain")
+                XCTAssertEqual(error!.code, AlamofireErrorCodes.InvalidStatusCode.rawValue, "error should have invalid status code code")
         }
 
         waitForExpectationsWithTimeout(10) { (error) in


### PR DESCRIPTION
Stop me if I'm missing something, but once a response fails validation, there's no way to tell what failed.
