### PR TITLE
Update swift3 conditions for "if let"

### DIFF
--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -268,7 +268,7 @@ public class MultipartFormData {
         var isDirectory: ObjCBool = false
 
         guard
-            let path = fileURL.path,
+            let path = fileURL.path where
             FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) && !isDirectory else
         {
             let failureReason = "The file URL is a directory, not a file: \(fileURL)"
@@ -404,7 +404,7 @@ public class MultipartFormData {
             throw bodyPartError
         }
 
-        if let path = fileURL.path, FileManager.default.fileExists(atPath: path) {
+        if let path = fileURL.path where FileManager.default.fileExists(atPath: path) {
             let failureReason = "A file already exists at the given file URL: \(fileURL)"
             throw Error.error(domain: NSURLErrorDomain, code: NSURLErrorBadURL, failureReason: failureReason)
         } else if !fileURL.isFileURL {

--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -117,9 +117,9 @@ public enum ParameterEncoding {
                 }
             }
 
-            if let method = Method(rawValue: urlRequest.httpMethod!), encodesParametersInURL(method) {
+            if let method = Method(rawValue: urlRequest.httpMethod!) where encodesParametersInURL(method) {
                 if var
-                    URLComponents = URLComponents(url: urlRequest.url!, resolvingAgainstBaseURL: false),
+                    URLComponents = URLComponents(url: urlRequest.url!, resolvingAgainstBaseURL: false) where
                     !parameters.isEmpty {
                     let percentEncodedQuery = (URLComponents.percentEncodedQuery.map { $0 + "&" } ?? "") + query(parameters)
                     URLComponents.percentEncodedQuery = percentEncodedQuery

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -510,7 +510,7 @@ extension Request: CustomDebugStringConvertible {
             return "$ curl command could not be created"
         }
 
-        if let httpMethod = request.httpMethod, httpMethod != "GET" {
+        if let httpMethod = request.httpMethod where httpMethod != "GET" {
             components.append("-X \(httpMethod)")
         }
 
@@ -536,7 +536,7 @@ extension Request: CustomDebugStringConvertible {
 
         if session.configuration.httpShouldSetCookies {
             if let cookieStorage = session.configuration.httpCookieStorage,
-               let cookies = cookieStorage.cookies(for: URL), !cookies.isEmpty
+               let cookies = cookieStorage.cookies(for: URL) where !cookies.isEmpty
             {
                 let string = cookies.reduce("") { $0 + "\($1.name)=\($1.value ?? String());" }
                 components.append("-b \"\(string.substring(to: string.characters.index(before: string.endIndex)))\"")

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -161,7 +161,7 @@ extension Request {
         return ResponseSerializer { _, response, data, error in
             guard error == nil else { return .failure(error!) }
 
-            if let response = response, response.statusCode == 204 { return .success(Data()) }
+            if let response = response where response.statusCode == 204 { return .success(Data()) }
 
             guard let validData = data else {
                 let failureReason = "Data could not be serialized. Input data was nil."
@@ -210,7 +210,7 @@ extension Request {
         return ResponseSerializer { _, response, data, error in
             guard error == nil else { return .failure(error!) }
 
-            if let response = response, response.statusCode == 204 { return .success("") }
+            if let response = response where response.statusCode == 204 { return .success("") }
 
             guard let validData = data else {
                 let failureReason = "String could not be serialized. Input data was nil."
@@ -220,7 +220,7 @@ extension Request {
 
             var convertedEncoding = encoding
 
-            if let encodingName = response?.textEncodingName, convertedEncoding == nil {
+            if let encodingName = response?.textEncodingName where convertedEncoding == nil {
                 convertedEncoding = String.Encoding(rawValue: CFStringConvertEncodingToNSStringEncoding(
                     CFStringConvertIANACharSetNameToEncoding(encodingName))
                 )
@@ -282,9 +282,9 @@ extension Request {
         return ResponseSerializer { _, response, data, error in
             guard error == nil else { return .failure(error!) }
 
-            if let response = response, response.statusCode == 204 { return .success(NSNull()) }
+            if let response = response where response.statusCode == 204 { return .success(NSNull()) }
 
-            guard let validData = data, validData.count > 0 else {
+            guard let validData = data where validData.count > 0 else {
                 let failureReason = "JSON could not be serialized. Input data was nil or zero length."
                 let error = Error.error(code: .jsonSerializationFailed, failureReason: failureReason)
                 return .failure(error)
@@ -341,9 +341,9 @@ extension Request {
         return ResponseSerializer { _, response, data, error in
             guard error == nil else { return .failure(error!) }
 
-            if let response = response, response.statusCode == 204 { return .success(NSNull()) }
+            if let response = response where response.statusCode == 204 { return .success(NSNull()) }
 
-            guard let validData = data, validData.count > 0 else {
+            guard let validData = data where validData.count > 0 else {
                 let failureReason = "Property list could not be serialized. Input data was nil or zero length."
                 let error = Error.error(code: .propertyListSerializationFailed, failureReason: failureReason)
                 return .failure(error)

--- a/Source/ServerTrustPolicy.swift
+++ b/Source/ServerTrustPolicy.swift
@@ -293,7 +293,7 @@ public enum ServerTrustPolicy {
         var trust: SecTrust?
         let trustCreationStatus = SecTrustCreateWithCertificates(certificate, policy, &trust)
 
-        if let trust = trust, trustCreationStatus == errSecSuccess {
+        if let trust = trust where trustCreationStatus == errSecSuccess {
             publicKey = SecTrustCopyPublicKey(trust)
         }
 

--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -55,7 +55,7 @@ extension Request {
     @discardableResult
     public func validate(_ validation: Validation) -> Self {
         delegate.queue.addOperation {
-            if let response = self.response, self.delegate.error == nil,
+            if let response = self.response where self.delegate.error == nil,
                case let .failure(error) = validation(self.request, response)
             {
                 self.delegate.error = error
@@ -143,19 +143,19 @@ extension Request {
     @discardableResult
     public func validate<S: Sequence where S.Iterator.Element == String>(contentType acceptableContentTypes: S) -> Self {
         return validate { _, response in
-            guard let validData = self.delegate.data, validData.count > 0 else { return .success }
+            guard let validData = self.delegate.data where validData.count > 0 else { return .success }
 
             if let responseContentType = response.mimeType,
                let responseMIMEType = MIMEType(responseContentType)
             {
                 for contentType in acceptableContentTypes {
-                    if let acceptableMIMEType = MIMEType(contentType), acceptableMIMEType.matches(responseMIMEType) {
+                    if let acceptableMIMEType = MIMEType(contentType) where acceptableMIMEType.matches(responseMIMEType) {
                         return .success
                     }
                 }
             } else {
                 for contentType in acceptableContentTypes {
-                    if let mimeType = MIMEType(contentType), mimeType.type == "*" && mimeType.subtype == "*" {
+                    if let mimeType = MIMEType(contentType) where mimeType.type == "*" && mimeType.subtype == "*" {
                         return .success
                     }
                 }


### PR DESCRIPTION
When you try to use the Alamofire from branch swift3 with Xcode Version 8.0 beta 2 (8S162m), the compiler complains about the old statements used. Like:  

Old one:
guard let validData = self.delegate.data, validData.count > 0 else { return .success }

New one
guard let validData = self.delegate.data where validData.count > 0 else { return .success }

This pull request updates all statements on this branch.
