### PR TITLE
Update ResponseSerialization.swift

### DIFF
--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -106,11 +106,14 @@ extension Request {
         -> Self
     {
         delegate.queue.addOperationWithBlock {
-            var result = responseSerializer.serializeResponse(self.request, self.response, self.delegate.data)
-
-            if let error = self.delegate.error {
-                result = .Failure(self.delegate.data, error)
-            }
+            
+            let result: Result<T.SerializedObject> = {
+                if let error = self.delegate.error {
+                    return .Failure(self.delegate.data, error)
+                } else {
+                    return responseSerializer.serializeResponse(self.request, self.response, self.delegate.data)
+                }
+            }()
 
             dispatch_async(queue ?? dispatch_get_main_queue()) {
                 completionHandler(self.request, self.response, result)

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -106,7 +106,6 @@ extension Request {
         -> Self
     {
         delegate.queue.addOperationWithBlock {
-            
             let result: Result<T.SerializedObject> = {
                 if let error = self.delegate.error {
                     return .Failure(self.delegate.data, error)


### PR DESCRIPTION
Prevent unnecessary call to the response serialiser in case of an error picked up by the TaskDelegate.