### PR TITLE
Fix - Retaining Custom Content Types

### DIFF
--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -142,7 +142,10 @@ public enum ParameterEncoding {
                 let options = NSJSONWritingOptions()
                 let data = try NSJSONSerialization.dataWithJSONObject(parameters, options: options)
 
-                mutableURLRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                if mutableURLRequest.valueForHTTPHeaderField("Content-Type") == nil {
+                    mutableURLRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                }
+
                 mutableURLRequest.HTTPBody = data
             } catch {
                 encodingError = error as NSError
@@ -154,7 +157,11 @@ public enum ParameterEncoding {
                     format: format,
                     options: options
                 )
-                mutableURLRequest.setValue("application/x-plist", forHTTPHeaderField: "Content-Type")
+
+                if mutableURLRequest.valueForHTTPHeaderField("Content-Type") == nil {
+                    mutableURLRequest.setValue("application/x-plist", forHTTPHeaderField: "Content-Type")
+                }
+
                 mutableURLRequest.HTTPBody = data
             } catch {
                 encodingError = error as NSError

--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -499,6 +499,22 @@ class JSONParameterEncodingTestCase: ParameterEncodingTestCase {
             XCTFail("JSON should not be nil")
         }
     }
+
+    func testJSONParameterEncodeParametersRetainsCustomContentType() {
+        // Given
+        let mutableURLRequest = NSMutableURLRequest(URL: NSURL(string: "https://example.com/")!)
+        mutableURLRequest.setValue("application/custom-json-type+json", forHTTPHeaderField: "Content-Type")
+
+        let parameters = ["foo": "bar"]
+
+        // When
+        let (URLRequest, error) = encoding.encode(mutableURLRequest, parameters: parameters)
+
+        // Then
+        XCTAssertNil(error)
+        XCTAssertNil(URLRequest.URL?.query)
+        XCTAssertEqual(URLRequest.valueForHTTPHeaderField("Content-Type"), "application/custom-json-type+json")
+    }
 }
 
 // MARK: -
@@ -605,6 +621,22 @@ class PropertyListParameterEncodingTestCase: ParameterEncodingTestCase {
         } else {
             XCTFail("HTTPBody should not be nil")
         }
+    }
+
+    func testPropertyListParameterEncodeParametersRetainsCustomContentType() {
+        // Given
+        let mutableURLRequest = NSMutableURLRequest(URL: NSURL(string: "https://example.com/")!)
+        mutableURLRequest.setValue("application/custom-plist-type+plist", forHTTPHeaderField: "Content-Type")
+
+        let parameters = ["foo": "bar"]
+
+        // When
+        let (URLRequest, error) = encoding.encode(mutableURLRequest, parameters: parameters)
+
+        // Then
+        XCTAssertNil(error)
+        XCTAssertNil(URLRequest.URL?.query)
+        XCTAssertEqual(URLRequest.valueForHTTPHeaderField("Content-Type"), "application/custom-plist-type+plist")
     }
 }
 


### PR DESCRIPTION
This PR fixes an issue in `ParameterEncoding` where custom content types are not maintained. If the custom content type has already been set on a `URLRequestConvertible`, it should be maintained rather than being stomped. This is necessary in cases where custom JSON or plist content types are used.

I also added two unit tests to verify this behavior works as intended.