### PR TITLE
Add indexing to queryComponents with Array as value

### DIFF
--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -191,8 +191,8 @@ public enum ParameterEncoding {
                 components += queryComponents("\(key)[\(nestedKey)]", value)
             }
         } else if let array = value as? [AnyObject] {
-            for value in array {
-                components += queryComponents("\(key)[]", value)
+            for (index, value) in array.enumerate() {
+                components += queryComponents("\(key)[\(index)]", value)
             }
         } else {
             components.append((escape(key), escape("\(value)")))

--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -136,7 +136,8 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
         let (URLRequest, _) = encoding.encode(self.URLRequest, parameters: parameters)
 
         // Then
-        XCTAssertEqual(URLRequest.URL?.query ?? "", "foo%5B%5D=a&foo%5B%5D=1&foo%5B%5D=1", "query is incorrect")
+        let expectedQuery = "foo%5B0%5D=a&foo%5B1%5D=1&foo%5B2%5D=1"
+        XCTAssertEqual(URLRequest.URL?.query ?? "", expectedQuery, "query is incorrect")
     }
 
     func testURLParameterEncodeStringKeyDictionaryValueParameter() {
@@ -169,7 +170,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
         let (URLRequest, _) = encoding.encode(self.URLRequest, parameters: parameters)
 
         // Then
-        let expectedQuery = "foo%5Bbar%5D%5Bbaz%5D%5B%5D=a&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1"
+        let expectedQuery = "foo%5Bbar%5D%5Bbaz%5D%5B0%5D=a&foo%5Bbar%5D%5Bbaz%5D%5B1%5D=1&foo%5Bbar%5D%5Bbaz%5D%5B2%5D=1"
         XCTAssertEqual(URLRequest.URL?.query ?? "", expectedQuery, "query is incorrect")
     }
 


### PR DESCRIPTION
When encoding(URL or URLEncodeInURL) a dictionary with array as value
the result combinations of main dictionary key and array elements must
be indexed.