### PR TITLE
Added hanlding of valid NSData object with 0 bytes for serializers

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -1361,7 +1361,7 @@ extension Request {
     */
     public class func JSONResponseSerializer(options: NSJSONReadingOptions = .AllowFragments) -> Serializer {
         return { (request, response, data) in
-            if data == nil {
+            if data == nil || data?.length == 0 {
                 return (nil, nil)
             }
 
@@ -1410,7 +1410,7 @@ extension Request {
     */
     public class func propertyListResponseSerializer(options: NSPropertyListReadOptions = 0) -> Serializer {
         return { (request, response, data) in
-            if data == nil {
+            if data == nil || data?.length == 0 {
                 return (nil, nil)
             }
 


### PR DESCRIPTION
When handling requests using a serializer (JSON, plist) it is possible that the response will valid `NSData` instance with 0 bytes which means the check for `data == nil` will pass and the serialization calls will fail. To prevent this, we can check if the `NSData` returned has bytes.
