### PR TITLE
Feature - Download Resume Data

### DIFF
--- a/Source/Download.swift
+++ b/Source/Download.swift
@@ -134,6 +134,17 @@ extension Request {
         }
     }
 
+    /// The resume data of the underlying download task if available after a failure.
+    public var resumeData: NSData? {
+        var data: NSData?
+
+        if let delegate = self.delegate as? DownloadTaskDelegate {
+            data = delegate.resumeData
+        }
+
+        return data
+    }
+
     // MARK: - DownloadTaskDelegate
 
     class DownloadTaskDelegate: TaskDelegate, NSURLSessionDownloadDelegate {

--- a/Source/Download.swift
+++ b/Source/Download.swift
@@ -141,7 +141,7 @@ extension Request {
         var downloadProgress: ((Int64, Int64, Int64) -> Void)?
 
         var resumeData: NSData?
-        override var data: NSData? { return resumeData }
+        override var data: NSData? { return self.resumeData }
 
         // MARK: - NSURLSessionDownloadDelegate
 

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -305,8 +305,16 @@ public class Request {
             if let taskDidCompleteWithError = self.taskDidCompleteWithError {
                 taskDidCompleteWithError(session, task, error)
             } else {
-                if error != nil {
+                if let error = error {
                     self.error = error
+
+                    if let
+                        downloadDelegate = self as? DownloadTaskDelegate,
+                        userInfo = error.userInfo as? [String: AnyObject],
+                        resumeData = userInfo[NSURLSessionDownloadTaskResumeData] as? NSData
+                    {
+                        downloadDelegate.resumeData = resumeData
+                    }
                 }
 
                 self.queue.suspended = false

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -253,6 +253,8 @@ class DownloadResumeDataTestCase: BaseTestCase {
         XCTAssertNil(response, "response should be nil")
         XCTAssertNil(data, "data should be nil")
         XCTAssertNotNil(error, "error should not be nil")
+
+        XCTAssertNil(download.resumeData, "resume data should be nil")
     }
 
     func testThatCancelledDownloadResponseDataMatchesResumeData() {

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -66,12 +66,8 @@ class DownloadInitializationTestCase: BaseTestCase {
 // MARK: -
 
 class DownloadResponseTestCase: BaseTestCase {
-    // MARK: - Properties
-
     let searchPathDirectory: NSSearchPathDirectory = .CachesDirectory
     let searchPathDomain: NSSearchPathDomainMask = .UserDomainMask
-
-    // MARK: - Tests
 
     func testDownloadRequest() {
         // Given
@@ -181,7 +177,7 @@ class DownloadResponseTestCase: BaseTestCase {
 
         // Then
         XCTAssertNotNil(responseRequest, "response request should not be nil")
-        XCTAssertNotNil(responseResponse, "response response should not be nil")
+        XCTAssertNotNil(responseResponse, "response should not be nil")
         XCTAssertNil(responseData, "response data should be nil")
         XCTAssertNil(responseError, "response error should be nil")
 
@@ -214,5 +210,125 @@ class DownloadResponseTestCase: BaseTestCase {
         var removalError: NSError?
         fileManager.removeItemAtURL(fileURL, error: &removalError)
         XCTAssertNil(removalError, "removal error should be nil")
+    }
+}
+
+// MARK: -
+
+class DownloadResumeDataTestCase: BaseTestCase {
+    let URLString = "https://upload.wikimedia.org/wikipedia/commons/6/69/NASA-HS201427a-HubbleUltraDeepField2014-20140603.jpg"
+    let destination: Request.DownloadFileDestination = {
+        let searchPathDirectory: NSSearchPathDirectory = .CachesDirectory
+        let searchPathDomain: NSSearchPathDomainMask = .UserDomainMask
+
+        return Request.suggestedDownloadDestination(directory: searchPathDirectory, domain: searchPathDomain)
+    }()
+
+    func testThatImmediatelyCancelledDownloadDoesNotHaveResumeDataAvailable() {
+        // Given
+        let expectation = expectationWithDescription("Download should be cancelled")
+
+        var request: NSURLRequest?
+        var response: NSHTTPURLResponse?
+        var data: AnyObject?
+        var error: NSError?
+
+        // When
+        let download = Alamofire.download(.GET, self.URLString, destination: self.destination)
+            .response { responseRequest, responseResponse, responseData, responseError in
+                request = responseRequest
+                response = responseResponse
+                data = responseData
+                error = responseError
+
+                expectation.fulfill()
+            }
+
+        download.cancel()
+
+        waitForExpectationsWithTimeout(self.defaultTimeout, handler: nil)
+
+        // Then
+        XCTAssertNotNil(request, "request should not be nil")
+        XCTAssertNil(response, "response should be nil")
+        XCTAssertNil(data, "data should be nil")
+        XCTAssertNotNil(error, "error should not be nil")
+    }
+
+    func testThatCancelledDownloadResponseDataMatchesResumeData() {
+        // Given
+        let expectation = expectationWithDescription("Download should be cancelled")
+
+        var request: NSURLRequest?
+        var response: NSHTTPURLResponse?
+        var data: AnyObject?
+        var error: NSError?
+
+        // When
+        let download = Alamofire.download(.GET, self.URLString, destination: self.destination)
+        download.progress { _, _, _ in
+            download.cancel()
+        }
+        download.response { responseRequest, responseResponse, responseData, responseError in
+            request = responseRequest
+            response = responseResponse
+            data = responseData
+            error = responseError
+
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(self.defaultTimeout, handler: nil)
+
+        // Then
+        XCTAssertNotNil(request, "request should not be nil")
+        XCTAssertNotNil(response, "response should not be nil")
+        XCTAssertNotNil(data, "data should not be nil")
+        XCTAssertNotNil(error, "error should not be nil")
+
+        XCTAssertNotNil(download.resumeData, "resume data should not be nil")
+
+        if let
+            responseData = data as? NSData,
+            resumeData = download.resumeData
+        {
+            XCTAssertEqual(responseData, resumeData, "response data should equal resume data")
+        } else {
+            XCTFail("response data or resume data was unexpectedly nil")
+        }
+    }
+
+    func testThatCancelledDownloadResumeDataIsAvailableWithJSONResponseSerializer() {
+        // Given
+        let expectation = expectationWithDescription("Download should be cancelled")
+
+        var request: NSURLRequest?
+        var response: NSHTTPURLResponse?
+        var JSON: AnyObject?
+        var error: NSError?
+
+        // When
+        let download = Alamofire.download(.GET, self.URLString, destination: self.destination)
+        download.progress { _, _, _ in
+            download.cancel()
+        }
+        download.responseJSON { responseRequest, responseResponse, responseJSON, responseError in
+            request = responseRequest
+            response = responseResponse
+            JSON = responseJSON
+            error = responseError
+
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(self.defaultTimeout, handler: nil)
+
+        // Then
+        XCTAssertNotNil(request, "request should not be nil")
+        XCTAssertNotNil(response, "response should not be nil")
+        XCTAssertNil(JSON, "JSON should be nil")
+        XCTAssertNotNil(error, "error should not be nil")
+
+        XCTAssertNotNil(download.resumeData, "resume data should not be nil")
     }
 }


### PR DESCRIPTION
This PR adds much better support for resume data with regards to download requests to address #141.

## Problem

Previously, there were only two ways to get resume data out of a request.

1. Cancel the request using the `Request.cancel()` method and retrieve the resume data from the `AnyObject?` in the `response` method.
1. Extract the resume data from the `error` returned in any of the `response` methods from the `userInfo` dictionary using the `NSURLSessionDownloadTaskResumeData` key.

The downsides to this is that you could only get direct access to the resume data by canceling the request. It would never be directly returned in the `response` method if it was interrupted by say a loss of network connection. Additionally, you could only ever access the resume data in the `response` parameters through either the `data` parameter in the event of a cancelled request, or through the `error` by digging the data out from the `userInfo` dictionary. This made it impossible to fetch the resume data without the use of the `response` serializers.

## Solution

To improve the resume data support, I made a couple of key changes that should make it MUCH easier to work with resume data.

1. For any failed download request, the resume data is automatically extracted out of the `error` object if it is available.
1. Added a `resumeData` computed property on the `Request` to allow you to access that data outside the `response` serialization methods. For example, you can now access the `resumeData` in any of the chained `Request` methods if you so choose.

  > This change coupled with the changes in #590 should give you complete customization control of the behavior of download requests and how the serial queue executes after completion.

I also added several tests around this behavior to demonstrate the usage and verify the behavior.