### PR TITLE
Resolves explicit self requirement in Swift 1.2

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -88,7 +88,7 @@ public enum ParameterEncoding {
                 var components: [(String, String)] = []
                 for key in sorted(Array(parameters.keys), <) {
                     let value: AnyObject! = parameters[key]
-                    components += queryComponents(key, value)
+                    components += self.queryComponents(key, value)
                 }
 
                 return join("&", components.map{"\($0)=\($1)"} as [String])


### PR DESCRIPTION
Resolves issue I encountered trying to build in Swift 1.2 beta 2: 

    Call to method 'queryComponents' in closure requires explicit 'self.' to make capture semantics explicit.

Not sure if this is a new requirement in beta 2 of Swift 1.2 or not, this is my first time using Alamofire.