### PR TITLE
Feature - Custom Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,7 +725,7 @@ extension Request {
 
             guard let validData = data else {
                 let failureReason = "Data could not be serialized. Input data was nil."
-                let error = Error.errorWithCode(.DataSerializationFailed, failureReason: failureReason)
+                let error = Error.error(code: .DataSerializationFailed, failureReason: failureReason)
                 return .Failure(error)
             }
 
@@ -770,7 +770,7 @@ extension Request {
                     return .Success(responseObject)
                 } else {
                     let failureReason = "JSON could not be serialized into response object: \(value)"
-                    let error = Error.errorWithCode(.JSONSerializationFailed, failureReason: failureReason)
+                    let error = Error.error(code: .JSONSerializationFailed, failureReason: failureReason)
                     return .Failure(error)
                 }
             case .Failure(let error):
@@ -823,7 +823,7 @@ extension Alamofire.Request {
                     return .Success(T.collection(response: response, representation: value))
                 } else {
                     let failureReason = "Response collection could not be serialized due to nil response"
-                    let error = Error.errorWithCode(.JSONSerializationFailed, failureReason: failureReason)
+                    let error = Error.error(code: .JSONSerializationFailed, failureReason: failureReason)
                     return .Failure(error)
                 }
             case .Failure(let error):

--- a/Source/Error.swift
+++ b/Source/Error.swift
@@ -77,11 +77,27 @@ public struct Error {
         return NSError(domain: Domain, code: code, userInfo: userInfo)
     }
 
-    static func error(domain domain: String = Error.Domain, code: Code, failureReason: String) -> NSError {
+    /**
+        Creates an `NSError` with the given domain, error code and failure reason.
+
+        - parameter code:          The error code.
+        - parameter failureReason: The failure reason.
+
+        - returns: An `NSError` with the given error code and failure reason.
+    */
+    public static func error(domain domain: String = Error.Domain, code: Code, failureReason: String) -> NSError {
         return error(domain: domain, code: code.rawValue, failureReason: failureReason)
     }
 
-    static func error(domain domain: String = Error.Domain, code: Int, failureReason: String) -> NSError {
+    /**
+        Creates an `NSError` with the given domain, error code and failure reason.
+
+        - parameter code:          The error code.
+        - parameter failureReason: The failure reason.
+
+        - returns: An `NSError` with the given error code and failure reason.
+    */
+    public static func error(domain domain: String = Error.Domain, code: Int, failureReason: String) -> NSError {
         let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
         return NSError(domain: domain, code: code, userInfo: userInfo)
     }


### PR DESCRIPTION
This PR opens up the static error methods that @0xced added in #1166.

> It also addresses #1240 and #1258.

While I completely get why @0xced was trying to lock down the ability to create errors with the Alamofire domain that don't use custom AF error codes, it's not really possible to guarantee this no matter how much we lock down the public APIs. Anyone could still create an `NSError` with the AF domain if they wanted, it would just be a bit more complicated to do so.

What types of errors a client should throw is their decision. IMO we should make it as easy for those clients to create errors as we can. It's their decision as to whether they should use the AF domain or their own. Either way, this isn't something that we can (or should) try to enforce. Because of this, I've opened up the new `error` APIs to allow clients to create errors by default under the AF domain, and easily customize with their own if they choose.