### PR TITLE
Feature - Moving SessionDelegate to Store Requests

### DIFF
--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -247,7 +247,7 @@ public class SessionManager {
         queue.sync { dataTask = self.session.dataTask(with: urlRequest.urlRequest) }
 
         let request = Request(session: session, task: dataTask)
-        delegate[request.delegate.task] = request.delegate
+        delegate[request.delegate.task] = request
 
         if startRequestsImmediately {
             request.resume()
@@ -353,7 +353,7 @@ public class SessionManager {
             }
         }
 
-        delegate[request.delegate.task] = request.delegate
+        delegate[request.delegate.task] = request
 
         if startRequestsImmediately {
             request.resume()
@@ -629,7 +629,7 @@ public class SessionManager {
             }
         }
 
-        delegate[request.delegate.task] = request.delegate
+        delegate[request.delegate.task] = request
 
         if startRequestsImmediately {
             request.resume()
@@ -689,7 +689,7 @@ public class SessionManager {
 
         let request = Request(session: session, task: streamTask)
 
-        delegate[request.delegate.task] = request.delegate
+        delegate[request.delegate.task] = request
 
         if startRequestsImmediately {
             request.resume()

--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -33,7 +33,7 @@ public class TaskDelegate: NSObject {
     /// The serial operation queue used to execute all operations after the task completes.
     public let queue: OperationQueue
 
-    let task: URLSessionTask
+    var task: URLSessionTask
     let progress: Progress
 
     var data: Data? { return nil }
@@ -56,11 +56,6 @@ public class TaskDelegate: NSObject {
 
             return operationQueue
         }()
-    }
-
-    deinit {
-        queue.cancelAllOperations()
-        queue.isSuspended = false
     }
 
     // MARK: NSURLSessionTaskDelegate

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -246,7 +246,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
                 }
 
                 let request = MockRequest(session: session, task: dataTask)
-                delegate[request.delegate.task] = request.delegate
+                delegate[request.delegate.task] = request
 
                 if startRequestsImmediately {
                     request.resume()


### PR DESCRIPTION
This PR modifies the `SessionDelegate` to store `Request`s internally instead of only the task delegates of the `Request` in preparation for more advanced features such as retry logic.

> There are no functional changes to the behavior in this PR.