### PR TITLE
Feature - Manager Initialization

### DIFF
--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -114,10 +114,12 @@ public class Manager {
     // MARK: - Lifecycle
 
     /**
-        Initializes the `Manager` instance with the given configuration and server trust policy.
+        Initializes the `Manager` instance with the specified configuration, delegate and server trust policy.
 
         - parameter configuration:            The configuration used to construct the managed session. 
                                               `NSURLSessionConfiguration.defaultSessionConfiguration()` by default.
+        - parameter delegate:                 The delegate used when initializing the session. `SessionDelegate()` by
+                                              default.
         - parameter serverTrustPolicyManager: The server trust policy manager to use for evaluating all server trust 
                                               challenges. `nil` by default.
 
@@ -125,13 +127,42 @@ public class Manager {
     */
     public init(
         configuration: NSURLSessionConfiguration = NSURLSessionConfiguration.defaultSessionConfiguration(),
+        delegate: SessionDelegate = SessionDelegate(),
         serverTrustPolicyManager: ServerTrustPolicyManager? = nil)
     {
-        self.delegate = SessionDelegate()
-        self.session = NSURLSession(configuration: configuration, delegate: self.delegate, delegateQueue: nil)
-        self.session.serverTrustPolicyManager = serverTrustPolicyManager
+        self.delegate = delegate
+        self.session = NSURLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
 
-        self.delegate.sessionDidFinishEventsForBackgroundURLSession = { [weak self] session in
+        commonInit(serverTrustPolicyManager: serverTrustPolicyManager)
+    }
+
+    /**
+        Initializes the `Manager` instance with the specified session, delegate and server trust policy.
+
+        - parameter session:                  The URL session.
+        - parameter delegate:                 The delegate of the URL session. Must equal the URL session's delegate.
+        - parameter serverTrustPolicyManager: The server trust policy manager to use for evaluating all server trust
+                                              challenges. `nil` by default.
+
+        - returns: The new `Manager` instance if the URL session's delegate matches the delegate parameter.
+    */
+    public init?(
+        session: NSURLSession,
+        delegate: SessionDelegate,
+        serverTrustPolicyManager: ServerTrustPolicyManager? = nil)
+    {
+        self.delegate = delegate
+        self.session = session
+
+        guard delegate === session.delegate else { return nil }
+
+        commonInit(serverTrustPolicyManager: serverTrustPolicyManager)
+    }
+
+    private func commonInit(serverTrustPolicyManager serverTrustPolicyManager: ServerTrustPolicyManager?) {
+        session.serverTrustPolicyManager = serverTrustPolicyManager
+
+        delegate.sessionDidFinishEventsForBackgroundURLSession = { [weak self] session in
             guard let strongSelf = self else { return }
             dispatch_async(dispatch_get_main_queue()) { strongSelf.backgroundCompletionHandler?() }
         }
@@ -217,6 +248,15 @@ public class Manager {
                     self.subdelegates[task.taskIdentifier] = newValue
                 }
             }
+        }
+
+        /**
+            Initializes the `SessionDelegate` instance.
+
+            - returns: The new `SessionDelegate` instance.
+        */
+        public override init() {
+            super.init()
         }
 
         // MARK: - NSURLSessionDelegate


### PR DESCRIPTION
This PR opens up the `Manager` initialization to allow users to use dependency injection for both the underlying `NSURLSession` and `SessionDelegate`. 

#### Using Dependency Injection for the URL Session

This change was really made due to #794. While libraries like Mockingjay and OHHTTPStubs are one way to perform automation, Alamofire should also allow a bit more control over the URL session creation to allow approaches like DVR to be possible. This PR adds a failable initializer allowing this to be possible.

#### Using Dependency Injection for the Session Delegate

The current design of the `Manager` initialization is tailored to starting up your app, setting up a `Manager` instance and start making requests. It does not however support background session callbacks very well. 

The problem is that you need to configure the override closures on the `SessionDelegate` before actually creating the NSURLSession. Otherwise, you could start receiving delegate callbacks before you've had a chance to hook up the override closures. This PR adds the ability to use dependency injection to pass in a pre-configured `SessionDelegate` that already has the override closures set.