### PR TITLE
Potential Fix for Wildcard Accept Type Failing Validation

### DIFF
--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -117,6 +117,12 @@ extension Request {
                         return true
                     }
                 }
+            } else {
+                for contentType in acceptableContentTypes {
+                    if let MIMEType = MIMEType(contentType) where MIMEType.type == "*" && MIMEType.subtype == "*" {
+                        return true
+                    }
+                }
             }
 
             return false


### PR DESCRIPTION
This PR hopefully addresses Issue #510.

## Quick Problem Summary

The issue is described in detail [here](https://github.com/Alamofire/Alamofire/issues/510#issuecomment-112581617). The validation is failing if no `Content-Type` comes back in the response.

## Reproduction Attempts

I tried every http://httpbin.org trick in the book to recreate the issue they are seeing in #510, but was unsuccessful. I cannot trick the `NSHTTPURLResponse` into be so confused that it cannot guess what the `MIMEType` is. It always comes back valid. I would really like to have a test around this change, but just can't seem to get httpbin to do my bidding. If someone could provide a test, that would be amazing!

## Solution

The solution here seems pretty simple. A wildcard accept type `*/*` should always pass validation whether a `MIMEType` exists on the response or not. The current implementation will only pass if the MIMEType on the response is valid. Therefore, my change just adds a small condition that allows `Content-Type` validation to succeed if one of the acceptable content types was `*/*`. Additionally, I can't see any downsides of this change.

Since I can't get a test around this change, I'd love it if @allaire and/or @MartinRogalla could confirm that this change does in fact fix the issue they reported in #510.