### PR TITLE
Use system provided SSL validation until proper customization is implemented

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -741,17 +741,17 @@ public class Request {
                 if challenge.previousFailureCount > 0 {
                     disposition = .CancelAuthenticationChallenge
                 } else {
-                    // TODO: Incorporate Trust Evaluation & TLS Chain Validation
 
                     switch challenge.protectionSpace.authenticationMethod! {
                     case NSURLAuthenticationMethodServerTrust:
-                        credential = NSURLCredential(forTrust: challenge.protectionSpace.serverTrust)
+                        // TODO: Incorporate custom Trust Evaluation & TLS Chain Validation
+                        // For now, fall back on default system SSL validation.
+                        break
                     default:
                         credential = self.credential ?? session.configuration.URLCredentialStorage?.defaultCredentialForProtectionSpace(challenge.protectionSpace)
-                    }
-
-                    if credential != nil {
-                        disposition = .UseCredential
+                        if credential != nil {
+                            disposition = .UseCredential
+                        }
                     }
                 }
             }


### PR DESCRIPTION
For `NSURLAuthenticationMethodServerTrust` authentication method, stop indiscriminately trusting all SecTrusts. Instead, rely on default behavior -- which will do basic evaluation of the certificate chain against the System's CA Root Certificates.

Alamofire will presumably want to implement custom SSL certificate pinning and the ability to turn invalid certificates, but IMO this is *much* better default behavior.