### PR TITLE
Bugfix - Reachability Issue

### DIFF
--- a/Source/NetworkReachabilityManager.swift
+++ b/Source/NetworkReachabilityManager.swift
@@ -114,14 +114,14 @@ public class NetworkReachabilityManager {
     }
 
     /**
-        Creates a `NetworkReachabilityManager` instance with the default socket address (`sockaddr_in6`).
+        Creates a `NetworkReachabilityManager` instance with the default socket address (`sockaddr_in`).
 
         - returns: The new `NetworkReachabilityManager` instance.
      */
     public convenience init?() {
-        var address = sockaddr_in6()
-        address.sin6_len = UInt8(sizeofValue(address))
-        address.sin6_family = sa_family_t(AF_INET6)
+        var address = sockaddr_in()
+        address.sin_len = UInt8(sizeofValue(address))
+        address.sin_family = sa_family_t(AF_INET)
 
         guard let reachability = withUnsafePointer(&address, {
             SCNetworkReachabilityCreateWithAddress(nil, UnsafePointer($0))


### PR DESCRIPTION
I was looking to clean up the unit test failures and the reachability issues reported in  #1086 and #1105 are causing unit test failures on iOS 8.x. It appears that reachability via IPv6 and `sockaddr_in6()` on iOS 8 is buggy. This updates the reachability check to use IPv4 and `sockaddr_in()` instead. That's the theory anyway, we'll see what the CI build says. I confirmed that the Reachability package that @kchromik confirmed as working is using this address.

This appears to be the simplest approach. I looked at doing some #if checks to only use ipv4 on iOS8, but it seemed to be a bit weird and inconsistent so I thought I'd go simple first. If IPv6 reachability was really desired an enum with IPV4 and IPV6 that is passed to the initializer with a default value of IPV4 would be easy.

