### PR TITLE
Podspec config to build target with Swift3

### DIFF
--- a/Alamofire.podspec
+++ b/Alamofire.podspec
@@ -14,4 +14,6 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
 
   s.source_files = 'Source/*.swift'
+  
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '3.0' }
 end


### PR DESCRIPTION
Adding this Podspec configuration line means that the SWIFT_VERSION does not need to manually set to 3.0 in Xcode and is done on install. This configuration is being followed conventionally by many Pods being updated for Swift 3.