### PR TITLE
Support the Custom encoding without parameters

### DIFF
--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -642,4 +642,31 @@ class CustomParameterEncodingTestCase: ParameterEncodingTestCase {
             "the encoded URL should match the expected value"
         )
     }
+
+    func testCustomParameterEncodeWithoutParameters() {
+        // Given
+        let encodingClosure: (URLRequestConvertible, [String: AnyObject]?) -> (NSMutableURLRequest, NSError?) = { URLRequest, _ in
+            var URLString = URLRequest.URLRequest.URLString + "?"
+
+            URLString += "foo=bar"
+
+            let mutableURLRequest = URLRequest.URLRequest
+            mutableURLRequest.URL = NSURL(string: URLString)!
+
+            return (mutableURLRequest, nil)
+        }
+
+        // When
+        let encoding: ParameterEncoding = .Custom(encodingClosure)
+
+        // Then
+        let URL = NSURL(string: "https://example.com")!
+        let URLRequest = NSURLRequest(URL: URL)
+
+        XCTAssertEqual(
+            encoding.encode(URLRequest, parameters: nil).0.URLString,
+            "https://example.com?foo=bar",
+            "the encoded URL should match the expected value"
+        )
+    }
 }


### PR DESCRIPTION
I need to use `.Custom` encoding without parameters.

This is a specific case in Dropbox's iOS SDK.

https://github.com/dropbox/SwiftyDropbox/blob/master/Source/Client.swift#L177-L181

```swift
// params: JSON
let request = client.manager.request(.POST, url, parameters: [:], headers: headers, encoding: ParameterEncoding.Custom {(convertible, _) in
    let mutableRequest = convertible.URLRequest.copy() as! NSMutableURLRequest
    mutableRequest.HTTPBody = dumpJSON(params)
    return (mutableRequest, nil)
})
```

In this case, parameters is not required but, the Custom encoding closure is not called.

I hope to fix it so that it does not check the parameters for only case of `.Custom`.