### PR TITLE
Added a completionQueue to the manager class.

### DIFF
--- a/Source/Download.swift
+++ b/Source/Download.swift
@@ -42,7 +42,7 @@ extension Manager {
             }
         }
 
-        let request = Request(session: session, task: downloadTask)
+        let request = Request(manager: self, task: downloadTask)
 
         if let downloadDelegate = request.delegate as? Request.DownloadTaskDelegate {
             downloadDelegate.downloadTaskDidFinishDownloadingToURL = { session, downloadTask, URL in

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -36,8 +36,13 @@ public class Request {
     /// The underlying task.
     public var task: NSURLSessionTask { return delegate.task }
 
+    /// The manager belonging to this Request.
+    public let manager: Manager
+    
     /// The session belonging to the underlying task.
-    public let session: NSURLSession
+    public var session: NSURLSession {
+        return manager.session
+    }
 
     /// The request sent or to be sent to the server.
     public var request: NSURLRequest? { return task.originalRequest }
@@ -50,8 +55,9 @@ public class Request {
 
     // MARK: - Lifecycle
 
-    init(session: NSURLSession, task: NSURLSessionTask) {
-        self.session = session
+    init(manager: Manager, task: NSURLSessionTask) {
+        
+        self.manager = manager
 
         switch task {
         case is NSURLSessionUploadTask:
@@ -63,6 +69,7 @@ public class Request {
         default:
             self.delegate = TaskDelegate(task: task)
         }
+        
     }
 
     // MARK: - Authentication

--- a/Source/Stream.swift
+++ b/Source/Stream.swift
@@ -45,7 +45,7 @@ extension Manager {
             }
         }
 
-        let request = Request(session: session, task: streamTask)
+        let request = Request(manager: self, task: streamTask)
 
         delegate[request.delegate.task] = request.delegate
 

--- a/Source/Upload.swift
+++ b/Source/Upload.swift
@@ -50,7 +50,7 @@ extension Manager {
             HTTPBodyStream = stream
         }
 
-        let request = Request(session: session, task: uploadTask)
+        let request = Request(manager: self, task: uploadTask)
 
         if HTTPBodyStream != nil {
             request.delegate.taskNeedNewBodyStream = { _, _ in

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -239,7 +239,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
                     dataTask = self.session.dataTaskWithRequest(URLRequest.URLRequest)
                 }
 
-                let request = MockRequest(session: session, task: dataTask)
+                let request = MockRequest(manager: self, task: dataTask)
                 delegate[request.delegate.task] = request.delegate
 
                 if startRequestsImmediately {


### PR DESCRIPTION
This change adds a completionQueue to the manager class.
It changes the initializer of the request class to get the manager object instead of an NSURLSession and uses the new completionQueue in responsehandling.

If set the completenQueue will be used to dispatch the completenHandler to in the response methods.