### PR TITLE
Bug fix for deinit race condition on task delegate queue

### DIFF
--- a/Tests/ManagerTests.swift
+++ b/Tests/ManagerTests.swift
@@ -57,4 +57,20 @@ class AlamofireManagerTestCase: XCTestCase {
         XCTAssert(request.task.state == .Suspended)
         XCTAssertNil(manager)
     }
+
+    func testReleasingManagerWithPendingCanceledRequestDeinitializesSuccessfully() {
+        var manager: Manager? = Alamofire.Manager()
+        manager!.startRequestsImmediately = false
+
+        let URL = NSURL(string: "http://httpbin.org/get")!
+        let URLRequest = NSURLRequest(URL: URL)
+
+        let request = manager!.request(URLRequest)
+        request.cancel()
+
+        manager = nil
+
+        XCTAssert(request.task.state == .Canceling)
+        XCTAssertNil(manager)
+    }
 }


### PR DESCRIPTION
This is essentially the same issue that I opened #269 for where `Manager` deinitialization was crashing.

#### Problem

Unfortunately, the test I wrote in that case did not reflect all the potential issues. By removing the deinit that contained the `session.invalidateAndCancel()`, that only ended up masking the root cause of the crash. I managed to unwind it today and get to the root issue.

The problem is that the `TaskDelegate` dispatch queue cannot be properly released when in a suspended state. The libdispatch library will fail under certain race conditions. If you do not actually call `resume` on the task, then the queue will always remain in the suspended state until the time when it is deinitialized. The root problem I believe stems from a mismatch between the `dispatch_resume` and `dispatch_suspend` calls. They need to [balance each other out](https://developer.apple.com/library/prerelease/ios/documentation/Performance/Reference/GCD_libdispatch_Ref/index.html#//apple_ref/c/func/dispatch_resume) and we cannot always guarantee that during deinitialization.

### Option 1 - dispatch_resume in `TaskDelegate.deinit`

There are several ways to approach the problem. The first would be to resume the queue during deinitialization of the `TaskDelegate` to attempt to balance out the suspend and resume calls. The problem with this approach is that you will then shut down the queue while it's in the middle of executing the closures inside it. Also, the potential for corrupting state is very high since Alamofire is designed to only `dispatch_resume` when the request has actually completed. I worked through this approach and it is terribly problematic and doesn't fix the race condition.

### Option 2 - Switch to `NSOperationQueue` for `TaskDelegate`

The solution I landed on was to swap out the `dispatch_queue_t` with an `NSOperationQueue`. This gives us the ability to do the following:

* We can still suspend and resume the queue
* We can still define a serial execution behavior
* We can cancel all the operations (biggest limitation of dispatch_queue_t)
* We can resume after canceling all operations to unsure the `underlyingQueue` is not `suspended`

After swapping out the old queue with the operation queue, everything is working exactly as it should. Manager deinitialization works flawlessly.

#### Added `invalidateAndCancel` back into Manager.deinit

IMO, this is the behavior that should be used rather than `finishTasksAndInvalidate`. If the Manager is attempting to deinitialize, then Alamofire should do everything in its power to make sure that deinitialization happens immediately. That cannot happen if there are current running tasks that will keep the session in memory along with the Manager. This seems very problematic when you consider that you're actually in the middle of terminating the app. You want to avoid having any queues working on closures when the termination actually happens to avoid corrupting state.

#### Summary

The change from a `TaskDelegate` `dispatch_queue_t` to an `NSOperationQueue` absolutely has to happen to fix the race condition crashing. Whether to `invalidateAndCancel` or `finishTasksAndInvalidate` or nothing in the `Manager.deinit` I think needs to input from the community.