### PR TITLE
Fixed build warnings in Xcode 7.3 beta 2 for Swift 2.2

### DIFF
--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -236,7 +236,7 @@ public enum ParameterEncoding {
             while index != string.endIndex {
                 let startIndex = index
                 let endIndex = index.advancedBy(batchSize, limit: string.endIndex)
-                let range = Range(start: startIndex, end: endIndex)
+                let range = startIndex ..< endIndex
 
                 let substring = string.substringWithRange(range)
 

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -470,7 +470,7 @@ extension Request: CustomDebugStringConvertible {
             let protectionSpace = NSURLProtectionSpace(
                 host: host,
                 port: URL.port?.integerValue ?? 0,
-                `protocol`: URL.scheme,
+                protocol: URL.scheme,
                 realm: host,
                 authenticationMethod: NSURLAuthenticationMethodHTTPBasic
             )

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -439,7 +439,7 @@ class RedirectResponseTestCase: BaseTestCase {
         var totalRedirectCount = 0
 
         delegate.taskWillPerformHTTPRedirection = { _, _, _, request in
-            ++totalRedirectCount
+            totalRedirectCount += 1
             return request
         }
 


### PR DESCRIPTION
Nothing major changed here really, and mostly ran with the suggestions from Xcode.

I'm not sure if this needs to go on a `swift-2.2` branch for now, but I though I'd make this for now to try and help out.