### PR TITLE
'URL' ParameterEncoding handles empty parameter dictionary

### DIFF
--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -43,6 +43,17 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
         // Then
         XCTAssertNil(URLRequest.URL?.query, "query should be nil")
     }
+    
+    func testURLParameterEncodeEmptyDictionaryParameter() {
+        // Given
+        let parameters: [String: AnyObject] = [:]
+        
+        // When
+        let (URLRequest, _) = encoding.encode(self.URLRequest, parameters: parameters)
+        
+        // Then
+        XCTAssertNil(URLRequest.URL?.query, "query should be nil")
+    }
 
     func testURLParameterEncodeOneStringKeyStringValueParameter() {
         // Given


### PR DESCRIPTION
When passing in an empty dictionary for `parameters`:

*Current:*

    let query = request.URL?.query    // "" (empty string)
    let URLString = request.URL?.absoluteString    // "http://www.example.com/&" (URL has "&" appended)

*This PR:*

    let query = request.URL?.query    // nil
    let URLString = request.URL?.absoluteString    // "http://www.example.com"