### PR TITLE
Stream Usage

### DIFF
--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -428,7 +428,6 @@ public class MultipartFormData {
             throw Error.errorWithCode(NSURLErrorCannotOpenFile, failureReason: failureReason)
         }
 
-        outputStream.scheduleInRunLoop(NSRunLoop.currentRunLoop(), forMode: NSDefaultRunLoopMode)
         outputStream.open()
 
         self.bodyParts.first?.hasInitialBoundary = true
@@ -439,7 +438,6 @@ public class MultipartFormData {
         }
 
         outputStream.close()
-        outputStream.removeFromRunLoop(NSRunLoop.currentRunLoop(), forMode: NSDefaultRunLoopMode)
     }
 
     // MARK: - Private - Body Part Encoding
@@ -476,7 +474,6 @@ public class MultipartFormData {
 
     private func encodeBodyStreamDataForBodyPart(bodyPart: BodyPart) throws -> NSData {
         let inputStream = bodyPart.bodyStream
-        inputStream.scheduleInRunLoop(NSRunLoop.currentRunLoop(), forMode: NSDefaultRunLoopMode)
         inputStream.open()
 
         var error: NSError?
@@ -503,7 +500,6 @@ public class MultipartFormData {
         }
 
         inputStream.close()
-        inputStream.removeFromRunLoop(NSRunLoop.currentRunLoop(), forMode: NSDefaultRunLoopMode)
 
         if let error = error {
             throw error
@@ -537,7 +533,6 @@ public class MultipartFormData {
 
     private func writeBodyStreamForBodyPart(bodyPart: BodyPart, toOutputStream outputStream: NSOutputStream) throws {
         let inputStream = bodyPart.bodyStream
-        inputStream.scheduleInRunLoop(NSRunLoop.currentRunLoop(), forMode: NSDefaultRunLoopMode)
         inputStream.open()
 
         while inputStream.hasBytesAvailable {
@@ -563,7 +558,6 @@ public class MultipartFormData {
         }
 
         inputStream.close()
-        inputStream.removeFromRunLoop(NSRunLoop.currentRunLoop(), forMode: NSDefaultRunLoopMode)
     }
 
     private func writeFinalBoundaryDataForBodyPart(


### PR DESCRIPTION
This is a small fix discovered by @wizzardchao in #1110, where the `NSInputStream` and `NSOutputStream` are used via the poll method and scheduled in the current runloop. The stream programming guide states that the stream should be used in one method or the other:

https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/Streams/Articles/PollingVersusRunloop.html#//apple_ref/doc/uid/20002275-CJBEDDBG

It doesn't appear to be causing any issues, but it should just use one method for clarity sake.