### PR TITLE
Removed ambiguous response serializer methods that collide with default parameters

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -1368,17 +1368,6 @@ extension Request {
     /**
         Adds a handler to be called once the request has finished.
 
-        :param: completionHandler A closure to be executed once the request has finished. The closure takes 4 arguments: the URL request, the URL response, if one was received, the string, if one could be created from the URL response and data, and any error produced while creating the string.
-
-        :returns: The request.
-    */
-    public func responseString(completionHandler: (NSURLRequest, NSHTTPURLResponse?, String?, NSError?) -> Void) -> Self {
-        return responseString(completionHandler: completionHandler)
-    }
-
-    /**
-        Adds a handler to be called once the request has finished.
-
         :param: encoding The string encoding. `NSUTF8StringEncoding` by default.
         :param: completionHandler A closure to be executed once the request has finished. The closure takes 4 arguments: the URL request, the URL response, if one was received, the string, if one could be created from the URL response and data, and any error produced while creating the string.
 
@@ -1450,17 +1439,6 @@ extension Request {
 
             return (plist, propertyListSerializationError)
         }
-    }
-
-    /**
-        Adds a handler to be called once the request has finished.
-
-        :param: completionHandler A closure to be executed once the request has finished. The closure takes 4 arguments: the URL request, the URL response, if one was received, the property list, if one could be created from the URL response and data, and any error produced while creating the property list.
-
-        :returns: The request.
-    */
-    public func responsePropertyList(completionHandler: (NSURLRequest, NSHTTPURLResponse?, AnyObject?, NSError?) -> Void) -> Self {
-        return responsePropertyList(completionHandler: completionHandler)
     }
 
     /**


### PR DESCRIPTION
Hey @mattt,

This is a bit of a strange pull request, but unfortunately, a necessary one. There are two different approaches to solving the problem, and this PR contains the one that I think is a more sensible solution.

### Problem

The surface issue that users are reporting is that trailing closures are broken for the `responseString` serializer (as seen in #406 and this StackOverflow [thread](http://stackoverflow.com/questions/28542575/alamofire-with-swift-1-2-ambiguous-use-of-responsejson/28552008#28552008)). The root problem is that there is ambiguity in the `responseString` and `responsePropertyList` convenience method implementations that collide with the actual `responseString` and `responsePropertyList` implementations with default parameters. I always wondered how Swift 1.1 was able to avoid infinitely recursing into itself in those methods and the Swift 1.2 compiler has actually tightened down on the ambiguity altogether.

### Option 1

The first option is to remove the convenience methods entirely. This removes the ambiguity and leverages default parameters that are an awesome new feature with Swift. I prefer this approach to avoid having multiple versions of the same API simply for convenience. A single API with default parameters seems more concise to me and makes the intent and behavior of the method very clear. The downside is that autocomplete doesn't pick up the fact that some of the parameters have default values...yet. I will be filing a radar against this shortly.

### Option 2

Remove the default values for the `responseString` : `encoding` parameter and the `responsePropertyList` : `options` parameter. This would also remove the ambiguity, but would no longer leverage Swift's default parameter values functionality. IMO, having two functions is more of the Objective-C way of doing things. The upside is that it makes autocomplete a bit easier. The downside is that you require multiple APIs to do exactly the same thing which requires more documentation. The default values will appear in the docs, but unfortunately not in the autocompletion highlighting.

---

I think either option is valid, but tend to lean towards Option 1. If you prefer Option 2, then just let me know and I can update the PR accordingly. I also wonder if we shouldn't cherry pick this change into the `master` branch as well. That would get the ambiguity removed from Alamofire altogether.