### PR TITLE
Only set cookies in debugPrintable when relevant

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -418,12 +418,14 @@ extension Request: DebugPrintable {
         // Temporarily disabled on OS X due to build failure for CocoaPods
         // See https://github.com/CocoaPods/swift/issues/24
         #if !os(OSX)
-            if let cookieStorage = session.configuration.HTTPCookieStorage,
-                cookies = cookieStorage.cookiesForURL(URL!) as? [NSHTTPCookie]
-                where !cookies.isEmpty
-            {
-                let string = cookies.reduce(""){ $0 + "\($1.name)=\($1.value ?? String());" }
-                components.append("-b \"\(string.substringToIndex(string.endIndex.predecessor()))\"")
+            if session.configuration.HTTPShouldSetCookies == true {
+                if let cookieStorage = session.configuration.HTTPCookieStorage,
+                    cookies = cookieStorage.cookiesForURL(URL!) as? [NSHTTPCookie]
+                    where !cookies.isEmpty
+                {
+                    let string = cookies.reduce(""){ $0 + "\($1.name)=\($1.value ?? String());" }
+                    components.append("-b \"\(string.substringToIndex(string.endIndex.predecessor()))\"")
+                }
             }
         #endif
 

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -195,6 +195,16 @@ class RequestDebugDescriptionTestCase: BaseTestCase {
         manager.startRequestsImmediately = false
         return manager
     }()
+    
+    let managerDisallowingCookies: Alamofire.Manager = {
+        let config = NSURLSessionConfiguration.defaultSessionConfiguration()
+        config.HTTPShouldSetCookies = false
+        
+        let manager = Alamofire.Manager(configuration: config)
+        manager.startRequestsImmediately = false
+        
+        return manager
+    }()
 
     // MARK: Tests
 
@@ -267,6 +277,28 @@ class RequestDebugDescriptionTestCase: BaseTestCase {
         #if !os(OSX)
         XCTAssertEqual(components[5..<6], ["-b"], "command should contain -b flag")
         #endif
+    }
+    
+    func testPOSTRequestWithCookiesDisabledDebugDescription() {
+        // Given
+        let URLString = "http://httpbin.org/post"
+        
+        let properties = [
+            NSHTTPCookieDomain: "httpbin.org",
+            NSHTTPCookiePath: "/post",
+            NSHTTPCookieName: "foo",
+            NSHTTPCookieValue: "bar",
+        ]
+        let cookie = NSHTTPCookie(properties: properties)!
+        managerDisallowingCookies.session.configuration.HTTPCookieStorage?.setCookie(cookie)
+        
+        // When
+        let request = managerDisallowingCookies.request(.POST, URLString)
+        let components = cURLCommandComponents(request)
+        
+        // Then
+        let cookieComponents = components.filter { $0 == "-b" }
+        XCTAssertEqual(cookieComponents.count, 0, "Cookie cURL argument should not exist if cookies are disabled in the session config")
     }
 
     // MARK: Test Helper Methods


### PR DESCRIPTION
If `HTTPShouldSetCookies` is set to `false` in the session's config then any cookies set will not be sent as part of the request.

Previously the cURL command output provided by `debugPrintln()` would include cookies whether or not `HTTPShouldSetCookies` was true or false. This commit will make it so `debugPrintln()` only prints cookies in the cURL output if they'll actually be sent.