### PR TITLE
Privatize NSURLSession & NSURLSessionTask objects.

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -286,6 +286,8 @@ public class Manager {
 
     /// The underlying session.
     private let session: NSURLSession
+    
+    public let configuration: NSURLSessionConfiguration?
 
     /// Whether to start requests immediately after being constructed. `true` by default.
     public var startRequestsImmediately: Bool = true
@@ -295,6 +297,7 @@ public class Manager {
     */
     required public init(configuration: NSURLSessionConfiguration? = nil) {
         self.delegate = SessionDelegate()
+        self.configuration = configuration
         self.session = NSURLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
     }
 

--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -285,7 +285,7 @@ public class Manager {
     private let queue = dispatch_queue_create(nil, DISPATCH_QUEUE_SERIAL)
 
     /// The underlying session.
-    public let session: NSURLSession
+    private let session: NSURLSession
 
     /// Whether to start requests immediately after being constructed. `true` by default.
     public var startRequestsImmediately: Bool = true
@@ -533,16 +533,19 @@ public class Request {
     private let delegate: TaskDelegate
 
     /// The underlying task.
-    public var task: NSURLSessionTask { return delegate.task }
+    private var task: NSURLSessionTask { return delegate.task }
 
     /// The session belonging to the underlying task.
-    public let session: NSURLSession
+    private let session: NSURLSession
 
     /// The request sent or to be sent to the server.
     public var request: NSURLRequest { return task.originalRequest }
 
     /// The response received from the server, if any.
     public var response: NSHTTPURLResponse? { return task.response as? NSHTTPURLResponse }
+    
+    /// The state of underlying task.
+    public var state: NSURLSessionTaskState { return task.state }
 
     /// The progress of the request lifecycle.
     public var progress: NSProgress? { return delegate.progress }

--- a/Tests/ManagerTests.swift
+++ b/Tests/ManagerTests.swift
@@ -54,7 +54,7 @@ class AlamofireManagerTestCase: XCTestCase {
 
         manager = nil
 
-        XCTAssert(request.task.state == .Suspended)
+        XCTAssert(request.state == .Suspended)
         XCTAssertNil(manager)
     }
 }

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -143,7 +143,7 @@ class AlamofireRequestDebugDescriptionTestCase: XCTestCase {
             NSHTTPCookieValue: "bar",
         ]
         let cookie = NSHTTPCookie(properties: properties)!
-        manager.session.configuration.HTTPCookieStorage?.setCookie(cookie)
+        manager.configuration?.HTTPCookieStorage?.setCookie(cookie)
 
         let request = manager.request(.POST, URL)
         let components = cURLCommandComponents(request)


### PR DESCRIPTION
Accessing raw `NSURLSession` & `NSURLSessionTask` objects outside of the framework should be prohibited (e.g. calling `session.invalidateAndCancel()`), so I marked those properties with `private` modifier. These objects's functionality should always be accessed via `Manager` & `Request`'s methods.