### PR TITLE
Made non-deprecated functions public in Error.swift :)

### DIFF
--- a/Source/Error.swift
+++ b/Source/Error.swift
@@ -77,11 +77,11 @@ public struct Error {
         return NSError(domain: Domain, code: code, userInfo: userInfo)
     }
 
-    static func error(domain domain: String = Error.Domain, code: Code, failureReason: String) -> NSError {
+    public static func error(domain domain: String = Error.Domain, code: Code, failureReason: String) -> NSError {
         return error(domain: domain, code: code.rawValue, failureReason: failureReason)
     }
 
-    static func error(domain domain: String = Error.Domain, code: Int, failureReason: String) -> NSError {
+    public static func error(domain domain: String = Error.Domain, code: Int, failureReason: String) -> NSError {
         let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
         return NSError(domain: domain, code: code, userInfo: userInfo)
     }


### PR DESCRIPTION
Pretty simple update. `errorWithCode` functions are deprecated, yet the new `error()` weren't made public yet.