### PR TITLE
Fixed unmatching Serializer with testThatJSONResponseSerializerSucceedsWhenDataIsValidJSON

### DIFF
--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -357,7 +357,7 @@ class ResponseSerializationTestCase: BaseTestCase {
 
     func testThatJSONResponseSerializerSucceedsWhenDataIsValidJSON() {
         // Given
-        let serializer = Request.stringResponseSerializer()
+        let serializer = Request.JSONResponseSerializer()
         let data = "{\"json\": true}".dataUsingEncoding(NSUTF8StringEncoding)!
 
         // When


### PR DESCRIPTION
- stringResponseSerializer on Testing JSONResponseSerializer

I think this must be typo.
