### PR TITLE
Drop mention of rdar://22307360, Xcode 7.1 is out

### DIFF
--- a/README.md
+++ b/README.md
@@ -1095,9 +1095,6 @@ The following rdars have some affect on the current implementation of Alamofire.
 
 * [rdar://22024442](http://www.openradar.me/radar?id=6082025006039040) - Array of [SecCertificate] crashing Swift 2.0 compiler in optimized builds
 * [rdar://21349340](http://www.openradar.me/radar?id=5517037090635776) - Compiler throwing warning due to toll-free bridging issue in test case
-* [rdar://22307360](http://www.openradar.me/radar?id=4895563208196096) - Swift #available check not working properly with min deployment target
-
-    > Resolved in Xcode 7.1 beta 2. Will remove once Xcode 7.1 is out of beta.
 
 ## FAQ
 


### PR DESCRIPTION
Xcode 7.1 is out in the App Store, the comment related to rdar://22307360 is no longer needed