### PR TITLE
Feature - Result.ResultType conformance

### DIFF
--- a/Source/Result.swift
+++ b/Source/Result.swift
@@ -99,3 +99,31 @@ extension Result: CustomDebugStringConvertible {
         }
     }
 }
+
+// MARK: ResultType Conformance
+
+extension Result {
+
+    /// Constructs a success wrapping a `value`.
+    public init(value: Value) {
+        self = .Success(value)
+    }
+
+    /// Constructs a failure wrapping an `error`.
+    public init(error: Error) {
+        self = .Failure(error)
+    }
+
+    /// Case analysis for Result.
+    ///
+    /// Returns the value produced by applying `ifFailure` to `Failure` Results, or `ifSuccess` to `Success` Results.
+    public func analysis<Result>(@noescape ifSuccess ifSuccess: Value -> Result, @noescape ifFailure: Error -> Result) -> Result {
+        switch self {
+        case let .Success(value):
+            return ifSuccess(value)
+        case let .Failure(value):
+            return ifFailure(value)
+        }
+    }
+
+}


### PR DESCRIPTION
I brought up lack of map support in #1072 and there was some discussion on adding some functionality to result. I was implementing the Result functionality from antitypical, when I realized we can add support for `Result.ResultType` to `Alamofire.Result` without actually depending on the protocol. Then consumers that desire map support can add the Result framework and a small extension:

```swift
extension Alamofire.Result : ResultType {}
```

Obviously we don't need to do this and we could just tell people to add the extension this PR adds
 to `Alamofire.Result`, but the initializers and the analysis functions are helpful on their own. Also from looking at the issues, this seems to be a re-occurring request, and having a documented answer to it would probably make your life easier.
