### PR TITLE
Define some notifications name as Enum

### DIFF
--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -488,7 +488,7 @@ public class Manager {
                 delegate.URLSession(session, task: task, didCompleteWithError: error)
             }
 
-            NSNotificationCenter.defaultCenter().postNotificationName(Notifications.Task.DidComplete, object: task)
+            NSNotificationCenter.defaultCenter().postNotificationName(Notifications.Task.DidComplete.rawValue, object: task)
 
             self[task] = nil
         }

--- a/Source/Notifications.swift
+++ b/Source/Notifications.swift
@@ -24,22 +24,24 @@ import Foundation
 
 /// Contains all the `NSNotification` names posted by Alamofire with descriptions of each notification's payload.
 public struct Notifications {
+
     /// Used as a namespace for all `NSURLSessionTask` related notifications.
-    public struct Task {
+    public enum Task: String {
         /// Notification posted when an `NSURLSessionTask` is resumed. The notification `object` contains the resumed
         /// `NSURLSessionTask`.
-        public static let DidResume = "com.alamofire.notifications.task.didResume"
+        case DidResume = "com.alamofire.notifications.task.didResume"
 
-        /// Notification posted when an `NSURLSessionTask` is suspended. The notification `object` contains the 
+        /// Notification posted when an `NSURLSessionTask` is suspended. The notification `object` contains the
         /// suspended `NSURLSessionTask`.
-        public static let DidSuspend = "com.alamofire.notifications.task.didSuspend"
+        case DidSuspend = "com.alamofire.notifications.task.didSuspend"
 
         /// Notification posted when an `NSURLSessionTask` is cancelled. The notification `object` contains the
         /// cancelled `NSURLSessionTask`.
-        public static let DidCancel = "com.alamofire.notifications.task.didCancel"
+        case DidCancel = "com.alamofire.notifications.task.didCancel"
 
         /// Notification posted when an `NSURLSessionTask` is completed. The notification `object` contains the
         /// completed `NSURLSessionTask`.
-        public static let DidComplete = "com.alamofire.notifications.task.didComplete"
+        case DidComplete = "com.alamofire.notifications.task.didComplete"
     }
+
 }

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -160,7 +160,7 @@ public class Request {
         if startTime == nil { startTime = CFAbsoluteTimeGetCurrent() }
 
         task.resume()
-        NSNotificationCenter.defaultCenter().postNotificationName(Notifications.Task.DidResume, object: task)
+        NSNotificationCenter.defaultCenter().postNotificationName(Notifications.Task.DidResume.rawValue, object: task)
     }
 
     /**
@@ -168,7 +168,7 @@ public class Request {
     */
     public func suspend() {
         task.suspend()
-        NSNotificationCenter.defaultCenter().postNotificationName(Notifications.Task.DidSuspend, object: task)
+        NSNotificationCenter.defaultCenter().postNotificationName(Notifications.Task.DidSuspend.rawValue, object: task)
     }
 
     /**
@@ -186,7 +186,7 @@ public class Request {
             task.cancel()
         }
 
-        NSNotificationCenter.defaultCenter().postNotificationName(Notifications.Task.DidCancel, object: task)
+        NSNotificationCenter.defaultCenter().postNotificationName(Notifications.Task.DidCancel.rawValue, object: task)
     }
 
     // MARK: - TaskDelegate


### PR DESCRIPTION
**IMO** I think this PR provides following advantages.

* Ensure unique notification name
* If receive multiple notifications in one method we can write more efficiently by using switch statement like below.
```swift
func observeNotification(notification: NSNotification) {
    guard let taskName = Notifications.Task(notification.name) else {
        return
    }
    switch taskName {
        case .DidResume:
            //Do anything ...
        case .DidSuspend:
            //Do anything ...
        ...
    }
}
```

Please review when you have enough time 🙇 