### PR TITLE
@jriehn more flexible server trust policy via public method

### DIFF
--- a/Source/ServerTrustPolicy.swift
+++ b/Source/ServerTrustPolicy.swift
@@ -42,7 +42,7 @@ public class ServerTrustPolicyManager {
         self.policies = policies
     }
 
-    func serverTrustPolicyForHost(host: String) -> ServerTrustPolicy? {
+    public func serverTrustPolicyForHost(host: String) -> ServerTrustPolicy? {
         return policies[host]
     }
 }


### PR DESCRIPTION
Hello,

as given in the documentation "...it is important to have the flexibility to specify evaluation policies on a per host basis." In addition it should also be possible to enabled a mapping on domain level or even for wildcards. 

By enriching the visibility of the server trust policy we enable clients to implement specific requirements.

Cheers,

Jan