### PR TITLE
Update deprecated playground function

### DIFF
--- a/Alamofire.playground/section-1.swift
+++ b/Alamofire.playground/section-1.swift
@@ -3,7 +3,7 @@ import Foundation
 import XCPlayground
 
 // Allow network requests to complete
-XCPSetExecutionShouldContinueIndefinitely()
+XCPlaygroundPage.currentPage.needsIndefiniteExecution = true
 
 Alamofire.request(.GET, "https://httpbin.org/get", parameters: ["foo": "bar"])
     .responseJSON { response in


### PR DESCRIPTION
```XCPSetExecutionShouldContinueIndefinitely()``` should now be ```XCPlaygroundPage.currentPage.needsIndefiniteExecution = true``` as the former was deprecated.