### PR TITLE
Add `basicAuthenticationHeader` function

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -72,6 +72,16 @@ public class Request {
 
     // MARK: - Authentication
 
+    public static func basicAuthenticationHeader(
+        user user: String,
+        password: String)
+        -> Dictionary<String, String>
+    {
+        let basicAuthCredentials = "\(user):\(password)".dataUsingEncoding(NSUTF8StringEncoding) ?? NSData()
+        let base64AuthCredentials = basicAuthCredentials.base64EncodedStringWithOptions([])
+        return ["Authorization": "Basic \(base64AuthCredentials)"]
+    }
+
     /**
         Associates an HTTP Basic credential with the request.
 

--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -120,6 +120,37 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
         XCTAssertNotNil(data, "data should not be nil")
         XCTAssertNil(error, "error should be nil")
     }
+
+    func testHiddenHTTPBasicAuthentication() {
+        // Given
+        let expectation = expectationWithDescription("\(URLString) 200")
+        
+        var request: NSURLRequest?
+        var response: NSHTTPURLResponse?
+        var data: NSData?
+        var error: NSError?
+        
+        // When
+        let authenticationHeader = Request.basicAuthenticationHeader(user: user, password: password)
+        manager.request(.GET, "http://httpbin.org/hidden-basic-auth/\(user)/\(password)", headers: authenticationHeader)
+            .response { responseRequest, responseResponse, responseData, responseError in
+                request = responseRequest
+                response = responseResponse
+                data = responseData
+                error = responseError
+                
+                expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // Then
+        XCTAssertNotNil(request, "request should not be nil")
+        XCTAssertNotNil(response, "response should not be nil")
+        XCTAssertEqual(response?.statusCode ?? 0, 200, "response status code should be 200")
+        XCTAssertNotNil(data, "data should not be nil")
+        XCTAssertNil(error, "error should be nil")
+    }
 }
 
 // MARK: -


### PR DESCRIPTION
This addresses the issue that the `Request.authenticate` function can’t be used to authenticate on servers that don’t send an authentication challenge.

This new function is roughly the equivalent of AFNetworking’s -[AFHTTPRequestSerializer setAuthorizationHeaderFieldWithUsername:password:]

Related to #1159.