### PR TITLE
[String Response] Respect remote server's content encoding

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -1376,12 +1376,13 @@ extension Request {
     /**
         Creates a response serializer that returns a string initialized from the response data with the specified string encoding.
 
-        :param: encoding The string encoding. `NSUTF8StringEncoding` by default.
-
         :returns: A string response serializer.
     */
-    public class func stringResponseSerializer(encoding: NSStringEncoding = NSUTF8StringEncoding) -> Serializer {
-        return { (_, _, data) in
+    public class func stringResponseSerializer() -> Serializer {
+        return { (_, response, data) in
+            let encodingName = response?.textEncodingName ?? "iso-8859-1"
+            let cfEncoding = CFStringConvertIANACharSetNameToEncoding(encodingName)
+            let encoding = CFStringConvertEncodingToNSStringEncoding(cfEncoding)
             let string = NSString(data: data!, encoding: encoding)
 
             return (string, nil)
@@ -1395,20 +1396,8 @@ extension Request {
 
         :returns: The request.
     */
-    public func responseString(completionHandler: (NSURLRequest, NSHTTPURLResponse?, String?, NSError?) -> Void) -> Self {
-        return responseString(completionHandler: completionHandler)
-    }
-
-    /**
-        Adds a handler to be called once the request has finished.
-
-        :param: encoding The string encoding. `NSUTF8StringEncoding` by default.
-        :param: completionHandler A closure to be executed once the request has finished. The closure takes 4 arguments: the URL request, the URL response, if one was received, the string, if one could be created from the URL response and data, and any error produced while creating the string.
-
-        :returns: The request.
-    */
-    public func responseString(encoding: NSStringEncoding = NSUTF8StringEncoding, completionHandler: (NSURLRequest, NSHTTPURLResponse?, String?, NSError?) -> Void) -> Self  {
-        return response(serializer: Request.stringResponseSerializer(encoding: encoding), completionHandler: { request, response, string, error in
+    public func responseString(completionHandler: (NSURLRequest, NSHTTPURLResponse?, String?, NSError?) -> Void) -> Self  {
+        return response(serializer: Request.stringResponseSerializer(), completionHandler: { request, response, string, error in
             completionHandler(request, response, string as? String, error)
         })
     }

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -48,7 +48,7 @@ class AlamofireRequestInitializationTestCase: XCTestCase {
 class AlamofireRequestResponseTestCase: XCTestCase {
     func testRequestResponse() {
         let URL = "http://httpbin.org/get"
-        let serializer = Alamofire.Request.stringResponseSerializer(encoding: NSUTF8StringEncoding)
+        let serializer = Alamofire.Request.stringResponseSerializer()
 
         let expectation = expectationWithDescription("\(URL)")
 


### PR DESCRIPTION
We should always follow the content encoding sent from the server instead of assuming UTF-8 or whatever the user has configured.

Note, `iso-8859-1` is the default encoding for HTTP 1.1. As such that is the default if a server didn't explicitly set it to utf-8.