### PR TITLE
Add --compressed to curl flags to match default Accept header

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -1234,7 +1234,7 @@ extension Request: Printable {
 
 extension Request: DebugPrintable {
     func cURLRepresentation() -> String {
-        var components: [String] = ["$ curl -i"]
+        var components: [String] = ["$ curl -i --compressed"]
 
         let URL = request.URL
 

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -101,7 +101,7 @@ class AlamofireRequestDebugDescriptionTestCase: XCTestCase {
         let request = Alamofire.request(.GET, URL)
         let components = cURLCommandComponents(request)
 
-        XCTAssert(components[0..<3] == ["$", "curl", "-i"], "components should be equal")
+        XCTAssert(components[0..<4] == ["$", "curl", "-i", "--compressed"], "components should be equal")
         XCTAssert(!contains(components, "-X"), "command should not contain explicit -X flag")
         XCTAssert(components.last! == "\"\(URL)\"", "URL component should be equal")
     }
@@ -111,8 +111,8 @@ class AlamofireRequestDebugDescriptionTestCase: XCTestCase {
         let request = Alamofire.request(.POST, URL)
         let components = cURLCommandComponents(request)
 
-        XCTAssert(components[0..<3] == ["$", "curl", "-i"], "components should be equal")
-        XCTAssert(components[3..<5] == ["-X", "POST"], "command should contain explicit -X flag")
+        XCTAssert(components[0..<4] == ["$", "curl", "-i", "--compressed"], "components should be equal")
+        XCTAssert(components[4..<6] == ["-X", "POST"], "command should contain explicit -X flag")
         XCTAssert(components.last! == "\"\(URL)\"", "URL component should be equal")
     }
 
@@ -121,8 +121,8 @@ class AlamofireRequestDebugDescriptionTestCase: XCTestCase {
         let request = Alamofire.request(.POST, URL, parameters: ["foo": "bar"], encoding: .JSON)
         let components = cURLCommandComponents(request)
 
-        XCTAssert(components[0..<3] == ["$", "curl", "-i"], "components should be equal")
-        XCTAssert(components[3..<5] == ["-X", "POST"], "command should contain explicit -X flag")
+        XCTAssert(components[0..<4] == ["$", "curl", "-i", "--compressed"], "components should be equal")
+        XCTAssert(components[4..<6] == ["-X", "POST"], "command should contain explicit -X flag")
         XCTAssert(request.debugDescription.rangeOfString("-H \"Content-Type: application/json\"") != nil)
         XCTAssert(request.debugDescription.rangeOfString("-d \"{\\\"foo\\\":\\\"bar\\\"}\"") != nil)
         XCTAssert(components.last! == "\"\(URL)\"", "URL component should be equal")
@@ -146,9 +146,9 @@ class AlamofireRequestDebugDescriptionTestCase: XCTestCase {
         let request = manager.request(.POST, URL)
         let components = cURLCommandComponents(request)
 
-        XCTAssert(components[0..<3] == ["$", "curl", "-i"], "components should be equal")
-        XCTAssert(components[3..<5] == ["-X", "POST"], "command should contain explicit -X flag")
-        XCTAssert(components[5..<7] == ["-b", "\"foo=bar\""], "command should contain -b flag")
+        XCTAssert(components[0..<4] == ["$", "curl", "-i", "--compressed"], "components should be equal")
+        XCTAssert(components[4..<6] == ["-X", "POST"], "command should contain explicit -X flag")
+        XCTAssert(components[6..<8] == ["-b", "\"foo=bar\""], "command should contain -b flag")
         XCTAssert(components.last! == "\"\(URL)\"", "URL component should be equal")
     }
 }


### PR DESCRIPTION
Splitting this out from #250.

The default singleton instance of `Alamofire.Manager` uses a configuration that adds compression to the `Accept-Encoding` header. curl's `--compressed` option does the same thing, but also will decompress the response. Indeed, it will end up having no effect on the request as the `-H` flag later on will override the `Accept-Encoding` header from the `--compressed` option.

Piping the response to `gunzip` or similar will be difficult, as the curl flags also include `-i`, putting headers in the response output.
