### PR TITLE
Feature - Opening up ParameterEncoding

### DIFF
--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -84,7 +84,7 @@ public enum ParameterEncoding {
             func query(parameters: [String: AnyObject]) -> String {
                 var components: [(String, String)] = []
                 for key in Array(parameters.keys).sort(<) {
-                    let value: AnyObject! = parameters[key]
+                    let value = parameters[key]!
                     components += queryComponents(key, value)
                 }
 
@@ -145,7 +145,15 @@ public enum ParameterEncoding {
         return (mutableURLRequest, encodingError)
     }
 
-    func queryComponents(key: String, _ value: AnyObject) -> [(String, String)] {
+    /**
+        Creates percent-escaped, URL encoded query string components from the given key-value pair using recursion.
+
+        - parameter key:   The key of the query component.
+        - parameter value: The value of the query component.
+
+        - returns: The percent-escaped, URL encoded query string components.
+    */
+    public func queryComponents(key: String, _ value: AnyObject) -> [(String, String)] {
         var components: [(String, String)] = []
         if let dictionary = value as? [String: AnyObject] {
             for (nestedKey, value) in dictionary {
@@ -163,7 +171,7 @@ public enum ParameterEncoding {
     }
 
     /**
-        Returns a percent escaped string following RFC 3986 for a query string key or value.
+        Returns a percent-escaped string following RFC 3986 for a query string key or value.
 
         RFC 3986 states that the following characters are "reserved" characters.
 
@@ -172,13 +180,13 @@ public enum ParameterEncoding {
 
         In RFC 3986 - Section 3.4, it states that the "?" and "/" characters should not be escaped to allow
         query strings to include a URL. Therefore, all "reserved" characters with the exception of "?" and "/"
-        should be percent escaped in the query string.
+        should be percent-escaped in the query string.
 
-        - parameter string: The string to be percent escaped.
+        - parameter string: The string to be percent-escaped.
 
-        - returns: The percent escaped string.
+        - returns: The percent-escaped string.
     */
-    func escape(string: String) -> String {
+    public func escape(string: String) -> String {
         let generalDelimitersToEncode = ":#[]@" // does not include "?" or "/" due to RFC 3986 - Section 3.4
         let subDelimitersToEncode = "!$&'()*+,;="
 


### PR DESCRIPTION
This PR changes the `queryComponents` and `escape` method ACLs from `internal` to `public`. This will make it easier for those implementing a `.Custom` parameter encoding. Right now if you need to use either function in a `.Custom` case, you have to implement both of these methods on your own.