### PR TITLE
Execute the taskDidComplete closure in addition to the default implementation

### DIFF
--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -277,9 +277,8 @@ public class Manager {
         }
 
         public func URLSession(session: NSURLSession, task: NSURLSessionTask, didCompleteWithError error: NSError?) {
-            if taskDidComplete != nil {
-                taskDidComplete!(session, task, error)
-            } else if let delegate = self[task] {
+            taskDidComplete?(session, task, error)
+            if let delegate = self[task] {
                 delegate.URLSession(session, task: task, didCompleteWithError: error)
 
                 self[task] = nil


### PR DESCRIPTION
We ran into the problem that when the taskDidComplete closure was set the response handlers were never executed because the closure replaced the default implementation.

This change fixed the problem for us and we think it would be useful for everyone.