### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ let manager = Alamofire.Manager(configuration: configuration)
 #### Creating a Manager with Background Configuration
 
 ```swift
-let configuration = NSURLSessionConfiguration.backgroundSessionConfiguration("com.example.app.background")
+let configuration = NSURLSessionConfiguration.backgroundSessionConfigurationWithIdentifier("com.example.app.background")
 let manager = Alamofire.Manager(configuration: configuration)
 ```
 


### PR DESCRIPTION
In README.md section "Creating a Manager with Background Configuration": replaced reference to deprecated method backgroundSessionConfiguration of NSURLSessionConfiguration with the new method as of iOS 8.0 called backgroundSessionConfigurationWithIdentifier