### PR TITLE
[1269] Update generation of the OS version part of the user agent to use non-localized sources.

### DIFF
--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -61,9 +61,29 @@ public class Manager {
                 let executable = info[kCFBundleExecutableKey as String] as? String ?? "Unknown"
                 let bundle = info[kCFBundleIdentifierKey as String] as? String ?? "Unknown"
                 let version = info[kCFBundleVersionKey as String] as? String ?? "Unknown"
-                let os = NSProcessInfo.processInfo().operatingSystemVersionString
+                let osNameVersion: String = {
+                    let version = NSProcessInfo.processInfo().operatingSystemVersion
+                    let versionString = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+                    let osName: String = {
+                        #if os(iOS)
+                            return "iOS"
+                        #elseif os(watchOS)
+                            return "watchOS"
+                        #elseif os(tvOS)
+                            return "tvOS"
+                        #elseif os(OSX)
+                            return "OS X"
+                        #elseif os(Linux)
+                            return "Linux"
+                        #else
+                            return "Unknown"
+                        #endif
+                    }()
+                    
+                    return "\(osName) \(versionString)"
+                }()
 
-                var mutableUserAgent = NSMutableString(string: "\(executable)/\(bundle) (\(version); OS \(os))") as CFMutableString
+                var mutableUserAgent = NSMutableString(string: "\(executable)/\(bundle) (\(version); \(osNameVersion))") as CFMutableString
                 let transform = NSString(string: "Any-Latin; Latin-ASCII; [:^ASCII:] Remove") as CFString
 
                 if CFStringTransform(mutableUserAgent, UnsafeMutablePointer<CFRange>(nil), transform, false) {

--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -61,9 +61,11 @@ public class Manager {
                 let executable = info[kCFBundleExecutableKey as String] as? String ?? "Unknown"
                 let bundle = info[kCFBundleIdentifierKey as String] as? String ?? "Unknown"
                 let version = info[kCFBundleVersionKey as String] as? String ?? "Unknown"
+
                 let osNameVersion: String = {
                     let version = NSProcessInfo.processInfo().operatingSystemVersion
                     let versionString = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+
                     let osName: String = {
                         #if os(iOS)
                             return "iOS"
@@ -79,16 +81,11 @@ public class Manager {
                             return "Unknown"
                         #endif
                     }()
-                    
+
                     return "\(osName) \(versionString)"
                 }()
 
-                var mutableUserAgent = NSMutableString(string: "\(executable)/\(bundle) (\(version); \(osNameVersion))") as CFMutableString
-                let transform = NSString(string: "Any-Latin; Latin-ASCII; [:^ASCII:] Remove") as CFString
-
-                if CFStringTransform(mutableUserAgent, UnsafeMutablePointer<CFRange>(nil), transform, false) {
-                    return mutableUserAgent as String
-                }
+                return "\(executable)/\(bundle) (\(version); \(osNameVersion))"
             }
 
             return "Alamofire"


### PR DESCRIPTION
Fixes #1269. Updates the user agent’s OS version to use non-localized sources. It also includes the actual OS name in the string.