### PR TITLE
Add 'public' to enum 'BackendError'

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,7 +718,7 @@ Requests can be suspended, resumed, and cancelled:
 Before implementing custom response serializers or object serialization methods, it's important to be prepared to handle any errors that may occur. Alamofire recommends handling these through the use of either your own `NSError` creation methods, or a simple `enum` that conforms to `ErrorType`. For example, this `BackendError` type, which will be used in later examples:
 
 ```swift
-enum BackendError: ErrorType {
+public enum BackendError: ErrorType {
     case Network(error: NSError)
     case DataSerialization(reason: String)
     case JSONSerialization(error: NSError)


### PR DESCRIPTION
Add the 'public' identifier to the 'BackendError' enum in the part about using Generics for Serialization. 

Reason:

The extension of Request throws an error ("Method cannot be declared public because its parameter uses an internal type") unless the enum is public.