### PR TITLE
Fixed ios deployment target (reflecting the README)

### DIFF
--- a/Alamofire.podspec
+++ b/Alamofire.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.authors = { 'Mattt Thompson' => 'm@mattt.me' }
   s.source = { :git => 'https://github.com/Alamofire/Alamofire.git', :tag => s.version }
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.9'
 
   s.source_files = 'Source/*.swift'


### PR DESCRIPTION
I know embedded frameworks only work on ios 8+ but I think the podspec should reflect the minimum needed target. 

More info: In my case, I'm targeting ios7 and I'm still using embedded frameworks since it works on dev. For releasing I'll probably create a script later that moves the .swift files from the embedded framework to the target project.