### PR TITLE
add function upload args URLRequest only.

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -215,6 +215,20 @@ public func upload(URLRequest: URLRequestConvertible, data: NSData) -> Request {
     return Manager.sharedInstance.upload(URLRequest, data: data)
 }
 
+// MARK: URLRequest
+
+/**
+ Creates an upload request using the shared manager instance for the specified URL request
+ 
+ - parameter URLRequest: The URL request.
+ 
+ - returns: The created upload request.
+ */
+
+public func upload(URLRequest: URLRequestConvertible) -> Request {
+    return Manager.sharedInstance.upload(URLRequest)
+}
+
 // MARK: Stream
 
 /**

--- a/Source/Upload.swift
+++ b/Source/Upload.swift
@@ -27,6 +27,7 @@ extension Manager {
         case Data(NSURLRequest, NSData)
         case File(NSURLRequest, NSURL)
         case Stream(NSURLRequest, NSInputStream)
+        case URL(NSURLRequest)
     }
 
     private func upload(uploadable: Uploadable) -> Request {
@@ -46,8 +47,12 @@ extension Manager {
             dispatch_sync(queue) {
                 uploadTask = self.session.uploadTaskWithStreamedRequest(request)
             }
-
             HTTPBodyStream = stream
+        case .URL(let request):
+            dispatch_sync(queue) {
+                uploadTask = self.session.uploadTaskWithRequest(request, fromData: NSData())
+            }
+            
         }
 
         let request = Request(session: session, task: uploadTask)
@@ -121,7 +126,23 @@ extension Manager {
     public func upload(URLRequest: URLRequestConvertible, data: NSData) -> Request {
         return upload(.Data(URLRequest.URLRequest, data))
     }
+    
+    // MARK: URLRequest
+    
+    /**
+    Creates a request for uploading data to the specified URL request.
+    
+    If `startRequestsImmediately` is `true`, the request will have `resume()` called before being returned.
+    
+    - parameter URLRequest: The URL request.
+    
+    - returns: The created upload request.
+    */
 
+    public func upload(URLRequest: URLRequestConvertible) -> Request {
+        return upload(.URL(URLRequest.URLRequest))
+    }
+    
     /**
         Creates a request for uploading data to the specified URL request.
 


### PR DESCRIPTION
like these case, add upload-function get args URLRequest only.
```swift
let image = UIImage(named: "sample")
        
if let image = UIImageJPEGRepresentation(image!, 0.8) {
    let mutableRequest = NSMutableURLRequest(URL: NSURL(string: URLString)!)
    mutableRequest.HTTPMethod = "POST"
    mutableRequest.setValue("image/jpeg", forHTTPHeaderField: "Content-Type")
    mutableRequest.setValue(String(image.length), forHTTPHeaderField: "Content-Length")
    mutableRequest.HTTPBody = image
    let request = Alamofire.upload(mutableRequest)
}
```