### PR TITLE
Remove optional type from Request.progress property.

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -545,7 +545,7 @@ public class Request {
     public var response: NSHTTPURLResponse? { return task.response as? NSHTTPURLResponse }
 
     /// The progress of the request lifecycle.
-    public var progress: NSProgress? { return delegate.progress }
+    public var progress: NSProgress { return delegate.progress }
 
     private init(session: NSURLSession, task: NSURLSessionTask) {
         self.session = session


### PR DESCRIPTION
The delegate.progress always has value so I don't see any point that Request.progress property to be Optional type. Please consider on removing Optional type from it.