### PR TITLE
Lint full podspec on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,6 @@ script:
       xcodebuild -project "iOS Example.xcodeproj" -scheme "iOS Example" -sdk "$SDK" -destination "$DESTINATION" 
       -configuration Release ONLY_ACTIVE_ARCH=NO build | xcpretty -c; 
     fi
-  - if [ $POD_LINT == "YES" ]; then 
-      pod lib lint --quick; 
+  - if [ $POD_LINT == "YES" ]; then
+      pod lib lint;
     fi


### PR DESCRIPTION
We originally linted the as quick because Travis CI didn't have a version of Xcode / CocoaPods that was compatible with this before.

Changing to full will mean that CocoaPods will build the project on the lowest supported platforms and ensures all the sources work together.