### PR TITLE
Added parameter encoding characters along with additional documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,7 +727,7 @@ enum Router: URLRequestConvertible {
 ```
 
 ```swift
-Alamofire.request(Router.Search(query: "foo bar", page: 1)) // ?q=foo+bar&offset=50
+Alamofire.request(Router.Search(query: "foo bar", page: 1)) // ?q=foo%20bar&offset=50
 ```
 
 #### CRUD & Authorization

--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -151,7 +151,11 @@ public enum ParameterEncoding {
     }
 
     func escape(string: String) -> String {
-        let legalURLCharactersToBeEscaped: CFStringRef = ":&=;+!@#$()',*"
+        let generalDelimiters = ":#[]@" // dropping "?" and "/" due to RFC 3986 - Section 3.4
+        let subDelimiters = "!$&'()*+,;="
+
+        let legalURLCharactersToBeEscaped: CFStringRef = generalDelimiters + subDelimiters
+
         return CFURLCreateStringByAddingPercentEscapes(nil, string, nil, legalURLCharactersToBeEscaped, CFStringBuiltInEncodings.UTF8.rawValue) as String
     }
 }

--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -150,8 +150,40 @@ public enum ParameterEncoding {
         return components
     }
 
+    /**
+        Returns a percent escaped string following RFC 3986 for query string formatting.
+
+        RFC 3986 states that the following characters are "reserved" characters.
+
+        - General Delimiters: ":", "#", "[", "]", "@", "?", "/"
+        - Sub-Delimiters: "!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "="
+
+        Core Foundation interprets RFC 3986 in terms of legal and illegal characters.
+
+        - Legal Numbers: "0123456789"
+        - Legal Letters: "abcdefghijklmnopqrstuvwxyz", "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        - Legal Characters: "!", "$", "&", "'", "(", ")", "*", "+", ",", "-",
+                            ".", "/", ":", ";", "=", "?", "@", "_", "~", "\""
+        - Illegal Characters: All characters not listed as Legal
+
+        While the Core Foundation `CFURLCreateStringByAddingPercentEscapes` documentation states
+        that it follows RFC 3986, the headers actually point out that it follows RFC 2396. This
+        explains why it does not consider "[", "]" and "#" to be "legal" characters even though 
+        they are specified as "reserved" characters in RFC 3986. The following rdar has been filed
+        to hopefully get the documentation updated.
+
+        - https://openradar.appspot.com/radar?id=5058257274011648
+
+        In RFC 3986 - Section 3.4, it states that the "?" and "/" characters should not be escaped to allow
+        query strings to include a URL. Therefore, all "reserved" characters with the exception of "?" and "/"
+        should be percent escaped in the query string.
+
+        :param: string The string to be percent escaped.
+
+        :returns: The percent escaped string.
+    */
     func escape(string: String) -> String {
-        let generalDelimiters = ":#[]@" // dropping "?" and "/" due to RFC 3986 - Section 3.4
+        let generalDelimiters = ":#[]@" // does not include "?" or "/" due to RFC 3986 - Section 3.4
         let subDelimiters = "!$&'()*+,;="
 
         let legalURLCharactersToBeEscaped: CFStringRef = generalDelimiters + subDelimiters

--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -30,6 +30,9 @@ class ParameterEncodingTestCase: BaseTestCase {
 
 // MARK: -
 
+/**
+    The URL parameter encoding tests cover a variety of cases for encoding query parameters in addition to percent escaping reserved characters. The percent escaping implementation follows RFC 3986 - Sections 2.2, 2.4 and 3.4. All reserved characters are percent encoded with the exception of the "?" and "/" characters. This exception was made to allow other URIs to be included as query parameters without issue. See RFC 3986 - Section 3.4 for more details.
+*/
 class URLParameterEncodingTestCase: ParameterEncodingTestCase {
     // MARK: Properties
 

--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -30,15 +30,12 @@ class ParameterEncodingTestCase: BaseTestCase {
 
 // MARK: -
 
-/**
-    The URL parameter encoding tests cover a variety of cases for encoding query parameters in addition to percent escaping reserved characters. The percent escaping implementation follows RFC 3986 - Sections 2.2, 2.4 and 3.4. All reserved characters are percent encoded with the exception of the "?" and "/" characters. This exception was made to allow other URIs to be included as query parameters without issue. See RFC 3986 - Section 3.4 for more details.
-*/
 class URLParameterEncodingTestCase: ParameterEncodingTestCase {
     // MARK: Properties
 
     let encoding: ParameterEncoding = .URL
 
-    // MARK: Tests
+    // MARK: Tests - Parameter Types
 
     func testURLParameterEncodeNilParameters() {
         // Given
@@ -164,6 +161,78 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
         XCTAssertEqual(URLRequest.URL?.query ?? "", "foo%5Bbar%5D%5Bbaz%5D%5B%5D=a&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1", "query is incorrect")
     }
 
+    // MARK: Tests - All Reserved / Unreserved / Illegal Characters According to RFC 3986
+
+    func testThatReservedCharactersArePercentEscapedMinusQuestionMarkAndForwardSlash() {
+        // Given
+        let generalDelimiters = ":#[]@"
+        let subDelimiters = "!$&'()*+,;="
+        let parameters = ["reserved": "\(generalDelimiters)\(subDelimiters)"]
+
+        // When
+        let (URLRequest, error) = self.encoding.encode(self.URLRequest, parameters: parameters)
+
+        // Then
+        XCTAssertEqual(URLRequest.URL?.query ?? "", "reserved=%3A%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D", "query is incorrect")
+    }
+
+    func testThatReservedCharactersQuestionMarkAndForwardSlashAreNotPercentEscaped() {
+        // Given
+        let parameters = ["reserved": "?/"]
+
+        // When
+        let (URLRequest, error) = self.encoding.encode(self.URLRequest, parameters: parameters)
+
+        // Then
+        XCTAssertEqual(URLRequest.URL?.query ?? "", "reserved=?/", "query is incorrect")
+    }
+
+    func testThatUnreservedNumericCharactersAreNotPercentEscaped() {
+        // Given
+        let parameters = ["numbers": "0123456789"]
+
+        // When
+        let (URLRequest, error) = self.encoding.encode(self.URLRequest, parameters: parameters)
+
+        // Then
+        XCTAssertEqual(URLRequest.URL?.query ?? "", "numbers=0123456789", "query is incorrect")
+    }
+
+    func testThatUnreservedLowercaseCharactersAreNotPercentEscaped() {
+        // Given
+        let parameters = ["lowercase": "abcdefghijklmnopqrstuvwxyz"]
+
+        // When
+        let (URLRequest, error) = self.encoding.encode(self.URLRequest, parameters: parameters)
+
+        // Then
+        XCTAssertEqual(URLRequest.URL?.query ?? "", "lowercase=abcdefghijklmnopqrstuvwxyz", "query is incorrect")
+    }
+
+    func testThatUnreservedUppercaseCharactersAreNotPercentEscaped() {
+        // Given
+        let parameters = ["uppercase": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"]
+
+        // When
+        let (URLRequest, error) = self.encoding.encode(self.URLRequest, parameters: parameters)
+
+        // Then
+        XCTAssertEqual(URLRequest.URL?.query ?? "", "uppercase=ABCDEFGHIJKLMNOPQRSTUVWXYZ", "query is incorrect")
+    }
+
+    func testThatIllegalASCIICharactersArePercentEscaped() {
+        // Given
+        let parameters = ["illegal": " \"#%<>[]\\^`{}|"]
+
+        // When
+        let (URLRequest, error) = self.encoding.encode(self.URLRequest, parameters: parameters)
+
+        // Then
+        XCTAssertEqual(URLRequest.URL?.query ?? "", "illegal=%20%22%23%25%3C%3E%5B%5D%5C%5E%60%7B%7D%7C", "query is incorrect")
+    }
+
+    // MARK: Tests - Special Character Queries
+
     func testURLParameterEncodeStringWithAmpersandKeyStringWithAmpersandValueParameter() {
         // Given
         let parameters = ["foo&bar": "baz&qux", "foobar": "bazqux"]
@@ -219,17 +288,6 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
         XCTAssertEqual(URLRequest.URL?.query ?? "", "%2Bfoo%2B=%2Bbar%2B", "query is incorrect")
     }
 
-    func testURLParameterEncodeStringKeyAllowedCharactersStringValueParameter() {
-        // Given
-        let parameters = ["allowed": " =\"#%<>@\\^`{}[]|&"]
-
-        // When
-        let (URLRequest, error) = self.encoding.encode(self.URLRequest, parameters: parameters)
-
-        // Then
-        XCTAssertEqual(URLRequest.URL?.query ?? "", "allowed=%20%3D%22%23%25%3C%3E%40%5C%5E%60%7B%7D%5B%5D%7C%26", "query is incorrect")
-    }
-
     func testURLParameterEncodeStringKeyPercentEncodedStringValueParameter() {
         // Given
         let parameters = ["percent": "%25"]
@@ -280,6 +338,8 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
         // Then
         XCTAssertEqual(URLRequest.URL?.query ?? "", "hd=%5B1%5D&%2Bfoo%2B=%2Bbar%2B", "query is incorrect")
     }
+
+    // MARK: Tests - Varying HTTP Methods
 
     func testURLParameterEncodeGETParametersInURL() {
         // Given


### PR DESCRIPTION
This PR originates from the discussion in Issue #497 and PR #500. I dug through all the past issues related to percent escaping characters and came across the following: #121, #155, #166, #206, #369 and #370. The percent escaping logic has progressed nicely and is solid and well tested.

To this end, I noticed a couple of things that could be improved.

1. It would be good to clarify in the `escape` function which characters we're escaping and why.
1. In the URL parameter encoding tests, give a description of the test cases and which specs they follow along with the exceptions that have been made.

All this PR does is add the "[" and "]" characters as well as split the legal escaped characters into `generalDelimiters` and `subDelimiters`. I think this makes it much easier to understand when referencing [RFC 3986 - Section 2.2](http://tools.ietf.org/html/rfc3986#section-2.2).

The final change was to update the README mismatch which was kindly pointed out by @joshuatbrown in PR #500. I simply corrected the character to `%2B`.