### PR TITLE
hold the original NSMutableURLRequest's allHTTPHeaderField and cacheP…

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -91,7 +91,8 @@ func URLRequest(
     headers: [String: String]? = nil)
     -> NSMutableURLRequest
 {
-    let mutableURLRequest = NSMutableURLRequest(URL: NSURL(string: URLString.URLString)!)
+    let mutableURLRequest = URLString as? NSMutableURLRequest ?? NSMutableURLRequest(URL: NSURL(string: URLString.URLString)!)
+
     mutableURLRequest.HTTPMethod = method.rawValue
 
     if let headers = headers {


### PR DESCRIPTION
I think the original NSMutableURLRequest's property should hold, not create just from request URL!