### PR TITLE
Fix Swift 1.2 ambiguity error in responseString.

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -1315,7 +1315,7 @@ extension Request {
         :returns: The request.
     */
     public func responseString(completionHandler: (NSURLRequest, NSHTTPURLResponse?, String?, NSError?) -> Void) -> Self {
-        return responseString(completionHandler: completionHandler)
+        return responseString(encoding: NSUTF8StringEncoding, completionHandler: completionHandler)
     }
 
     /**
@@ -1326,7 +1326,7 @@ extension Request {
 
         :returns: The request.
     */
-    public func responseString(encoding: NSStringEncoding = NSUTF8StringEncoding, completionHandler: (NSURLRequest, NSHTTPURLResponse?, String?, NSError?) -> Void) -> Self  {
+    public func responseString(#encoding: NSStringEncoding, completionHandler: (NSURLRequest, NSHTTPURLResponse?, String?, NSError?) -> Void) -> Self  {
         return response(serializer: Request.stringResponseSerializer(encoding: encoding), completionHandler: { request, response, string, error in
             completionHandler(request, response, string as? String, error)
         })


### PR DESCRIPTION
Calling responseString without an encoding yielded an error: Ambiguous use of 'responseString'.

This change shifts the default into the reponseString(completionHandler) function and makes the encoding argument explicit to match default argument behavior.