### PR TITLE
Requests with invalid credentials should terminate with a 401 code

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -284,7 +284,7 @@ public class Request {
                 }
             } else {
                 if challenge.previousFailureCount > 0 {
-                    disposition = .CancelAuthenticationChallenge
+                    disposition = .RejectProtectionSpace
                 } else {
                     credential = self.credential ?? session.configuration.URLCredentialStorage?.defaultCredentialForProtectionSpace(challenge.protectionSpace)
 

--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -84,13 +84,10 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
 
         // Then
         XCTAssertNotNil(request, "request should not be nil")
-        XCTAssertNil(response, "response should be nil")
+        XCTAssertNotNil(response, "response should not be nil")
+        XCTAssertEqual(response?.statusCode ?? 0, 401, "response status code should be 401")
         XCTAssertNotNil(data, "data should not be nil")
-        XCTAssertNotNil(error, "error should not be nil")
-
-        if let code = error?.code {
-            XCTAssertEqual(code, -999, "error should be NSURLErrorDomain Code -999 'cancelled'")
-        }
+        XCTAssertNil(error, "error should be nil")
     }
 
     func testHTTPBasicAuthenticationWithValidCredentials() {
@@ -160,13 +157,10 @@ class HTTPDigestAuthenticationTestCase: AuthenticationTestCase {
 
         // Then
         XCTAssertNotNil(request, "request should not be nil")
-        XCTAssertNil(response, "response should be nil")
+        XCTAssertNotNil(response, "response should not be nil")
+        XCTAssertEqual(response?.statusCode ?? 0, 401, "response status code should be 401")
         XCTAssertNotNil(data, "data should not be nil")
-        XCTAssertNotNil(error, "error should not be nil")
-
-        if let code = error?.code {
-            XCTAssertEqual(code, -999, "error should be NSURLErrorDomain Code -999 'cancelled'")
-        }
+        XCTAssertNil(error, "error should be nil")
     }
 
     func testHTTPDigestAuthenticationWithValidCredentials() {


### PR DESCRIPTION
As defined in RFC 7235 https://tools.ietf.org/html/rfc7235#section-3.1

Fixes #1159