### PR TITLE
Testing NSURLSessionDataTask download progress

### DIFF
--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -53,7 +53,7 @@ class AlamofireRequestResponseTestCase: XCTestCase {
         let expectation = expectationWithDescription("\(URL)")
 
         Alamofire.request(.GET, URL, parameters: ["foo": "bar"])
-                 .response(serializer: serializer){ (request, response, string, error) in
+                 .response(serializer: serializer) { request, response, string, error in
                     XCTAssertNotNil(request, "request should not be nil")
                     XCTAssertNotNil(response, "response should not be nil")
                     XCTAssertNotNil(string, "string should not be nil")


### PR DESCRIPTION
This PR adds a test around data task progress monitoring. It is built with the `Given / When / Then` [structure](http://www.objc.io/issue-15/xctest.html) to make it easy to understand the different portions of the test. By gathering all the data and testing it within the `Then` section, it allows us to test all different combinations of the data once it has all been collected.