### PR TITLE
Added failing test for releasing a manager with a pending request

### DIFF
--- a/Tests/ManagerTests.swift
+++ b/Tests/ManagerTests.swift
@@ -42,5 +42,16 @@ class AlamofireManagerTestCase: XCTestCase {
             XCTAssertNil(error, "\(error)")
         }
     }
-}
 
+    func testReleasingManagerWithPendingRequestDeinitializesSuccessfully() {
+        var manager: Manager? = Alamofire.Manager()
+        manager!.startRequestsImmediately = false
+
+        let URL = NSURL(string: "http://httpbin.org/get")!
+        let URLRequest = NSURLRequest(URL: URL)
+
+        manager!.request(URLRequest)
+
+        manager = nil
+    }
+}


### PR DESCRIPTION
I ran across an interesting crash case today that I wanted to get in front of the community. While I don't think it's incredibly likely that you will have too many people run into this case, I actually did today and thought I'd write a failing test for it that reproduces the crash.

The test creates a manager and then a request with that manager. The manager is then released before the request task is ever started. The `deinit` of the manager stack crashes every time.

I ran into this case because I wrote some integration tests where I was forgetting to cancel the request if I didn't end up running it. I was surprised that forgetting to resume the request actually causes the `deinit` to crash.

I haven't quite been able to figure out how to fix this case yet, but I wanted to at least get the test submitted to get some more experienced Alamofire eyes on the problem.
