### PR TITLE
Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: objective-c
 osx_image: xcode611
+env:
+- LC_CTYPE=en_US.UTF-8 LANG=en_US.UTF-8
 before_install:
-- gem install xcpretty
+- gem install xcpretty -N
 script:
 - set -o pipefail
-- xcodebuild -project Alamofire.xcodeproj -scheme "Alamofire iOS" test -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO | xcpretty -c
-- xcodebuild -project "iOS Example.xcodeproj" -scheme "iOS Example" build -sdk iphonesimulator ONLY_ACTIVE_ARCH=YES | xcpretty -c
+- xcodebuild -project Alamofire.xcodeproj -scheme "Alamofire iOS" -sdk iphonesimulator
+  -destination "platform=iOS Simulator,name=iPhone 6" ONLY_ACTIVE_ARCH=NO  test | xcpretty -c
+- xcodebuild -project "iOS Example.xcodeproj" -scheme "iOS Example" -sdk iphonesimulator 
+  -destination "platform=iOS Simulator,name=iPhone 6" ONLY_ACTIVE_ARCH=YES build | xcpretty -c
+- pod lib lint --quick


### PR DESCRIPTION
- Resolves this Travis error, fixing the build, by running tests on the iPhone 6 simulator:

```
xcodebuild: error: Failed to build project Alamofire with scheme Alamofire iOS
    Reason: The run destination iPad 2 is not valid for Testing the scheme 'Alamofire iOS'.
```

- Added some recommended ENV variables for `xcpretty`
- Speeds up `xcpretty` install by ignoring documentation
- Added a podspec linting step 