### PR TITLE
Fix - String Interpolation Leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1250,6 +1250,7 @@ There are some important things to remember when using network reachability to d
 The following rdars have some affect on the current implementation of Alamofire.
 
 * [rdar://21349340](http://www.openradar.me/radar?id=5517037090635776) - Compiler throwing warning due to toll-free bridging issue in test case
+* [rdar://26761490](http://www.openradar.me/radar?id=5010235949318144) - Swift string interpolation causing memory leak with common usage
 
 ## FAQ
 

--- a/Source/Timeline.swift
+++ b/Source/Timeline.swift
@@ -92,13 +92,13 @@ extension Timeline: CustomStringConvertible {
         let totalDuration = String(format: "%.3f", self.totalDuration)
 
         let timings = [
-            "\"Latency\": \(latency) secs",
-            "\"Request Duration\": \(requestDuration) secs",
-            "\"Serialization Duration\": \(serializationDuration) secs",
-            "\"Total Duration\": \(totalDuration) secs"
+            "\"Latency\": " + latency + " secs",
+            "\"Request Duration\": " + requestDuration + " secs",
+            "\"Serialization Duration\": " + serializationDuration + " secs",
+            "\"Total Duration\": " + totalDuration + " secs"
         ]
 
-        return "Timeline: { \(timings.joinWithSeparator(", ")) }"
+        return "Timeline: { " + timings.joinWithSeparator(", ") + " }"
     }
 }
 
@@ -109,17 +109,26 @@ extension Timeline: CustomDebugStringConvertible {
     /// initial response time, the request completed time, the serialization completed time, the latency, the request
     /// duration and the total duration.
     public var debugDescription: String {
+        let requestStartTime = String(format: "%.3f", self.requestStartTime)
+        let initialResponseTime = String(format: "%.3f", self.initialResponseTime)
+        let requestCompletedTime = String(format: "%.3f", self.requestCompletedTime)
+        let serializationCompletedTime = String(format: "%.3f", self.serializationCompletedTime)
+        let latency = String(format: "%.3f", self.latency)
+        let requestDuration = String(format: "%.3f", self.requestDuration)
+        let serializationDuration = String(format: "%.3f", self.serializationDuration)
+        let totalDuration = String(format: "%.3f", self.totalDuration)
+
         let timings = [
-            "\"Request Start Time\": \(requestStartTime)",
-            "\"Initial Response Time\": \(initialResponseTime)",
-            "\"Request Completed Time\": \(requestCompletedTime)",
-            "\"Serialization Completed Time\": \(serializationCompletedTime)",
-            "\"Latency\": \(latency) secs",
-            "\"Request Duration\": \(requestDuration) secs",
-            "\"Serialization Duration\": \(serializationDuration) secs",
-            "\"Total Duration\": \(totalDuration) secs"
+            "\"Request Start Time\": " + requestStartTime,
+            "\"Initial Response Time\": " + initialResponseTime,
+            "\"Request Completed Time\": " + requestCompletedTime,
+            "\"Serialization Completed Time\": " + serializationCompletedTime,
+            "\"Latency\": " + latency + " secs",
+            "\"Request Duration\": " + requestDuration + " secs",
+            "\"Serialization Duration\": " + serializationDuration + " secs",
+            "\"Total Duration\": " + totalDuration + " secs"
         ]
 
-        return "Timeline: { \(timings.joinWithSeparator(", ")) }"
+        return "Timeline: { " + timings.joinWithSeparator(", ") + " }"
     }
 }

--- a/Source/Timeline.swift
+++ b/Source/Timeline.swift
@@ -91,6 +91,8 @@ extension Timeline: CustomStringConvertible {
         let serializationDuration = String(format: "%.3f", self.serializationDuration)
         let totalDuration = String(format: "%.3f", self.totalDuration)
 
+        // NOTE: Had to move to string concatenation due to memory leak filed as rdar://26761490. Once memory leak is
+        // fixed, we should move back to string interpolation by reverting commit 7d4a43b1.
         let timings = [
             "\"Latency\": " + latency + " secs",
             "\"Request Duration\": " + requestDuration + " secs",
@@ -118,6 +120,8 @@ extension Timeline: CustomDebugStringConvertible {
         let serializationDuration = String(format: "%.3f", self.serializationDuration)
         let totalDuration = String(format: "%.3f", self.totalDuration)
 
+        // NOTE: Had to move to string concatenation due to memory leak filed as rdar://26761490. Once memory leak is
+        // fixed, we should move back to string interpolation by reverting commit 7d4a43b1.
         let timings = [
             "\"Request Start Time\": " + requestStartTime,
             "\"Initial Response Time\": " + initialResponseTime,


### PR DESCRIPTION
This PR fixes memory leaks that were occurring in the string interpolation for the `description` and `debugDescription` implementations in the `Timeline` struct. None of these changes "should" be necessary, but unfortunately are at the moment. The main change was to switch over from string interpolation to string concatenation. I've been debugging with the sample project provided in #1232 and everything seems to be resolved with these changes.