### PR TITLE
Added UIImageView extension to support remote and placeholder images

### DIFF
--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4CD394561A6078BE00872098 /* UIImageView+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD394551A6078BE00872098 /* UIImageView+Alamofire.swift */; };
 		4DD67C241A5C58FB00ED2280 /* Alamofire.h in Headers */ = {isa = PBXBuildFile; fileRef = F8111E3819A95C8B0040E7D1 /* Alamofire.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4DD67C251A5C590000ED2280 /* Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = F897FF4019AA800700AB5182 /* Alamofire.swift */; };
 		F8111E3919A95C8B0040E7D1 /* Alamofire.h in Headers */ = {isa = PBXBuildFile; fileRef = F8111E3819A95C8B0040E7D1 /* Alamofire.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -32,6 +33,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4CD394551A6078BE00872098 /* UIImageView+Alamofire.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImageView+Alamofire.swift"; sourceTree = "<group>"; };
 		4DD67C0B1A5C55C900ED2280 /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8111E3319A95C8B0040E7D1 /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8111E3719A95C8B0040E7D1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -74,6 +76,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4CD394541A6078AD00872098 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				4CD394551A6078BE00872098 /* UIImageView+Alamofire.swift */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
 		F8111E2919A95C8B0040E7D1 = {
 			isa = PBXGroup;
 			children = (
@@ -98,6 +108,7 @@
 			children = (
 				F8111E3819A95C8B0040E7D1 /* Alamofire.h */,
 				F897FF4019AA800700AB5182 /* Alamofire.swift */,
+				4CD394541A6078AD00872098 /* iOS */,
 				F8111E3619A95C8B0040E7D1 /* Supporting Files */,
 			);
 			path = Source;
@@ -288,6 +299,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F897FF4119AA800700AB5182 /* Alamofire.swift in Sources */,
+				4CD394561A6078BE00872098 /* UIImageView+Alamofire.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -522,6 +534,7 @@
 				4DD67C201A5C55C900ED2280 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		F8111E2D19A95C8B0040E7D1 /* Build configuration list for PBXProject "Alamofire" */ = {
 			isa = XCConfigurationList;

--- a/Source/UIImageView+Alamofire.swift
+++ b/Source/UIImageView+Alamofire.swift
@@ -1,0 +1,185 @@
+// Alamofire.swift
+//
+// Copyright (c) 2014 Alamofire (http://alamofire.org)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import UIKit
+
+@objc public protocol ImageCache : NSObjectProtocol {
+    func cachedImageForRequest(request: NSURLRequest) -> UIImage?
+    func cacheImage(image: UIImage, forRequest request: NSURLRequest)
+    func removeAllCachedImages()
+}
+
+// MARK: -
+
+public class ImageViewCache : NSCache, ImageCache {
+    
+    // MARK: - Lifecycle Methods
+    
+    override init() {
+        super.init()
+        
+        NSNotificationCenter.defaultCenter().addObserverForName(UIApplicationDidReceiveMemoryWarningNotification,
+            object: nil,
+            queue: NSOperationQueue.mainQueue(),
+            usingBlock: {[weak self] (notification) -> Void in
+                if let strongSelf = self {
+                    strongSelf.removeAllObjects()
+                }
+            }
+        )
+    }
+    
+    deinit {
+        NSNotificationCenter.defaultCenter().removeObserver(self)
+    }
+    
+    // MARK: - Cache Methods
+    
+    public func cachedImageForRequest(request: NSURLRequest) -> UIImage? {
+        switch request.cachePolicy {
+        case .ReloadIgnoringLocalCacheData, .ReloadIgnoringLocalAndRemoteCacheData:
+            return nil
+        default:
+            let key = ImageViewCache.imageCacheKeyFromURLRequest(request)
+            return objectForKey(key) as? UIImage
+        }
+    }
+    
+    public func cacheImage(image: UIImage, forRequest request: NSURLRequest) {
+        let key = ImageViewCache.imageCacheKeyFromURLRequest(request)
+        setObject(image, forKey: key)
+    }
+    
+    public func removeAllCachedImages() {
+        removeAllObjects()
+    }
+    
+    // MARK: - Private - Helper Methods
+    
+    private class func imageCacheKeyFromURLRequest(request: NSURLRequest) -> String {
+        return request.URL.absoluteString!
+    }
+}
+
+// MARK: -
+
+public extension UIImageView {
+    
+    // MARK: - Image Cache Methods
+    
+    public class func sharedImageCache() -> ImageCache {
+        struct Static { static let imageCache = ImageViewCache() }
+        
+        let userDefinedCache: AnyObject! = objc_getAssociatedObject(self, &sharedImageCacheKey)
+        if let userDefinedCache = userDefinedCache as? ImageCache {
+            return userDefinedCache
+        }
+        
+        return Static.imageCache
+    }
+    
+    public class func setSharedImageCache(imageCache: ImageCache) {
+        objc_setAssociatedObject(self, &sharedImageCacheKey, imageCache, UInt(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
+    }
+    
+    // MARK: - Remote Image Methods
+    
+    public func setImage(#URL: NSURL) {
+        setImage(URL: URL, placeHolderImage: nil)
+    }
+
+    public func setImage(#URL: NSURL, placeHolderImage: UIImage?) {
+        let mutableURLRequest = NSMutableURLRequest(URL: URL)
+        mutableURLRequest.addValue("image/*", forHTTPHeaderField: "Accept")
+        
+        let URLRequest = mutableURLRequest.copy() as NSURLRequest
+        
+        setImage(URLRequest: URLRequest, placeholderImage: placeHolderImage, success: nil, failure: nil)
+    }
+    
+    public func setImage(
+        #URLRequest: NSURLRequest,
+        placeholderImage: UIImage?,
+        success: ((NSURLRequest?, NSHTTPURLResponse?, UIImage?) -> Void)?,
+        failure: ((NSURLRequest?, NSHTTPURLResponse?, NSError?) -> Void)?)
+    {
+        cancelImageRequest()
+        
+        if let image = UIImageView.sharedImageCache().cachedImageForRequest(URLRequest) {
+            if let success = success {
+                success(URLRequest, nil, image)
+            } else {
+                self.image = image
+            }
+        } else {
+            if let placeholderImage = placeholderImage {
+                self.image = placeholderImage
+            }
+            
+            let request = Alamofire.request(URLRequest)
+            request.validate()
+            request.responseImage {[weak self] (request, response, image, error) -> Void in
+                if let strongSelf = self {
+                    if error == nil && image is UIImage {
+                        let image = image! as UIImage
+                        
+                        if let success = success {
+                            success(request, response, image)
+                        } else {
+                            strongSelf.image = image
+                        }
+                        
+                        UIImageView.sharedImageCache().cacheImage(image, forRequest: request)
+                    } else {
+                        failure?(request, response, error)
+                    }
+                    
+                    strongSelf.setActiveTask(nil)
+                }
+            }
+            
+            setActiveTask(request.task)
+        }
+    }
+    
+    public func cancelImageRequest() {
+        activeTask()?.cancel()
+    }
+    
+    // MARK: - Private - Task Property Methods
+    
+    private func activeTask() -> NSURLSessionTask? {
+        let userDefinedTask: AnyObject! = objc_getAssociatedObject(self, &activeTaskKey)
+        if let userDefinedTask = userDefinedTask as? NSURLSessionTask {
+            return userDefinedTask
+        }
+        
+        return nil
+    }
+    
+    private func setActiveTask(task: NSURLSessionTask?) {
+        objc_setAssociatedObject(self, &activeTaskKey, task, UInt(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
+    }
+}
+
+private var sharedImageCacheKey = "UIImageView.SharedImageCache"
+private var activeTaskKey = "UIImageView.ActiveTask"


### PR DESCRIPTION
NOTE: This PR first requires PR #290 to get merged.

I built a `UIImageView` extension with a supported `ImageCache` based off the `AFNetworking` `UIImageView` category. There are certainly some modifications, but the general idea and interface is the same. In Swift, we can't support a custom image response serializer unless we wrap the object inside some `NSObject` subclass in order to attach it to the `UIImageView` as an associated property. Curious to see what your thoughts are there.

I also made the assumption that you would like to start splitting `UIKit` extensions into separate Swift files and placing them in the iOS target. I could certainly modify this approach and wrap the entire set of logic in `#if os(iOS)` blocks if you would rather use that approach. This would also allow us to share the `ImageCache` logic with `OSX` if you wanted to. Had to start somewhere...