### PR TITLE
Replace ++ with +=

### DIFF
--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -439,7 +439,7 @@ class RedirectResponseTestCase: BaseTestCase {
         var totalRedirectCount = 0
 
         delegate.taskWillPerformHTTPRedirection = { _, _, _, request in
-            ++totalRedirectCount
+            totalRedirectCount += 1
             return request
         }
 


### PR DESCRIPTION
The increment (++) and decrement (--) operators will be deprecated with Swift 3.

For more information, see proposal SE-0004: https://github.com/apple/swift-evolution/blob/master/proposals/0004-remove-pre-post-inc-decrement.md