### PR TITLE
Update 'Generic Response Object Serialization' section on README by using protocol extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,22 @@ public protocol ResponseCollectionSerializable {
     static func collection(response response: NSHTTPURLResponse, representation: AnyObject) -> [Self]
 }
 
+extension ResponseCollectionSerializable where Self: ResponseObjectSerializable {
+    static func collection(response response: NSHTTPURLResponse, representation: AnyObject) -> [Self] {
+        var collection = [Self]()
+        
+        if let representation = representation as? [[String: AnyObject]] {
+            for itemRepresentation in representation {
+                if let item = Self(response: response, representation: itemRepresentation) {
+                    collection.append(item)
+                }
+            }
+        }
+        
+        return collection
+    }
+}
+
 extension Alamofire.Request {
     public func responseCollection<T: ResponseCollectionSerializable>(completionHandler: Response<[T], NSError> -> Void) -> Self {
         let responseSerializer = ResponseSerializer<[T], NSError> { request, response, data, error in
@@ -844,20 +860,6 @@ final class User: ResponseObjectSerializable, ResponseCollectionSerializable {
     init?(response: NSHTTPURLResponse, representation: AnyObject) {
         self.username = response.URL!.lastPathComponent!
         self.name = representation.valueForKeyPath("name") as! String
-    }
-
-    static func collection(response response: NSHTTPURLResponse, representation: AnyObject) -> [User] {
-        var users: [User] = []
-
-        if let representation = representation as? [[String: AnyObject]] {
-            for userRepresentation in representation {
-                if let user = User(response: response, representation: userRepresentation) {
-                    users.append(user)
-                }
-            }
-        }
-
-        return users
     }
 }
 ```


### PR DESCRIPTION
Hi guys, I'm wondering if would be a good idea on README to use a protocol extension instead of a direct implementation of `ResponseCollectionSerializable ` on `User`. This way it's easier to make any type conform to `ResponseCollectionSerializable`.

If you guys feel like a more functional approach I can change to 

```Swift
extension ResponseCollectionSerializable where Self: ResponseObjectSerializable {
    static func collection(response response: NSHTTPURLResponse, representation: AnyObject) -> [Self] {
        guard let representation = representation as? [[String: AnyObject]] else { return [] }
        return representation.flatMap { Self(response: response, representation: $0) }
    }
}
```  

Happy to hear your thoughts. 🙂