### PR TITLE
Update podspec to 4.0.0, update deployment targets.

### DIFF
--- a/Alamofire.podspec
+++ b/Alamofire.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Alamofire'
-  s.version = '3.4.1'
+  s.version = '4.0.0'
   s.license = 'MIT'
   s.summary = 'Elegant HTTP Networking in Swift'
   s.homepage = 'https://github.com/Alamofire/Alamofire'
@@ -8,8 +8,8 @@ Pod::Spec.new do |s|
   s.authors = { 'Alamofire Software Foundation' => 'info@alamofire.org' }
   s.source = { :git => 'https://github.com/Alamofire/Alamofire.git', :tag => s.version }
 
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.9'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.11'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
 

--- a/Example/Source/MasterViewController.swift
+++ b/Example/Source/MasterViewController.swift
@@ -79,8 +79,8 @@ class MasterViewController: UITableViewController {
                 case "DOWNLOAD":
                     detailViewController.segueIdentifier = "DOWNLOAD"
                     let destination = Alamofire.Request.suggestedDownloadDestination(
-                        directory: .cachesDirectory,
-                        domain: .userDomainMask
+                        for: .cachesDirectory,
+                        in: .userDomainMask
                     )
                     return Alamofire.download("https://httpbin.org/stream/1", to: destination, withMethod: .get)
                 default:


### PR DESCRIPTION
Updates the podspec to version 4.0.0 and sets the deployment targets to match the project’s new deployment targets.

Also fixes a build issue with the iOS Example app.