### PR TITLE
Add support for Swift Package Manager (SPM)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,8 @@ DerivedData
 *.ipa
 *.xcuserstate
 
+# SPM
+.build/
+
 # Carthage
 Carthage/Build

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,6 @@
+import PackageDescription
+
+
+let package = Package(
+  name: "Alamofire"
+)


### PR DESCRIPTION
There are various warnings when building Alamofire with SPM, however it does build fine. I'd suggest we add initial support using this PR and then work on the warnings closer to the next Swift release that goes into Xcode.