### PR TITLE
Fix - Network Reachability IPv6 Support

### DIFF
--- a/Source/NetworkReachabilityManager.swift
+++ b/Source/NetworkReachabilityManager.swift
@@ -116,32 +116,23 @@ public class NetworkReachabilityManager {
     }
 
     /**
-        Creates a `NetworkReachabilityManager` instance with the default socket IPv4 or IPv6 address.
+        Creates a `NetworkReachabilityManager` instance that monitors the address 0.0.0.0.
+
+        Reachability treats the 0.0.0.0 address as a special token that causes it to monitor the general routing
+        status of the device, both IPv4 and IPv6.
 
         - returns: The new `NetworkReachabilityManager` instance.
-     */
+    */
     public convenience init?() {
-        if #available(iOS 9.0, OSX 10.10, *) {
-            var address = sockaddr_in6()
-            address.sin6_len = UInt8(sizeofValue(address))
-            address.sin6_family = sa_family_t(AF_INET6)
+        var address = sockaddr_in()
+        address.sin_len = UInt8(sizeofValue(address))
+        address.sin_family = sa_family_t(AF_INET)
 
-            guard let reachability = withUnsafePointer(&address, {
-                SCNetworkReachabilityCreateWithAddress(nil, UnsafePointer($0))
-            }) else { return nil }
+        guard let reachability = withUnsafePointer(&address, {
+            SCNetworkReachabilityCreateWithAddress(nil, UnsafePointer($0))
+        }) else { return nil }
 
-            self.init(reachability: reachability)
-        } else {
-            var address = sockaddr_in()
-            address.sin_len = UInt8(sizeofValue(address))
-            address.sin_family = sa_family_t(AF_INET)
-
-            guard let reachability = withUnsafePointer(&address, {
-                SCNetworkReachabilityCreateWithAddress(nil, UnsafePointer($0))
-            }) else { return nil }
-
-            self.init(reachability: reachability)
-        }
+        self.init(reachability: reachability)
     }
 
     private init(reachability: SCNetworkReachability) {

--- a/Tests/NetworkReachabilityManagerTests.swift
+++ b/Tests/NetworkReachabilityManagerTests.swift
@@ -106,18 +106,22 @@ class NetworkReachabilityManagerTestCase: BaseTestCase {
 
     func testThatHostManagerIsNotifiedWhenStartListeningIsCalled() {
         // Given
-        let manager = NetworkReachabilityManager(host: "localhost")
-        let expectation = expectationWithDescription("listener closure should be executed")
+        guard let manager = NetworkReachabilityManager(host: "store.apple.com") else {
+            XCTFail("manager should NOT be nil")
+            return
+        }
 
+        let expectation = expectationWithDescription("listener closure should be executed")
         var networkReachabilityStatus: NetworkReachabilityManager.NetworkReachabilityStatus?
 
-        manager?.listener = { status in
+        manager.listener = { status in
+            guard networkReachabilityStatus == nil else { return }
             networkReachabilityStatus = status
             expectation.fulfill()
         }
 
         // When
-        manager?.startListening()
+        manager.startListening()
         waitForExpectationsWithTimeout(timeout, handler: nil)
 
         // Then


### PR DESCRIPTION
This PR removes the explicit IPv6 support from the `NetworkReachabilityManager` since it is not needed according to Apple in their new [Reachability](https://developer.apple.com/library/ios/samplecode/Reachability/Listings/Reachability_Reachability_m.html#//apple_ref/doc/uid/DTS40007324-Reachability_Reachability_m-DontLinkElementID_9) example.

> This should close out #1228.