### PR TITLE
Feature - Custom Header Support

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -87,7 +87,7 @@ extension NSURLRequest: URLRequestConvertible {
 
 // MARK: - Convenience
 
-func URLRequest(method: Method, URL: URLStringConvertible) -> NSURLRequest {
+func URLRequest(method: Method, URL: URLStringConvertible) -> NSMutableURLRequest {
     let mutableURLRequest = NSMutableURLRequest(URL: NSURL(string: URL.URLString)!)
     mutableURLRequest.HTTPMethod = method.rawValue
 

--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -144,7 +144,7 @@ public func request(URLRequest: URLRequestConvertible) -> Request {
 
     :returns: The created upload request.
 */
-public func upload(method: Method, URLString: URLStringConvertible, headers: [String: String]? = nil, file: NSURL) -> Request {
+public func upload(method: Method, URLString: URLStringConvertible, headers: [String: String]? = nil, #file: NSURL) -> Request {
     return Manager.sharedInstance.upload(method, URLString, headers: headers, file: file)
 }
 
@@ -156,7 +156,7 @@ public func upload(method: Method, URLString: URLStringConvertible, headers: [St
 
     :returns: The created upload request.
 */
-public func upload(URLRequest: URLRequestConvertible, file: NSURL) -> Request {
+public func upload(URLRequest: URLRequestConvertible, #file: NSURL) -> Request {
     return Manager.sharedInstance.upload(URLRequest, file: file)
 }
 
@@ -172,7 +172,7 @@ public func upload(URLRequest: URLRequestConvertible, file: NSURL) -> Request {
 
     :returns: The created upload request.
 */
-public func upload(method: Method, URLString: URLStringConvertible, headers: [String: String]? = nil, data: NSData) -> Request {
+public func upload(method: Method, URLString: URLStringConvertible, headers: [String: String]? = nil, #data: NSData) -> Request {
     return Manager.sharedInstance.upload(method, URLString, headers: headers, data: data)
 }
 
@@ -184,7 +184,7 @@ public func upload(method: Method, URLString: URLStringConvertible, headers: [St
 
     :returns: The created upload request.
 */
-public func upload(URLRequest: URLRequestConvertible, data: NSData) -> Request {
+public func upload(URLRequest: URLRequestConvertible, #data: NSData) -> Request {
     return Manager.sharedInstance.upload(URLRequest, data: data)
 }
 
@@ -200,7 +200,7 @@ public func upload(URLRequest: URLRequestConvertible, data: NSData) -> Request {
 
     :returns: The created upload request.
 */
-public func upload(method: Method, URLString: URLStringConvertible, headers: [String: String]? = nil, stream: NSInputStream) -> Request {
+public func upload(method: Method, URLString: URLStringConvertible, headers: [String: String]? = nil, #stream: NSInputStream) -> Request {
     return Manager.sharedInstance.upload(method, URLString, headers: headers, stream: stream)
 }
 
@@ -212,7 +212,7 @@ public func upload(method: Method, URLString: URLStringConvertible, headers: [St
 
     :returns: The created upload request.
 */
-public func upload(URLRequest: URLRequestConvertible, stream: NSInputStream) -> Request {
+public func upload(URLRequest: URLRequestConvertible, #stream: NSInputStream) -> Request {
     return Manager.sharedInstance.upload(URLRequest, stream: stream)
 }
 
@@ -284,7 +284,7 @@ public func upload(
 
     :returns: The created download request.
 */
-public func download(method: Method, URLString: URLStringConvertible, headers: [String: String]? = nil, destination: Request.DownloadFileDestination) -> Request {
+public func download(method: Method, URLString: URLStringConvertible, headers: [String: String]? = nil, #destination: Request.DownloadFileDestination) -> Request {
     return Manager.sharedInstance.download(method, URLString, headers: headers, destination: destination)
 }
 
@@ -296,7 +296,7 @@ public func download(method: Method, URLString: URLStringConvertible, headers: [
 
     :returns: The created download request.
 */
-public func download(URLRequest: URLRequestConvertible, destination: Request.DownloadFileDestination) -> Request {
+public func download(URLRequest: URLRequestConvertible, #destination: Request.DownloadFileDestination) -> Request {
     return Manager.sharedInstance.download(URLRequest, destination: destination)
 }
 
@@ -310,6 +310,6 @@ public func download(URLRequest: URLRequestConvertible, destination: Request.Dow
 
     :returns: The created download request.
 */
-public func download(resumeData data: NSData, destination: Request.DownloadFileDestination) -> Request {
+public func download(resumeData data: NSData, #destination: Request.DownloadFileDestination) -> Request {
     return Manager.sharedInstance.download(data, destination: destination)
 }

--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -87,9 +87,15 @@ extension NSURLRequest: URLRequestConvertible {
 
 // MARK: - Convenience
 
-func URLRequest(method: Method, URL: URLStringConvertible) -> NSMutableURLRequest {
-    let mutableURLRequest = NSMutableURLRequest(URL: NSURL(string: URL.URLString)!)
+func URLRequest(method: Method, URLString: URLStringConvertible, headers: [String: String]? = nil) -> NSMutableURLRequest {
+    let mutableURLRequest = NSMutableURLRequest(URL: NSURL(string: URLString.URLString)!)
     mutableURLRequest.HTTPMethod = method.rawValue
+
+    if let headers = headers {
+        for (headerField, headerValue) in headers {
+            mutableURLRequest.setValue(headerValue, forHTTPHeaderField: headerField)
+        }
+    }
 
     return mutableURLRequest
 }
@@ -103,11 +109,12 @@ func URLRequest(method: Method, URL: URLStringConvertible) -> NSMutableURLReques
     :param: URLString The URL string.
     :param: parameters The parameters. `nil` by default.
     :param: encoding The parameter encoding. `.URL` by default.
+    :param: headers The HTTP headers. `nil` by default.
 
     :returns: The created request.
 */
-public func request(method: Method, URLString: URLStringConvertible, parameters: [String: AnyObject]? = nil, encoding: ParameterEncoding = .URL) -> Request {
-    return Manager.sharedInstance.request(method, URLString, parameters: parameters, encoding: encoding)
+public func request(method: Method, URLString: URLStringConvertible, parameters: [String: AnyObject]? = nil, encoding: ParameterEncoding = .URL, headers: [String: String]? = nil) -> Request {
+    return Manager.sharedInstance.request(method, URLString, parameters: parameters, encoding: encoding, headers: headers)
 }
 
 /**
@@ -132,12 +139,13 @@ public func request(URLRequest: URLRequestConvertible) -> Request {
 
     :param: method The HTTP method.
     :param: URLString The URL string.
+    :param: headers The HTTP headers. `nil` by default.
     :param: file The file to upload.
 
     :returns: The created upload request.
 */
-public func upload(method: Method, URLString: URLStringConvertible, file: NSURL) -> Request {
-    return Manager.sharedInstance.upload(method, URLString, file: file)
+public func upload(method: Method, URLString: URLStringConvertible, headers: [String: String]? = nil, file: NSURL) -> Request {
+    return Manager.sharedInstance.upload(method, URLString, headers: headers, file: file)
 }
 
 /**
@@ -159,12 +167,13 @@ public func upload(URLRequest: URLRequestConvertible, file: NSURL) -> Request {
 
     :param: method The HTTP method.
     :param: URLString The URL string.
+    :param: headers The HTTP headers. `nil` by default.
     :param: data The data to upload.
 
     :returns: The created upload request.
 */
-public func upload(method: Method, URLString: URLStringConvertible, data: NSData) -> Request {
-    return Manager.sharedInstance.upload(method, URLString, data: data)
+public func upload(method: Method, URLString: URLStringConvertible, headers: [String: String]? = nil, data: NSData) -> Request {
+    return Manager.sharedInstance.upload(method, URLString, headers: headers, data: data)
 }
 
 /**
@@ -186,12 +195,13 @@ public func upload(URLRequest: URLRequestConvertible, data: NSData) -> Request {
 
     :param: method The HTTP method.
     :param: URLString The URL string.
+    :param: headers The HTTP headers. `nil` by default.
     :param: stream The stream to upload.
 
     :returns: The created upload request.
 */
-public func upload(method: Method, URLString: URLStringConvertible, stream: NSInputStream) -> Request {
-    return Manager.sharedInstance.upload(method, URLString, stream: stream)
+public func upload(method: Method, URLString: URLStringConvertible, headers: [String: String]? = nil, stream: NSInputStream) -> Request {
+    return Manager.sharedInstance.upload(method, URLString, headers: headers, stream: stream)
 }
 
 /**
@@ -213,6 +223,7 @@ public func upload(URLRequest: URLRequestConvertible, stream: NSInputStream) -> 
 
     :param: method                  The HTTP method.
     :param: URLString               The URL string.
+    :param: headers The HTTP headers. `nil` by default.
     :param: multipartFormData       The closure used to append body parts to the `MultipartFormData`.
     :param: encodingMemoryThreshold The encoding memory threshold in bytes. `MultipartFormDataEncodingMemoryThreshold` 
                                     by default.
@@ -221,6 +232,7 @@ public func upload(URLRequest: URLRequestConvertible, stream: NSInputStream) -> 
 public func upload(
     method: Method,
     #URLString: URLStringConvertible,
+    headers: [String: String]? = nil,
     #multipartFormData: MultipartFormData -> Void,
     encodingMemoryThreshold: UInt64 = Manager.MultipartFormDataEncodingMemoryThreshold,
     #encodingCompletion: (Manager.MultipartFormDataEncodingResult -> Void)?)
@@ -228,6 +240,7 @@ public func upload(
     return Manager.sharedInstance.upload(
         method,
         URLString,
+        headers: headers,
         multipartFormData: multipartFormData,
         encodingMemoryThreshold: encodingMemoryThreshold,
         encodingCompletion: encodingCompletion
@@ -266,12 +279,13 @@ public func upload(
 
     :param: method The HTTP method.
     :param: URLString The URL string.
+    :param: headers The HTTP headers. `nil` by default.
     :param: destination The closure used to determine the destination of the downloaded file.
 
     :returns: The created download request.
 */
-public func download(method: Method, URLString: URLStringConvertible, destination: Request.DownloadFileDestination) -> Request {
-    return Manager.sharedInstance.download(method, URLString, destination: destination)
+public func download(method: Method, URLString: URLStringConvertible, headers: [String: String]? = nil, destination: Request.DownloadFileDestination) -> Request {
+    return Manager.sharedInstance.download(method, URLString, headers: headers, destination: destination)
 }
 
 /**

--- a/Source/Download.swift
+++ b/Source/Download.swift
@@ -64,12 +64,14 @@ extension Manager {
 
         :param: method The HTTP method.
         :param: URLString The URL string.
+        :param: headers The HTTP headers. `nil` by default.
         :param: destination The closure used to determine the destination of the downloaded file.
 
         :returns: The created download request.
     */
-    public func download(method: Method, _ URLString: URLStringConvertible, destination: Request.DownloadFileDestination) -> Request {
-        return download(URLRequest(method, URLString), destination: destination)
+    public func download(method: Method, _ URLString: URLStringConvertible, headers: [String: String]? = nil, destination: Request.DownloadFileDestination) -> Request {
+        let mutableURLRequest = URLRequest(method, URLString, headers: headers)
+        return download(mutableURLRequest, destination: destination)
     }
 
     /**

--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -130,11 +130,21 @@ public class Manager {
         :param: URLString The URL string.
         :param: parameters The parameters. `nil` by default.
         :param: encoding The parameter encoding. `.URL` by default.
+        :param: headers The HTTP headers. `nil` by default.
 
         :returns: The created request.
     */
-    public func request(method: Method, _ URLString: URLStringConvertible, parameters: [String: AnyObject]? = nil, encoding: ParameterEncoding = .URL) -> Request {
-        return request(encoding.encode(URLRequest(method, URLString), parameters: parameters).0)
+    public func request(
+        method: Method,
+        _ URLString: URLStringConvertible,
+        parameters: [String: AnyObject]? = nil,
+        encoding: ParameterEncoding = .URL,
+        headers: [String: String]? = nil)
+        -> Request
+    {
+        let mutableURLRequest = URLRequest(method, URLString, headers: headers)
+        let encodedURLRequest = encoding.encode(mutableURLRequest, parameters: parameters).0
+        return request(encodedURLRequest)
     }
 
     /**

--- a/Source/Upload.swift
+++ b/Source/Upload.swift
@@ -87,12 +87,14 @@ extension Manager {
 
         :param: method The HTTP method.
         :param: URLString The URL string.
-        :param: file The file to upload
+        :param: headers The HTTP headers. `nil` by default.
+        :param: file The file to upload.
 
         :returns: The created upload request.
     */
-    public func upload(method: Method, _ URLString: URLStringConvertible, file: NSURL) -> Request {
-        return upload(URLRequest(method, URLString), file: file)
+    public func upload(method: Method, _ URLString: URLStringConvertible, headers: [String: String]? = nil, file: NSURL) -> Request {
+        let mutableURLRequest = URLRequest(method, URLString, headers: headers)
+        return upload(mutableURLRequest, file: file)
     }
 
     // MARK: Data
@@ -102,8 +104,8 @@ extension Manager {
 
         If `startRequestsImmediately` is `true`, the request will have `resume()` called before being returned.
 
-        :param: URLRequest The URL request
-        :param: data The data to upload
+        :param: URLRequest The URL request.
+        :param: data The data to upload.
 
         :returns: The created upload request.
     */
@@ -118,12 +120,14 @@ extension Manager {
 
         :param: method The HTTP method.
         :param: URLString The URL string.
-        :param: data The data to upload
+        :param: headers The HTTP headers. `nil` by default.
+        :param: data The data to upload.
 
         :returns: The created upload request.
     */
-    public func upload(method: Method, _ URLString: URLStringConvertible, data: NSData) -> Request {
-        return upload(URLRequest(method, URLString), data: data)
+    public func upload(method: Method, _ URLString: URLStringConvertible, headers: [String: String]? = nil, data: NSData) -> Request {
+        let mutableURLRequest = URLRequest(method, URLString, headers: headers)
+        return upload(mutableURLRequest, data: data)
     }
 
     // MARK: Stream
@@ -133,8 +137,8 @@ extension Manager {
 
         If `startRequestsImmediately` is `true`, the request will have `resume()` called before being returned.
 
-        :param: URLRequest The URL request
-        :param: stream The stream to upload
+        :param: URLRequest The URL request.
+        :param: stream The stream to upload.
 
         :returns: The created upload request.
     */
@@ -149,12 +153,14 @@ extension Manager {
 
         :param: method The HTTP method.
         :param: URLString The URL string.
+        :param: headers The HTTP headers. `nil` by default.
         :param: stream The stream to upload.
 
         :returns: The created upload request.
     */
-    public func upload(method: Method, _ URLString: URLStringConvertible, stream: NSInputStream) -> Request {
-        return upload(URLRequest(method, URLString), stream: stream)
+    public func upload(method: Method, _ URLString: URLStringConvertible, headers: [String: String]? = nil, stream: NSInputStream) -> Request {
+        let mutableURLRequest = URLRequest(method, URLString, headers: headers)
+        return upload(mutableURLRequest, stream: stream)
     }
 
     // MARK: MultipartFormData
@@ -196,6 +202,7 @@ extension Manager {
 
         :param: method                  The HTTP method.
         :param: URLString               The URL string.
+        :param: headers                 The HTTP headers. `nil` by default.
         :param: multipartFormData       The closure used to append body parts to the `MultipartFormData`.
         :param: encodingMemoryThreshold The encoding memory threshold in bytes. `MultipartFormDataEncodingMemoryThreshold`
                                         by default.
@@ -204,14 +211,15 @@ extension Manager {
     public func upload(
         method: Method,
         _ URLString: URLStringConvertible,
+        headers: [String: String]? = nil,
         multipartFormData: MultipartFormData -> Void,
         encodingMemoryThreshold: UInt64 = Manager.MultipartFormDataEncodingMemoryThreshold,
         encodingCompletion: (MultipartFormDataEncodingResult -> Void)?)
     {
-        let urlRequest = URLRequest(method, URLString)
+        let mutableURLRequest = URLRequest(method, URLString, headers: headers)
 
         return upload(
-            urlRequest,
+            mutableURLRequest,
             multipartFormData: multipartFormData,
             encodingMemoryThreshold: encodingMemoryThreshold,
             encodingCompletion: encodingCompletion

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -46,7 +46,7 @@ class DownloadResponseTestCase: BaseTestCase {
         var error: NSError?
 
         // When
-        Alamofire.download(.GET, URLString, destination)
+        Alamofire.download(.GET, URLString, destination: destination)
             .response { responseRequest, responseResponse, _, responseError in
                 request = responseRequest
                 response = responseResponse

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -24,6 +24,47 @@ import Alamofire
 import Foundation
 import XCTest
 
+class DownloadInitializationTestCase: BaseTestCase {
+    let searchPathDirectory: NSSearchPathDirectory = .CachesDirectory
+    let searchPathDomain: NSSearchPathDomainMask = .UserDomainMask
+
+    func testDownloadClassMethodWithMethodURLAndDestination() {
+        // Given
+        let URLString = "http://httpbin.org/"
+        let destination = Request.suggestedDownloadDestination(directory: searchPathDirectory, domain: searchPathDomain)
+
+        // When
+        let request = Alamofire.download(.GET, URLString, destination: destination)
+
+        // Then
+        XCTAssertNotNil(request.request, "request should not be nil")
+        XCTAssertEqual(request.request.HTTPMethod ?? "", "GET", "request HTTP method should be GET")
+        XCTAssertEqual(request.request.URL!, NSURL(string: URLString)!, "request URL should be equal")
+        XCTAssertNil(request.response, "response should be nil")
+    }
+
+    func testDownloadClassMethodWithMethodURLHeadersAndDestination() {
+        // Given
+        let URLString = "http://httpbin.org/"
+        let destination = Request.suggestedDownloadDestination(directory: searchPathDirectory, domain: searchPathDomain)
+
+        // When
+        let request = Alamofire.download(.GET, URLString, headers: ["Authorization": "123456"], destination: destination)
+
+        // Then
+        XCTAssertNotNil(request.request, "request should not be nil")
+        XCTAssertEqual(request.request.HTTPMethod ?? "", "GET", "request HTTP method should be GET")
+        XCTAssertEqual(request.request.URL!, NSURL(string: URLString)!, "request URL should be equal")
+
+        let authorizationHeader = request.request.valueForHTTPHeaderField("Authorization") ?? ""
+        XCTAssertEqual(authorizationHeader, "123456", "Authorization header is incorrect")
+
+        XCTAssertNil(request.response, "response should be nil")
+    }
+}
+
+// MARK: -
+
 class DownloadResponseTestCase: BaseTestCase {
     // MARK: - Properties
 

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -34,6 +34,7 @@ class RequestInitializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertNotNil(request.request, "request should not be nil")
+        XCTAssertEqual(request.request.HTTPMethod ?? "", "GET", "request HTTP method should match expected value")
         XCTAssertEqual(request.request.URL!, NSURL(string: URLString)!, "request URL should be equal")
         XCTAssertNil(request.response, "response should be nil")
     }
@@ -47,8 +48,28 @@ class RequestInitializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertNotNil(request.request, "request should not be nil")
+        XCTAssertEqual(request.request.HTTPMethod ?? "", "GET", "request HTTP method should match expected value")
         XCTAssertNotEqual(request.request.URL!, NSURL(string: URLString)!, "request URL should be equal")
         XCTAssertEqual(request.request.URL?.query ?? "", "foo=bar", "query is incorrect")
+        XCTAssertNil(request.response, "response should be nil")
+    }
+
+    func testRequestClassMethodWithMethodURLParametersAndHeaders() {
+        // Given
+        let URLString = "http://httpbin.org/get"
+
+        // When
+        let request = Alamofire.request(.GET, URLString, parameters: ["foo": "bar"], headers: ["Authorization": "123456"])
+
+        // Then
+        XCTAssertNotNil(request.request, "request should not be nil")
+        XCTAssertEqual(request.request.HTTPMethod ?? "", "GET", "request HTTP method should match expected value")
+        XCTAssertNotEqual(request.request.URL!, NSURL(string: URLString)!, "request URL should be equal")
+        XCTAssertEqual(request.request.URL?.query ?? "", "foo=bar", "query is incorrect")
+
+        let authorizationHeader = request.request.valueForHTTPHeaderField("Authorization") ?? ""
+        XCTAssertEqual(authorizationHeader, "123456", "Authorization header is incorrect")
+
         XCTAssertNil(request.response, "response should be nil")
     }
 }

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -24,6 +24,120 @@ import Alamofire
 import Foundation
 import XCTest
 
+class UploadFileInitializationTestCase: BaseTestCase {
+    func testUploadClassMethodWithMethodURLAndFile() {
+        // Given
+        let URLString = "http://httpbin.org/"
+        let imageURL = URLForResource("rainbow", withExtension: "jpg")
+
+        // When
+        let request = Alamofire.upload(.POST, URLString, file: imageURL)
+
+        // Then
+        XCTAssertNotNil(request.request, "request should not be nil")
+        XCTAssertEqual(request.request.HTTPMethod ?? "", "POST", "request HTTP method should be POST")
+        XCTAssertEqual(request.request.URL!, NSURL(string: URLString)!, "request URL should be equal")
+        XCTAssertNil(request.response, "response should be nil")
+    }
+
+    func testUploadClassMethodWithMethodURLHeadersAndFile() {
+        // Given
+        let URLString = "http://httpbin.org/"
+        let imageURL = URLForResource("rainbow", withExtension: "jpg")
+
+        // When
+        let request = Alamofire.upload(.POST, URLString, headers: ["Authorization": "123456"], file: imageURL)
+
+        // Then
+        XCTAssertNotNil(request.request, "request should not be nil")
+        XCTAssertEqual(request.request.HTTPMethod ?? "", "POST", "request HTTP method should be POST")
+        XCTAssertEqual(request.request.URL!, NSURL(string: URLString)!, "request URL should be equal")
+
+        let authorizationHeader = request.request.valueForHTTPHeaderField("Authorization") ?? ""
+        XCTAssertEqual(authorizationHeader, "123456", "Authorization header is incorrect")
+
+        XCTAssertNil(request.response, "response should be nil")
+    }
+}
+
+// MARK: -
+
+class UploadDataInitializationTestCase: BaseTestCase {
+    func testUploadClassMethodWithMethodURLAndData() {
+        // Given
+        let URLString = "http://httpbin.org/"
+
+        // When
+        let request = Alamofire.upload(.POST, URLString, data: NSData())
+
+        // Then
+        XCTAssertNotNil(request.request, "request should not be nil")
+        XCTAssertEqual(request.request.HTTPMethod ?? "", "POST", "request HTTP method should be POST")
+        XCTAssertEqual(request.request.URL!, NSURL(string: URLString)!, "request URL should be equal")
+        XCTAssertNil(request.response, "response should be nil")
+    }
+
+    func testUploadClassMethodWithMethodURLHeadersAndData() {
+        // Given
+        let URLString = "http://httpbin.org/"
+
+        // When
+        let request = Alamofire.upload(.POST, URLString, headers: ["Authorization": "123456"], data: NSData())
+
+        // Then
+        XCTAssertNotNil(request.request, "request should not be nil")
+        XCTAssertEqual(request.request.HTTPMethod ?? "", "POST", "request HTTP method should be POST")
+        XCTAssertEqual(request.request.URL!, NSURL(string: URLString)!, "request URL should be equal")
+
+        let authorizationHeader = request.request.valueForHTTPHeaderField("Authorization") ?? ""
+        XCTAssertEqual(authorizationHeader, "123456", "Authorization header is incorrect")
+
+        XCTAssertNil(request.response, "response should be nil")
+    }
+}
+
+// MARK: -
+
+class UploadStreamInitializationTestCase: BaseTestCase {
+    func testUploadClassMethodWithMethodURLAndStream() {
+        // Given
+        let URLString = "http://httpbin.org/"
+        let imageURL = URLForResource("rainbow", withExtension: "jpg")
+        let imageStream = NSInputStream(URL: imageURL)!
+
+        // When
+        let request = Alamofire.upload(.POST, URLString, stream: imageStream)
+
+        // Then
+        XCTAssertNotNil(request.request, "request should not be nil")
+        XCTAssertEqual(request.request.HTTPMethod ?? "", "POST", "request HTTP method should be POST")
+        XCTAssertEqual(request.request.URL!, NSURL(string: URLString)!, "request URL should be equal")
+        XCTAssertNil(request.response, "response should be nil")
+    }
+
+    func testUploadClassMethodWithMethodURLHeadersAndStream() {
+        // Given
+        let URLString = "http://httpbin.org/"
+        let imageURL = URLForResource("rainbow", withExtension: "jpg")
+        let imageStream = NSInputStream(URL: imageURL)!
+
+        // When
+        let request = Alamofire.upload(.POST, URLString, headers: ["Authorization": "123456"], stream: imageStream)
+
+        // Then
+        XCTAssertNotNil(request.request, "request should not be nil")
+        XCTAssertEqual(request.request.HTTPMethod ?? "", "POST", "request HTTP method should be POST")
+        XCTAssertEqual(request.request.URL!, NSURL(string: URLString)!, "request URL should be equal")
+
+        let authorizationHeader = request.request.valueForHTTPHeaderField("Authorization") ?? ""
+        XCTAssertEqual(authorizationHeader, "123456", "Authorization header is incorrect")
+
+        XCTAssertNil(request.response, "response should be nil")
+    }
+}
+
+// MARK: -
+
 class UploadDataTestCase: BaseTestCase {
     func testUploadDataRequest() {
         // Given

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -37,7 +37,7 @@ class UploadDataTestCase: BaseTestCase {
         var error: NSError?
 
         // When
-        Alamofire.upload(.POST, URLString, data)
+        Alamofire.upload(.POST, URLString, data: data)
             .response { responseRequest, responseResponse, _, responseError in
                 request = responseRequest
                 response = responseResponse
@@ -76,7 +76,7 @@ class UploadDataTestCase: BaseTestCase {
         var responseError: NSError?
 
         // When
-        let upload = Alamofire.upload(.POST, URLString, data)
+        let upload = Alamofire.upload(.POST, URLString, data: data)
         upload.progress { bytesWritten, totalBytesWritten, totalBytesExpectedToWrite in
             let bytes = (bytes: bytesWritten, totalBytes: totalBytesWritten, totalBytesExpected: totalBytesExpectedToWrite)
             byteValues.append(bytes)


### PR DESCRIPTION
This PR contains several changes:

1. Modified internal `URLRequest(method:URLString:)` method to accept an optional `headers` dictionary and also made the return value an `NSMutableURLRequest` to make it easier to work with.
1. Extended the `request`, `upload` and `download` methods on `Manager` to accept an optional `headers` parameter.
1. Extended the global `request`, `upload` and `download` methods to accept an optional `headers` parameter.
1. Modified the global `upload` and `download` method external parameters to match the `request` method structure.
1. Added initialization tests for `request`, `upload` and `download` methods to ensure we can now create requests with and without custom headers.

This has been a feature that has been requested by a large portion of our community. Please see the following issues for more info: #27, #32, #99, #111, #113, #119 and #490.