### PR TITLE
Add TLS MinimumVersion to NSAppTransportSecurity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1101,6 +1101,9 @@ If you run into this problem (high probability with self-signed certificates), y
 				<false/>
 				<key>NSIncludesSubdomains</key>
 				<true/>
+				 <!--Optional: Specify minimum TLS version-->
+                		<key>NSTemporaryExceptionMinimumTLSVersion</key>
+                		<string>TLSv1.2</string>
 			</dict>
 		</dict>
 	</dict>


### PR DESCRIPTION
Added an optional TLSv1.2 NSTemporaryExceptionMinimumTLSVersion exception setting to the proposed NSAppTransportSecurityException

Considering that many user will copy-paste the settings proposed by Alamofire, it wouldn't hurt to make it more secure.