### PR TITLE
Update README.md - remove deprecated functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,7 +725,8 @@ extension Request {
 
             guard let validData = data else {
                 let failureReason = "Data could not be serialized. Input data was nil."
-                let error = Error.errorWithCode(.DataSerializationFailed, failureReason: failureReason)
+                let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+                let error = NSError(domain: Error.Domain, code: Error.Code.JSONSerializationFailed.rawValue, userInfo: userInfo)
                 return .Failure(error)
             }
 
@@ -770,7 +771,8 @@ extension Request {
                     return .Success(responseObject)
                 } else {
                     let failureReason = "JSON could not be serialized into response object: \(value)"
-                    let error = Error.errorWithCode(.JSONSerializationFailed, failureReason: failureReason)
+                    let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+                    let error = NSError(domain: Error.Domain, code: Error.Code.JSONSerializationFailed.rawValue, userInfo: userInfo)
                     return .Failure(error)
                 }
             case .Failure(let error):
@@ -823,7 +825,8 @@ extension Alamofire.Request {
                     return .Success(T.collection(response: response, representation: value))
                 } else {
                     let failureReason = "Response collection could not be serialized due to nil response"
-                    let error = Error.errorWithCode(.JSONSerializationFailed, failureReason: failureReason)
+                    let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+                    let error = NSError(domain: Error.Domain, code: Error.Code.JSONSerializationFailed.rawValue, userInfo: userInfo)
                     return .Failure(error)
                 }
             case .Failure(let error):


### PR DESCRIPTION
Usage of `Error.errorWithCode` have been deprecated in the project.

Updating README.md to reflect that change