### PR TITLE
fix escaping query parameters / and ? are valid characters in the query parameters

### DIFF
--- a/Example/DetailViewController.swift
+++ b/Example/DetailViewController.swift
@@ -68,7 +68,7 @@ class DetailViewController: UITableViewController {
         self.refreshControl?.beginRefreshing()
 
         let start = CACurrentMediaTime()
-        self.request?.responseString { (request, response, body, error) in
+        self.request?.responseString (completionHandler:{ (request, response, body, error) -> Void in
             let end = CACurrentMediaTime()
             self.elapsedTime = end - start
 
@@ -80,7 +80,7 @@ class DetailViewController: UITableViewController {
 
             self.tableView.reloadData()
             self.refreshControl?.endRefreshing()
-        }
+        })
     }
 
     // MARK: UITableViewDataSource
@@ -100,7 +100,7 @@ class DetailViewController: UITableViewController {
 
         switch Sections(rawValue: indexPath.section)! {
         case .Headers:
-            let cell = self.tableView.dequeueReusableCellWithIdentifier("Header") as UITableViewCell
+            let cell = self.tableView.dequeueReusableCellWithIdentifier("Header") as! UITableViewCell
             let field = self.headers.keys.array.sorted(<)[indexPath.row]
             let value = self.headers[field]
 
@@ -109,7 +109,7 @@ class DetailViewController: UITableViewController {
 
             return cell
         case .Body:
-            let cell = self.tableView.dequeueReusableCellWithIdentifier("Body") as UITableViewCell
+            let cell = self.tableView.dequeueReusableCellWithIdentifier("Body")as! UITableViewCell
 
             cell.textLabel?.text = self.body
 

--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -145,14 +145,15 @@ public enum ParameterEncoding {
                 components += queryComponents("\(key)[]", value)
             }
         } else {
-            components.extend([(escape(key), escape("\(value)"))])
+            components.extend([(escapeQuery(key), escapeQuery("\(value)"))])
         }
 
         return components
     }
 
-    func escape(string: String) -> String {
-        let legalURLCharactersToBeEscaped: CFStringRef = ":/?&=;+!@#$()',*"
+    // See http://tools.ietf.org/html/rfc3986#section-3.4
+    func escapeQuery(string: String) -> String {
+        let legalURLCharactersToBeEscaped: CFStringRef = ":&=;+!@#$()',*"
         return CFURLCreateStringByAddingPercentEscapes(nil, string, nil, legalURLCharactersToBeEscaped, CFStringBuiltInEncodings.UTF8.rawValue) as! String
     }
 }


### PR DESCRIPTION
See [RFC 3986  $ 3.4] (http://tools.ietf.org/html/rfc3986#section-3.4)