### PR TITLE
updated iOS availability conditions

### DIFF
--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -256,7 +256,7 @@ public class MultipartFormData {
 
         var isReachable = true
 
-        if #available(OSX 10.10, *) {
+        if #available(OSX 10.10, iOS 8.0, *) {
             isReachable = fileURL.checkPromisedItemIsReachableAndReturnError(nil)
         }
 

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -205,7 +205,7 @@ public class Request {
                 operationQueue.maxConcurrentOperationCount = 1
                 operationQueue.suspended = true
 
-                if #available(OSX 10.10, *) {
+                if #available(OSX 10.10, iOS 8.0, *) {
                     operationQueue.qualityOfService = NSQualityOfService.Utility
                 }
 


### PR DESCRIPTION
This adds missing minimum iOS version specifiers in some `#availability` clauses.