### PR TITLE
Update Alamofire.swift

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -95,12 +95,13 @@ public enum ParameterEncoding {
             }
 
             func encodesParametersInURL(method: Method) -> Bool {
-                switch method {
+                /*switch method {
                 case .GET, .HEAD, .DELETE:
                     return true
                 default:
                     return false
-                }
+                }*/
+                return true
             }
 
             let method = Method(rawValue: mutableURLRequest.HTTPMethod)


### PR DESCRIPTION
It's illogical (in my opinion) to force the user to not encode parameters into the URL, even though it may be bad practice. If the encoding is `.URL`, then let it be a URL encoding.

Forcing the user to not use a URL encoding gives him/her potential confusion, since there are no warnings or notifications saying that their encoding type was overridden and changed to `.JSON`.

Thanks!
