### PR TITLE
Add podspec file

### DIFF
--- a/Alamofire.podspec
+++ b/Alamofire.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name         = "Alamofire"
+  s.version      = "1.1.2"
+  s.summary      = "Elegant HTTP Networking in Swift"
+  s.homepage     = "https://github.com/Alamofire/Alamofire"
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.author       = { 'Mattt Thompson' => 'm@mattt.me' }
+  s.source       = { :git => "https://github.com/Alamofire/Alamofire.git", :tag => s.version }
+
+  s.ios.deployment_target = '7.0'
+  s.osx.deployment_target = "10.9"
+  s.requires_arc = true
+
+  s.source_files  = "Source/*.swift"
+end


### PR DESCRIPTION
As of [0.36.0.beta.1](073888038b01bd1dd9c99537313ff1c9b44b86ec), CocoaPods supports Frameworks and Swift source files

I tested it with a basic project with the local podspec file. I wasn't sure if I needed to include the `.h` files as well to `s.source_files`. Let me know if I should make that change.
