### PR TITLE
Re-enabled Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: objective-c
 osx_image: beta-xcode6.3
 env:
-- LC_CTYPE=en_US.UTF-8 LANG=en_US.UTF-8
+  - LC_CTYPE=en_US.UTF-8 LANG=en_US.UTF-8
 before_install:
-- gem install xcpretty -N
+  - gem install cocoapods --no-rdoc --no-ri --no-document --quiet
+  - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
 script:
-- set -o pipefail
-- xcodebuild -project Alamofire.xcodeproj -scheme "Alamofire iOS" -sdk iphonesimulator
-  -destination "platform=iOS Simulator,name=iPhone 6" ONLY_ACTIVE_ARCH=NO test | xcpretty -c
-- xcodebuild -project Alamofire.xcodeproj -scheme "Alamofire OSX" -sdk macosx10.10
-  -destination "platform=OS X,arch=x86_64" ONLY_ACTIVE_ARCH=NO test | xcpretty -c
-- xcodebuild -project "iOS Example.xcodeproj" -scheme "iOS Example" -sdk iphonesimulator
-  -destination "platform=iOS Simulator,name=iPhone 6" ONLY_ACTIVE_ARCH=YES build | xcpretty -c
-- gem install cocoapods
-- pod lib lint --quick
+  - set -o pipefail
+  - xcodebuild -project Alamofire.xcodeproj -scheme "Alamofire iOS" -sdk iphonesimulator
+    -destination "platform=iOS Simulator,name=iPhone 6" ONLY_ACTIVE_ARCH=NO test | xcpretty -c
+  - xcodebuild -project Alamofire.xcodeproj -scheme "Alamofire OSX" -sdk macosx10.10
+    -destination "platform=OS X,arch=x86_64" ONLY_ACTIVE_ARCH=NO test | xcpretty -c
+  - xcodebuild -project "iOS Example.xcodeproj" -scheme "iOS Example" -sdk iphonesimulator
+    -destination "platform=iOS Simulator,name=iPhone 6" ONLY_ACTIVE_ARCH=YES build | xcpretty -c
+  - pod lib lint --quick

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ script:
   -destination "platform=OS X,arch=x86_64" ONLY_ACTIVE_ARCH=NO test | xcpretty -c
 - xcodebuild -project "iOS Example.xcodeproj" -scheme "iOS Example" -sdk iphonesimulator
   -destination "platform=iOS Simulator,name=iPhone 6" ONLY_ACTIVE_ARCH=YES build | xcpretty -c
+- gem install cocoapods
 - pod lib lint --quick

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode63
+osx_image: beta-xcode6.3
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: objective-c
 osx_image: beta-xcode6.3
-branches:
-  only:
-    - master
 env:
 - LC_CTYPE=en_US.UTF-8 LANG=en_US.UTF-8
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ before_install:
 script:
 - set -o pipefail
 - xcodebuild -project Alamofire.xcodeproj -scheme "Alamofire iOS" -sdk iphonesimulator
-  -destination "platform=iOS Simulator,name=iPhone 6" ONLY_ACTIVE_ARCH=NO  test | xcpretty -c
+  -destination "platform=iOS Simulator,name=iPhone 6" ONLY_ACTIVE_ARCH=NO test | xcpretty -c
+- xcodebuild -project Alamofire.xcodeproj -scheme "Alamofire OSX" -sdk macosx10.10
+  -destination "platform=OS X,arch=x86_64" ONLY_ACTIVE_ARCH=NO test | xcpretty -c
 - xcodebuild -project "iOS Example.xcodeproj" -scheme "iOS Example" -sdk iphonesimulator
   -destination "platform=iOS Simulator,name=iPhone 6" ONLY_ACTIVE_ARCH=YES build | xcpretty -c
 - pod lib lint --quick

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![Alamofire: Elegant Networking in Swift](https://raw.githubusercontent.com/Alamofire/Alamofire/assets/alamofire.png)
 
+[![Build Status](https://travis-ci.org/Alamofire/Alamofire.svg)](https://travis-ci.org/Alamofire/Alamofire)
+
 Alamofire is an HTTP networking library written in Swift.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ![Alamofire: Elegant Networking in Swift](https://raw.githubusercontent.com/Alamofire/Alamofire/assets/alamofire.png)
 
 [![Build Status](https://travis-ci.org/Alamofire/Alamofire.svg)](https://travis-ci.org/Alamofire/Alamofire)
+[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/Alamofire.svg)](https://img.shields.io/cocoapods/v/Alamofire.svg)
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 Alamofire is an HTTP networking library written in Swift.
 


### PR DESCRIPTION
I managed to re-enable our Travis-CI builds for Alamofire. This is really my first trial with Travis-CI so I'd appreciate it if others could look this over for me. Here's a list of changes that I made.

* Switched to the latest `osx_image` which is `beta-code6.3`
* Added xcodebuild phase for the OS X tests which are now passing
* Added a `gem install cocoapods` to make sure we're linting with the latest version
* Added a CocoaPods Compatible tag to the top of the README
* Added a Carthage Compatible tag to the top of the README