### PR TITLE
Feature - Double Generic Result Type

### DIFF
--- a/Example/DetailViewController.swift
+++ b/Example/DetailViewController.swift
@@ -75,7 +75,7 @@ class DetailViewController: UITableViewController {
         refreshControl?.beginRefreshing()
 
         let start = CACurrentMediaTime()
-        request.responseString { request, response, result in
+        request.responseString { request, response, _, result in
             let end = CACurrentMediaTime()
             self.elapsedTime = end - start
 

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -193,7 +193,7 @@ public class Request {
         let progress: NSProgress
 
         var data: NSData? { return nil }
-        var error: ErrorType?
+        var error: NSError?
 
         var credential: NSURLCredential?
 

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -30,6 +30,8 @@ import Foundation
 public protocol ResponseSerializer {
     /// The type of serialized object to be created by this `ResponseSerializer`.
     typealias SerializedObject
+
+    /// The type of error to be created by this `ResponseSerializer` if serialization fails.
     typealias Error: ErrorType
 
     /**

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -35,9 +35,9 @@ public protocol ResponseSerializer {
     typealias Error: ErrorType
 
     /**
-        A closure used by response handlers that takes a request, response, and data and returns a result.
+        A closure used by response handlers that takes a request, response, data and error and returns a result.
     */
-    var serializeResponse: (NSURLRequest?, NSHTTPURLResponse?, NSData?) -> Result<SerializedObject, Error> { get }
+    var serializeResponse: (NSURLRequest?, NSHTTPURLResponse?, NSData?, NSError?) -> Result<SerializedObject, Error> { get }
 }
 
 // MARK: -
@@ -53,9 +53,9 @@ public struct GenericResponseSerializer<T, E: ErrorType>: ResponseSerializer {
     public typealias Error = E
 
     /**
-        A closure used by response handlers that takes a request, response, and data and returns a result.
+        A closure used by response handlers that takes a request, response, data and error and returns a result.
     */
-    public var serializeResponse: (NSURLRequest?, NSHTTPURLResponse?, NSData?) -> Result<T, E>
+    public var serializeResponse: (NSURLRequest?, NSHTTPURLResponse?, NSData?, NSError?) -> Result<T, E>
 
     /**
         Initializes the `GenericResponseSerializer` instance with the given serialize response closure.
@@ -64,7 +64,7 @@ public struct GenericResponseSerializer<T, E: ErrorType>: ResponseSerializer {
 
         - returns: The new generic response serializer instance.
     */
-    public init(serializeResponse: (NSURLRequest?, NSHTTPURLResponse?, NSData?) -> Result<T, E>) {
+    public init(serializeResponse: (NSURLRequest?, NSHTTPURLResponse?, NSData?, NSError?) -> Result<T, E>) {
         self.serializeResponse = serializeResponse
     }
 }
@@ -112,7 +112,12 @@ extension Request {
         -> Self
     {
         delegate.queue.addOperationWithBlock {
-            let result = responseSerializer.serializeResponse(self.request, self.response, self.delegate.data)
+            let result = responseSerializer.serializeResponse(
+                self.request,
+                self.response,
+                self.delegate.data,
+                self.delegate.error
+            )
 
             dispatch_async(queue ?? dispatch_get_main_queue()) {
                 completionHandler(self.request, self.response, self.delegate.data, result)
@@ -133,7 +138,9 @@ extension Request {
         - returns: A data response serializer.
     */
     public static func dataResponseSerializer() -> GenericResponseSerializer<NSData, NSError> {
-        return GenericResponseSerializer { _, _, data in
+        return GenericResponseSerializer { _, _, data, error in
+            guard error == nil else { return .Failure(error!) }
+
             guard let validData = data where validData.length > 0 else {
                 let failureReason = "Data could not be serialized. Input data was nil or zero length."
                 let error = Error.errorWithCode(.DataSerializationFailed, failureReason: failureReason)
@@ -178,7 +185,9 @@ extension Request {
         var encoding encoding: NSStringEncoding? = nil)
         -> GenericResponseSerializer<String, NSError>
     {
-        return GenericResponseSerializer { _, response, data in
+        return GenericResponseSerializer { _, response, data, error in
+            guard error == nil else { return .Failure(error!) }
+
             guard let validData = data where validData.length > 0 else {
                 let failureReason = "String could not be serialized. Input data was nil or zero length."
                 let error = Error.errorWithCode(.StringSerializationFailed, failureReason: failureReason)
@@ -243,7 +252,9 @@ extension Request {
         options options: NSJSONReadingOptions = .AllowFragments)
         -> GenericResponseSerializer<AnyObject, NSError>
     {
-        return GenericResponseSerializer { _, _, data in
+        return GenericResponseSerializer { _, _, data, error in
+            guard error == nil else { return .Failure(error!) }
+
             guard let validData = data where validData.length > 0 else {
                 let failureReason = "JSON could not be serialized. Input data was nil or zero length."
                 let error = Error.errorWithCode(.JSONSerializationFailed, failureReason: failureReason)
@@ -297,7 +308,9 @@ extension Request {
         options options: NSPropertyListReadOptions = NSPropertyListReadOptions())
         -> GenericResponseSerializer<AnyObject, NSError>
     {
-        return GenericResponseSerializer { _, _, data in
+        return GenericResponseSerializer { _, _, data, error in
+            guard error == nil else { return .Failure(error!) }
+
             guard let validData = data where validData.length > 0 else {
                 let failureReason = "Property list could not be serialized. Input data was nil or zero length."
                 let error = Error.errorWithCode(.PropertyListSerializationFailed, failureReason: failureReason)

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -102,7 +102,7 @@ extension Request {
     public func response<T: ResponseSerializer, V where T.SerializedObject == V>(
         queue queue: dispatch_queue_t? = nil,
         responseSerializer: T,
-        completionHandler: (NSURLRequest?, NSHTTPURLResponse?, Result<V>) -> Void)
+        completionHandler: (NSURLRequest?, NSHTTPURLResponse?, NSData?, Result<V>) -> Void)
         -> Self
     {
         delegate.queue.addOperationWithBlock {
@@ -115,7 +115,7 @@ extension Request {
             }()
 
             dispatch_async(queue ?? dispatch_get_main_queue()) {
-                completionHandler(self.request, self.response, result)
+                completionHandler(self.request, self.response, self.delegate.data, result)
             }
         }
 
@@ -151,7 +151,7 @@ extension Request {
 
         - returns: The request.
     */
-    public func responseData(completionHandler: (NSURLRequest?, NSHTTPURLResponse?, Result<NSData>) -> Void) -> Self {
+    public func responseData(completionHandler: (NSURLRequest?, NSHTTPURLResponse?, NSData?, Result<NSData>) -> Void) -> Self {
         return response(responseSerializer: Request.dataResponseSerializer(), completionHandler: completionHandler)
     }
 }
@@ -212,7 +212,7 @@ extension Request {
     */
     public func responseString(
         encoding encoding: NSStringEncoding? = nil,
-        completionHandler: (NSURLRequest?, NSHTTPURLResponse?, Result<String>) -> Void)
+        completionHandler: (NSURLRequest?, NSHTTPURLResponse?, NSData?, Result<String>) -> Void)
         -> Self
     {
         return response(
@@ -266,7 +266,7 @@ extension Request {
     */
     public func responseJSON(
         options options: NSJSONReadingOptions = .AllowFragments,
-        completionHandler: (NSURLRequest?, NSHTTPURLResponse?, Result<AnyObject>) -> Void)
+        completionHandler: (NSURLRequest?, NSHTTPURLResponse?, NSData?, Result<AnyObject>) -> Void)
         -> Self
     {
         return response(
@@ -320,7 +320,7 @@ extension Request {
     */
     public func responsePropertyList(
         options options: NSPropertyListReadOptions = NSPropertyListReadOptions(),
-        completionHandler: (NSURLRequest?, NSHTTPURLResponse?, Result<AnyObject>) -> Void)
+        completionHandler: (NSURLRequest?, NSHTTPURLResponse?, NSData?, Result<AnyObject>) -> Void)
         -> Self
     {
         return response(

--- a/Source/Result.swift
+++ b/Source/Result.swift
@@ -30,9 +30,9 @@ import Foundation
     - Failure: The request encountered an error resulting in a failure. The associated values are the original data 
                provided by the server as well as the error that caused the failure.
 */
-public enum Result<Value> {
+public enum Result<Value, Error: ErrorType> {
     case Success(Value)
-    case Failure(NSData?, ErrorType)
+    case Failure(Error)
 
     /// Returns `true` if the result is a success, `false` otherwise.
     public var isSuccess: Bool {
@@ -59,22 +59,12 @@ public enum Result<Value> {
         }
     }
 
-    /// Returns the associated data value if the result is a failure, `nil` otherwise.
-    public var data: NSData? {
-        switch self {
-        case .Success:
-            return nil
-        case .Failure(let data, _):
-            return data
-        }
-    }
-
     /// Returns the associated error value if the result is a failure, `nil` otherwise.
-    public var error: ErrorType? {
+    public var error: Error? {
         switch self {
         case .Success:
             return nil
-        case .Failure(_, let error):
+        case .Failure(let error):
             return error
         }
     }
@@ -100,15 +90,8 @@ extension Result: CustomDebugStringConvertible {
         switch self {
         case .Success(let value):
             return "SUCCESS: \(value)"
-        case .Failure(let data, let error):
-            if let
-                data = data,
-                utf8Data = NSString(data: data, encoding: NSUTF8StringEncoding)
-            {
-                return "FAILURE: \(error) \(utf8Data)"
-            } else {
-                return "FAILURE with Error: \(error)"
-            }
+        case .Failure(let error):
+            return "FAILURE: \(error)"
         }
     }
 }

--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -32,7 +32,7 @@ extension Request {
     */
     public enum ValidationResult {
         case Success
-        case Failure(ErrorType)
+        case Failure(NSError)
     }
 
     /**

--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -57,7 +57,7 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)
@@ -79,7 +79,7 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
         XCTAssertNotNil(data, "data should not be nil")
         XCTAssertNotNil(error, "error should not be nil")
 
-        if let code = (error as? NSError)?.code {
+        if let code = error?.code {
             XCTAssertEqual(code, -999, "error should be NSURLErrorDomain Code -999 'cancelled'")
         }
     }
@@ -91,7 +91,7 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)
@@ -133,7 +133,7 @@ class HTTPDigestAuthenticationTestCase: AuthenticationTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)
@@ -155,7 +155,7 @@ class HTTPDigestAuthenticationTestCase: AuthenticationTestCase {
         XCTAssertNotNil(data, "data should not be nil")
         XCTAssertNotNil(error, "error should not be nil")
 
-        if let code = (error as? NSError)?.code {
+        if let code = error?.code {
             XCTAssertEqual(code, -999, "error should be NSURLErrorDomain Code -999 'cancelled'")
         }
     }
@@ -167,7 +167,7 @@ class HTTPDigestAuthenticationTestCase: AuthenticationTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -432,6 +432,7 @@ class DownloadResumeDataTestCase: BaseTestCase {
 
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
+        var data: NSData?
         var result: Result<AnyObject>!
 
         // When
@@ -439,9 +440,10 @@ class DownloadResumeDataTestCase: BaseTestCase {
         download.progress { _, _, _ in
             download.cancel()
         }
-        download.responseJSON { responseRequest, responseResponse, responseResult in
+        download.responseJSON { responseRequest, responseResponse, responseData, responseResult in
             request = responseRequest
             response = responseResponse
+            data = responseData
             result = responseResult
 
             expectation.fulfill()
@@ -452,6 +454,7 @@ class DownloadResumeDataTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNotNil(response, "response should not be nil")
+        XCTAssertNotNil(data, "data should not be nil")
 
         XCTAssertTrue(result.isFailure, "result should be a failure")
         XCTAssertNotNil(result.data, "data should not be nil")

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -94,7 +94,7 @@ class DownloadResponseTestCase: BaseTestCase {
 
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.download(.GET, URLString, destination: destination)
@@ -265,7 +265,7 @@ class DownloadResponseTestCase: BaseTestCase {
 
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.download(.GET, URLString, parameters: parameters, destination: destination)
@@ -307,7 +307,7 @@ class DownloadResponseTestCase: BaseTestCase {
 
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.download(.GET, URLString, headers: headers, destination: destination)
@@ -357,7 +357,7 @@ class DownloadResumeDataTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: AnyObject?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         let download = Alamofire.download(.GET, URLString, destination: destination)
@@ -390,7 +390,7 @@ class DownloadResumeDataTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: AnyObject?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         let download = Alamofire.download(.GET, URLString, destination: destination)
@@ -433,7 +433,7 @@ class DownloadResumeDataTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var result: Result<AnyObject>!
+        var result: Result<AnyObject, NSError>?
 
         // When
         let download = Alamofire.download(.GET, URLString, destination: destination)
@@ -456,9 +456,12 @@ class DownloadResumeDataTestCase: BaseTestCase {
         XCTAssertNotNil(response, "response should not be nil")
         XCTAssertNotNil(data, "data should not be nil")
 
-        XCTAssertTrue(result.isFailure, "result should be a failure")
-        XCTAssertNotNil(result.data, "data should not be nil")
-        XCTAssertTrue(result.error != nil, "error should not be nil")
+        if let result = result {
+            XCTAssertTrue(result.isFailure, "result should be a failure")
+            XCTAssertTrue(result.error != nil, "error should not be nil")
+        } else {
+            XCTFail("result should not be nil")
+        }
 
         XCTAssertNotNil(download.resumeData, "resume data should not be nil")
     }

--- a/Tests/ManagerTests.swift
+++ b/Tests/ManagerTests.swift
@@ -141,13 +141,15 @@ class ManagerConfigurationHeadersTestCase: BaseTestCase {
 
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
+        var data: NSData?
         var result: Result<AnyObject>?
 
         // When
         manager.request(.GET, "https://httpbin.org/headers")
-            .responseJSON { responseRequest, responseResponse, responseResult in
+            .responseJSON { responseRequest, responseResponse, responseData, responseResult in
                 request = responseRequest
                 response = responseResponse
+                data = responseData
                 result = responseResult
 
                 expectation.fulfill()
@@ -158,6 +160,7 @@ class ManagerConfigurationHeadersTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNotNil(response, "response should not be nil")
+        XCTAssertNotNil(data, "data should not be nil")
 
         if let result = result {
             XCTAssertTrue(result.isSuccess, "result should be a success")

--- a/Tests/ManagerTests.swift
+++ b/Tests/ManagerTests.swift
@@ -142,7 +142,7 @@ class ManagerConfigurationHeadersTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var result: Result<AnyObject>?
+        var result: Result<AnyObject, NSError>?
 
         // When
         manager.request(.GET, "https://httpbin.org/headers")

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -292,13 +292,15 @@ class RequestResponseTestCase: BaseTestCase {
 
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
+        var data: NSData?
         var result: Result<AnyObject>?
 
         // When
         Alamofire.request(.POST, URLString, parameters: parameters)
-            .responseJSON { responseRequest, responseResponse, responseResult in
+            .responseJSON { responseRequest, responseResponse, responseData, responseResult in
                 request = responseRequest
                 response = responseResponse
+                data = responseData
                 result = responseResult
 
                 expectation.fulfill()
@@ -309,6 +311,7 @@ class RequestResponseTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNotNil(response, "response should not be nil")
+        XCTAssertNotNil(data, "data should not be nil")
         XCTAssertNotNil(result, "result should be nil")
 
         if let
@@ -352,13 +355,15 @@ class RequestResponseTestCase: BaseTestCase {
 
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
+        var data: NSData?
         var result: Result<AnyObject>?
 
         // When
         Alamofire.request(.POST, URLString, parameters: parameters)
-            .responseJSON { responseRequest, responseResponse, responseResult in
+            .responseJSON { responseRequest, responseResponse, responseData, responseResult in
                 request = responseRequest
                 response = responseResponse
+                data = responseData
                 result = responseResult
 
                 expectation.fulfill()
@@ -369,6 +374,7 @@ class RequestResponseTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNotNil(response, "response should not be nil")
+        XCTAssertNotNil(data, "data should not be nil")
         XCTAssertNotNil(result, "result should be nil")
 
         if let

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -87,7 +87,7 @@ class RequestResponseTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString, parameters: ["foo": "bar"])
@@ -293,7 +293,7 @@ class RequestResponseTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var result: Result<AnyObject>?
+        var result: Result<AnyObject, NSError>?
 
         // When
         Alamofire.request(.POST, URLString, parameters: parameters)
@@ -356,7 +356,7 @@ class RequestResponseTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var result: Result<AnyObject>?
+        var result: Result<AnyObject, NSError>?
 
         // When
         Alamofire.request(.POST, URLString, parameters: parameters)

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -325,7 +325,7 @@ class ResponseSerializationTestCase: BaseTestCase {
 
     func testThatPropertyListResponseSerializerFailsWhenDataIsInvalidPropertyListData() {
         // Given
-        let serializer = Request.JSONResponseSerializer()
+        let serializer = Request.propertyListResponseSerializer()
         let data = "definitely not valid plist data".dataUsingEncoding(NSUTF8StringEncoding)!
 
         // When

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -34,7 +34,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         let data = "data".dataUsingEncoding(NSUTF8StringEncoding)!
 
         // When
-        let result = serializer.serializeResponse(nil, nil, data)
+        let result = serializer.serializeResponse(nil, nil, data, nil)
 
         // Then
         XCTAssertTrue(result.isSuccess, "result is success should be true")
@@ -47,7 +47,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         let serializer = Request.dataResponseSerializer()
 
         // When
-        let result = serializer.serializeResponse(nil, nil, nil)
+        let result = serializer.serializeResponse(nil, nil, nil, nil)
 
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
@@ -69,7 +69,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         let serializer = Request.stringResponseSerializer()
 
         // When
-        let result = serializer.serializeResponse(nil, nil, nil)
+        let result = serializer.serializeResponse(nil, nil, nil, nil)
 
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
@@ -89,7 +89,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         let serializer = Request.stringResponseSerializer()
 
         // When
-        let result = serializer.serializeResponse(nil, nil, NSData())
+        let result = serializer.serializeResponse(nil, nil, NSData(), nil)
 
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
@@ -102,7 +102,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         let data = "data".dataUsingEncoding(NSUTF8StringEncoding)!
 
         // When
-        let result = serializer.serializeResponse(nil, nil, data)
+        let result = serializer.serializeResponse(nil, nil, data, nil)
 
         // Then
         XCTAssertTrue(result.isSuccess, "result is success should be true")
@@ -115,7 +115,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         let data = "data".dataUsingEncoding(NSUTF8StringEncoding)!
 
         // When
-        let result = serializer.serializeResponse(nil, nil, data)
+        let result = serializer.serializeResponse(nil, nil, data, nil)
 
         // Then
         XCTAssertTrue(result.isSuccess, "result is success should be true")
@@ -134,7 +134,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         )
 
         // When
-        let result = serializer.serializeResponse(nil, response, data)
+        let result = serializer.serializeResponse(nil, response, data, nil)
 
         // Then
         XCTAssertTrue(result.isSuccess, "result is success should be true")
@@ -148,7 +148,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         let data = "random data".dataUsingEncoding(NSUTF32StringEncoding)!
 
         // When
-        let result = serializer.serializeResponse(nil, nil, data)
+        let result = serializer.serializeResponse(nil, nil, data, nil)
 
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
@@ -175,7 +175,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         )
 
         // When
-        let result = serializer.serializeResponse(nil, response, data)
+        let result = serializer.serializeResponse(nil, response, data, nil)
 
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
@@ -197,7 +197,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         let serializer = Request.JSONResponseSerializer()
 
         // When
-        let result = serializer.serializeResponse(nil, nil, nil)
+        let result = serializer.serializeResponse(nil, nil, nil, nil)
 
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
@@ -217,7 +217,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         let serializer = Request.JSONResponseSerializer()
 
         // When
-        let result = serializer.serializeResponse(nil, nil, NSData())
+        let result = serializer.serializeResponse(nil, nil, NSData(), nil)
 
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
@@ -238,7 +238,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         let data = "{\"json\": true}".dataUsingEncoding(NSUTF8StringEncoding)!
 
         // When
-        let result = serializer.serializeResponse(nil, nil, data)
+        let result = serializer.serializeResponse(nil, nil, data, nil)
 
         // Then
         XCTAssertTrue(result.isSuccess, "result is success should be true")
@@ -252,7 +252,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         let data = "definitely not valid json".dataUsingEncoding(NSUTF8StringEncoding)!
 
         // When
-        let result = serializer.serializeResponse(nil, nil, data)
+        let result = serializer.serializeResponse(nil, nil, data, nil)
 
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
@@ -274,7 +274,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         let serializer = Request.propertyListResponseSerializer()
 
         // When
-        let result = serializer.serializeResponse(nil, nil, nil)
+        let result = serializer.serializeResponse(nil, nil, nil, nil)
 
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
@@ -294,7 +294,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         let serializer = Request.propertyListResponseSerializer()
 
         // When
-        let result = serializer.serializeResponse(nil, nil, NSData())
+        let result = serializer.serializeResponse(nil, nil, NSData(), nil)
 
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
@@ -315,7 +315,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         let data = NSKeyedArchiver.archivedDataWithRootObject(["foo": "bar"])
 
         // When
-        let result = serializer.serializeResponse(nil, nil, data)
+        let result = serializer.serializeResponse(nil, nil, data, nil)
 
         // Then
         XCTAssertTrue(result.isSuccess, "result is success should be true")
@@ -329,7 +329,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         let data = "definitely not valid plist data".dataUsingEncoding(NSUTF8StringEncoding)!
 
         // When
-        let result = serializer.serializeResponse(nil, nil, data)
+        let result = serializer.serializeResponse(nil, nil, data, nil)
 
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -39,8 +39,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         // Then
         XCTAssertTrue(result.isSuccess, "result is success should be true")
         XCTAssertNotNil(result.value, "result value should not be nil")
-        XCTAssertNil(result.data, "result data should be nil")
-        XCTAssertTrue(result.error == nil, "result error should be nil")
+        XCTAssertNil(result.error, "result error should be nil")
     }
 
     func testThatDataResponseSerializerFailsWhenDataIsNil() {
@@ -53,10 +52,9 @@ class ResponseSerializationTestCase: BaseTestCase {
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
         XCTAssertNil(result.value, "result value should be nil")
-        XCTAssertNil(result.data, "result data should be nil")
-        XCTAssertTrue(result.error != nil, "result error should not be nil")
+        XCTAssertNotNil(result.error, "result error should not be nil")
 
-        if let error = result.error as? NSError {
+        if let error = result.error {
             XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
             XCTAssertEqual(error.code, Error.Code.DataSerializationFailed.rawValue, "error code should match expected value")
         } else {
@@ -76,10 +74,9 @@ class ResponseSerializationTestCase: BaseTestCase {
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
         XCTAssertNil(result.value, "result value should be nil")
-        XCTAssertNil(result.data, "result data should be nil")
-        XCTAssertTrue(result.error != nil, "result error should not be nil")
+        XCTAssertNotNil(result.error, "result error should not be nil")
 
-        if let error = result.error as? NSError {
+        if let error = result.error {
             XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
             XCTAssertEqual(error.code, Error.Code.StringSerializationFailed.rawValue, "error code should match expected value")
         } else {
@@ -87,7 +84,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         }
     }
 
-    func testThatStringResponseSerializerSucceedsWhenDataIsEmpty() {
+    func testThatStringResponseSerializerFailsWhenDataIsEmpty() {
         // Given
         let serializer = Request.stringResponseSerializer()
 
@@ -95,10 +92,9 @@ class ResponseSerializationTestCase: BaseTestCase {
         let result = serializer.serializeResponse(nil, nil, NSData())
 
         // Then
-        XCTAssertTrue(result.isSuccess, "result is success should be true")
-        XCTAssertNotNil(result.value, "result value should not be nil")
-        XCTAssertNil(result.data, "result data should be nil")
-        XCTAssertTrue(result.error == nil, "result error should be nil")
+        XCTAssertTrue(result.isFailure, "result is failure should be true")
+        XCTAssertNil(result.value, "result value should be nil")
+        XCTAssertNotNil(result.error, "result error should not be nil")
     }
 
     func testThatStringResponseSerializerSucceedsWithUTF8DataAndNoProvidedEncoding() {
@@ -111,8 +107,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         // Then
         XCTAssertTrue(result.isSuccess, "result is success should be true")
         XCTAssertNotNil(result.value, "result value should not be nil")
-        XCTAssertNil(result.data, "result data should be nil")
-        XCTAssertTrue(result.error == nil, "result error should be nil")
+        XCTAssertNil(result.error, "result error should be nil")
     }
 
     func testThatStringResponseSerializerSucceedsWithUTF8DataAndUTF8ProvidedEncoding() {
@@ -125,8 +120,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         // Then
         XCTAssertTrue(result.isSuccess, "result is success should be true")
         XCTAssertNotNil(result.value, "result value should not be nil")
-        XCTAssertNil(result.data, "result data should be nil")
-        XCTAssertTrue(result.error == nil, "result error should be nil")
+        XCTAssertNil(result.error, "result error should be nil")
     }
 
     func testThatStringResponseSerializerSucceedsWithUTF8DataUsingResponseTextEncodingName() {
@@ -145,8 +139,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         // Then
         XCTAssertTrue(result.isSuccess, "result is success should be true")
         XCTAssertNotNil(result.value, "result value should not be nil")
-        XCTAssertNil(result.data, "result data should be nil")
-        XCTAssertTrue(result.error == nil, "result error should be nil")
+        XCTAssertNil(result.error, "result error should be nil")
     }
 
     func testThatStringResponseSerializerFailsWithUTF32DataAndUTF8ProvidedEncoding() {
@@ -160,10 +153,9 @@ class ResponseSerializationTestCase: BaseTestCase {
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
         XCTAssertNil(result.value, "result value should be nil")
-        XCTAssertNotNil(result.data, "result data should not be nil")
-        XCTAssertTrue(result.error != nil, "result error should not be nil")
+        XCTAssertNotNil(result.error, "result error should not be nil")
 
-        if let error = result.error as? NSError {
+        if let error = result.error {
             XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
             XCTAssertEqual(error.code, Error.Code.StringSerializationFailed.rawValue, "error code should match expected value")
         } else {
@@ -188,10 +180,9 @@ class ResponseSerializationTestCase: BaseTestCase {
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
         XCTAssertNil(result.value, "result value should be nil")
-        XCTAssertNotNil(result.data, "result data should not be nil")
-        XCTAssertTrue(result.error != nil, "result error should not be nil")
+        XCTAssertNotNil(result.error, "result error should not be nil")
 
-        if let error = result.error as? NSError {
+        if let error = result.error {
             XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
             XCTAssertEqual(error.code, Error.Code.StringSerializationFailed.rawValue, "error code should match expected value")
         } else {
@@ -211,10 +202,9 @@ class ResponseSerializationTestCase: BaseTestCase {
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
         XCTAssertNil(result.value, "result value should be nil")
-        XCTAssertNil(result.data, "result data should be nil")
-        XCTAssertTrue(result.error != nil, "result error should not be nil")
+        XCTAssertNotNil(result.error, "result error should not be nil")
 
-        if let error = result.error as? NSError {
+        if let error = result.error {
             XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
             XCTAssertEqual(error.code, Error.Code.JSONSerializationFailed.rawValue, "error code should match expected value")
         } else {
@@ -232,12 +222,11 @@ class ResponseSerializationTestCase: BaseTestCase {
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
         XCTAssertNil(result.value, "result value should be nil")
-        XCTAssertNotNil(result.data, "result data should not be nil")
-        XCTAssertTrue(result.error != nil, "result error should not be nil")
+        XCTAssertNotNil(result.error, "result error should not be nil")
 
-        if let error = result.error as? NSError {
-            XCTAssertEqual(error.domain, NSCocoaErrorDomain, "error domain should match expected value")
-            XCTAssertEqual(error.code, 3840, "error code should match expected value")
+        if let error = result.error {
+            XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
+            XCTAssertEqual(error.code, Error.Code.JSONSerializationFailed.rawValue, "error code should match expected value")
         } else {
             XCTFail("error should not be nil")
         }
@@ -254,8 +243,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         // Then
         XCTAssertTrue(result.isSuccess, "result is success should be true")
         XCTAssertNotNil(result.value, "result value should not be nil")
-        XCTAssertNil(result.data, "result data should be nil")
-        XCTAssertTrue(result.error == nil, "result error should be nil")
+        XCTAssertNil(result.error, "result error should be nil")
     }
 
     func testThatJSONResponseSerializerFailsWhenDataIsInvalidJSON() {
@@ -269,10 +257,9 @@ class ResponseSerializationTestCase: BaseTestCase {
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
         XCTAssertNil(result.value, "result value should be nil")
-        XCTAssertNotNil(result.data, "result data should not be nil")
-        XCTAssertTrue(result.error != nil, "result error should not be nil")
+        XCTAssertNotNil(result.error, "result error should not be nil")
 
-        if let error = result.error as? NSError {
+        if let error = result.error {
             XCTAssertEqual(error.domain, NSCocoaErrorDomain, "error domain should match expected value")
             XCTAssertEqual(error.code, 3840, "error code should match expected value")
         } else {
@@ -292,10 +279,9 @@ class ResponseSerializationTestCase: BaseTestCase {
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
         XCTAssertNil(result.value, "result value should be nil")
-        XCTAssertNil(result.data, "result data should be nil")
-        XCTAssertTrue(result.error != nil, "result error should not be nil")
+        XCTAssertNotNil(result.error, "result error should not be nil")
 
-        if let error = result.error as? NSError {
+        if let error = result.error {
             XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
             XCTAssertEqual(error.code, Error.Code.PropertyListSerializationFailed.rawValue, "error code should match expected value")
         } else {
@@ -313,12 +299,11 @@ class ResponseSerializationTestCase: BaseTestCase {
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
         XCTAssertNil(result.value, "result value should be nil")
-        XCTAssertNotNil(result.data, "result data should not be nil")
-        XCTAssertTrue(result.error != nil, "result error should not be nil")
+        XCTAssertNotNil(result.error, "result error should not be nil")
 
-        if let error = result.error as? NSError {
-            XCTAssertEqual(error.domain, NSCocoaErrorDomain, "error domain should match expected value")
-            XCTAssertEqual(error.code, 3840, "error code should match expected value")
+        if let error = result.error {
+            XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
+            XCTAssertEqual(error.code, Error.Code.PropertyListSerializationFailed.rawValue, "error code should match expected value")
         } else {
             XCTFail("error should not be nil")
         }
@@ -335,8 +320,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         // Then
         XCTAssertTrue(result.isSuccess, "result is success should be true")
         XCTAssertNotNil(result.value, "result value should not be nil")
-        XCTAssertNil(result.data, "result data should be nil")
-        XCTAssertTrue(result.error == nil, "result error should be nil")
+        XCTAssertNil(result.error, "result error should be nil")
     }
 
     func testThatPropertyListResponseSerializerFailsWhenDataIsInvalidPropertyListData() {
@@ -350,10 +334,9 @@ class ResponseSerializationTestCase: BaseTestCase {
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
         XCTAssertNil(result.value, "result value should be nil")
-        XCTAssertNotNil(result.data, "result data should not be nil")
-        XCTAssertTrue(result.error != nil, "result error should not be nil")
+        XCTAssertNotNil(result.error, "result error should not be nil")
 
-        if let error = result.error as? NSError {
+        if let error = result.error {
             XCTAssertEqual(error.domain, NSCocoaErrorDomain, "error domain should match expected value")
             XCTAssertEqual(error.code, 3840, "error code should match expected value")
         } else {

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -25,6 +25,7 @@ import Foundation
 import XCTest
 
 class ResponseSerializationTestCase: BaseTestCase {
+    let error = NSError(domain: Error.Domain, code: -10000, userInfo: nil)
 
     // MARK: - Data Response Serializer Tests
 
@@ -57,6 +58,26 @@ class ResponseSerializationTestCase: BaseTestCase {
         if let error = result.error {
             XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
             XCTAssertEqual(error.code, Error.Code.DataSerializationFailed.rawValue, "error code should match expected value")
+        } else {
+            XCTFail("error should not be nil")
+        }
+    }
+
+    func testThatDataResponseSerializerFailsWhenErrorIsNotNil() {
+        // Given
+        let serializer = Request.dataResponseSerializer()
+
+        // When
+        let result = serializer.serializeResponse(nil, nil, nil, error)
+
+        // Then
+        XCTAssertTrue(result.isFailure, "result is failure should be true")
+        XCTAssertNil(result.value, "result value should be nil")
+        XCTAssertNotNil(result.error, "result error should not be nil")
+
+        if let error = result.error {
+            XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
+            XCTAssertEqual(error.code, self.error.code, "error code should match expected value")
         } else {
             XCTFail("error should not be nil")
         }
@@ -190,6 +211,26 @@ class ResponseSerializationTestCase: BaseTestCase {
         }
     }
 
+    func testThatStringResponseSerializerFailsWhenErrorIsNotNil() {
+        // Given
+        let serializer = Request.stringResponseSerializer()
+
+        // When
+        let result = serializer.serializeResponse(nil, nil, nil, error)
+
+        // Then
+        XCTAssertTrue(result.isFailure, "result is failure should be true")
+        XCTAssertNil(result.value, "result value should be nil")
+        XCTAssertNotNil(result.error, "result error should not be nil")
+
+        if let error = result.error {
+            XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
+            XCTAssertEqual(error.code, self.error.code, "error code should match expected value")
+        } else {
+            XCTFail("error should not be nil")
+        }
+    }
+
     // MARK: - JSON Response Serializer Tests
 
     func testThatJSONResponseSerializerFailsWhenDataIsNil() {
@@ -267,6 +308,26 @@ class ResponseSerializationTestCase: BaseTestCase {
         }
     }
 
+    func testThatJSONResponseSerializerFailsWhenErrorIsNotNil() {
+        // Given
+        let serializer = Request.JSONResponseSerializer()
+
+        // When
+        let result = serializer.serializeResponse(nil, nil, nil, error)
+
+        // Then
+        XCTAssertTrue(result.isFailure, "result is failure should be true")
+        XCTAssertNil(result.value, "result value should be nil")
+        XCTAssertNotNil(result.error, "result error should not be nil")
+
+        if let error = result.error {
+            XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
+            XCTAssertEqual(error.code, self.error.code, "error code should match expected value")
+        } else {
+            XCTFail("error should not be nil")
+        }
+    }
+
     // MARK: - Property List Response Serializer Tests
 
     func testThatPropertyListResponseSerializerFailsWhenDataIsNil() {
@@ -339,6 +400,26 @@ class ResponseSerializationTestCase: BaseTestCase {
         if let error = result.error {
             XCTAssertEqual(error.domain, NSCocoaErrorDomain, "error domain should match expected value")
             XCTAssertEqual(error.code, 3840, "error code should match expected value")
+        } else {
+            XCTFail("error should not be nil")
+        }
+    }
+
+    func testThatPropertyListResponseSerializerFailsWhenErrorIsNotNil() {
+        // Given
+        let serializer = Request.propertyListResponseSerializer()
+
+        // When
+        let result = serializer.serializeResponse(nil, nil, nil, error)
+
+        // Then
+        XCTAssertTrue(result.isFailure, "result is failure should be true")
+        XCTAssertNil(result.value, "result value should be nil")
+        XCTAssertNotNil(result.error, "result error should not be nil")
+
+        if let error = result.error {
+            XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
+            XCTAssertEqual(error.code, self.error.code, "error code should match expected value")
         } else {
             XCTFail("error should not be nil")
         }

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -33,7 +33,7 @@ class ResponseDataTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var result: Result<NSData>!
+        var result: Result<NSData, NSError>?
 
         // When
         Alamofire.request(.GET, URLString, parameters: ["foo": "bar"])
@@ -52,11 +52,7 @@ class ResponseDataTestCase: BaseTestCase {
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNotNil(response, "response should not be nil")
         XCTAssertNotNil(data, "data should not be nil")
-
-        XCTAssertTrue(result.isSuccess, "result should be success")
-        XCTAssertNotNil(result.value, "result value should not be nil")
-        XCTAssertNil(result.data, "result data should be nil")
-        XCTAssertTrue(result.error == nil, "result error should be nil")
+        XCTAssertTrue(result?.isSuccess ?? false, "result should be success")
     }
 
     func testThatResponseDataReturnsFailureResultWithOptionalDataAndError() {
@@ -67,7 +63,7 @@ class ResponseDataTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var result: Result<NSData>!
+        var result: Result<NSData, NSError>?
 
         // When
         Alamofire.request(.GET, URLString, parameters: ["foo": "bar"])
@@ -86,11 +82,7 @@ class ResponseDataTestCase: BaseTestCase {
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNil(response, "response should be nil")
         XCTAssertNotNil(data, "data should not be nil")
-
-        XCTAssertTrue(result.isFailure, "result should be a failure")
-        XCTAssertNil(result.value, "result value should not be nil")
-        XCTAssertNotNil(result.data, "result data should be nil")
-        XCTAssertTrue(result.error != nil, "result error should not be nil")
+        XCTAssertTrue(result?.isFailure ?? false, "result should be failure")
     }
 }
 
@@ -105,7 +97,7 @@ class ResponseStringTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var result: Result<String>!
+        var result: Result<String, NSError>?
 
         // When
         Alamofire.request(.GET, URLString, parameters: ["foo": "bar"])
@@ -124,11 +116,7 @@ class ResponseStringTestCase: BaseTestCase {
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNotNil(response, "response should not be nil")
         XCTAssertNotNil(data, "data should not be nil")
-
-        XCTAssertTrue(result.isSuccess, "result should be success")
-        XCTAssertNotNil(result.value, "result value should not be nil")
-        XCTAssertNil(result.data, "result data should be nil")
-        XCTAssertTrue(result.error == nil, "result error should be nil")
+        XCTAssertTrue(result?.isSuccess ?? false, "result should be success")
     }
 
     func testThatResponseStringReturnsFailureResultWithOptionalDataAndError() {
@@ -139,7 +127,7 @@ class ResponseStringTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var result: Result<String>!
+        var result: Result<String, NSError>?
 
         // When
         Alamofire.request(.GET, URLString, parameters: ["foo": "bar"])
@@ -158,11 +146,7 @@ class ResponseStringTestCase: BaseTestCase {
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNil(response, "response should be nil")
         XCTAssertNotNil(data, "data should not be nil")
-
-        XCTAssertTrue(result.isFailure, "result should be a failure")
-        XCTAssertNil(result.value, "result value should not be nil")
-        XCTAssertNotNil(result.data, "result data should not be nil")
-        XCTAssertTrue(result.error != nil, "result error should not be nil")
+        XCTAssertTrue(result?.isFailure ?? false, "result should be failure")
     }
 }
 
@@ -177,7 +161,7 @@ class ResponseJSONTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var result: Result<AnyObject>!
+        var result: Result<AnyObject, NSError>?
 
         // When
         Alamofire.request(.GET, URLString, parameters: ["foo": "bar"])
@@ -196,11 +180,7 @@ class ResponseJSONTestCase: BaseTestCase {
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNotNil(response, "response should not be nil")
         XCTAssertNotNil(data, "data should not be nil")
-
-        XCTAssertTrue(result.isSuccess, "result should be success")
-        XCTAssertNotNil(result.value, "result value should not be nil")
-        XCTAssertNil(result.data, "result data should be nil")
-        XCTAssertTrue(result.error == nil, "result error should be nil")
+        XCTAssertTrue(result?.isSuccess ?? false, "result should be success")
     }
 
     func testThatResponseStringReturnsFailureResultWithOptionalDataAndError() {
@@ -211,7 +191,7 @@ class ResponseJSONTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var result: Result<AnyObject>!
+        var result: Result<AnyObject, NSError>?
 
         // When
         Alamofire.request(.GET, URLString, parameters: ["foo": "bar"])
@@ -230,11 +210,7 @@ class ResponseJSONTestCase: BaseTestCase {
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNil(response, "response should be nil")
         XCTAssertNotNil(data, "data should not be nil")
-
-        XCTAssertTrue(result.isFailure, "result should be a failure")
-        XCTAssertNil(result.value, "result value should not be nil")
-        XCTAssertNotNil(result.data, "result data should not be nil")
-        XCTAssertTrue(result.error != nil, "result error should not be nil")
+        XCTAssertTrue(result?.isFailure ?? false, "result should be failure")
     }
 
     func testThatResponseJSONReturnsSuccessResultForGETRequest() {
@@ -245,7 +221,7 @@ class ResponseJSONTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var result: Result<AnyObject>!
+        var result: Result<AnyObject, NSError>?
 
         // When
         Alamofire.request(.GET, URLString, parameters: ["foo": "bar"])
@@ -264,11 +240,11 @@ class ResponseJSONTestCase: BaseTestCase {
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNotNil(response, "response should not be nil")
         XCTAssertNotNil(data, "data should not be nil")
-        XCTAssertTrue(result.isSuccess, "result should be success")
+        XCTAssertTrue(result?.isSuccess ?? false, "result should be success")
 
         // The `as NSString` cast is necessary due to a compiler bug. See the following rdar for more info.
         // - https://openradar.appspot.com/radar?id=5517037090635776
-        if let args = result.value?["args" as NSString] as? [String: String] {
+        if let args = result?.value?["args" as NSString] as? [String: String] {
             XCTAssertEqual(args, ["foo": "bar"], "args should match parameters")
         } else {
             XCTFail("args should not be nil")
@@ -283,7 +259,7 @@ class ResponseJSONTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var result: Result<AnyObject>!
+        var result: Result<AnyObject, NSError>?
 
         // When
         Alamofire.request(.POST, URLString, parameters: ["foo": "bar"])
@@ -302,11 +278,11 @@ class ResponseJSONTestCase: BaseTestCase {
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNotNil(response, "response should not be nil")
         XCTAssertNotNil(data, "data should not be nil")
-        XCTAssertTrue(result.isSuccess, "result should be success")
+        XCTAssertTrue(result?.isSuccess ?? false, "result should be success")
 
         // The `as NSString` cast is necessary due to a compiler bug. See the following rdar for more info.
         // - https://openradar.appspot.com/radar?id=5517037090635776
-        if let form = result.value?["form" as NSString] as? [String: String] {
+        if let form = result?.value?["form" as NSString] as? [String: String] {
             XCTAssertEqual(form, ["foo": "bar"], "form should match parameters")
         } else {
             XCTFail("form should not be nil")
@@ -327,7 +303,7 @@ class RedirectResponseTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)
@@ -362,7 +338,7 @@ class RedirectResponseTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)
@@ -402,7 +378,7 @@ class RedirectResponseTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)
@@ -442,7 +418,7 @@ class RedirectResponseTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)
@@ -484,7 +460,7 @@ class RedirectResponseTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -32,13 +32,15 @@ class ResponseDataTestCase: BaseTestCase {
 
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
+        var data: NSData?
         var result: Result<NSData>!
 
         // When
         Alamofire.request(.GET, URLString, parameters: ["foo": "bar"])
-            .responseData { responseRequest, responseResponse, responseResult in
+            .responseData { responseRequest, responseResponse, responseData, responseResult in
                 request = responseRequest
                 response = responseResponse
+                data = responseData
                 result = responseResult
 
                 expectation.fulfill()
@@ -49,6 +51,8 @@ class ResponseDataTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNotNil(response, "response should not be nil")
+        XCTAssertNotNil(data, "data should not be nil")
+
         XCTAssertTrue(result.isSuccess, "result should be success")
         XCTAssertNotNil(result.value, "result value should not be nil")
         XCTAssertNil(result.data, "result data should be nil")
@@ -62,13 +66,15 @@ class ResponseDataTestCase: BaseTestCase {
 
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
+        var data: NSData?
         var result: Result<NSData>!
 
         // When
         Alamofire.request(.GET, URLString, parameters: ["foo": "bar"])
-            .responseData { responseRequest, responseResponse, responseResult in
+            .responseData { responseRequest, responseResponse, responseData, responseResult in
                 request = responseRequest
                 response = responseResponse
+                data = responseData
                 result = responseResult
 
                 expectation.fulfill()
@@ -79,6 +85,8 @@ class ResponseDataTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNil(response, "response should be nil")
+        XCTAssertNotNil(data, "data should not be nil")
+
         XCTAssertTrue(result.isFailure, "result should be a failure")
         XCTAssertNil(result.value, "result value should not be nil")
         XCTAssertNotNil(result.data, "result data should be nil")
@@ -96,13 +104,15 @@ class ResponseStringTestCase: BaseTestCase {
 
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
+        var data: NSData?
         var result: Result<String>!
 
         // When
         Alamofire.request(.GET, URLString, parameters: ["foo": "bar"])
-            .responseString { responseRequest, responseResponse, responseResult in
+            .responseString { responseRequest, responseResponse, responseData, responseResult in
                 request = responseRequest
                 response = responseResponse
+                data = responseData
                 result = responseResult
 
                 expectation.fulfill()
@@ -113,6 +123,8 @@ class ResponseStringTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNotNil(response, "response should not be nil")
+        XCTAssertNotNil(data, "data should not be nil")
+
         XCTAssertTrue(result.isSuccess, "result should be success")
         XCTAssertNotNil(result.value, "result value should not be nil")
         XCTAssertNil(result.data, "result data should be nil")
@@ -126,13 +138,15 @@ class ResponseStringTestCase: BaseTestCase {
 
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
+        var data: NSData?
         var result: Result<String>!
 
         // When
         Alamofire.request(.GET, URLString, parameters: ["foo": "bar"])
-            .responseString { responseRequest, responseResponse, responseResult in
+            .responseString { responseRequest, responseResponse, responseData, responseResult in
                 request = responseRequest
                 response = responseResponse
+                data = responseData
                 result = responseResult
 
                 expectation.fulfill()
@@ -143,9 +157,11 @@ class ResponseStringTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNil(response, "response should be nil")
+        XCTAssertNotNil(data, "data should not be nil")
+
         XCTAssertTrue(result.isFailure, "result should be a failure")
         XCTAssertNil(result.value, "result value should not be nil")
-        XCTAssertNotNil(result.data, "result data should be nil")
+        XCTAssertNotNil(result.data, "result data should not be nil")
         XCTAssertTrue(result.error != nil, "result error should not be nil")
     }
 }
@@ -160,13 +176,15 @@ class ResponseJSONTestCase: BaseTestCase {
 
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
+        var data: NSData?
         var result: Result<AnyObject>!
 
         // When
         Alamofire.request(.GET, URLString, parameters: ["foo": "bar"])
-            .responseJSON { responseRequest, responseResponse, responseResult in
+            .responseJSON { responseRequest, responseResponse, responseData, responseResult in
                 request = responseRequest
                 response = responseResponse
+                data = responseData
                 result = responseResult
 
                 expectation.fulfill()
@@ -177,6 +195,8 @@ class ResponseJSONTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNotNil(response, "response should not be nil")
+        XCTAssertNotNil(data, "data should not be nil")
+
         XCTAssertTrue(result.isSuccess, "result should be success")
         XCTAssertNotNil(result.value, "result value should not be nil")
         XCTAssertNil(result.data, "result data should be nil")
@@ -190,13 +210,15 @@ class ResponseJSONTestCase: BaseTestCase {
 
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
+        var data: NSData?
         var result: Result<AnyObject>!
 
         // When
         Alamofire.request(.GET, URLString, parameters: ["foo": "bar"])
-            .responseJSON { responseRequest, responseResponse, responseResult in
+            .responseJSON { responseRequest, responseResponse, responseData, responseResult in
                 request = responseRequest
                 response = responseResponse
+                data = responseData
                 result = responseResult
 
                 expectation.fulfill()
@@ -207,9 +229,11 @@ class ResponseJSONTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNil(response, "response should be nil")
+        XCTAssertNotNil(data, "data should not be nil")
+
         XCTAssertTrue(result.isFailure, "result should be a failure")
         XCTAssertNil(result.value, "result value should not be nil")
-        XCTAssertNotNil(result.data, "result data should be nil")
+        XCTAssertNotNil(result.data, "result data should not be nil")
         XCTAssertTrue(result.error != nil, "result error should not be nil")
     }
 
@@ -220,13 +244,15 @@ class ResponseJSONTestCase: BaseTestCase {
 
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
+        var data: NSData?
         var result: Result<AnyObject>!
 
         // When
         Alamofire.request(.GET, URLString, parameters: ["foo": "bar"])
-            .responseJSON { responseRequest, responseResponse, responseResult in
+            .responseJSON { responseRequest, responseResponse, responseData, responseResult in
                 request = responseRequest
                 response = responseResponse
+                data = responseData
                 result = responseResult
 
                 expectation.fulfill()
@@ -237,6 +263,7 @@ class ResponseJSONTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNotNil(response, "response should not be nil")
+        XCTAssertNotNil(data, "data should not be nil")
         XCTAssertTrue(result.isSuccess, "result should be success")
 
         // The `as NSString` cast is necessary due to a compiler bug. See the following rdar for more info.
@@ -255,13 +282,15 @@ class ResponseJSONTestCase: BaseTestCase {
 
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
+        var data: NSData?
         var result: Result<AnyObject>!
 
         // When
         Alamofire.request(.POST, URLString, parameters: ["foo": "bar"])
-            .responseJSON { responseRequest, responseResponse, responseResult in
+            .responseJSON { responseRequest, responseResponse, responseData, responseResult in
                 request = responseRequest
                 response = responseResponse
+                data = responseData
                 result = responseResult
 
                 expectation.fulfill()
@@ -272,6 +301,7 @@ class ResponseJSONTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request, "request should not be nil")
         XCTAssertNotNil(response, "response should not be nil")
+        XCTAssertNotNil(data, "data should not be nil")
         XCTAssertTrue(result.isSuccess, "result should be success")
 
         // The `as NSString` cast is necessary due to a compiler bug. See the following rdar for more info.

--- a/Tests/ResultTests.swift
+++ b/Tests/ResultTests.swift
@@ -30,18 +30,16 @@ class ResultTestCase: BaseTestCase {
     // MARK: - Is Success Tests
 
     func testThatIsSuccessPropertyReturnsTrueForSuccessCase() {
-        // Given
-        // When
-        let result = Result.Success("success")
+        // Given, When
+        let result = Result<String, NSError>.Success("success")
 
         // Then
         XCTAssertTrue(result.isSuccess, "result is success should be true for success case")
     }
 
     func testThatIsSuccessPropertyReturnsFalseForFailureCase() {
-        // Given
-        // When
-        let result = Result<String>.Failure(NSData(), error)
+        // Given, When
+        let result = Result<String, NSError>.Failure(error)
 
         // Then
         XCTAssertFalse(result.isSuccess, "result is success should be true for failure case")
@@ -50,18 +48,16 @@ class ResultTestCase: BaseTestCase {
     // MARK: - Is Failure Tests
 
     func testThatIsFailurePropertyReturnsFalseForSuccessCase() {
-        // Given
-        // When
-        let result = Result.Success("success")
+        // Given, When
+        let result = Result<String, NSError>.Success("success")
 
         // Then
         XCTAssertFalse(result.isFailure, "result is failure should be false for success case")
     }
 
     func testThatIsFailurePropertyReturnsTrueForFailureCase() {
-        // Given
-        // When
-        let result = Result<String>.Failure(NSData(), error)
+        // Given, When
+        let result = Result<String, NSError>.Failure(error)
 
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true for failure case")
@@ -70,60 +66,34 @@ class ResultTestCase: BaseTestCase {
     // MARK: - Value Tests
 
     func testThatValuePropertyReturnsValueForSuccessCase() {
-        // Given
-        // When
-        let result = Result.Success("success")
+        // Given, When
+        let result = Result<String, NSError>.Success("success")
 
         // Then
         XCTAssertEqual(result.value ?? "", "success", "result value should match expected value")
     }
 
     func testThatValuePropertyReturnsNilForFailureCase() {
-        // Given
-        // When
-        let result = Result<String>.Failure(NSData(), error)
+        // Given, When
+        let result = Result<String, NSError>.Failure(error)
 
         // Then
         XCTAssertNil(result.value, "result value should be nil for failure case")
     }
 
-    // MARK: - Data Tests
-
-    func testThatDataPropertyReturnsNilForSuccessCase() {
-        // Given
-        // When
-        let result = Result.Success("success")
-
-        // Then
-        XCTAssertNil(result.data, "result data should be nil for success case")
-    }
-
-    func testThatDataPropertyReturnsDataForFailureCase() {
-        // Given
-        // When
-        let resultWithData = Result<String>.Failure(NSData(), error)
-        let resultWithoutData = Result<String>.Failure(nil, error)
-
-        // Then
-        XCTAssertNotNil(resultWithData.data, "result with data should not be nil for failure case")
-        XCTAssertNil(resultWithoutData.data, "result without data should be nil for failure case")
-    }
-
     // MARK: - Error Tests
 
     func testThatErrorPropertyReturnsNilForSuccessCase() {
-        // Given
-        // When
-        let result = Result.Success("success")
+        // Given, When
+        let result = Result<String, NSError>.Success("success")
 
         // Then
         XCTAssertTrue(result.error == nil, "result error should be nil for success case")
     }
 
     func testThatErrorPropertyReturnsErrorForFailureCase() {
-        // Given
-        // When
-        let result = Result<String>.Failure(nil, error)
+        // Given, When
+        let result = Result<String, NSError>.Failure(error)
 
         // Then
         XCTAssertTrue(result.error != nil, "result error should not be nil for failure case")
@@ -132,18 +102,16 @@ class ResultTestCase: BaseTestCase {
     // MARK: - Description Tests
 
     func testThatDescriptionStringMatchesExpectedValueForSuccessCase() {
-        // Given
-        // When
-        let result = Result.Success("success")
+        // Given, When
+        let result = Result<String, NSError>.Success("success")
 
         // Then
         XCTAssertEqual(result.description, "SUCCESS", "result description should match expected value for success case")
     }
 
     func testThatDescriptionStringMatchesExpectedValueForFailureCase() {
-        // Given
-        // When
-        let result = Result<String>.Failure(nil, error)
+        // Given, When
+        let result = Result<String, NSError>.Failure(error)
 
         // Then
         XCTAssertEqual(result.description, "FAILURE", "result description should match expected value for failure case")
@@ -152,9 +120,8 @@ class ResultTestCase: BaseTestCase {
     // MARK: - Debug Description Tests
 
     func testThatDebugDescriptionStringMatchesExpectedValueForSuccessCase() {
-        // Given
-        // When
-        let result = Result.Success("success value")
+        // Given, When
+        let result = Result<String, NSError>.Success("success value")
 
         // Then
         XCTAssertEqual(
@@ -165,29 +132,13 @@ class ResultTestCase: BaseTestCase {
     }
 
     func testThatDebugDescriptionStringMatchesExpectedValueForFailureCase() {
-        // Given
-        let utf8Data = "failure value".dataUsingEncoding(NSUTF8StringEncoding)!
-        let imageData = NSData(contentsOfURL: URLForResource("rainbow", withExtension: "jpg"))!
-
-        // When
-        let resultWithUTF8Data = Result<String>.Failure(utf8Data, error)
-        let resultWithImageData = Result<String>.Failure(imageData, error)
-        let resultWithNoData = Result<String>.Failure(nil, error)
+        // Given, When
+        let result = Result<String, NSError>.Failure(error)
 
         // Then
         XCTAssertEqual(
-            resultWithUTF8Data.debugDescription,
-            "FAILURE: \(error) failure value",
-            "result debug description should match expected value for failure case"
-        )
-        XCTAssertEqual(
-            resultWithImageData.debugDescription,
-            "FAILURE with Error: \(error)",
-            "result debug description should match expected value for failure case"
-        )
-        XCTAssertEqual(
-            resultWithNoData.debugDescription,
-            "FAILURE with Error: \(error)",
+            result.debugDescription,
+            "FAILURE: \(error)",
             "result debug description should match expected value for failure case"
         )
     }

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -77,7 +77,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         // Given
         let expectation = expectationWithDescription("\(URL)")
         let manager = Manager(configuration: configuration)
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         manager.request(.GET, URL)
@@ -91,7 +91,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error, "error should not be nil")
 
-        if let code = (error as? NSError)?.code {
+        if let code = error?.code {
             XCTAssertEqual(code, NSURLErrorServerCertificateUntrusted, "code should be untrusted server certficate")
         } else {
             XCTFail("error should be an NSError")
@@ -109,7 +109,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         )
 
         let expectation = expectationWithDescription("\(URL)")
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         manager.request(.GET, URL)
@@ -123,7 +123,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error, "error should not be nil")
 
-        if let code = (error as? NSError)?.code {
+        if let code = error?.code {
             XCTAssertEqual(code, NSURLErrorCancelled, "code should be cancelled")
         } else {
             XCTFail("error should be an NSError")
@@ -145,7 +145,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         )
 
         let expectation = expectationWithDescription("\(URL)")
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         manager.request(.GET, URL)
@@ -159,7 +159,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error, "error should not be nil")
 
-        if let code = (error as? NSError)?.code {
+        if let code = error?.code {
             XCTAssertEqual(code, NSURLErrorCancelled, "code should be cancelled")
         } else {
             XCTFail("error should be an NSError")
@@ -179,7 +179,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         )
 
         let expectation = expectationWithDescription("\(URL)")
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         manager.request(.GET, URL)
@@ -193,7 +193,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error, "error should not be nil")
 
-        if let code = (error as? NSError)?.code {
+        if let code = error?.code {
             XCTAssertEqual(code, NSURLErrorCancelled, "code should be cancelled")
         } else {
             XCTFail("error should be an NSError")
@@ -213,7 +213,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         )
 
         let expectation = expectationWithDescription("\(URL)")
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         manager.request(.GET, URL)
@@ -241,7 +241,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         )
 
         let expectation = expectationWithDescription("\(URL)")
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         manager.request(.GET, URL)
@@ -269,7 +269,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         )
 
         let expectation = expectationWithDescription("\(URL)")
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         manager.request(.GET, URL)
@@ -299,7 +299,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         )
 
         let expectation = expectationWithDescription("\(URL)")
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         manager.request(.GET, URL)
@@ -313,7 +313,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error, "error should not be nil")
 
-        if let code = (error as? NSError)?.code {
+        if let code = error?.code {
             XCTAssertEqual(code, NSURLErrorCancelled, "code should be cancelled")
         } else {
             XCTFail("error should be an NSError")
@@ -333,7 +333,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         )
 
         let expectation = expectationWithDescription("\(URL)")
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         manager.request(.GET, URL)
@@ -361,7 +361,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         )
 
         let expectation = expectationWithDescription("\(URL)")
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         manager.request(.GET, URL)
@@ -389,7 +389,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         )
 
         let expectation = expectationWithDescription("\(URL)")
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         manager.request(.GET, URL)
@@ -415,7 +415,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         )
 
         let expectation = expectationWithDescription("\(URL)")
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         manager.request(.GET, URL)
@@ -447,7 +447,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         )
 
         let expectation = expectationWithDescription("\(URL)")
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         manager.request(.GET, URL)
@@ -477,7 +477,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         )
 
         let expectation = expectationWithDescription("\(URL)")
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         manager.request(.GET, URL)
@@ -491,7 +491,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error, "error should not be nil")
 
-        if let code = (error as? NSError)?.code {
+        if let code = error?.code {
             XCTAssertEqual(code, NSURLErrorCancelled, "code should be cancelled")
         } else {
             XCTFail("error should be an NSError")

--- a/Tests/URLProtocolTests.swift
+++ b/Tests/URLProtocolTests.swift
@@ -138,7 +138,7 @@ class URLProtocolTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(URLRequest)

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -148,7 +148,7 @@ class UploadDataTestCase: BaseTestCase {
 
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.upload(.POST, URLString, data: data)
@@ -275,7 +275,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.upload(
@@ -332,7 +332,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.upload(
@@ -601,7 +601,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var error: ErrorType?
+        var error: NSError?
         var streamingFromDisk: Bool?
 
         // When
@@ -675,7 +675,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         var request: NSURLRequest?
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.upload(

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -30,7 +30,7 @@ class StatusCodeValidationTestCase: BaseTestCase {
         let URLString = "https://httpbin.org/status/200"
         let expectation = expectationWithDescription("request should return 200 status code")
 
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)
@@ -51,7 +51,7 @@ class StatusCodeValidationTestCase: BaseTestCase {
         let URLString = "https://httpbin.org/status/404"
         let expectation = expectationWithDescription("request should return 404 status code")
 
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)
@@ -66,7 +66,7 @@ class StatusCodeValidationTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error, "error should not be nil")
 
-        if let error = error as? NSError {
+        if let error = error {
             XCTAssertEqual(error.domain, Error.Domain, "domain should be Alamofire error domain")
             XCTAssertEqual(error.code, Error.Code.StatusCodeValidationFailed.rawValue, "code should be status code validation failure")
         } else {
@@ -79,7 +79,7 @@ class StatusCodeValidationTestCase: BaseTestCase {
         let URLString = "https://httpbin.org/status/201"
         let expectation = expectationWithDescription("request should return 201 status code")
 
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)
@@ -94,7 +94,7 @@ class StatusCodeValidationTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error, "error should not be nil")
 
-        if let error = error as? NSError {
+        if let error = error {
             XCTAssertEqual(error.domain, Error.Domain, "domain should be Alamofire error domain")
             XCTAssertEqual(error.code, Error.Code.StatusCodeValidationFailed.rawValue, "code should be status code validation failure")
         } else {
@@ -111,7 +111,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
         let URLString = "https://httpbin.org/ip"
         let expectation = expectationWithDescription("request should succeed and return ip")
 
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)
@@ -132,7 +132,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
         let URLString = "https://httpbin.org/ip"
         let expectation = expectationWithDescription("request should succeed and return ip")
 
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)
@@ -155,7 +155,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
         let URLString = "https://httpbin.org/xml"
         let expectation = expectationWithDescription("request should succeed and return xml")
 
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)
@@ -170,7 +170,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error, "error should not be nil")
 
-        if let error = error as? NSError {
+        if let error = error {
             XCTAssertEqual(error.domain, Error.Domain, "domain should be Alamofire error domain")
             XCTAssertEqual(error.code, Error.Code.ContentTypeValidationFailed.rawValue, "code should be content type validation failure")
         } else {
@@ -183,7 +183,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
         let URLString = "https://httpbin.org/xml"
         let expectation = expectationWithDescription("request should succeed and return xml")
 
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)
@@ -198,7 +198,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error, "error should not be nil")
 
-        if let error = error as? NSError {
+        if let error = error {
             XCTAssertEqual(error.domain, Error.Domain, "domain should be Alamofire error domain")
             XCTAssertEqual(error.code, Error.Code.ContentTypeValidationFailed.rawValue, "code should be content type validation failure")
         } else {
@@ -258,7 +258,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
 
         var response: NSHTTPURLResponse?
         var data: NSData?
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         manager.request(.DELETE, URLString)
@@ -293,7 +293,7 @@ class MultipleValidationTestCase: BaseTestCase {
         let URLString = "https://httpbin.org/ip"
         let expectation = expectationWithDescription("request should succeed and return ip")
 
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)
@@ -315,7 +315,7 @@ class MultipleValidationTestCase: BaseTestCase {
         let URLString = "https://httpbin.org/xml"
         let expectation = expectationWithDescription("request should succeed and return xml")
 
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)
@@ -331,7 +331,7 @@ class MultipleValidationTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error, "error should not be nil")
 
-        if let error = error as? NSError {
+        if let error = error {
             XCTAssertEqual(error.domain, Error.Domain, "domain should be Alamofire error domain")
             XCTAssertEqual(error.code, Error.Code.StatusCodeValidationFailed.rawValue, "code should be status code validation failure")
         } else {
@@ -344,7 +344,7 @@ class MultipleValidationTestCase: BaseTestCase {
         let URLString = "https://httpbin.org/xml"
         let expectation = expectationWithDescription("request should succeed and return xml")
 
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)
@@ -360,7 +360,7 @@ class MultipleValidationTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error, "error should not be nil")
 
-        if let error = error as? NSError {
+        if let error = error {
             XCTAssertEqual(error.domain, Error.Domain, "domain should be Alamofire error domain")
             XCTAssertEqual(error.code, Error.Code.ContentTypeValidationFailed.rawValue, "code should be content type validation failure")
         } else {
@@ -380,7 +380,7 @@ class AutomaticValidationTestCase: BaseTestCase {
 
         let expectation = expectationWithDescription("request should succeed and return ip")
 
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(mutableURLRequest)
@@ -401,7 +401,7 @@ class AutomaticValidationTestCase: BaseTestCase {
         let URLString = "https://httpbin.org/status/404"
         let expectation = expectationWithDescription("request should return 404 status code")
 
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(.GET, URLString)
@@ -416,7 +416,7 @@ class AutomaticValidationTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error, "error should not be nil")
 
-        if let error = error as? NSError {
+        if let error = error {
             XCTAssertEqual(error.domain, Error.Domain, "domain should be Alamofire error domain")
             XCTAssertEqual(error.code, Error.Code.StatusCodeValidationFailed.rawValue, "code should be status code validation failure")
         } else {
@@ -432,7 +432,7 @@ class AutomaticValidationTestCase: BaseTestCase {
 
         let expectation = expectationWithDescription("request should succeed and return ip")
 
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(mutableURLRequest)
@@ -458,7 +458,7 @@ class AutomaticValidationTestCase: BaseTestCase {
 
         let expectation = expectationWithDescription("request should succeed and return xml")
 
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(mutableURLRequest)
@@ -482,7 +482,7 @@ class AutomaticValidationTestCase: BaseTestCase {
 
         let expectation = expectationWithDescription("request should succeed and return xml")
 
-        var error: ErrorType?
+        var error: NSError?
 
         // When
         Alamofire.request(mutableURLRequest)
@@ -497,7 +497,7 @@ class AutomaticValidationTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error, "error should not be nil")
 
-        if let error = error as? NSError {
+        if let error = error {
             XCTAssertEqual(error.domain, Error.Domain, "domain should be Alamofire error domain")
             XCTAssertEqual(error.code, Error.Code.ContentTypeValidationFailed.rawValue, "code should be content type validation failure")
         } else {


### PR DESCRIPTION
This PR is a non-backwards compatible set of changes solving several shortcomings of the current `Result` and `ResponseSerializer` design. Here is a quick list of callouts:

* `Result` type now takes two generic parameters (Value and Error) where the Error conforms to `ErrorType`.
    > No longer stores the `data` in the `.Failure` case.

* All response serializers now return the original server data as an `NSData` optional.
    > This solves all the issues reported in #779.

* The `TaskDelegate` now stores the error as an `NSError` instead of an `ErrorType`.
    > This was changed in #732 and this should not have been. With these changes, consumers no longer need to cast the `error` to an `NSError`. 

* The `ValidationResult` failure case now requires an `NSError` and not an `ErrorType`.
    > This means that a custom `Validation` closure MUST return an `NSError`. The change made to address #732 should NOT have been made. All errors generated by Alamofire (including custom Validation) need to generate `NSError` types. Otherwise we force all consumers to have to cast all error objects returned from Alamofire even though they are not using their own custom validation error types.

For more details, please refer to #732, #757 and #779.