### PR TITLE
Explicitly set iOS deployment target to 7.0

### DIFF
--- a/Configurations/UniversalFramework_Base.xcconfig
+++ b/Configurations/UniversalFramework_Base.xcconfig
@@ -25,6 +25,7 @@ SUPPORTED_PLATFORMS                    = iphonesimulator iphoneos macosx
 VALID_ARCHS[sdk=iphoneos*]             = arm64 armv7 armv7s
 VALID_ARCHS[sdk=iphonesimulator*]      = arm64 armv7 armv7s
 VALID_ARCHS[sdk=macosx*]               = i386 x86_64
+IPHONEOS_DEPLOYMENT_TARGET             = 7.0
 
 // Dynamic linking uses different default copy paths
 LD_RUNPATH_SEARCH_PATHS[sdk=iphoneos*]        = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'


### PR DESCRIPTION
After the switch to a universal framework to in #326, Xcode automatically chooses the latest version of iOS as the deployment target when compiling the framework for iOS (i.e. compiling with Xcode 6.3b1 results in iOS 8.3 being chosen as the deployment target).

This change explicitly sets the deployment target to iOS 7.0 to avoid this issue.