### PR TITLE
Update readme - fix cocoapods file example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,12 @@ $ gem install cocoapods --pre
 To integrate Alamofire into your Xcode project using CocoaPods, specify it in your `Podfile`:
 
 ```ruby
-use_frameworks!
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
 
-pod 'Alamofire', '~> 1.1'
+platform :ios, '8.0'
+use_frameworks!
+
+pod 'Alamofire', '~> 1.1.4'
 ```
 
 Then, run the following command:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ $ gem install cocoapods --pre
 To integrate Alamofire into your Xcode project using CocoaPods, specify it in your `Podfile`:
 
 ```ruby
+use_frameworks!
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 


### PR DESCRIPTION
With your Podfile example `pod` (0.36.0.rc.1) gets error:
>[!] Pods written in Swift can only be integrated as frameworks; this feature is still in beta. Add `use_frameworks!` to your Podfile or target to opt into using it.

So, you should set additional flag in the beginning if the Podfile.