### PR TITLE
Using `stringByAddingPercentEncodingWithAllowedCharacters()` to promi…

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -43,13 +43,13 @@ public protocol URLStringConvertible {
 
 extension String: URLStringConvertible {
     public var URLString: String {
-        return self
+        return self.stringByAddingPercentEncodingWithAllowedCharacters(.URLQueryAllowedCharacterSet()) ?? ""
     }
 }
 
 extension NSURL: URLStringConvertible {
     public var URLString: String {
-        return absoluteString
+        return absoluteString.stringByAddingPercentEncodingWithAllowedCharacters(.URLQueryAllowedCharacterSet()) ?? ""
     }
 }
 


### PR DESCRIPTION
Using `stringByAddingPercentEncodingWithAllowedCharacters()` to promise the URL encoding;

Changes to be committed:
	modified:   Source/Alamofire.swift