### PR TITLE
Updated character

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014–2016 Alamofire Software Foundation (http://alamofire.org/)
+Copyright (c) 2014-2016 Alamofire Software Foundation (http://alamofire.org/)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updated to a different unicode dash (U+002D rather than U+2013) so that it is parsed correctly by markdown, when converting the CocoaPods Acknowledgements.markdown to HTML.

Please see https://github.com/AFNetworking/AFNetworking/pull/3488 for a screenshot of the effect this change has.