### PR TITLE
Replace http to https on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,13 @@ $ git submodule add https://github.com/Alamofire/Alamofire.git
 ```swift
 import Alamofire
 
-Alamofire.request(.GET, "http://httpbin.org/get")
+Alamofire.request(.GET, "https://httpbin.org/get")
 ```
 
 ### Response Handling
 
 ```swift
-Alamofire.request(.GET, "http://httpbin.org/get", parameters: ["foo": "bar"])
+Alamofire.request(.GET, "https://httpbin.org/get", parameters: ["foo": "bar"])
          .responseJSON { response in
              print(response.request)  // original URL request
              print(response.response) // URL response
@@ -174,7 +174,7 @@ Alamofire.request(.GET, "http://httpbin.org/get", parameters: ["foo": "bar"])
 #### Response Handler
 
 ```swift
-Alamofire.request(.GET, "http://httpbin.org/get", parameters: ["foo": "bar"])
+Alamofire.request(.GET, "https://httpbin.org/get", parameters: ["foo": "bar"])
          .response { request, response, data, error in
              print(request)
              print(response)
@@ -188,7 +188,7 @@ Alamofire.request(.GET, "http://httpbin.org/get", parameters: ["foo": "bar"])
 #### Response Data Handler
 
 ```swift
-Alamofire.request(.GET, "http://httpbin.org/get", parameters: ["foo": "bar"])
+Alamofire.request(.GET, "https://httpbin.org/get", parameters: ["foo": "bar"])
          .responseData { response in
              print(response.request)
              print(response.response)
@@ -199,7 +199,7 @@ Alamofire.request(.GET, "http://httpbin.org/get", parameters: ["foo": "bar"])
 #### Response String Handler
 
 ```swift
-Alamofire.request(.GET, "http://httpbin.org/get")
+Alamofire.request(.GET, "https://httpbin.org/get")
          .responseString { response in
              print("Success: \(response.result.isSuccess)")
              print("Response String: \(response.result.value)")
@@ -209,7 +209,7 @@ Alamofire.request(.GET, "http://httpbin.org/get")
 #### Response JSON Handler
 
 ```swift
-Alamofire.request(.GET, "http://httpbin.org/get")
+Alamofire.request(.GET, "https://httpbin.org/get")
          .responseJSON { response in
              debugPrint(response)
          }
@@ -220,7 +220,7 @@ Alamofire.request(.GET, "http://httpbin.org/get")
 Response handlers can even be chained:
 
 ```swift
-Alamofire.request(.GET, "http://httpbin.org/get")
+Alamofire.request(.GET, "https://httpbin.org/get")
          .responseString { response in
              print("Response String: \(response.result.value)")
          }
@@ -242,11 +242,11 @@ public enum Method: String {
 These values can be passed as the first argument of the `Alamofire.request` method:
 
 ```swift
-Alamofire.request(.POST, "http://httpbin.org/post")
+Alamofire.request(.POST, "https://httpbin.org/post")
 
-Alamofire.request(.PUT, "http://httpbin.org/put")
+Alamofire.request(.PUT, "https://httpbin.org/put")
 
-Alamofire.request(.DELETE, "http://httpbin.org/delete")
+Alamofire.request(.DELETE, "https://httpbin.org/delete")
 ```
 
 ### Parameters
@@ -254,8 +254,8 @@ Alamofire.request(.DELETE, "http://httpbin.org/delete")
 #### GET Request With URL-Encoded Parameters
 
 ```swift
-Alamofire.request(.GET, "http://httpbin.org/get", parameters: ["foo": "bar"])
-// http://httpbin.org/get?foo=bar
+Alamofire.request(.GET, "https://httpbin.org/get", parameters: ["foo": "bar"])
+// https://httpbin.org/get?foo=bar
 ```
 
 #### POST Request With URL-Encoded Parameters
@@ -271,7 +271,7 @@ let parameters = [
     ]
 ]
 
-Alamofire.request(.POST, "http://httpbin.org/post", parameters: parameters)
+Alamofire.request(.POST, "https://httpbin.org/post", parameters: parameters)
 // HTTP body: foo=bar&baz[]=a&baz[]=1&qux[x]=1&qux[y]=2&qux[z]=3
 ```
 
@@ -301,7 +301,7 @@ enum ParameterEncoding {
 #### Manual Parameter Encoding of an NSURLRequest
 
 ```swift
-let URL = NSURL(string: "http://httpbin.org/get")!
+let URL = NSURL(string: "https://httpbin.org/get")!
 var request = NSMutableURLRequest(URL: URL)
 
 let parameters = ["foo": "bar"]
@@ -319,7 +319,7 @@ let parameters = [
     ]
 ]
 
-Alamofire.request(.POST, "http://httpbin.org/post", parameters: parameters, encoding: .JSON)
+Alamofire.request(.POST, "https://httpbin.org/post", parameters: parameters, encoding: .JSON)
 // HTTP body: {"foo": [1, 2, 3], "bar": {"baz": "qux"}}
 ```
 
@@ -335,7 +335,7 @@ let headers = [
     "Content-Type": "application/x-www-form-urlencoded"
 ]
 
-Alamofire.request(.GET, "http://httpbin.org/get", headers: headers)
+Alamofire.request(.GET, "https://httpbin.org/get", headers: headers)
          .responseJSON { response in
              debugPrint(response)
          }
@@ -358,13 +358,13 @@ Caching is handled on the system framework level by [`NSURLCache`](https://devel
 
 ```swift
 let fileURL = NSBundle.mainBundle().URLForResource("Default", withExtension: "png")
-Alamofire.upload(.POST, "http://httpbin.org/post", file: fileURL)
+Alamofire.upload(.POST, "https://httpbin.org/post", file: fileURL)
 ```
 
 #### Uploading with Progress
 
 ```swift
-Alamofire.upload(.POST, "http://httpbin.org/post", file: fileURL)
+Alamofire.upload(.POST, "https://httpbin.org/post", file: fileURL)
          .progress { bytesWritten, totalBytesWritten, totalBytesExpectedToWrite in
              print(totalBytesWritten)
 
@@ -384,7 +384,7 @@ Alamofire.upload(.POST, "http://httpbin.org/post", file: fileURL)
 ```swift
 Alamofire.upload(
     .POST,
-    "http://httpbin.org/post",
+    "https://httpbin.org/post",
     multipartFormData: { multipartFormData in
         multipartFormData.appendBodyPart(fileURL: unicornImageURL, name: "unicorn")
         multipartFormData.appendBodyPart(fileURL: rainbowImageURL, name: "rainbow")
@@ -412,7 +412,7 @@ Alamofire.upload(
 #### Downloading a File
 
 ```swift
-Alamofire.download(.GET, "http://httpbin.org/stream/100") { temporaryURL, response in
+Alamofire.download(.GET, "https://httpbin.org/stream/100") { temporaryURL, response in
     let fileManager = NSFileManager.defaultManager()
     let directoryURL = fileManager.URLsForDirectory(.DocumentDirectory, inDomains: .UserDomainMask)[0]
     let pathComponent = response.suggestedFilename
@@ -425,13 +425,13 @@ Alamofire.download(.GET, "http://httpbin.org/stream/100") { temporaryURL, respon
 
 ```swift
 let destination = Alamofire.Request.suggestedDownloadDestination(directory: .DocumentDirectory, domain: .UserDomainMask)
-Alamofire.download(.GET, "http://httpbin.org/stream/100", destination: destination)
+Alamofire.download(.GET, "https://httpbin.org/stream/100", destination: destination)
 ```
 
 #### Downloading a File w/Progress
 
 ```swift
-Alamofire.download(.GET, "http://httpbin.org/stream/100", destination: destination)
+Alamofire.download(.GET, "https://httpbin.org/stream/100", destination: destination)
          .progress { bytesRead, totalBytesRead, totalBytesExpectedToRead in
              print(totalBytesRead)
 
@@ -453,7 +453,7 @@ Alamofire.download(.GET, "http://httpbin.org/stream/100", destination: destinati
 #### Accessing Resume Data for Failed Downloads
 
 ```swift
-Alamofire.download(.GET, "http://httpbin.org/stream/100", destination: destination)
+Alamofire.download(.GET, "https://httpbin.org/stream/100", destination: destination)
          .response { _, _, data, _ in
              if let
                  data = data,
@@ -469,7 +469,7 @@ Alamofire.download(.GET, "http://httpbin.org/stream/100", destination: destinati
 > The `data` parameter is automatically populated with the `resumeData` if available.
 
 ```swift
-let download = Alamofire.download(.GET, "http://httpbin.org/stream/100", destination: destination)
+let download = Alamofire.download(.GET, "https://httpbin.org/stream/100", destination: destination)
 download.response { _, _, _, _ in
     if let
         resumeData = download.resumeData,
@@ -519,7 +519,7 @@ let base64Credentials = credentialData.base64EncodedStringWithOptions([])
 
 let headers = ["Authorization": "Basic \(base64Credentials)"]
 
-Alamofire.request(.GET, "http://httpbin.org/basic-auth/user/password", headers: headers)
+Alamofire.request(.GET, "https://httpbin.org/basic-auth/user/password", headers: headers)
          .responseJSON { response in
              debugPrint(response)
          }
@@ -547,7 +547,7 @@ By default, Alamofire treats any completed request to be successful, regardless 
 #### Manual Validation
 
 ```swift
-Alamofire.request(.GET, "http://httpbin.org/get", parameters: ["foo": "bar"])
+Alamofire.request(.GET, "https://httpbin.org/get", parameters: ["foo": "bar"])
          .validate(statusCode: 200..<300)
          .validate(contentType: ["application/json"])
          .response { response in
@@ -560,7 +560,7 @@ Alamofire.request(.GET, "http://httpbin.org/get", parameters: ["foo": "bar"])
 Automatically validates status code within `200...299` range, and that the `Content-Type` header of the response matches the `Accept` header of the request, if one is provided.
 
 ```swift
-Alamofire.request(.GET, "http://httpbin.org/get", parameters: ["foo": "bar"])
+Alamofire.request(.GET, "https://httpbin.org/get", parameters: ["foo": "bar"])
          .validate()
          .responseJSON { response in
              switch response.result {
@@ -575,16 +575,16 @@ Alamofire.request(.GET, "http://httpbin.org/get", parameters: ["foo": "bar"])
 ### Printable
 
 ```swift
-let request = Alamofire.request(.GET, "http://httpbin.org/ip")
+let request = Alamofire.request(.GET, "https://httpbin.org/ip")
 
 print(request)
-// GET http://httpbin.org/ip (200)
+// GET https://httpbin.org/ip (200)
 ```
 
 ### DebugPrintable
 
 ```swift
-let request = Alamofire.request(.GET, "http://httpbin.org/get", parameters: ["foo": "bar"])
+let request = Alamofire.request(.GET, "https://httpbin.org/get", parameters: ["foo": "bar"])
 
 debugPrint(request)
 ```
@@ -596,7 +596,7 @@ $ curl -i \
 	-H "User-Agent: Alamofire" \
 	-H "Accept-Encoding: Accept-Encoding: gzip;q=1.0,compress;q=0.5" \
 	-H "Accept-Language: en;q=1.0,fr;q=0.9,de;q=0.8,zh-Hans;q=0.7,zh-Hant;q=0.6,ja;q=0.5" \
-	"http://httpbin.org/get?foo=bar"
+	"https://httpbin.org/get?foo=bar"
 ```
 
 ---
@@ -620,12 +620,12 @@ Top-level convenience methods like `Alamofire.request` use a shared instance of 
 As such, the following two statements are equivalent:
 
 ```swift
-Alamofire.request(.GET, "http://httpbin.org/get")
+Alamofire.request(.GET, "https://httpbin.org/get")
 ```
 
 ```swift
 let manager = Alamofire.Manager.sharedInstance
-manager.request(NSURLRequest(URL: NSURL(string: "http://httpbin.org/get")!))
+manager.request(NSURLRequest(URL: NSURL(string: "https://httpbin.org/get")!))
 ```
 
 Applications can create managers for background and ephemeral sessions, as well as new managers that customize the default session configuration, such as for default headers (`HTTPAdditionalHeaders`) or timeout interval (`timeoutIntervalForRequest`).
@@ -842,7 +842,7 @@ Alamofire.request(.GET, "http://example.com/users")
 Types adopting the `URLStringConvertible` protocol can be used to construct URL strings, which are then used to construct URL requests. `NSString`, `NSURL`, `NSURLComponents`, and `NSURLRequest` conform to `URLStringConvertible` by default, allowing any of them to be passed as `URLString` parameters to the `request`, `upload`, and `download` methods:
 
 ```swift
-let string = NSString(string: "http://httpbin.org/post")
+let string = NSString(string: "https://httpbin.org/post")
 Alamofire.request(.POST, string)
 
 let URL = NSURL(string: string)!
@@ -879,7 +879,7 @@ Alamofire.request(.GET, user) // http://example.com/users/mattt
 Types adopting the `URLRequestConvertible` protocol can be used to construct URL requests. `NSURLRequest` conforms to `URLRequestConvertible` by default, allowing it to be passed into `request`, `upload`, and `download` methods directly (this is the recommended way to specify custom HTTP body for individual requests):
 
 ```swift
-let URL = NSURL(string: "http://httpbin.org/post")!
+let URL = NSURL(string: "https://httpbin.org/post")!
 let mutableURLRequest = NSMutableURLRequest(URL: URL)
 mutableURLRequest.HTTPMethod = "POST"
 


### PR DESCRIPTION
Sample code does not work, because of ATS in iOS9. I made a change in README as follows; replace http with https.