### PR TITLE
Import MobileCoreServices for tvOS

### DIFF
--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -22,7 +22,7 @@
 
 import Foundation
 
-#if os(iOS) || os(watchOS)
+#if os(iOS) || os(watchOS) || os(tvOS)
 import MobileCoreServices
 #elseif os(OSX)
 import CoreServices


### PR DESCRIPTION
Importing MobileCoreServices for os=tvOS allows Alamofire to compile on tvOS