### PR TITLE
Add compatibility checks for pre-iOS 8.

### DIFF
--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -256,8 +256,8 @@ public class MultipartFormData {
 
         var isReachable = true
 
-        if #available(OSX 10.10, *) {
-            isReachable = fileURL.checkPromisedItemIsReachableAndReturnError(nil)
+        if #available(OSX 10.10, *), #available(iOS 8.0, *) {
+			isReachable = fileURL.checkPromisedItemIsReachableAndReturnError(nil)
         }
 
         guard isReachable else {

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -205,8 +205,8 @@ public class Request {
                 operationQueue.maxConcurrentOperationCount = 1
                 operationQueue.suspended = true
 
-                if #available(OSX 10.10, *) {
-                    operationQueue.qualityOfService = NSQualityOfService.Utility
+				if #available(OSX 10.10, *), #available(iOS 8.0, *) {
+					operationQueue.qualityOfService = NSQualityOfService.Utility
                 }
 
                 return operationQueue


### PR DESCRIPTION
When the library is included as source for projects targetting iOS 7.0, the compiler fails because of this compatibility check.