### PR TITLE
Feature - Request Adapter and Retrier System

### DIFF
--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -53,6 +53,10 @@
 		4C3D00581C66A8B900D1F709 /* NetworkReachabilityManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3D00571C66A8B900D1F709 /* NetworkReachabilityManagerTests.swift */; };
 		4C3D00591C66A8B900D1F709 /* NetworkReachabilityManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3D00571C66A8B900D1F709 /* NetworkReachabilityManagerTests.swift */; };
 		4C3D005A1C66A8B900D1F709 /* NetworkReachabilityManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3D00571C66A8B900D1F709 /* NetworkReachabilityManagerTests.swift */; };
+		4C43669B1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C43669A1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift */; };
+		4C43669C1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C43669A1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift */; };
+		4C43669D1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C43669A1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift */; };
+		4C43669E1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C43669A1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift */; };
 		4C4CBE7B1BAF700C0024D659 /* String+AlamofireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4CBE7A1BAF700C0024D659 /* String+AlamofireTests.swift */; };
 		4C4CBE7C1BAF700C0024D659 /* String+AlamofireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4CBE7A1BAF700C0024D659 /* String+AlamofireTests.swift */; };
 		4C574E6A1C67D207000B3128 /* Timeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C574E691C67D207000B3128 /* Timeline.swift */; };
@@ -269,6 +273,7 @@
 		4C341BB91B1A865A00C1B34D /* CacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CacheTests.swift; sourceTree = "<group>"; };
 		4C3D00531C66A63000D1F709 /* NetworkReachabilityManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachabilityManager.swift; sourceTree = "<group>"; };
 		4C3D00571C66A8B900D1F709 /* NetworkReachabilityManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachabilityManagerTests.swift; sourceTree = "<group>"; };
+		4C43669A1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+Alamofire.swift"; sourceTree = "<group>"; };
 		4C4CBE7A1BAF700C0024D659 /* String+AlamofireTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+AlamofireTests.swift"; sourceTree = "<group>"; };
 		4C574E691C67D207000B3128 /* Timeline.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Timeline.swift; sourceTree = "<group>"; };
 		4C811F8C1B51856D00E0F59A /* ServerTrustPolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerTrustPolicy.swift; sourceTree = "<group>"; };
@@ -495,6 +500,14 @@
 			name = "Signed by CA2";
 			sourceTree = "<group>";
 		};
+		4C4366991D7BB92700C38AAD /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				4C43669A1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift */,
+			);
+			name = Extensions;
+			sourceTree = "<group>";
+		};
 		4C7C8D201B9D0D7300948136 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -599,6 +612,7 @@
 			children = (
 				F897FF4019AA800700AB5182 /* Alamofire.swift */,
 				4CDE2C481AF8A14A00BABAE5 /* Core */,
+				4C4366991D7BB92700C38AAD /* Extensions */,
 				4CDE2C491AF8A14E00BABAE5 /* Features */,
 				F8111E3619A95C8B0040E7D1 /* Supporting Files */,
 			);
@@ -1027,6 +1041,7 @@
 				4CF627091BA7CBF60011A099 /* SessionManager.swift in Sources */,
 				4CF6270F1BA7CBF60011A099 /* ResponseSerialization.swift in Sources */,
 				4CF6270B1BA7CBF60011A099 /* Request.swift in Sources */,
+				4C43669D1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift in Sources */,
 				4C3D00561C66A63000D1F709 /* NetworkReachabilityManager.swift in Sources */,
 				4CFCFE3B1D56E8D900A76388 /* TaskDelegate.swift in Sources */,
 				4CF6270A1BA7CBF60011A099 /* ParameterEncoding.swift in Sources */,
@@ -1077,6 +1092,7 @@
 				4CB9282A1C66BFBC00CE5F08 /* Notifications.swift in Sources */,
 				4DD67C251A5C590000ED2280 /* Alamofire.swift in Sources */,
 				4C23EB441B327C5B0090E0BC /* MultipartFormData.swift in Sources */,
+				4C43669C1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift in Sources */,
 				4C811F8E1B51856D00E0F59A /* ServerTrustPolicy.swift in Sources */,
 				4CFCFE3A1D56E8D900A76388 /* TaskDelegate.swift in Sources */,
 				4C3D00551C66A63000D1F709 /* NetworkReachabilityManager.swift in Sources */,
@@ -1100,6 +1116,7 @@
 				4C0B62531BB1001C009302D3 /* Response.swift in Sources */,
 				4CB9282C1C66BFBC00CE5F08 /* Notifications.swift in Sources */,
 				4CEC605B1B745C9100E684F4 /* Result.swift in Sources */,
+				4C43669E1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift in Sources */,
 				E4202FD41B667AA100C997FB /* Alamofire.swift in Sources */,
 				4CFCFE3C1D56E8D900A76388 /* TaskDelegate.swift in Sources */,
 				E4202FD51B667AA100C997FB /* MultipartFormData.swift in Sources */,
@@ -1123,6 +1140,7 @@
 				F897FF4119AA800700AB5182 /* Alamofire.swift in Sources */,
 				4C23EB431B327C5B0090E0BC /* MultipartFormData.swift in Sources */,
 				4C811F8D1B51856D00E0F59A /* ServerTrustPolicy.swift in Sources */,
+				4C43669B1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift in Sources */,
 				4C3D00541C66A63000D1F709 /* NetworkReachabilityManager.swift in Sources */,
 				4CFCFE391D56E8D900A76388 /* TaskDelegate.swift in Sources */,
 				4CDE2C431AF89F0900BABAE5 /* Validation.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -1149,6 +1149,10 @@ sessionManager.request("https://httpbin.org/get", withMethod: .get)
 
 The `RequestRetrier` protocol allows a `Request` that encountered an `Error` while being executed to be retried. When using both the `RequestAdapter` and `RequestRetrier` protocols together, you can create credential refresh systems for OAuth1, OAuth2, Basic Auth and even exponential backoff retry policies. The possibilities are endless. Here's a short example of how you could implement a refresh flow for OAuth2 access tokens.
 
+> Please note that this is not a global `OAuth2` solution. It is merely an example demonstrating how one could use the `RequestAdapter` in conjunction with the `RequestRetrier` to create a thread-safe refresh system. 
+
+> To reiterate, **do NOT copy** this sample code and drop it into a production application. This is merely an example. Each authentication system must be tailored to a particular platform and authentication type.
+
 ```swift
 class OAuth2Handler: RequestAdapter, RequestRetrier {
     private typealias RefreshCompletion = (_ succeeded: Bool, _ accessToken: String?, _ refreshToken: String?) -> Void
@@ -1276,8 +1280,6 @@ Once the `OAuth2Handler` is applied as both the `adapter` and `retrier` for the 
 The example above only checks for a `401` response code which is not nearly robust enough, but does demonstrate how one could check for an invalid access token error. In a production application, one would want to check the `realm` and most likely the `www-authenticate` header response although it depends on the OAuth2 implementation.
 
 Another important note is that this authentication system could be shared between multiple session managers. For example, you may need to use both a `default` and `ephemeral` session configuration for the same set of web services. The example above allows the same `oauthHandler` instance to be shared across multiple session managers to manage the single refresh flow.
-
-> Please note that this is not a global OAuth2 solution. It is merely an example demonstrating how one could use the `RequestAdapter` in conjunction with the `RequestRetrier` to create a thread-safe refresh system.
 
 ### Security
 

--- a/Source/DispatchQueue+Alamofire.swift
+++ b/Source/DispatchQueue+Alamofire.swift
@@ -1,0 +1,36 @@
+//
+//  DispatchQueue+Alamofire.swift
+//
+//  Copyright (c) 2014-2016 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Dispatch
+
+extension DispatchQueue {
+    static var userInteractive: DispatchQueue { return DispatchQueue.global(qos: .userInteractive) }
+    static var userInitiated: DispatchQueue { return DispatchQueue.global(qos: .userInitiated) }
+    static var utility: DispatchQueue { return DispatchQueue.global(qos: .utility) }
+    static var background: DispatchQueue { return DispatchQueue.global(qos: .background) }
+
+    func after(_ delay: TimeInterval, execute closure: @escaping () -> Void) {
+        asyncAfter(deadline: .now() + delay, execute: closure)
+    }
+}

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -24,9 +24,9 @@
 
 import Foundation
 
-/// A type that can adapt a `URLRequest` in some manner.
+/// A type that can inspect and optionally adapt a `URLRequest` in some manner if necessary.
 public protocol RequestAdapter {
-    /// Adapts the specified `URLRequest` in some manner and returns the result.
+    /// Inspects and adapts the specified `URLRequest` in some manner if necessary and returns the result.
     ///
     /// - parameter urlRequest: The URL request to adapt.
     ///

--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -33,7 +33,10 @@ open class TaskDelegate: NSObject {
     /// The serial operation queue used to execute all operations after the task completes.
     open let queue: OperationQueue
 
-    var task: URLSessionTask
+    var task: URLSessionTask {
+        didSet { reset() }
+    }
+
     let progress: Progress
 
     var data: Data? { return nil }
@@ -56,6 +59,11 @@ open class TaskDelegate: NSObject {
 
             return operationQueue
         }()
+    }
+
+    func reset() {
+        error = nil
+        initialResponseTime = nil
     }
 
     // MARK: URLSessionTaskDelegate
@@ -189,6 +197,14 @@ class DataTaskDelegate: TaskDelegate, URLSessionDataDelegate {
         super.init(task: task)
     }
 
+    override func reset() {
+        super.reset()
+
+        totalBytesReceived = 0
+        mutableData = Data()
+        expectedContentLength = nil
+    }
+
     // MARK: URLSessionDataDelegate
 
     var dataTaskDidReceiveResponse: ((URLSession, URLSessionDataTask, URLResponse) -> URLSession.ResponseDisposition)?
@@ -275,6 +291,14 @@ class DownloadTaskDelegate: TaskDelegate, URLSessionDownloadDelegate {
 
     var resumeData: Data?
     override var data: Data? { return resumeData }
+
+
+    // MARK: Lifecycle
+
+    override func reset() {
+        super.reset()
+        resumeData = nil
+    }
 
     // MARK: URLSessionDownloadDelegate
 

--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -47,7 +47,7 @@ extension Request {
     /// - returns: The request.
     @discardableResult
     public func validate(_ validation: Validation) -> Self {
-        delegate.queue.addOperation {
+        let validationExecution: () -> Void = {
             if
                 let response = self.response,
                 self.delegate.error == nil,
@@ -56,6 +56,8 @@ extension Request {
                 self.delegate.error = error
             }
         }
+
+        validations.append(validationExecution)
 
         return self
     }

--- a/Tests/AFError+AlamofireTests.swift
+++ b/Tests/AFError+AlamofireTests.swift
@@ -119,6 +119,8 @@ extension AFError {
     }
 }
 
+// MARK: -
+
 extension AFError.MultipartEncodingFailureReason {
     var isBodyPartURLInvalid: Bool {
         if case .bodyPartURLInvalid = self { return true }
@@ -186,6 +188,8 @@ extension AFError.MultipartEncodingFailureReason {
     }
 }
 
+// MARK: -
+
 extension AFError.SerializationFailureReason {
     var isInputDataNil: Bool {
         if case .inputDataNil = self { return true }
@@ -212,6 +216,8 @@ extension AFError.SerializationFailureReason {
         return false
     }
 }
+
+// MARK: -
 
 extension AFError.ValidationFailureReason {
     var isMissingContentType: Bool {

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -237,13 +237,12 @@ class ContentTypeValidationTestCase: BaseTestCase {
         // Given
         class MockManager: SessionManager {
             override func request(_ urlRequest: URLRequestConvertible) -> Request {
+                let urlRequest = urlRequest.urlRequest
                 var dataTask: URLSessionDataTask!
 
-                queue.sync {
-                    dataTask = self.session.dataTask(with: urlRequest.urlRequest)
-                }
+                queue.sync { dataTask = self.session.dataTask(with: urlRequest) }
 
-                let request = MockRequest(session: session, task: dataTask)
+                let request = MockRequest(session: session, task: dataTask, originalTask: .data(urlRequest))
                 delegate[request.delegate.task] = request
 
                 if startRequestsImmediately {


### PR DESCRIPTION
This PR adds a couple powerful protocols, `RequestAdapter` and `RequestRetrier`, that open up all sorts of possibilities including:

* Easing `Request` modifications for `Authorization` headers
* Retrying requests that encountered an error with a custom exponential backoff retry policy
* Completely thread-safe refresh systems for web services behind OAuth2 authentication

I'm sure there are all sorts of other cool things you could do with this, but these are the main things I had in mind when putting this together.

## RequestAdapter

The `RequestAdapter` protocol allows each `Request` made on a `SessionManager` to be inspected and adapted before being created. One very specific way to use an adapter is to append an `Authorization` header to requests behind a certain type of authentication.

```swift
class AccessTokenAdapter: RequestAdapter {
	private let accessToken: String
	
	init(accessToken: String) {
		self.accessToken = accessToken
	}

	func adapt(_ urlRequest: URLRequest) -> URLRequest {
	    var urlRequest = urlRequest

	    if urlRequest.urlString.hasPrefix("https://httpbin.org") {
		    urlRequest.setValue("Bearer " + accessToken, forHTTPHeaderField: "Authorization")
	    }

	    return urlRequest
	}
}

let sessionManager = SessionManager()
sessionManager.adapter = AccessTokenAdapter(accessToken: "1234")

sessionManager.request("https://httpbin.org/get", withMethod: .get)
```

## RequestRetrier

The `RequestRetrier` protocol allows a `Request` that encountered an `Error` while being executed to be retried. When using both the `RequestAdapter` and `RequestRetrier` protocols together, you can create credential refresh systems for OAuth1, OAuth2, Basic Auth and even exponential backoff retry policies. The possibilities are endless. Here's a short example of how you could implement a refresh flow for OAuth2 access tokens.

```swift
class OAuth2Handler: RequestAdapter, RequestRetrier {
    private typealias RefreshCompletion = (_ succeeded: Bool, _ accessToken: String?, _ refreshToken: String?) -> Void

    private let sessionManager: SessionManager = {
        let configuration = URLSessionConfiguration.default
        configuration.httpAdditionalHeaders = SessionManager.defaultHTTPHeaders

        return SessionManager(configuration: configuration)
    }()

    private let lock = NSLock()

    private var clientID: String
    private var baseURLString: String
    private var accessToken: String
    private var refreshToken: String

    private var isRefreshing = false
    private var requestsToRetry: [RequestRetryCompletion] = []

    // MARK: - Initialization

    public init(clientID: String, baseURLString: String, accessToken: String, refreshToken: String) {
        self.clientID = clientID
        self.baseURLString = baseURLString
        self.accessToken = accessToken
        self.refreshToken = refreshToken
    }

    // MARK: - RequestAdapter

    public func adapt(_ urlRequest: URLRequest) -> URLRequest {
        if urlRequest.urlString.hasPrefix(baseURLString) {
            var mutableURLRequest = urlRequest
            mutableURLRequest.setValue("Bearer " + accessToken, forHTTPHeaderField: "Authorization")
            return mutableURLRequest
        }

        return urlRequest
    }

    // MARK: - RequestRetrier

    public func should(_ manager: SessionManager, retry request: Request, with error: Error, completion: RequestRetryCompletion) {
        lock.lock() ; defer { lock.unlock() }

        if let response = request.task.response as? HTTPURLResponse, response.statusCode == 401 {
            requestsToRetry.append(completion)

            if !isRefreshing {
                refreshTokens { [weak self] succeeded, accessToken, refreshToken in
                    guard let strongSelf = self else { return }

                    strongSelf.lock.lock() ; defer { strongSelf.lock.unlock() }

                    if let accessToken = accessToken, let refreshToken = refreshToken {
                        strongSelf.accessToken = accessToken
                        strongSelf.refreshToken = refreshToken
                    }

                    strongSelf.requestsToRetry.forEach { $0(succeeded, 0.0) }
                    strongSelf.requestsToRetry.removeAll()
                }
            }
        } else {
            completion(false, 0.0)
        }
    }

    // MARK: - Private - Refresh Tokens

    private func refreshTokens(completion: RefreshCompletion) {
        guard !isRefreshing else { return }

        isRefreshing = true

        let urlString = "\(baseURLString)/oauth2/token"

        let parameters: [String: Any] = [
            "access_token": accessToken,
            "refresh_token": refreshToken,
            "client_id": clientID,
            "grant_type": "refresh_token"
        ]

        sessionManager.request(urlString, withMethod: .post, parameters: parameters, encoding: .json).responseJSON { [weak self] response in
            guard let strongSelf = self else { return }

            if let json = response.result.value as? [String: String] {
                completion(true, json["access_token"], json["refresh_token"])
            } else {
                completion(false, nil, nil)
            }

            strongSelf.isRefreshing = false
        }
    }
}

let baseURLString = "https://some.domain-behind-oauth2.com"

let oauthHandler = OAuth2Handler(
    clientID: "12345678",
    baseURLString: baseURLString,
    accessToken: "abcd1234",
    refreshToken: "ef56789a"
)

let sessionManager = SessionManager()
sessionManager.adapter = oauthHandler
sessionManager.retrier = oauthHandler

let urlString = "\(baseURLString)/some/endpoint"

manager.request(urlString, withMethod: .get).validate().responseJSON { response in
    debugPrint(response)
}
```

---

## Tests

I've added tests around the `RequestAdapter` to make sure all the `SessionManager` APIs actually  call the `adapter` if set. I also added tests verifying the `retrier` is called when errors occur and that the `adapter` will be called again when the request is retried.

## Internal Modifications

There are several internal changes that are worth calling out to make this work.

### Validations

The first is that `Validation` is no longer run on the delegate's `OperationQueue`. In order to determine whether a `Request` encountered an error, we need to make sure we run all the validations first, otherwise the error won't be set and the `retrier` won't be called. This was a trivial change to implement, but is an important callout.

### TaskConvertible

The `TaskConvertible` enum nested in the `Request` class allows us to store the un-adapted version of the `Request` before it is adapted and turned into a `URLSessionTask`. The `retry` method on the `SessionManager` uses the new `originalTask` property to extract the original urlRequest, adapt it if necessary, then create the new task and apply it to the `Request`. By setting a new task on the `TaskDelegate`, it automatically resets all the data tracked in the `TaskDelegate` as though it is a brand new task.

### SessionDelegate

The `SessionManager` must be passed down to the `SessionDelegate` as a `weak` property in order to allow the `SessionManager` to retry the `Request` from the `SessionDelegate`. I originally had the retry logic in the `Request` class, but it became problematic when trying to figure out how to lock down the task creation on the `SessionManager` queue. While I don't love having to store the parent reference in the child, it's not so bad since it's not exposed publicly and it doesn't result in a retain cycle since it's a `weak` reference. 

> I'm very open to suggestions here on a better approach, but I think this is about the cleanest way to do it.

## README Updates

I've added a `Adapting and Retrying Requests` section to the README to walk users through some of the ways you could use these protocols. I also created a fairly detailed `OAuth2` example to demonstrate how to start to build a thread-safe refresh system that could be shared across multiple session managers.

---

## Summary

Overall I think these are two very powerful protocols that will open up all sorts of possibilities for the Alamofire community. I'd love to see custom `RequestRetrier` implementations for linear and exponential back-off policies for things like background sync operations. Can't wait to see what everyone comes up with!