### PR TITLE
Feature - Added 204 Support to Response Serializers

### DIFF
--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -261,8 +261,8 @@ extension Request {
 
             guard response?.statusCode ?? -1 != 204 else { return .Success(NSNull()) }
 
-            guard let validData = data else {
-                let failureReason = "JSON could not be serialized. Input data was nil."
+            guard let validData = data where validData.length > 0 else {
+                let failureReason = "JSON could not be serialized. Input data was nil or zero length."
                 let error = Error.errorWithCode(.JSONSerializationFailed, failureReason: failureReason)
                 return .Failure(error)
             }
@@ -317,8 +317,8 @@ extension Request {
 
             guard response?.statusCode ?? -1 != 204 else { return .Success(NSNull()) }
 
-            guard let validData = data else {
-                let failureReason = "Property list could not be serialized. Input data was nil."
+            guard let validData = data where validData.length > 0 else {
+                let failureReason = "Property list could not be serialized. Input data was nil or zero length."
                 let error = Error.errorWithCode(.PropertyListSerializationFailed, failureReason: failureReason)
                 return .Failure(error)
             }

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -145,11 +145,13 @@ extension Request {
         - returns: A data response serializer.
     */
     public static func dataResponseSerializer() -> ResponseSerializer<NSData, NSError> {
-        return ResponseSerializer { _, _, data, error in
+        return ResponseSerializer { _, response, data, error in
             guard error == nil else { return .Failure(error!) }
 
-            guard let validData = data where validData.length > 0 else {
-                let failureReason = "Data could not be serialized. Input data was nil or zero length."
+            guard response?.statusCode ?? -1 != 204 else { return .Success(NSData()) }
+
+            guard let validData = data else {
+                let failureReason = "Data could not be serialized. Input data was nil."
                 let error = Error.errorWithCode(.DataSerializationFailed, failureReason: failureReason)
                 return .Failure(error)
             }
@@ -190,8 +192,10 @@ extension Request {
         return ResponseSerializer { _, response, data, error in
             guard error == nil else { return .Failure(error!) }
 
-            guard let validData = data where validData.length > 0 else {
-                let failureReason = "String could not be serialized. Input data was nil or zero length."
+            guard response?.statusCode ?? -1 != 204 else { return .Success("") }
+
+            guard let validData = data else {
+                let failureReason = "String could not be serialized. Input data was nil."
                 let error = Error.errorWithCode(.StringSerializationFailed, failureReason: failureReason)
                 return .Failure(error)
             }
@@ -252,11 +256,13 @@ extension Request {
         options options: NSJSONReadingOptions = .AllowFragments)
         -> ResponseSerializer<AnyObject, NSError>
     {
-        return ResponseSerializer { _, _, data, error in
+        return ResponseSerializer { _, response, data, error in
             guard error == nil else { return .Failure(error!) }
 
-            guard let validData = data where validData.length > 0 else {
-                let failureReason = "JSON could not be serialized. Input data was nil or zero length."
+            guard response?.statusCode ?? -1 != 204 else { return .Success(NSNull()) }
+
+            guard let validData = data else {
+                let failureReason = "JSON could not be serialized. Input data was nil."
                 let error = Error.errorWithCode(.JSONSerializationFailed, failureReason: failureReason)
                 return .Failure(error)
             }
@@ -306,11 +312,13 @@ extension Request {
         options options: NSPropertyListReadOptions = NSPropertyListReadOptions())
         -> ResponseSerializer<AnyObject, NSError>
     {
-        return ResponseSerializer { _, _, data, error in
+        return ResponseSerializer { _, response, data, error in
             guard error == nil else { return .Failure(error!) }
 
-            guard let validData = data where validData.length > 0 else {
-                let failureReason = "Property list could not be serialized. Input data was nil or zero length."
+            guard response?.statusCode ?? -1 != 204 else { return .Success(NSNull()) }
+
+            guard let validData = data else {
+                let failureReason = "Property list could not be serialized. Input data was nil."
                 let error = Error.errorWithCode(.PropertyListSerializationFailed, failureReason: failureReason)
                 return .Failure(error)
             }

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -148,7 +148,7 @@ extension Request {
         return ResponseSerializer { _, response, data, error in
             guard error == nil else { return .Failure(error!) }
 
-            guard response?.statusCode ?? -1 != 204 else { return .Success(NSData()) }
+            if let response = response where response.statusCode == 204 { return .Success(NSData()) }
 
             guard let validData = data else {
                 let failureReason = "Data could not be serialized. Input data was nil."
@@ -192,7 +192,7 @@ extension Request {
         return ResponseSerializer { _, response, data, error in
             guard error == nil else { return .Failure(error!) }
 
-            guard response?.statusCode ?? -1 != 204 else { return .Success("") }
+            if let response = response where response.statusCode == 204 { return .Success("") }
 
             guard let validData = data else {
                 let failureReason = "String could not be serialized. Input data was nil."
@@ -259,7 +259,7 @@ extension Request {
         return ResponseSerializer { _, response, data, error in
             guard error == nil else { return .Failure(error!) }
 
-            guard response?.statusCode ?? -1 != 204 else { return .Success(NSNull()) }
+            if let response = response where response.statusCode == 204 { return .Success(NSNull()) }
 
             guard let validData = data where validData.length > 0 else {
                 let failureReason = "JSON could not be serialized. Input data was nil or zero length."
@@ -315,7 +315,7 @@ extension Request {
         return ResponseSerializer { _, response, data, error in
             guard error == nil else { return .Failure(error!) }
 
-            guard response?.statusCode ?? -1 != 204 else { return .Success(NSNull()) }
+            if let response = response where response.statusCode == 204 { return .Success(NSNull()) }
 
             guard let validData = data where validData.length > 0 else {
                 let failureReason = "Property list could not be serialized. Input data was nil or zero length."

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -348,8 +348,8 @@ class ResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error, "result error should not be nil")
 
         if let error = result.error {
-            XCTAssertEqual(error.domain, NSCocoaErrorDomain, "error domain should match expected value")
-            XCTAssertEqual(error.code, 3840, "error code should match expected value")
+            XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
+            XCTAssertEqual(error.code, Error.Code.JSONSerializationFailed.rawValue, "error code should match expected value")
         } else {
             XCTFail("error should not be nil")
         }
@@ -486,8 +486,8 @@ class ResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error, "result error should not be nil")
 
         if let error = result.error {
-            XCTAssertEqual(error.domain, NSCocoaErrorDomain, "error domain should match expected value")
-            XCTAssertEqual(error.code, 3840, "error code should match expected value")
+            XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
+            XCTAssertEqual(error.code, Error.Code.PropertyListSerializationFailed.rawValue, "error code should match expected value")
         } else {
             XCTFail("error should not be nil")
         }

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -348,7 +348,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error, "result error should not be nil")
 
         if let error = result.error {
-            XCTAssertEqual(error.domain, "NSCocoaErrorDomain", "error domain should match expected value")
+            XCTAssertEqual(error.domain, NSCocoaErrorDomain, "error domain should match expected value")
             XCTAssertEqual(error.code, 3840, "error code should match expected value")
         } else {
             XCTFail("error should not be nil")
@@ -486,7 +486,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error, "result error should not be nil")
 
         if let error = result.error {
-            XCTAssertEqual(error.domain, "NSCocoaErrorDomain", "error domain should match expected value")
+            XCTAssertEqual(error.domain, NSCocoaErrorDomain, "error domain should match expected value")
             XCTAssertEqual(error.code, 3840, "error code should match expected value")
         } else {
             XCTFail("error should not be nil")

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -83,6 +83,47 @@ class ResponseSerializationTestCase: BaseTestCase {
         }
     }
 
+    func testThatDataResponseSerializerFailsWhenDataIsNilWithNon204ResponseStatusCode() {
+        // Given
+        let serializer = Request.dataResponseSerializer()
+        let URL = NSURL(string: "https://httpbin.org/get")!
+        let response = NSHTTPURLResponse(URL: URL, statusCode: 200, HTTPVersion: "HTTP/1.1", headerFields: nil)
+
+        // When
+        let result = serializer.serializeResponse(nil, response, nil, nil)
+
+        // Then
+        XCTAssertTrue(result.isFailure, "result is failure should be true")
+        XCTAssertNil(result.value, "result value should be nil")
+        XCTAssertNotNil(result.error, "result error should not be nil")
+
+        if let error = result.error {
+            XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
+            XCTAssertEqual(error.code, Error.Code.DataSerializationFailed.rawValue, "error code should match expected value")
+        } else {
+            XCTFail("error should not be nil")
+        }
+    }
+
+    func testThatDataResponseSerializerSucceedsWhenDataIsNilWith204ResponseStatusCode() {
+        // Given
+        let serializer = Request.dataResponseSerializer()
+        let URL = NSURL(string: "https://httpbin.org/get")!
+        let response = NSHTTPURLResponse(URL: URL, statusCode: 204, HTTPVersion: "HTTP/1.1", headerFields: nil)
+
+        // When
+        let result = serializer.serializeResponse(nil, response, nil, nil)
+
+        // Then
+        XCTAssertTrue(result.isSuccess, "result is success should be true")
+        XCTAssertNotNil(result.value, "result value should not be nil")
+        XCTAssertNil(result.error, "result error should be nil")
+
+        if let data = result.value {
+            XCTAssertEqual(data.length, 0, "data length should be zero")
+        }
+    }
+
     // MARK: - String Response Serializer Tests
 
     func testThatStringResponseSerializerFailsWhenDataIsNil() {
@@ -105,7 +146,7 @@ class ResponseSerializationTestCase: BaseTestCase {
         }
     }
 
-    func testThatStringResponseSerializerFailsWhenDataIsEmpty() {
+    func testThatStringResponseSerializerSucceedsWhenDataIsEmpty() {
         // Given
         let serializer = Request.stringResponseSerializer()
 
@@ -113,9 +154,9 @@ class ResponseSerializationTestCase: BaseTestCase {
         let result = serializer.serializeResponse(nil, nil, NSData(), nil)
 
         // Then
-        XCTAssertTrue(result.isFailure, "result is failure should be true")
-        XCTAssertNil(result.value, "result value should be nil")
-        XCTAssertNotNil(result.error, "result error should not be nil")
+        XCTAssertTrue(result.isSuccess, "result is success should be true")
+        XCTAssertNotNil(result.value, "result value should not be nil")
+        XCTAssertNil(result.error, "result error should be nil")
     }
 
     func testThatStringResponseSerializerSucceedsWithUTF8DataAndNoProvidedEncoding() {
@@ -231,6 +272,47 @@ class ResponseSerializationTestCase: BaseTestCase {
         }
     }
 
+    func testThatStringResponseSerializerFailsWhenDataIsNilWithNon204ResponseStatusCode() {
+        // Given
+        let serializer = Request.stringResponseSerializer()
+        let URL = NSURL(string: "https://httpbin.org/get")!
+        let response = NSHTTPURLResponse(URL: URL, statusCode: 200, HTTPVersion: "HTTP/1.1", headerFields: nil)
+
+        // When
+        let result = serializer.serializeResponse(nil, response, nil, nil)
+
+        // Then
+        XCTAssertTrue(result.isFailure, "result is failure should be true")
+        XCTAssertNil(result.value, "result value should be nil")
+        XCTAssertNotNil(result.error, "result error should not be nil")
+
+        if let error = result.error {
+            XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
+            XCTAssertEqual(error.code, Error.Code.StringSerializationFailed.rawValue, "error code should match expected value")
+        } else {
+            XCTFail("error should not be nil")
+        }
+    }
+
+    func testThatStringResponseSerializerSucceedsWhenDataIsNilWith204ResponseStatusCode() {
+        // Given
+        let serializer = Request.stringResponseSerializer()
+        let URL = NSURL(string: "https://httpbin.org/get")!
+        let response = NSHTTPURLResponse(URL: URL, statusCode: 204, HTTPVersion: "HTTP/1.1", headerFields: nil)
+
+        // When
+        let result = serializer.serializeResponse(nil, response, nil, nil)
+
+        // Then
+        XCTAssertTrue(result.isSuccess, "result is success should be true")
+        XCTAssertNotNil(result.value, "result value should not be nil")
+        XCTAssertNil(result.error, "result error should be nil")
+
+        if let string = result.value {
+            XCTAssertEqual(string, "", "string should be equal to empty string")
+        }
+    }
+
     // MARK: - JSON Response Serializer Tests
 
     func testThatJSONResponseSerializerFailsWhenDataIsNil() {
@@ -266,8 +348,8 @@ class ResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error, "result error should not be nil")
 
         if let error = result.error {
-            XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
-            XCTAssertEqual(error.code, Error.Code.JSONSerializationFailed.rawValue, "error code should match expected value")
+            XCTAssertEqual(error.domain, "NSCocoaErrorDomain", "error domain should match expected value")
+            XCTAssertEqual(error.code, 3840, "error code should match expected value")
         } else {
             XCTFail("error should not be nil")
         }
@@ -328,6 +410,47 @@ class ResponseSerializationTestCase: BaseTestCase {
         }
     }
 
+    func testThatJSONResponseSerializerFailsWhenDataIsNilWithNon204ResponseStatusCode() {
+        // Given
+        let serializer = Request.JSONResponseSerializer()
+        let URL = NSURL(string: "https://httpbin.org/get")!
+        let response = NSHTTPURLResponse(URL: URL, statusCode: 200, HTTPVersion: "HTTP/1.1", headerFields: nil)
+
+        // When
+        let result = serializer.serializeResponse(nil, response, nil, nil)
+
+        // Then
+        XCTAssertTrue(result.isFailure, "result is failure should be true")
+        XCTAssertNil(result.value, "result value should be nil")
+        XCTAssertNotNil(result.error, "result error should not be nil")
+
+        if let error = result.error {
+            XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
+            XCTAssertEqual(error.code, Error.Code.JSONSerializationFailed.rawValue, "error code should match expected value")
+        } else {
+            XCTFail("error should not be nil")
+        }
+    }
+
+    func testThatJSONResponseSerializerSucceedsWhenDataIsNilWith204ResponseStatusCode() {
+        // Given
+        let serializer = Request.JSONResponseSerializer()
+        let URL = NSURL(string: "https://httpbin.org/get")!
+        let response = NSHTTPURLResponse(URL: URL, statusCode: 204, HTTPVersion: "HTTP/1.1", headerFields: nil)
+
+        // When
+        let result = serializer.serializeResponse(nil, response, nil, nil)
+
+        // Then
+        XCTAssertTrue(result.isSuccess, "result is success should be true")
+        XCTAssertNotNil(result.value, "result value should not be nil")
+        XCTAssertNil(result.error, "result error should be nil")
+
+        if let json = result.value as? NSNull {
+            XCTAssertEqual(json, NSNull(), "json should be equal to NSNull")
+        }
+    }
+
     // MARK: - Property List Response Serializer Tests
 
     func testThatPropertyListResponseSerializerFailsWhenDataIsNil() {
@@ -363,8 +486,8 @@ class ResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error, "result error should not be nil")
 
         if let error = result.error {
-            XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
-            XCTAssertEqual(error.code, Error.Code.PropertyListSerializationFailed.rawValue, "error code should match expected value")
+            XCTAssertEqual(error.domain, "NSCocoaErrorDomain", "error domain should match expected value")
+            XCTAssertEqual(error.code, 3840, "error code should match expected value")
         } else {
             XCTFail("error should not be nil")
         }
@@ -422,6 +545,47 @@ class ResponseSerializationTestCase: BaseTestCase {
             XCTAssertEqual(error.code, self.error.code, "error code should match expected value")
         } else {
             XCTFail("error should not be nil")
+        }
+    }
+
+    func testThatPropertyListResponseSerializerFailsWhenDataIsNilWithNon204ResponseStatusCode() {
+        // Given
+        let serializer = Request.propertyListResponseSerializer()
+        let URL = NSURL(string: "https://httpbin.org/get")!
+        let response = NSHTTPURLResponse(URL: URL, statusCode: 200, HTTPVersion: "HTTP/1.1", headerFields: nil)
+
+        // When
+        let result = serializer.serializeResponse(nil, response, nil, nil)
+
+        // Then
+        XCTAssertTrue(result.isFailure, "result is failure should be true")
+        XCTAssertNil(result.value, "result value should be nil")
+        XCTAssertNotNil(result.error, "result error should not be nil")
+
+        if let error = result.error {
+            XCTAssertEqual(error.domain, Error.Domain, "error domain should match expected value")
+            XCTAssertEqual(error.code, Error.Code.PropertyListSerializationFailed.rawValue, "error code should match expected value")
+        } else {
+            XCTFail("error should not be nil")
+        }
+    }
+
+    func testThatPropertyListResponseSerializerSucceedsWhenDataIsNilWith204ResponseStatusCode() {
+        // Given
+        let serializer = Request.propertyListResponseSerializer()
+        let URL = NSURL(string: "https://httpbin.org/get")!
+        let response = NSHTTPURLResponse(URL: URL, statusCode: 204, HTTPVersion: "HTTP/1.1", headerFields: nil)
+
+        // When
+        let result = serializer.serializeResponse(nil, response, nil, nil)
+
+        // Then
+        XCTAssertTrue(result.isSuccess, "result is success should be true")
+        XCTAssertNotNil(result.value, "result value should not be nil")
+        XCTAssertNil(result.error, "result error should be nil")
+
+        if let plist = result.value as? NSNull {
+            XCTAssertEqual(plist, NSNull(), "plist should be equal to NSNull")
         }
     }
 }


### PR DESCRIPTION
We've been tracking this closely in our Trello project. Alamofire could greatly benefit from better 204 support. Therefore, we've been discussing the options in how to actually handle this. This PR puts forward the most sensible, non-invasive support for this behavior IMO.

The only other thing I question about this approach is whether we should require validation on the 204 as an acceptable status code before allowing this check in the response serializers. That would better help identify intent. I also hate to require that though as I feel it is a bit heavy handed.

I'm very interested to get everyone else's thoughts on this change. Anyone out there that has had to work through a 204 use case, please get your feedback in now!