### PR TITLE
Removed unnecessary declaration. No functional changes.

### DIFF
--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -33,7 +33,7 @@ public class Manager {
         A shared instance of `Manager`, used by top-level Alamofire request methods, and suitable for use directly for any ad hoc requests.
     */
     public static let sharedInstance: Manager = {
-        let configuration: NSURLSessionConfiguration = NSURLSessionConfiguration.defaultSessionConfiguration()
+        let configuration = NSURLSessionConfiguration.defaultSessionConfiguration()
         configuration.HTTPAdditionalHeaders = Manager.defaultHTTPHeaders
 
         return Manager(configuration: configuration)


### PR DESCRIPTION
The type of `configuration` object is automatically inferred.