### PR TITLE
Updated typo in API Paramater Abstraction in README (#497)

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ enum Router: URLRequestConvertible {
 ```
 
 ```swift
-Alamofire.request(Router.Search(query: "foo bar", page: 1)) // ?q=foo+bar&offset=50
+Alamofire.request(Router.Search(query: "foo bar", page: 1)) // ?q=foo%20bar&offset=50
 ```
 
 #### CRUD & Authorization


### PR DESCRIPTION
This fixes #497 