### PR TITLE
Extracted default HTTP header creation into a public class method

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -221,46 +221,7 @@ public class Manager {
         struct Singleton {
             static var configuration: NSURLSessionConfiguration = {
                 var configuration = NSURLSessionConfiguration.defaultSessionConfiguration()
-
-                configuration.HTTPAdditionalHeaders = {
-                    // Accept-Encoding HTTP Header; see http://tools.ietf.org/html/rfc7230#section-4.2.3
-                    let acceptEncoding: String = "gzip;q=1.0,compress;q=0.5"
-
-                    // Accept-Language HTTP Header; see http://tools.ietf.org/html/rfc7231#section-5.3.5
-                    let acceptLanguage: String = {
-                        var components: [String] = []
-                        for (index, languageCode) in enumerate(NSLocale.preferredLanguages() as [String]) {
-                            let q = 1.0 - (Double(index) * 0.1)
-                            components.append("\(languageCode);q=\(q)")
-                            if q <= 0.5 {
-                                break
-                            }
-                        }
-
-                        return join(",", components)
-                    }()
-
-                    // User-Agent Header; see http://tools.ietf.org/html/rfc7231#section-5.5.3
-                    let userAgent: String = {
-                        if let info = NSBundle.mainBundle().infoDictionary {
-                            let executable: AnyObject = info[kCFBundleExecutableKey] ?? "Unknown"
-                            let bundle: AnyObject = info[kCFBundleIdentifierKey] ?? "Unknown"
-                            let version: AnyObject = info[kCFBundleVersionKey] ?? "Unknown"
-                            let os: AnyObject = NSProcessInfo.processInfo().operatingSystemVersionString ?? "Unknown"
-
-                            var mutableUserAgent = NSMutableString(string: "\(executable)/\(bundle) (\(version); OS \(os))") as CFMutableString
-                            let transform = NSString(string: "Any-Latin; Latin-ASCII; [:^ASCII:] Remove") as CFString
-                            if CFStringTransform(mutableUserAgent, nil, transform, 0) == 1 {
-                                return mutableUserAgent as NSString
-                            }
-                        }
-                        return "Alamofire"
-                    }()
-
-                    return ["Accept-Encoding": acceptEncoding,
-                            "Accept-Language": acceptLanguage,
-                            "User-Agent": userAgent]
-                }()
+                configuration.HTTPAdditionalHeaders = Manager.defaultHTTPHeaders()
 
                 return configuration
             }()
@@ -269,6 +230,52 @@ public class Manager {
         }
 
         return Singleton.instance
+    }
+
+    /**
+        Creates default values for the "Accept-Encoding", "Accept-Language" and "User-Agent" headers.
+
+        :returns: The default header values.
+    */
+    public class func defaultHTTPHeaders() -> [String: String] {
+
+        // Accept-Encoding HTTP Header; see http://tools.ietf.org/html/rfc7230#section-4.2.3
+        let acceptEncoding: String = "gzip;q=1.0,compress;q=0.5"
+
+        // Accept-Language HTTP Header; see http://tools.ietf.org/html/rfc7231#section-5.3.5
+        let acceptLanguage: String = {
+            var components: [String] = []
+            for (index, languageCode) in enumerate(NSLocale.preferredLanguages() as [String]) {
+                let q = 1.0 - (Double(index) * 0.1)
+                components.append("\(languageCode);q=\(q)")
+                if q <= 0.5 {
+                    break
+                }
+            }
+
+            return join(",", components)
+        }()
+
+        // User-Agent Header; see http://tools.ietf.org/html/rfc7231#section-5.5.3
+        let userAgent: String = {
+            if let info = NSBundle.mainBundle().infoDictionary {
+                let executable: AnyObject = info[kCFBundleExecutableKey] ?? "Unknown"
+                let bundle: AnyObject = info[kCFBundleIdentifierKey] ?? "Unknown"
+                let version: AnyObject = info[kCFBundleVersionKey] ?? "Unknown"
+                let os: AnyObject = NSProcessInfo.processInfo().operatingSystemVersionString ?? "Unknown"
+
+                var mutableUserAgent = NSMutableString(string: "\(executable)/\(bundle) (\(version); OS \(os))") as CFMutableString
+                let transform = NSString(string: "Any-Latin; Latin-ASCII; [:^ASCII:] Remove") as CFString
+                if CFStringTransform(mutableUserAgent, nil, transform, 0) == 1 {
+                    return mutableUserAgent as NSString
+                }
+            }
+            return "Alamofire"
+        }()
+
+        return ["Accept-Encoding": acceptEncoding,
+                "Accept-Language": acceptLanguage,
+                "User-Agent": userAgent]
     }
 
     private let delegate: SessionDelegate


### PR DESCRIPTION
In the current implementation, I can't access logic for building those headers without creating the Alamofire SessionManager singleton like so.

```
Alamofire.Manager.sharedInstance.session.configuration.HTTPAdditionalHeaders
```

It seems that for those of us creating our own `SessionManager` subclasses, we should be able to access that header creation logic without having to instantiate the singleton object. This pull request extracts the header logic into a separate class method to allow subclassed `SessionManager` objects access.
