### PR TITLE
Added `URLEncodedInURL` case to Parameter Encoding

### DIFF
--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -36,23 +36,32 @@ public enum Method: String {
 /**
     Used to specify the way in which a set of parameters are applied to a URL request.
 
-    - URL:          A query string to be set as or appended to any existing URL query for `GET`, `HEAD`, and `DELETE` 
-                    requests, or set as the body for requests with any other HTTP method. The `Content-Type` HTTP header 
-                    field of an encoded request with HTTP body is set to `application/x-www-form-urlencoded`. Since 
-                    there is no published specification for how to encode collection types, the convention of appending 
-                    `[]` to the key for array values (`foo[]=1&foo[]=2`), and appending the key surrounded by square 
-                    brackets for nested dictionary values (`foo[bar]=baz`).
-    - JSON:         Uses `NSJSONSerialization` to create a JSON representation of the parameters object, which is set as 
-                    the body of the request. The `Content-Type` HTTP header field of an encoded request is set to 
-                    `application/json`.
-    - PropertyList: Uses `NSPropertyListSerialization` to create a plist representation of the parameters object, 
-                    according to the associated format and write options values, which is set as the body of the 
-                    request. The `Content-Type` HTTP header field of an encoded request is set to `application/x-plist`.
-    - Custom:       Uses the associated closure value to construct a new request given an existing request and 
-                    parameters.
+    - `URL`:             Creates a query string to be set as or appended to any existing URL query for `GET`, `HEAD`, 
+                         and `DELETE` requests, or set as the body for requests with any other HTTP method. The 
+                         `Content-Type` HTTP header field of an encoded request with HTTP body is set to
+                         `application/x-www-form-urlencoded; charset=utf-8`. Since there is no published specification
+                         for how to encode collection types, the convention of appending `[]` to the key for array
+                         values (`foo[]=1&foo[]=2`), and appending the key surrounded by square brackets for nested
+                         dictionary values (`foo[bar]=baz`).
+
+    - `URLEncodedInURL`: Creates query string to be set as or appended to any existing URL query. Uses the same
+                         implementation as the `.URL` case, but always applies the encoded result to the URL.
+
+    - `JSON`:            Uses `NSJSONSerialization` to create a JSON representation of the parameters object, which is 
+                         set as the body of the request. The `Content-Type` HTTP header field of an encoded request is 
+                         set to `application/json`.
+
+    - `PropertyList`:    Uses `NSPropertyListSerialization` to create a plist representation of the parameters object,
+                         according to the associated format and write options values, which is set as the body of the
+                         request. The `Content-Type` HTTP header field of an encoded request is set to
+                         `application/x-plist`.
+
+    - `Custom`:          Uses the associated closure value to construct a new request given an existing request and
+                         parameters.
 */
 public enum ParameterEncoding {
     case URL
+    case URLEncodedInURL
     case JSON
     case PropertyList(NSPropertyListFormat, NSPropertyListWriteOptions)
     case Custom((URLRequestConvertible, [String: AnyObject]?) -> (NSMutableURLRequest, NSError?))
@@ -80,7 +89,7 @@ public enum ParameterEncoding {
         var encodingError: NSError? = nil
 
         switch self {
-        case .URL:
+        case .URL, .URLEncodedInURL:
             func query(parameters: [String: AnyObject]) -> String {
                 var components: [(String, String)] = []
                 for key in Array(parameters.keys).sort(<) {
@@ -92,6 +101,13 @@ public enum ParameterEncoding {
             }
 
             func encodesParametersInURL(method: Method) -> Bool {
+                switch self {
+                case .URLEncodedInURL:
+                    return true
+                default:
+                    break
+                }
+
                 switch method {
                 case .GET, .HEAD, .DELETE:
                     return true

--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -352,7 +352,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
 
     // MARK: Tests - Varying HTTP Methods
 
-    func testURLParameterEncodeGETParametersInURL() {
+    func testThatURLParameterEncodingEncodesGETParametersInURL() {
         // Given
         let mutableURLRequest = self.URLRequest.URLRequest
         mutableURLRequest.HTTPMethod = Method.GET.rawValue
@@ -367,7 +367,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
         XCTAssertNil(URLRequest.HTTPBody, "HTTPBody should be nil")
     }
 
-    func testURLParameterEncodePOSTParametersInHTTPBody() {
+    func testThatURLParameterEncodingEncodesPOSTParametersInHTTPBody() {
         // Given
         let mutableURLRequest = self.URLRequest.URLRequest
         mutableURLRequest.HTTPMethod = Method.POST.rawValue
@@ -392,6 +392,21 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
         } else {
             XCTFail("decoded http body should not be nil")
         }
+    }
+
+    func testThatURLEncodedInURLParameterEncodingEncodesPOSTParametersInURL() {
+        // Given
+        let mutableURLRequest = self.URLRequest.URLRequest
+        mutableURLRequest.HTTPMethod = Method.POST.rawValue
+        let parameters = ["foo": 1, "bar": 2]
+
+        // When
+        let (URLRequest, _) = ParameterEncoding.URLEncodedInURL.encode(mutableURLRequest, parameters: parameters)
+
+        // Then
+        XCTAssertEqual(URLRequest.URL?.query ?? "", "bar=2&foo=1", "query is incorrect")
+        XCTAssertNil(URLRequest.valueForHTTPHeaderField("Content-Type"), "Content-Type should be nil")
+        XCTAssertNil(URLRequest.HTTPBody, "HTTPBody should be nil")
     }
 }
 


### PR DESCRIPTION
This has been a long withstanding problem that has been reported and questions many times on GitHub or Stack Overflow (#283, #374, #623, #646). Issue #374 has a wealth of information about the different options and a healthy debate between @mattt and @mxl. For this particular issue, I tend to side with @mxl.

Having personally had to deal with services constantly that require appending parameters to the query string for .POST and .PUT methods, I felt it was time to add support into Alamofire to make this situation more palatable for everyone. The main challenge is avoid complicating the `ParameterEncoding` enumeration to keep it simple even though we need to add another case or condition. I think this change strikes a nice balance.

I tried to update the documentation to make it as clear as possible to understand the differences between the two cases.

Other alternatives I consider were `.URLEncodedInQueryString` (too verbose), `.URLQuery` (too vague), and also adding a flag to the `.URL` case such as `.URL(encodedInURL: Bool)`. The problem with this approach is that you cannot specify a default parameter in an associated value.