### PR TITLE
Switched iOS deployment target to iOS 8.0 for iOS target and tests

### DIFF
--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -533,6 +533,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = Alamofire;
 				SKIP_INSTALL = YES;
@@ -552,6 +553,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = Alamofire;
 				SKIP_INSTALL = YES;
@@ -571,6 +573,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -584,6 +587,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};


### PR DESCRIPTION
Setting the iOS deployment target to iOS 7.0 causes warnings all over this project and all other projects that include it. While I understand that Alamofire can be used in iOS 7.0 projects by dragging the `Alamofire.swift` file into the project, the iOS deployment target inside the Xcode project is ignored in those cases.

![embedded framework warning](https://cloud.githubusercontent.com/assets/169110/6831673/098d3fd2-d2df-11e4-8a2f-890fd2c7fcd3.png)

In all cases where the Xcode project is actually being used (Alamofire Xcode project, git submodules for other apps and libraries and Carthage) the warning is actually being thrown. The Xcode project deployment target should be updated to iOS 8.0 to allow all these Xcode project use cases to no longer see the warning which will not affect the actual iOS 7.0 use case.

Hopefully that all makes sense.