### PR TITLE
experimental implementation of Request.retry(count)

### DIFF
--- a/Example/MasterViewController.swift
+++ b/Example/MasterViewController.swift
@@ -64,23 +64,23 @@ class MasterViewController: UITableViewController {
                 switch segue.identifier! {
                 case "GET":
                     detailViewController.segueIdentifier = "GET"
-                    return Alamofire.request(.GET, "https://httpbin.org/get")
+                    return Alamofire.request(.GET, "https://httpbin.org/get").retry(5)
                 case "POST":
                     detailViewController.segueIdentifier = "POST"
-                    return Alamofire.request(.POST, "https://httpbin.org/post")
+                    return Alamofire.request(.POST, "https://httpbin.org/post").retry(5)
                 case "PUT":
                     detailViewController.segueIdentifier = "PUT"
-                    return Alamofire.request(.PUT, "https://httpbin.org/put")
+                    return Alamofire.request(.PUT, "https://httpbin.org/put").retry(5)
                 case "DELETE":
                     detailViewController.segueIdentifier = "DELETE"
-                    return Alamofire.request(.DELETE, "https://httpbin.org/delete")
+                    return Alamofire.request(.DELETE, "https://httpbin.org/delete").retry(5)
                 case "DOWNLOAD":
                     detailViewController.segueIdentifier = "DOWNLOAD"
                     let destination = Alamofire.Request.suggestedDownloadDestination(
                         directory: .CachesDirectory,
                         domain: .UserDomainMask
                     )
-                    return Alamofire.download(.GET, "https://httpbin.org/stream/1", destination: destination)
+                    return Alamofire.download(.GET, "https://httpbin.org/stream/1", destination: destination).retry(5)
                 default:
                     return nil
                 }


### PR DESCRIPTION
Hi!

This is a silly pull request, please, feel free to close it immediately if you find it intrusive or anything like that.
This contains a hacky implementation of .retry(count), that you can use to chain any Request on.

It doesn't include any tests and it shouldn't be merged.
It includes a modified Example-iOS project that demonstrates its usage.

I'd really appreciate if I could get some feedback on this.
I read that the reason why retry() is left out of this library is the extra clutter it would bring to the public API. I'm definitely not saying that this simplistic implementation (with basically zero configuration options) would do the trick, but it would have definitely helped me in certain scenarios. I also feel like the fluent interface of Request makes it an ideal candidate to choose between retry policies (including custom ones) in the future.

I am motivated here by the poor retry implementations I've seen in different apps I worked on. It would be awesome to give people a tool to manage it better!:) And I'm happy to contribute in the proper implementation of this feature.

Thanks!