### PR TITLE
Swift 2.0

### DIFF
--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -738,6 +738,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
+				GCC_OPTIMIZATION_LEVEL = 0;
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -747,6 +748,7 @@
 				PRODUCT_NAME = Alamofire;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Release;
 		};

--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -870,6 +870,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_OPTIMIZATION_LEVEL = 0;
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -878,6 +879,7 @@
 				PRODUCT_NAME = Alamofire;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Release;
 		};

--- a/Tests/ServerTrustPolicyTests.swift
+++ b/Tests/ServerTrustPolicyTests.swift
@@ -51,7 +51,7 @@ private struct TestCertificates {
         let data = NSData(contentsOfFile: filePath)!
         let certificate = SecCertificateCreateWithData(nil, data)!
 
-        return certificate
+        return certificate.takeRetainedValue()
     }
 }
 
@@ -79,12 +79,13 @@ private struct TestPublicKeys {
     static let LeafValidURI = TestPublicKeys.publicKeyForCertificate(TestCertificates.LeafValidURI)
 
     static func publicKeyForCertificate(certificate: SecCertificate) -> SecKey {
+        
+
         let policy = SecPolicyCreateBasicX509()
-        var trust: SecTrust?
-        SecTrustCreateWithCertificates(certificate, policy, &trust)
+        var trust: Unmanaged<SecTrust>?
+        SecTrustCreateWithCertificates(certificate, policy.takeRetainedValue(), &trust)
 
-        let publicKey = SecTrustCopyPublicKey(trust!)!
-
+        let publicKey = SecTrustCopyPublicKey(trust?.takeRetainedValue()).takeRetainedValue()
         return publicKey
     }
 }
@@ -185,10 +186,10 @@ private enum TestTrusts {
 
     static func trustWithCertificates(certificates: [SecCertificate]) -> SecTrust {
         let policy = SecPolicyCreateBasicX509()
-        var trust: SecTrust?
-        SecTrustCreateWithCertificates(certificates, policy, &trust)
+        var trust: Unmanaged<SecTrust>?
+        SecTrustCreateWithCertificates(certificates, policy.takeRetainedValue(), &trust)
 
-        return trust!
+        return trust!.takeRetainedValue()
     }
 }
 
@@ -231,7 +232,7 @@ class ServerTrustPolicyExplorationBasicX509PolicyValidationTestCase: ServerTrust
         setRootCertificateAsLoneAnchorCertificateForTrust(trust)
 
         // When
-        let policies = [SecPolicyCreateBasicX509()]
+        let policies = [SecPolicyCreateBasicX509().takeRetainedValue()]
         SecTrustSetPolicies(trust, policies)
 
         // Then
@@ -244,7 +245,7 @@ class ServerTrustPolicyExplorationBasicX509PolicyValidationTestCase: ServerTrust
         setRootCertificateAsLoneAnchorCertificateForTrust(trust)
 
         // When
-        let policies = [SecPolicyCreateBasicX509()]
+        let policies = [SecPolicyCreateBasicX509().takeRetainedValue()]
         SecTrustSetPolicies(trust, policies)
 
         // Then
@@ -257,7 +258,7 @@ class ServerTrustPolicyExplorationBasicX509PolicyValidationTestCase: ServerTrust
         setRootCertificateAsLoneAnchorCertificateForTrust(trust)
 
         // When
-        let policies = [SecPolicyCreateBasicX509()]
+        let policies = [SecPolicyCreateBasicX509().takeRetainedValue()]
         SecTrustSetPolicies(trust, policies)
 
         // Then
@@ -270,7 +271,7 @@ class ServerTrustPolicyExplorationBasicX509PolicyValidationTestCase: ServerTrust
         setRootCertificateAsLoneAnchorCertificateForTrust(trust)
 
         // When
-        let policies = [SecPolicyCreateBasicX509()]
+        let policies = [SecPolicyCreateBasicX509().takeRetainedValue()]
         SecTrustSetPolicies(trust, policies)
 
         // Then
@@ -292,7 +293,7 @@ class ServerTrustPolicyExplorationSSLPolicyValidationTestCase: ServerTrustPolicy
         setRootCertificateAsLoneAnchorCertificateForTrust(trust)
 
         // When
-        let policies = [SecPolicyCreateSSL(1, "test.alamofire.org")]
+        let policies = [SecPolicyCreateSSL(1, "test.alamofire.org").takeRetainedValue()]
         SecTrustSetPolicies(trust, policies)
 
         // Then
@@ -305,7 +306,7 @@ class ServerTrustPolicyExplorationSSLPolicyValidationTestCase: ServerTrustPolicy
         setRootCertificateAsLoneAnchorCertificateForTrust(trust)
 
         // When
-        let policies = [SecPolicyCreateSSL(1, "test.alamofire.org")]
+        let policies = [SecPolicyCreateSSL(1, "test.alamofire.org").takeRetainedValue()]
         SecTrustSetPolicies(trust, policies)
 
         // Then
@@ -318,7 +319,7 @@ class ServerTrustPolicyExplorationSSLPolicyValidationTestCase: ServerTrustPolicy
         setRootCertificateAsLoneAnchorCertificateForTrust(trust)
 
         // When
-        let policies = [SecPolicyCreateSSL(1, "test.alamofire.org")]
+        let policies = [SecPolicyCreateSSL(1, "test.alamofire.org").takeRetainedValue()]
         SecTrustSetPolicies(trust, policies)
 
         // Then
@@ -331,7 +332,7 @@ class ServerTrustPolicyExplorationSSLPolicyValidationTestCase: ServerTrustPolicy
         setRootCertificateAsLoneAnchorCertificateForTrust(trust)
 
         // When
-        let policies = [SecPolicyCreateSSL(1, "test.alamofire.org")]
+        let policies = [SecPolicyCreateSSL(1, "test.alamofire.org").takeRetainedValue()]
         SecTrustSetPolicies(trust, policies)
 
         // Then
@@ -344,7 +345,7 @@ class ServerTrustPolicyExplorationSSLPolicyValidationTestCase: ServerTrustPolicy
         setRootCertificateAsLoneAnchorCertificateForTrust(trust)
 
         // When
-        let policies = [SecPolicyCreateSSL(1, "test.alamofire.org")]
+        let policies = [SecPolicyCreateSSL(1, "test.alamofire.org").takeRetainedValue()]
         SecTrustSetPolicies(trust, policies)
 
         // Then
@@ -357,7 +358,7 @@ class ServerTrustPolicyExplorationSSLPolicyValidationTestCase: ServerTrustPolicy
         setRootCertificateAsLoneAnchorCertificateForTrust(trust)
 
         // When
-        let policies = [SecPolicyCreateSSL(1, "test.alamofire.org")]
+        let policies = [SecPolicyCreateSSL(1, "test.alamofire.org").takeRetainedValue()]
         SecTrustSetPolicies(trust, policies)
 
         // Then
@@ -371,9 +372,9 @@ class ServerTrustPolicyExplorationSSLPolicyValidationTestCase: ServerTrustPolicy
 
         // When
         let policies = [
-            SecPolicyCreateSSL(1, "test.alamofire.org"),
-            SecPolicyCreateSSL(1, "blog.alamofire.org"),
-            SecPolicyCreateSSL(1, "www.alamofire.org")
+            SecPolicyCreateSSL(1, "test.alamofire.org").takeRetainedValue(),
+            SecPolicyCreateSSL(1, "blog.alamofire.org").takeRetainedValue(),
+            SecPolicyCreateSSL(1, "www.alamofire.org").takeRetainedValue()
         ]
         SecTrustSetPolicies(trust, policies)
 
@@ -387,7 +388,7 @@ class ServerTrustPolicyExplorationSSLPolicyValidationTestCase: ServerTrustPolicy
         setRootCertificateAsLoneAnchorCertificateForTrust(trust)
 
         // When
-        let policies = [SecPolicyCreateSSL(1, nil)]
+        let policies = [SecPolicyCreateSSL(1, nil).takeRetainedValue()]
         SecTrustSetPolicies(trust, policies)
 
         // Then
@@ -400,7 +401,7 @@ class ServerTrustPolicyExplorationSSLPolicyValidationTestCase: ServerTrustPolicy
         setRootCertificateAsLoneAnchorCertificateForTrust(trust)
 
         // When
-        let policies = [SecPolicyCreateSSL(1, "test.alamofire.org")]
+        let policies = [SecPolicyCreateSSL(1, "test.alamofire.org").takeRetainedValue()]
         SecTrustSetPolicies(trust, policies)
 
         // Then

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -35,7 +35,7 @@ private struct TestCertificates {
         let data = NSData(contentsOfFile: filePath)!
         let certificate = SecCertificateCreateWithData(nil, data)!
 
-        return certificate
+        return certificate.takeRetainedValue()
     }
 }
 
@@ -48,10 +48,10 @@ private struct TestPublicKeys {
 
     static func publicKeyForCertificate(certificate: SecCertificate) -> SecKey {
         let policy = SecPolicyCreateBasicX509()
-        var trust: SecTrust?
-        SecTrustCreateWithCertificates(certificate, policy, &trust)
+        var trust: Unmanaged<SecTrust>?
+        SecTrustCreateWithCertificates(certificate, policy.takeRetainedValue(), &trust)
 
-        let publicKey = SecTrustCopyPublicKey(trust!)!
+        let publicKey = SecTrustCopyPublicKey(trust!.takeRetainedValue()).takeRetainedValue()
 
         return publicKey
     }


### PR DESCRIPTION
I ran into the same issues as mentioned here:
https://github.com/Alamofire/Alamofire/issues/610

Forking and doing my own exploration, I found a number of type errors. Using the method `takeRetainedValue()` alleviated those errors. Additionally, I could not get release versions to build unless I shut off optimization.

If optimization is on, it throws the following error (full directory paths removed):

```swift
Assertion failed: (isa<X>(Val) && "cast<Ty>() argument of incompatible type!"), function cast, file /Library/Caches/com.apple.xbs/Sources/swiftlang/swiftlang-700.0.45/src/llvm/include/llvm/Support/Casting.h, line 237.
0  swift                    0x00000001104a501b llvm::sys::PrintStackTrace(__sFILE*) + 43
1  swift                    0x00000001104a575b SignalHandler(int) + 379
2  libsystem_platform.dylib 0x00007fff8674cf1a _sigtramp + 26
3  libsystem_platform.dylib 0x00007ffd745349a0 _sigtramp + 3990780576
4  libsystem_c.dylib        0x00007fff88bd6b53 abort + 129
5  libsystem_c.dylib        0x00007fff88b9ec39 basename + 0
6  swift                    0x000000010e9c4d20 hoistOrCopySelf(swift::ApplyInst*, swift::SILInstruction*, swift::DominanceInfo*, bool) + 624
7  swift                    0x000000010e9c46ff swift::ArraySemanticsCall::hoistOrCopy(swift::SILInstruction*, swift::DominanceInfo*, bool) + 319
8  swift                    0x000000010e817edb (anonymous namespace)::SwiftArrayOptPass::run() + 4283
9  swift                    0x000000010e78b49e swift::SILPassManager::runFunctionPasses(llvm::ArrayRef<swift::SILFunctionTransform*>) + 1598
10 swift                    0x000000010e78c118 swift::SILPassManager::runOneIteration() + 984
11 swift                    0x000000010e7890c4 swift::runSILOptimizationPasses(swift::SILModule&) + 500
12 swift                    0x000000010e497ff8 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&) + 9576
13 swift                    0x000000010e495873 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2515
14 swift                    0x000000010e4919ff main + 1983
15 libdyld.dylib            0x00007fff8b56a5c9 start + 1
Stack dump:
0.	Program arguments: /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift -frontend -c PATH_TO_ALAMO/Alamofire/Source/Upload.swift PATH_TO_ALAMO/Alamofire/Source/ParameterEncoding.swift PATH_TO_ALAMO/Alamofire/Source/Request.swift PATH_TO_ALAMO/Alamofire/Source/ResponseSerialization.swift PATH_TO_ALAMO/Alamofire/Source/Manager.swift PATH_TO_ALAMO/Alamofire/Source/Alamofire.swift PATH_TO_ALAMO/Alamofire/Source/MultipartFormData.swift -primary-file PATH_TO_ALAMO/Alamofire/Source/ServerTrustPolicy.swift PATH_TO_ALAMO/Alamofire/Source/Download.swift PATH_TO_ALAMO/Alamofire/Source/Validation.swift -target x86_64-apple-ios8.0 -enable-objc-interop -sdk /Applications/Xcode-beta.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator9.0.sdk -I HOME/Library/Developer/Xcode/DerivedData/Alamofire-gtihnsuowttctwaxgdndjwvmkgvf/Build/Products/Release-iphonesimulator -F HOME/Library/Developer/Xcode/DerivedData/Alamofire-gtihnsuowttctwaxgdndjwvmkgvf/Build/Products/Release-iphonesimulator -application-extension -g -import-underlying-module -module-cache-path HOME/Library/Developer/Xcode/DerivedData/ModuleCache -serialize-debugging-options -Xcc -IHOME/Library/Developer/Xcode/DerivedData/Alamofire-gtihnsuowttctwaxgdndjwvmkgvf/Build/Intermediates/Alamofire.build/Release-iphonesimulator/Alamofire iOS.build/swift-overrides.hmap -Xcc -iquote -Xcc HOME/Library/Developer/Xcode/DerivedData/Alamofire-gtihnsuowttctwaxgdndjwvmkgvf/Build/Intermediates/Alamofire.build/Release-iphonesimulator/Alamofire iOS.build/Alamofire-generated-files.hmap -Xcc -IHOME/Library/Developer/Xcode/DerivedData/Alamofire-gtihnsuowttctwaxgdndjwvmkgvf/Build/Intermediates/Alamofire.build/Release-iphonesimulator/Alamofire iOS.build/Alamofire-own-target-headers.hmap -Xcc -IHOME/Library/Developer/Xcode/DerivedData/Alamofire-gtihnsuowttctwaxgdndjwvmkgvf/Build/Intermediates/Alamofire.build/Release-iphonesimulator/Alamofire iOS.build/Alamofire-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc HOME/Library/Developer/Xcode/DerivedData/Alamofire-gtihnsuowttctwaxgdndjwvmkgvf/Build/Intermediates/Alamofire.build/all-product-headers.yaml -Xcc -iquote -Xcc HOME/Library/Developer/Xcode/DerivedData/Alamofire-gtihnsuowttctwaxgdndjwvmkgvf/Build/Intermediates/Alamofire.build/Release-iphonesimulator/Alamofire iOS.build/Alamofire-project-headers.hmap -Xcc -IHOME/Library/Developer/Xcode/DerivedData/Alamofire-gtihnsuowttctwaxgdndjwvmkgvf/Build/Products/Release-iphonesimulator/include -Xcc -IHOME/Library/Developer/Xcode/DerivedData/Alamofire-gtihnsuowttctwaxgdndjwvmkgvf/Build/Intermediates/Alamofire.build/Release-iphonesimulator/Alamofire iOS.build/DerivedSources/x86_64 -Xcc -IHOME/Library/Developer/Xcode/DerivedData/Alamofire-gtihnsuowttctwaxgdndjwvmkgvf/Build/Intermediates/Alamofire.build/Release-iphonesimulator/Alamofire iOS.build/DerivedSources -Xcc -ivfsoverlay -Xcc HOME/Library/Developer/Xcode/DerivedData/Alamofire-gtihnsuowttctwaxgdndjwvmkgvf/Build/Intermediates/Alamofire.build/Release-iphonesimulator/Alamofire iOS.build/unextended-module-overlay.yaml -Xcc -working-directoryPATH_TO_ALAMO/Alamofire -emit-module-doc-path HOME/Library/Developer/Xcode/DerivedData/Alamofire-gtihnsuowttctwaxgdndjwvmkgvf/Build/Intermediates/Alamofire.build/Release-iphonesimulator/Alamofire iOS.build/Objects-normal/x86_64/ServerTrustPolicy~partial.swiftdoc -O -module-name Alamofire -emit-module-path HOME/Library/Developer/Xcode/DerivedData/Alamofire-gtihnsuowttctwaxgdndjwvmkgvf/Build/Intermediates/Alamofire.build/Release-iphonesimulator/Alamofire iOS.build/Objects-normal/x86_64/ServerTrustPolicy~partial.swiftmodule -serialize-diagnostics-path HOME/Library/Developer/Xcode/DerivedData/Alamofire-gtihnsuowttctwaxgdndjwvmkgvf/Build/Intermediates/Alamofire.build/Release-iphonesimulator/Alamofire iOS.build/Objects-normal/x86_64/ServerTrustPolicy.dia -emit-dependencies-path HOME/Library/Developer/Xcode/DerivedData/Alamofire-gtihnsuowttctwaxgdndjwvmkgvf/Build/Intermediates/Alamofire.build/Release-iphonesimulator/Alamofire iOS.build/Objects-normal/x86_64/ServerTrustPolicy.d -emit-reference-dependencies-path HOME/Library/Developer/Xcode/DerivedData/Alamofire-gtihnsuowttctwaxgdndjwvmkgvf/Build/Intermediates/Alamofire.build/Release-iphonesimulator/Alamofire iOS.build/Objects-normal/x86_64/ServerTrustPolicy.swiftdeps -o HOME/Library/Developer/Xcode/DerivedData/Alamofire-gtihnsuowttctwaxgdndjwvmkgvf/Build/Intermediates/Alamofire.build/Release-iphonesimulator/Alamofire iOS.build/Objects-normal/x86_64/ServerTrustPolicy.o 
1.	While running SILFunctionTransform "SIL Swift Array Optimization" on SILFunction "@_TFO9Alamofire17ServerTrustPolicy19evaluateServerTrustfS0_FTCSo8SecTrust14isValidForHostSS_Sb".
```