### PR TITLE
README: remove content-type header field in GET request

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,8 +338,7 @@ Adding a custom HTTP header to a `Request` is supported directly in the global `
 
 ```swift
 let headers = [
-    "Authorization": "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==",
-    "Content-Type": "application/x-www-form-urlencoded"
+    "Authorization": "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
 ]
 
 Alamofire.request(.GET, "https://httpbin.org/get", headers: headers)


### PR DESCRIPTION
It's confused to contain content-type header field in GET request