### PR TITLE
User-Agent header using build number instead of version number

### DIFF
--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -60,7 +60,7 @@ public class Manager {
             if let info = NSBundle.mainBundle().infoDictionary {
                 let executable = info[kCFBundleExecutableKey as String] as? String ?? "Unknown"
                 let bundle = info[kCFBundleIdentifierKey as String] as? String ?? "Unknown"
-                let version = info[kCFBundleVersionKey as String] as? String ?? "Unknown"
+                let version = info["CFBundleShortVersionString"] as? String ?? "Unknown"
 
                 let osNameVersion: String = {
                     let versionString: String


### PR DESCRIPTION
The User-Agent header is grabbing the infoDictionary object for the kCFBundleVersionKey key which is the app build number. It should be grabbing the object for the CFBundleShortVersionString key which is the actual version number. Same issue was fixed in AFNetworking, [issue 1907.](https://github.com/AFNetworking/AFNetworking/issues/1907)