### PR TITLE
Fix test in case of respone is nil

### DIFF
--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -118,8 +118,10 @@ class AlamofireRedirectResponseTestCase: XCTestCase {
                 XCTAssertNotNil(data, "data should not be nil")
                 XCTAssertNil(error, "error should be nil")
 
-                XCTAssertEqual(response!.URL!, NSURL(string: URL)!, "request should not have followed a redirect")
-                XCTAssertEqual(response!.statusCode, 301, "response should have a 301 status code")
+                if let optionalResponse = response {
+                    XCTAssertEqual(optionalResponse.URL!, NSURL(string: URL)!, "request should not have followed a redirect")
+                    XCTAssertEqual(optionalResponse.statusCode, 301, "response should have a 301 status code")
+                }
 
                 expectation.fulfill()
         }


### PR DESCRIPTION

Fix test in case of response is `nil` (in my case it is) - we are get crash when try to unwrap optional variable and test not finished at all. So I add additional check, that response is not nil.

![screen shot 2015-05-13 at 19 48 13](https://cloud.githubusercontent.com/assets/3356474/7615879/267761cc-f9a9-11e4-88be-aadd0c3396c8.png)
