### PR TITLE
Add optional queue: argument to responseJSON

### DIFF
--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -285,11 +285,13 @@ extension Request {
         - returns: The request.
     */
     public func responseJSON(
-        options options: NSJSONReadingOptions = .AllowFragments,
+        queue queue: dispatch_queue_t? = nil,
+        options: NSJSONReadingOptions = .AllowFragments,
         completionHandler: Response<AnyObject, NSError> -> Void)
         -> Self
     {
         return response(
+            queue: queue,
             responseSerializer: Request.JSONResponseSerializer(options: options),
             completionHandler: completionHandler
         )


### PR DESCRIPTION
This makes it possible to specify a dispatch queue when using responseJSON.

Also it's not possible to get this behaviour with the current version of Alamofire, because the property `response` from `Request` hides the function 
```swift
func response<T: ResponseSerializerType>(
        queue queue: dispatch_queue_t? = nil,
        responseSerializer: T,
        completionHandler: Response<T.SerializedObject, T.ErrorObject> -> Void)
        -> Self
```