### PR TITLE
Setting right availability guard for iOS, fixing build for Xcode 7

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -217,7 +217,7 @@ public class Request {
                 operationQueue.maxConcurrentOperationCount = 1
                 operationQueue.suspended = true
 
-                if #available(OSX 10.10, *) {
+                if #available(OSX 10.10, iOS 8.0, *) {
                     operationQueue.qualityOfService = NSQualityOfService.Utility
                 }
 


### PR DESCRIPTION
Without this fix, Alamofire doesn't compile for iOS 7 targets with Xcode 7.

Test project doesn't reveal this because it's iOS 8 and up, but the same guard as for 10.10 is needed for iOS as well. 