### PR TITLE
fixing a missing #available flag (needed for iOS 7.0 targets..)

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -217,7 +217,7 @@ public class Request {
                 operationQueue.maxConcurrentOperationCount = 1
                 operationQueue.suspended = true
 
-                if #available(OSX 10.10, *) {
+                if #available(iOS 8.0, OSX 10.10, *) {
                     operationQueue.qualityOfService = NSQualityOfService.Utility
                 }
 


### PR DESCRIPTION
Your iOS target level is set to iOS 8 in the project, so it doesn't see this compiler error.  (Since it makes a dynamic framework).

For those of us still "dropping" the swift into the project without pods or carthage (I REALLY want to drop iOS 7.0 support asap) than you won't see this.

You may want to think about adjusting the IOS target level in the project also, so you can spot any more of these in future.  I THINK it's ok, even though the dynamic framework can't run on iOS 7.
