### PR TITLE
Fixed Swift 2.2 compiler warnings

### DIFF
--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -377,7 +377,8 @@ public class Manager {
             completionHandler: ((NSURLSessionAuthChallengeDisposition, NSURLCredential?) -> Void))
         {
             if let taskDidReceiveChallenge = taskDidReceiveChallenge {
-                completionHandler(taskDidReceiveChallenge(session, task, challenge))
+                let (authChallengeDisposition, credential) = taskDidReceiveChallenge(session, task, challenge)
+                completionHandler(authChallengeDisposition, credential)
             } else if let delegate = self[task] {
                 delegate.URLSession(
                     session,
@@ -677,15 +678,15 @@ public class Manager {
 
         public override func respondsToSelector(selector: Selector) -> Bool {
             switch selector {
-            case "URLSession:didBecomeInvalidWithError:":
+            case #selector(NSURLSessionDelegate.URLSession(_:didBecomeInvalidWithError:)):
                 return sessionDidBecomeInvalidWithError != nil
-            case "URLSession:didReceiveChallenge:completionHandler:":
+            case #selector(NSURLSessionDelegate.URLSession(_:didReceiveChallenge:completionHandler:)):
                 return sessionDidReceiveChallenge != nil
-            case "URLSessionDidFinishEventsForBackgroundURLSession:":
+            case #selector(NSURLSessionDelegate.URLSessionDidFinishEventsForBackgroundURLSession(_:)):
                 return sessionDidFinishEventsForBackgroundURLSession != nil
-            case "URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:":
+            case #selector(NSURLSessionTaskDelegate.URLSession(_:task:willPerformHTTPRedirection:newRequest:completionHandler:)):
                 return taskWillPerformHTTPRedirection != nil
-            case "URLSession:dataTask:didReceiveResponse:completionHandler:":
+            case #selector(NSURLSessionDataDelegate.URLSession(_:dataTask:didReceiveResponse:completionHandler:)):
                 return dataTaskDidReceiveResponse != nil
             default:
                 return self.dynamicType.instancesRespondToSelector(selector)

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -29,10 +29,10 @@ import Foundation
 */
 public protocol ResponseSerializerType {
     /// The type of serialized object to be created by this `ResponseSerializerType`.
-    typealias SerializedObject
+    associatedtype SerializedObject
 
     /// The type of error to be created by this `ResponseSerializer` if serialization fails.
-    typealias ErrorObject: ErrorType
+    associatedtype ErrorObject: ErrorType
 
     /**
         A closure used by response handlers that takes a request, response, data and error and returns a result.
@@ -195,7 +195,7 @@ extension Request {
         - returns: A string response serializer.
     */
     public static func stringResponseSerializer(
-        var encoding encoding: NSStringEncoding? = nil)
+        encoding encoding: NSStringEncoding? = nil)
         -> ResponseSerializer<String, NSError>
     {
         return ResponseSerializer { _, response, data, error in
@@ -209,13 +209,14 @@ extension Request {
                 return .Failure(error)
             }
 
-            if let encodingName = response?.textEncodingName where encoding == nil {
-                encoding = CFStringConvertEncodingToNSStringEncoding(
+            var requestedEncoding = encoding
+            if let encodingName = response?.textEncodingName where requestedEncoding == nil {
+                requestedEncoding = CFStringConvertEncodingToNSStringEncoding(
                     CFStringConvertIANACharSetNameToEncoding(encodingName)
                 )
             }
 
-            let actualEncoding = encoding ?? NSISOLatin1StringEncoding
+            let actualEncoding = requestedEncoding ?? NSISOLatin1StringEncoding
 
             if let string = String(data: validData, encoding: actualEncoding) {
                 return .Success(string)


### PR DESCRIPTION
With this PR I just want to fix all warnings that Swift 2.2 is raising. This will break compatibility (because of the new keywords `associatedtype` and `#selector()`) with Swift 2.1 or less.