### PR TITLE
Fix link to the 2.0 upgrade guide in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Alamofire is an HTTP networking library written in Swift.
 
 ## Migration Guides
 
-- [Alamofire 2.0 Migration Guide](https://github.com/Alamofire/Alamofire/blob/swift-2.0/Documentation/Alamofire%202.0%20Migration%20Guide.md)
+- [Alamofire 2.0 Migration Guide](https://github.com/Alamofire/Alamofire/blob/master/Documentation/Alamofire%202.0%20Migration%20Guide.md)
 
 ## Communication
 


### PR DESCRIPTION
Now that the `swift-2.0` branch has been merged and deleted the migration guide is located on the `master` branch.