### PR TITLE
JSON parameters shouldn't be expected to be in a particular order

### DIFF
--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -597,12 +597,10 @@ class RequestDebugDescriptionTestCase: BaseTestCase {
             "command should contain 'application/json' Content-Type"
         )
 
-        let expectedBody = "-d \"{\\\"f'oo\\\":\\\"ba'r\\\",\\\"fo\\\\\\\"o\\\":\\\"b\\\\\\\"ar\\\",\\\"foo\\\":\\\"bar\\\"}\""
-
-        XCTAssertTrue(
-            request.debugDescription.rangeOfString(expectedBody) != nil,
-            "command data should contain JSON encoded parameters"
-        )
+        XCTAssertTrue(request.debugDescription.rangeOfString("-d \"{") != nil, "command should contain the body parameter")
+        XCTAssertTrue(request.debugDescription.rangeOfString("\\\"f'oo\\\":\\\"ba'r\\\"") != nil, "command data should contain JSON encoded parameters")
+        XCTAssertTrue(request.debugDescription.rangeOfString("\\\"fo\\\\\\\"o\\\":\\\"b\\\\\\\"ar\\\"") != nil, "command data should contain JSON encoded parameters")
+        XCTAssertTrue(request.debugDescription.rangeOfString("\\\"foo\\\":\\\"bar\\") != nil, "command data should contain JSON encoded parameters")
 
         XCTAssertEqual(components.last ?? "", "\"\(URLString)\"", "URL component should be equal")
     }


### PR DESCRIPTION
This fixes the unit [test failure](https://travis-ci.org/Alamofire/Alamofire/jobs/137143030) on iOS 8.1 and 8.2 simulator.

The cause of the issue was that the order of items in a dictionary is different between iOS 8 and iOS 9.