### PR TITLE
Add support for empty responses to JSONResponseSerializer

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -1234,7 +1234,7 @@ extension Request: Printable {
 
 extension Request: DebugPrintable {
     func cURLRepresentation() -> String {
-        var components: [String] = ["$ curl -i"]
+        var components: [String] = ["$ curl -i --compressed"]
 
         let URL = request.URL
 
@@ -1361,7 +1361,7 @@ extension Request {
     */
     public class func JSONResponseSerializer(options: NSJSONReadingOptions = .AllowFragments) -> Serializer {
         return { (request, response, data) in
-            if data == nil {
+            if data == nil || data!.length == 0 {
                 return (nil, nil)
             }
 

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -101,7 +101,7 @@ class AlamofireRequestDebugDescriptionTestCase: XCTestCase {
         let request = Alamofire.request(.GET, URL)
         let components = cURLCommandComponents(request)
 
-        XCTAssert(components[0..<3] == ["$", "curl", "-i"], "components should be equal")
+        XCTAssert(components[0..<4] == ["$", "curl", "-i", "--compressed"], "components should be equal")
         XCTAssert(!contains(components, "-X"), "command should not contain explicit -X flag")
         XCTAssert(components.last! == "\"\(URL)\"", "URL component should be equal")
     }
@@ -111,8 +111,8 @@ class AlamofireRequestDebugDescriptionTestCase: XCTestCase {
         let request = Alamofire.request(.POST, URL)
         let components = cURLCommandComponents(request)
 
-        XCTAssert(components[0..<3] == ["$", "curl", "-i"], "components should be equal")
-        XCTAssert(components[3..<5] == ["-X", "POST"], "command should contain explicit -X flag")
+        XCTAssert(components[0..<4] == ["$", "curl", "-i", "--compressed"], "components should be equal")
+        XCTAssert(components[4..<6] == ["-X", "POST"], "command should contain explicit -X flag")
         XCTAssert(components.last! == "\"\(URL)\"", "URL component should be equal")
     }
 
@@ -121,8 +121,8 @@ class AlamofireRequestDebugDescriptionTestCase: XCTestCase {
         let request = Alamofire.request(.POST, URL, parameters: ["foo": "bar"], encoding: .JSON)
         let components = cURLCommandComponents(request)
 
-        XCTAssert(components[0..<3] == ["$", "curl", "-i"], "components should be equal")
-        XCTAssert(components[3..<5] == ["-X", "POST"], "command should contain explicit -X flag")
+        XCTAssert(components[0..<4] == ["$", "curl", "-i", "--compressed"], "components should be equal")
+        XCTAssert(components[4..<6] == ["-X", "POST"], "command should contain explicit -X flag")
         XCTAssert(request.debugDescription.rangeOfString("-H \"Content-Type: application/json\"") != nil)
         XCTAssert(request.debugDescription.rangeOfString("-d \"{\\\"foo\\\":\\\"bar\\\"}\"") != nil)
         XCTAssert(components.last! == "\"\(URL)\"", "URL component should be equal")

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -44,4 +44,22 @@ class AlamofireJSONResponseTestCase: XCTestCase {
             XCTAssertNil(error, "\(error)")
         }
     }
+
+    func testJSONResponseWithEmptyBody() {
+        let URL = "http://httpbin.org/status/204"
+        let expectation = expectationWithDescription("\(URL)")
+
+        Alamofire.request(.GET, URL)
+            .responseJSON { (request, response, JSON, error) in
+                expectation.fulfill()
+                XCTAssertNotNil(request, "request should not be nil")
+                XCTAssertNotNil(response, "response should not be nil")
+                XCTAssertNil(JSON, "JSON should be nil")
+                XCTAssertNil(error, "error should be nil")
+        }
+
+        waitForExpectationsWithTimeout(10) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
 }


### PR DESCRIPTION
Also add `--compressed` flag to `curl` output.
