### PR TITLE
Move expectation.fulfill() to end of blocks

### DIFF
--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -35,12 +35,12 @@ class AlamofireAuthenticationTestCase: XCTestCase {
         Alamofire.request(.GET, URL)
             .authenticate(user: "invalid", password: "credentials")
             .response { (request, response, _, error) in
-                invalidCredentialsExpectation.fulfill()
-
                 XCTAssertNotNil(request, "request should not be nil")
                 XCTAssertNil(response, "response should be nil")
                 XCTAssertNotNil(error, "error should not be nil")
                 XCTAssert(error?.code == -999, "error should be NSURLErrorDomain Code -999 'cancelled'")
+
+                invalidCredentialsExpectation.fulfill()
         }
 
         let validCredentialsExpectation = expectationWithDescription("\(URL) 200")
@@ -48,12 +48,12 @@ class AlamofireAuthenticationTestCase: XCTestCase {
         Alamofire.request(.GET, URL)
             .authenticate(user: user, password: password)
             .response { (request, response, _, error) in
-                validCredentialsExpectation.fulfill()
-
                 XCTAssertNotNil(request, "request should not be nil")
                 XCTAssertNotNil(response, "response should not be nil")
                 XCTAssert(response?.statusCode == 200, "response status code should be 200")
                 XCTAssertNil(error, "error should be nil")
+
+                validCredentialsExpectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in
@@ -72,12 +72,12 @@ class AlamofireAuthenticationTestCase: XCTestCase {
         Alamofire.request(.GET, URL)
             .authenticate(user: "invalid", password: "credentials")
             .response { (request, response, _, error) in
-                invalidCredentialsExpectation.fulfill()
-
                 XCTAssertNotNil(request, "request should not be nil")
                 XCTAssertNil(response, "response should be nil")
                 XCTAssertNotNil(error, "error should not be nil")
                 XCTAssert(error?.code == -999, "error should be NSURLErrorDomain Code -999 'cancelled'")
+
+                invalidCredentialsExpectation.fulfill()
         }
 
         let validCredentialsExpectation = expectationWithDescription("\(URL) 200")
@@ -85,12 +85,12 @@ class AlamofireAuthenticationTestCase: XCTestCase {
         Alamofire.request(.GET, URL)
             .authenticate(user: user, password: password)
             .response { (request, response, _, error) in
-                validCredentialsExpectation.fulfill()
-
                 XCTAssertNotNil(request, "request should not be nil")
                 XCTAssertNotNil(response, "response should not be nil")
                 XCTAssert(response?.statusCode == 200, "response status code should be 200")
                 XCTAssertNil(error, "error should be nil")
+
+                validCredentialsExpectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -40,8 +40,6 @@ class AlamofireDownloadResponseTestCase: XCTestCase {
 
         Alamofire.download(.GET, URL, destination)
             .response { request, response, _, error in
-                expectation.fulfill()
-
                 XCTAssertNotNil(request, "request should not be nil")
                 XCTAssertNotNil(response, "response should not be nil")
 
@@ -74,6 +72,8 @@ class AlamofireDownloadResponseTestCase: XCTestCase {
                 }
 
                 fileManager.removeItemAtURL(file, error: nil)
+
+                expectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in
@@ -91,13 +91,13 @@ class AlamofireDownloadResponseTestCase: XCTestCase {
 
         let download = Alamofire.download(.GET, URL, destination)
         download.progress { (bytesRead, totalBytesRead, totalBytesExpectedToRead) -> Void in
-            expectation.fulfill()
-
             XCTAssert(bytesRead > 0, "bytesRead should be > 0")
             XCTAssert(totalBytesRead > 0, "totalBytesRead should be > 0")
             XCTAssert(totalBytesExpectedToRead == -1, "totalBytesExpectedToRead should be -1")
 
             download.cancel()
+
+            expectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -54,13 +54,13 @@ class AlamofireRequestResponseTestCase: XCTestCase {
 
         Alamofire.request(.GET, URL, parameters: ["foo": "bar"])
                  .response(serializer: serializer){ (request, response, string, error) in
-                    expectation.fulfill()
-
                     XCTAssertNotNil(request, "request should not be nil")
                     XCTAssertNotNil(response, "response should not be nil")
                     XCTAssertNotNil(string, "string should not be nil")
                     XCTAssertNil(error, "error should be nil")
-                 }
+
+                    expectation.fulfill()
+        }
 
         waitForExpectationsWithTimeout(10) { (error) in
             XCTAssertNil(error, "\(error)")
@@ -78,9 +78,9 @@ class AlamofireRequestDescriptionTestCase: XCTestCase {
         let expectation = expectationWithDescription("\(URL)")
 
         request.response { (_, response,_,_) in
-            expectation.fulfill()
-
             XCTAssertEqual(request.description, "GET http://httpbin.org/get (\(response!.statusCode))", "incorrect request description")
+
+            expectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -31,14 +31,15 @@ class AlamofireJSONResponseTestCase: XCTestCase {
 
         Alamofire.request(.GET, URL, parameters: ["foo": "bar"])
                  .responseJSON { (request, response, JSON, error) in
-                    expectation.fulfill()
                     XCTAssertNotNil(request, "request should not be nil")
                     XCTAssertNotNil(response, "response should not be nil")
                     XCTAssertNotNil(JSON, "JSON should not be nil")
                     XCTAssertNil(error, "error should be nil")
 
                     XCTAssertEqual(JSON!["args"] as NSObject, ["foo": "bar"], "args should be equal")
-                 }
+
+                    expectation.fulfill()
+        }
 
         waitForExpectationsWithTimeout(10) { (error) in
             XCTAssertNil(error, "\(error)")
@@ -51,13 +52,14 @@ class AlamofireJSONResponseTestCase: XCTestCase {
 
         Alamofire.request(.POST, URL, parameters: ["foo": "bar"])
             .responseJSON { (request, response, JSON, error) in
-                expectation.fulfill()
                 XCTAssertNotNil(request, "request should not be nil")
                 XCTAssertNotNil(response, "response should not be nil")
                 XCTAssertNotNil(JSON, "JSON should not be nil")
                 XCTAssertNil(error, "error should be nil")
 
                 XCTAssertEqual(JSON!["form"] as NSObject, ["foo": "bar"], "args should be equal")
+
+                expectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -33,12 +33,12 @@ class UploadResponseTestCase: XCTestCase {
 
         Alamofire.upload(.POST, URL, data!)
                  .response { (request, response, _, error) in
-                    expectation.fulfill()
-
                     XCTAssertNotNil(request, "request should not be nil")
                     XCTAssertNotNil(response, "response should not be nil")
                     XCTAssertNil(error, "error should be nil")
-                }
+
+                    expectation.fulfill()
+        }
 
         waitForExpectationsWithTimeout(10) { (error) in
             XCTAssertNil(error, "\(error)")
@@ -53,13 +53,13 @@ class UploadResponseTestCase: XCTestCase {
 
         let upload = Alamofire.upload(.POST, URL, data!)
         upload.progress { (bytesWritten, totalBytesWritten, totalBytesExpectedToWrite) -> Void in
-            expectation.fulfill()
-
             XCTAssert(bytesWritten > 0, "bytesWritten should be > 0")
             XCTAssert(totalBytesWritten > 0, "totalBytesWritten should be > 0")
             XCTAssert(totalBytesExpectedToWrite > 0, "totalBytesExpectedToWrite should be > 0")
 
             upload.cancel()
+
+            expectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -33,9 +33,9 @@ class AlamofireStatusCodeValidationTestCase: XCTestCase {
         Alamofire.request(.GET, URL)
             .validate(statusCode: 200..<300)
             .response { (_, _, _, error) in
-                expectation.fulfill()
-
                 XCTAssertNil(error, "error should be nil")
+
+                expectation.fulfill()
             }
 
         waitForExpectationsWithTimeout(10) { (error) in
@@ -51,10 +51,10 @@ class AlamofireStatusCodeValidationTestCase: XCTestCase {
         Alamofire.request(.GET, URL)
             .validate(statusCode: [200])
             .response { (_, _, _, error) in
-                expectation.fulfill()
-
                 XCTAssertNotNil(error, "error should not be nil")
                 XCTAssertEqual(error!.domain, AlamofireErrorDomain, "error should be in Alamofire error domain")
+
+                expectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in
@@ -70,10 +70,10 @@ class AlamofireStatusCodeValidationTestCase: XCTestCase {
         Alamofire.request(.GET, URL)
             .validate(statusCode: [])
             .response { (_, _, _, error) in
-                expectation.fulfill()
-
                 XCTAssertNotNil(error, "error should not be nil")
                 XCTAssertEqual(error!.domain, AlamofireErrorDomain, "error should be in Alamofire error domain")
+
+                expectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in
@@ -91,9 +91,9 @@ class AlamofireContentTypeValidationTestCase: XCTestCase {
         Alamofire.request(.GET, URL)
             .validate(contentType: ["application/json"])
             .response { (_, _, _, error) in
-                expectation.fulfill()
-
                 XCTAssertNil(error, "error should be nil")
+
+                expectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in
@@ -111,9 +111,9 @@ class AlamofireContentTypeValidationTestCase: XCTestCase {
             .validate(contentType: ["application/*"])
             .validate(contentType: ["*/json"])
             .response { (_, _, _, error) in
-                expectation.fulfill()
-
                 XCTAssertNil(error, "error should be nil")
+
+                expectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in
@@ -129,10 +129,10 @@ class AlamofireContentTypeValidationTestCase: XCTestCase {
         Alamofire.request(.GET, URL)
             .validate(contentType: ["application/octet-stream"])
             .response { (_, _, _, error) in
-                expectation.fulfill()
-
                 XCTAssertNotNil(error, "error should not be nil")
                 XCTAssertEqual(error!.domain, AlamofireErrorDomain, "error should be in Alamofire error domain")
+
+                expectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in
@@ -148,10 +148,10 @@ class AlamofireContentTypeValidationTestCase: XCTestCase {
         Alamofire.request(.GET, URL)
             .validate(contentType: [])
             .response { (_, _, _, error) in
-                expectation.fulfill()
-
                 XCTAssertNotNil(error, "error should not be nil")
                 XCTAssertEqual(error!.domain, AlamofireErrorDomain, "error should be in Alamofire error domain")
+
+                expectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in
@@ -170,9 +170,9 @@ class AlamofireMultipleValidationTestCase: XCTestCase {
             .validate(statusCode: 200..<300)
             .validate(contentType: ["application/json"])
             .response { (_, _, _, error) in
-                expectation.fulfill()
-
                 XCTAssertNil(error, "error should be nil")
+
+                expectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in
@@ -189,10 +189,10 @@ class AlamofireMultipleValidationTestCase: XCTestCase {
             .validate(statusCode: 400..<600)
             .validate(contentType: ["application/octet-stream"])
             .response { (_, _, _, error) in
-                expectation.fulfill()
-
                 XCTAssertNotNil(error, "error should not be nil")
                 XCTAssertEqual(error!.domain, AlamofireErrorDomain, "error should be in Alamofire error domain")
+
+                expectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in
@@ -212,9 +212,9 @@ class AlamofireAutomaticValidationTestCase: XCTestCase {
         Alamofire.request(.GET, URL)
             .validate()
             .response { (_, _, _, error) in
-                expectation.fulfill()
-
                 XCTAssertNil(error, "error should be nil")
+
+                expectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in
@@ -230,10 +230,10 @@ class AlamofireAutomaticValidationTestCase: XCTestCase {
         Alamofire.request(.GET, URL)
             .validate()
             .response { (_, _, _, error) in
-                expectation.fulfill()
-
                 XCTAssertNotNil(error, "error should not be nil")
                 XCTAssertEqual(error!.domain, AlamofireErrorDomain, "error should be in Alamofire error domain")
+
+                expectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in
@@ -252,9 +252,9 @@ class AlamofireAutomaticValidationTestCase: XCTestCase {
         Alamofire.request(.GET, URL)
             .validate()
             .response { (_, _, _, error) in
-                expectation.fulfill()
-
                 XCTAssertNil(error, "error should be nil")
+
+                expectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in
@@ -272,9 +272,9 @@ class AlamofireAutomaticValidationTestCase: XCTestCase {
         Alamofire.request(.GET, URL)
             .validate()
             .response { (_, _, _, error) in
-                expectation.fulfill()
-
                 XCTAssertNil(error, "error should be nil")
+
+                expectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in
@@ -292,9 +292,9 @@ class AlamofireAutomaticValidationTestCase: XCTestCase {
         Alamofire.request(.GET, URL)
             .validate()
             .response { (_, _, _, error) in
-                expectation.fulfill()
-
                 XCTAssertNil(error, "error should be nil")
+
+                expectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(10) { (error) in


### PR DESCRIPTION
This is a proposed fix for issue #419.