### PR TITLE
Convenience upload functions in Manager

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -1031,6 +1031,21 @@ extension Manager {
     public func upload(URLRequest: URLRequestConvertible, file: NSURL) -> Request {
         return upload(.File(URLRequest.URLRequest, file))
     }
+  
+    /**
+        Creates a request for uploading a file to the specified URL request.
+  
+        If `startRequestsImmediately` is `true`, the request will have `resume()` called before being returned.
+  
+        :param: method The HTTP method.
+        :param: URLString The URL string.
+        :param: file The file to upload
+  
+        :returns: The created upload request.
+    */
+    public func upload(method: Method, _ URLString: URLStringConvertible, file: NSURL) -> Request {
+        return upload(URLRequest(method, URLString), file: file)
+    }
 
     // MARK: Data
 
@@ -1047,6 +1062,21 @@ extension Manager {
     public func upload(URLRequest: URLRequestConvertible, data: NSData) -> Request {
         return upload(.Data(URLRequest.URLRequest, data))
     }
+  
+    /**
+        Creates a request for uploading data to the specified URL request.
+  
+        If `startRequestsImmediately` is `true`, the request will have `resume()` called before being returned.
+  
+        :param: method The HTTP method.
+        :param: URLString The URL string.
+        :param: data The data to upload
+  
+        :returns: The created upload request.
+    */
+    public func upload(method: Method, _ URLString: URLStringConvertible, data: NSData) -> Request {
+        return upload(URLRequest(method, URLString), data: data)
+    }
 
     // MARK: Stream
 
@@ -1062,6 +1092,21 @@ extension Manager {
     */
     public func upload(URLRequest: URLRequestConvertible, stream: NSInputStream) -> Request {
         return upload(.Stream(URLRequest.URLRequest, stream))
+    }
+  
+    /**
+        Creates a request for uploading a stream to the specified URL request.
+  
+        If `startRequestsImmediately` is `true`, the request will have `resume()` called before being returned.
+  
+        :param: method The HTTP method.
+        :param: URLString The URL string.
+        :param: stream The stream to upload.
+
+        :returns: The created upload request.
+    */
+    public func upload(method: Method, _ URLString: URLStringConvertible, stream: NSInputStream) -> Request {
+        return upload(URLRequest(method, URLString), stream: stream)
     }
 }
 


### PR DESCRIPTION
After switching from using Alamofire.xxx to using a Manager instance i realized that some functions signatures were missing for upload.

Those new convenience functions allow us to use Manager.upload functions directly without having our own
```swift
private func URLRequest(method: Method, URL: URLStringConvertible) -> NSURLRequest {
    let mutableURLRequest = NSMutableURLRequest(URL: NSURL(string: URL.URLString)!)
    mutableURLRequest.HTTPMethod = method.rawValue

    return mutableURLRequest
}
```