### PR TITLE
moved a guarded variable to a specific use case for that var

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -470,8 +470,7 @@ extension Request: CustomDebugStringConvertible {
 
         guard let
             request = self.request,
-            URL = request.URL,
-            host = URL.host
+            URL = request.URL
         else {
             return "$ curl command could not be created"
         }
@@ -480,7 +479,8 @@ extension Request: CustomDebugStringConvertible {
             components.append("-X \(HTTPMethod)")
         }
 
-        if let credentialStorage = self.session.configuration.URLCredentialStorage {
+        if let credentialStorage = self.session.configuration.URLCredentialStorage,
+            let host = URL.host {
             let protectionSpace = NSURLProtectionSpace(
                 host: host,
                 port: URL.port?.integerValue ?? 0,


### PR DESCRIPTION
extension Request: CustomDebugStringConvertible 
Moved the URL.host form the guard to where it is actually needed, in my testing this was safe and allowed more requests to be converted.

not sure why URL.host was not returning a valid value but the requests succeed, so I'd love to have the curl command.