### PR TITLE
Feature - Content Type Validation on Empty Data

### DIFF
--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -130,6 +130,8 @@ extension Request {
     */
     public func validate<S : SequenceType where S.Generator.Element == String>(contentType acceptableContentTypes: S) -> Self {
         return validate { _, response in
+            guard let validData = self.delegate.data where validData.length > 0 else { return .Success }
+
             if let
                 responseContentType = response.MIMEType,
                 responseMIMEType = MIMEType(responseContentType)

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -220,12 +220,6 @@ class ContentTypeValidationTestCase: BaseTestCase {
             .validate(contentType: [])
             .response { _, response, data, responseError in
                 error = responseError
-
-                print(response)
-                if let data = data {
-                    print(String(data: data, encoding: NSUTF8StringEncoding)!)
-                }
-
                 expectation.fulfill()
             }
 

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -208,6 +208,33 @@ class ContentTypeValidationTestCase: BaseTestCase {
         }
     }
 
+    func testThatValidationForRequestWithNoAcceptableContentTypeResponseSucceedsWhenNoDataIsReturned() {
+        // Given
+        let URLString = "https://httpbin.org/status/204"
+        let expectation = expectationWithDescription("request should succeed and return no data")
+
+        var error: NSError?
+
+        // When
+        Alamofire.request(.GET, URLString)
+            .validate(contentType: [])
+            .response { _, response, data, responseError in
+                error = responseError
+
+                print(response)
+                if let data = data {
+                    print(String(data: data, encoding: NSUTF8StringEncoding)!)
+                }
+
+                expectation.fulfill()
+            }
+
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+
+        // Then
+        XCTAssertNil(error, "error should be nil")
+    }
+
     func testThatValidationForRequestWithAcceptableWildcardContentTypeResponseSucceedsWhenResponseIsNil() {
         // Given
         class MockManager: Manager {


### PR DESCRIPTION
Content Type validation now always succeeds when server data is nil or empty. Content type validation should NEVER fail when there is no data to actually validate against. For example, if someone specifies they want to use `application/json` validation for all their JSON requests, this check would always fail on DELETE requests that most likely will return a 204. This change ensures this common use case is better supported.