### PR TITLE
Add Carthage/Build folder into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
+
+# Carthage
+
+Carthage/Build


### PR DESCRIPTION
When is Alamofire used with Carthage `--use-submodules` flag, folder `Carthage/Build` is automatically tracked as uncommitted change. But this is unnecessary in this case, so I think that is better to ignore it.