### PR TITLE
Replace return from NSURLRequest type to NSMutableURLRequest in encode function

### DIFF
--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -63,7 +63,7 @@ public enum ParameterEncoding {
     /**
         Uses the associated closure value to construct a new request given an existing request and parameters.
     */
-    case Custom((URLRequestConvertible, [String: AnyObject]?) -> (NSURLRequest, NSError?))
+    case Custom((URLRequestConvertible, [String: AnyObject]?) -> (NSMutableURLRequest, NSError?))
 
     /**
         Creates a URL request by encoding parameters and applying them onto an existing request.
@@ -73,9 +73,9 @@ public enum ParameterEncoding {
 
         :returns: A tuple containing the constructed request and the error that occurred during parameter encoding, if any.
     */
-    public func encode(URLRequest: URLRequestConvertible, parameters: [String: AnyObject]?) -> (NSURLRequest, NSError?) {
+    public func encode(URLRequest: URLRequestConvertible, parameters: [String: AnyObject]?) -> (NSMutableURLRequest, NSError?) {
         if parameters == nil {
-            return (URLRequest.URLRequest, nil)
+            return (URLRequest.URLRequest.mutableCopy() as! NSMutableURLRequest, nil)
         }
 
         var mutableURLRequest: NSMutableURLRequest! = URLRequest.URLRequest.mutableCopy() as! NSMutableURLRequest

--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -341,7 +341,7 @@ class AlamofirePropertyListParameterEncodingTestCase: XCTestCase {
 
 class AlamofireCustomParameterEncodingTestCase: XCTestCase {
     func testCustomParameterEncode() {
-        let encodingClosure: (URLRequestConvertible, [String: AnyObject]?) -> (NSURLRequest, NSError?) = { URLRequest, parameters in
+        let encodingClosure: (URLRequestConvertible, [String: AnyObject]?) -> (NSMutableURLRequest, NSError?) = { URLRequest, parameters in
             let mutableURLRequest = URLRequest.URLRequest.mutableCopy() as! NSMutableURLRequest
             mutableURLRequest.setValue("Xcode", forHTTPHeaderField: "User-Agent")
             return (mutableURLRequest, nil)


### PR DESCRIPTION
Replace return from NSURLRequest type to `NSMutableURLRequest` since it's
always `NSMutableURLRequest` except one case (when parameters == nil).
This change get users more flexibility in usage of this `encode` function and eliminate of redundant casting of `NSMutableURLRequest` to `NSMutableURLRequest` after (because in most of cases `encode` function returns `NSMutableURLRequest` already).