### PR TITLE
Feature - Request Subclasses and New Progress APIs

### DIFF
--- a/Example/Source/MasterViewController.swift
+++ b/Example/Source/MasterViewController.swift
@@ -78,7 +78,7 @@ class MasterViewController: UITableViewController {
                     return Alamofire.request("https://httpbin.org/delete", withMethod: .delete)
                 case "DOWNLOAD":
                     detailViewController.segueIdentifier = "DOWNLOAD"
-                    let destination = Alamofire.Request.suggestedDownloadDestination(
+                    let destination = DownloadRequest.suggestedDownloadDestination(
                         for: .cachesDirectory,
                         in: .userDomainMask
                     )

--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -93,11 +93,16 @@ extension URLRequest {
             }
         }
     }
+
+    func adapt(using adapter: RequestAdapter?) -> URLRequest {
+        guard let adapter = adapter else { return self }
+        return adapter.adapt(self)
+    }
 }
 
 // MARK: - Data Request
 
-/// Creates a data `Request` using the default `SessionManager` to retrieve the contents of a URL based on the
+/// Creates a `DataRequest` using the default `SessionManager` to retrieve the contents of a URL based on the
 /// specified `urlString`, `method`, `parameters`, `encoding` and `headers`.
 ///
 /// - parameter urlString:  The URL string.
@@ -106,7 +111,7 @@ extension URLRequest {
 /// - parameter encoding:   The parameter encoding. `.url` by default.
 /// - parameter headers:    The HTTP headers. `nil` by default.
 ///
-/// - returns: The created data `Request`.
+/// - returns: The created `DataRequest`.
 @discardableResult
 public func request(
     _ urlString: URLStringConvertible,
@@ -114,7 +119,7 @@ public func request(
     parameters: [String: Any]? = nil,
     encoding: ParameterEncoding = .url,
     headers: [String: String]? = nil)
-    -> Request
+    -> DataRequest
 {
     return SessionManager.default.request(
         urlString,
@@ -125,14 +130,14 @@ public func request(
     )
 }
 
-/// Creates a data `Request` using the default `SessionManager` to retrieve the contents of a URL based on the
+/// Creates a `DataRequest` using the default `SessionManager` to retrieve the contents of a URL based on the
 /// specified `urlRequest`.
 ///
 /// - parameter urlRequest: The URL request
 ///
-/// - returns: The created data `Request`.
+/// - returns: The created `DataRequest`.
 @discardableResult
-public func request(_ urlRequest: URLRequestConvertible) -> Request {
+public func request(_ urlRequest: URLRequestConvertible) -> DataRequest {
     return SessionManager.default.request(urlRequest.urlRequest)
 }
 
@@ -140,7 +145,7 @@ public func request(_ urlRequest: URLRequestConvertible) -> Request {
 
 // MARK: URL Request
 
-/// Creates a download `Request` using the default `SessionManager` to retrieve the contents of a URL based on the
+/// Creates a `DownloadRequest` using the default `SessionManager` to retrieve the contents of a URL based on the
 /// specified `urlString`, `method`, `parameters`, `encoding`, `headers` and save them to the `destination`.
 ///
 /// - parameter urlString:   The URL string.
@@ -150,16 +155,16 @@ public func request(_ urlRequest: URLRequestConvertible) -> Request {
 /// - parameter encoding:    The parameter encoding. `.url` by default.
 /// - parameter headers:     The HTTP headers. `nil` by default.
 ///
-/// - returns: The created download `Request`.
+/// - returns: The created `DownloadRequest`.
 @discardableResult
 public func download(
     _ urlString: URLStringConvertible,
-    to destination: Request.DownloadFileDestination,
+    to destination: DownloadRequest.DownloadFileDestination,
     withMethod method: HTTPMethod,
     parameters: [String: Any]? = nil,
     encoding: ParameterEncoding = .url,
     headers: [String: String]? = nil)
-    -> Request
+    -> DownloadRequest
 {
     return SessionManager.default.download(
         urlString,
@@ -171,25 +176,25 @@ public func download(
     )
 }
 
-/// Creates a download `Request` using the default `SessionManager` to retrieve the contents of a URL based on the
+/// Creates a `DownloadRequest` using the default `SessionManager` to retrieve the contents of a URL based on the
 /// specified `urlRequest` and save them to the `destination`.
 ///
 /// - parameter urlRequest:  The URL request.
 /// - parameter destination: The closure used to determine the destination of the downloaded file.
 ///
-/// - returns: The created download `Request`.
+/// - returns: The created `DownloadRequest`.
 @discardableResult
 public func download(
     _ urlRequest: URLRequestConvertible,
-    to destination: Request.DownloadFileDestination)
-    -> Request
+    to destination: DownloadRequest.DownloadFileDestination)
+    -> DownloadRequest
 {
     return SessionManager.default.download(urlRequest, to: destination)
 }
 
 // MARK: Resume Data
 
-/// Creates a download `Request` using the default `SessionManager` from the `resumeData` produced from a
+/// Creates a `DownloadRequest` using the default `SessionManager` from the `resumeData` produced from a
 /// previous request cancellation to retrieve the contents of the original request and save them to the `destination`.
 ///
 /// - parameter resumeData:  The resume data. This is an opaque data blob produced by `URLSessionDownloadTask`
@@ -197,9 +202,13 @@ public func download(
 ///                          information.
 /// - parameter destination: The closure used to determine the destination of the downloaded file.
 ///
-/// - returns: The created download `Request`.
+/// - returns: The created `DownloadRequest`.
 @discardableResult
-public func download(resourceWithin resumeData: Data, to destination: Request.DownloadFileDestination) -> Request {
+public func download(
+    resourceWithin resumeData: Data,
+    to destination: DownloadRequest.DownloadFileDestination)
+    -> DownloadRequest
+{
     return SessionManager.default.download(resourceWithin: resumeData, to: destination)
 }
 
@@ -207,7 +216,7 @@ public func download(resourceWithin resumeData: Data, to destination: Request.Do
 
 // MARK: File
 
-/// Creates an upload `Request` using the default `SessionManager` from the specified `method`, `urlString`
+/// Creates an `UploadRequest` using the default `SessionManager` from the specified `method`, `urlString`
 /// and `headers` for uploading the `file`.
 ///
 /// - parameter file:      The file to upload.
@@ -215,33 +224,33 @@ public func download(resourceWithin resumeData: Data, to destination: Request.Do
 /// - parameter urlString: The URL string.
 /// - parameter headers:   The HTTP headers. `nil` by default.
 ///
-/// - returns: The created upload `Request`.
+/// - returns: The created `UploadRequest`.
 @discardableResult
 public func upload(
     _ fileURL: URL,
     to urlString: URLStringConvertible,
     withMethod method: HTTPMethod,
     headers: [String: String]? = nil)
-    -> Request
+    -> UploadRequest
 {
     return SessionManager.default.upload(fileURL, to: urlString, withMethod: method, headers: headers)
 }
 
-/// Creates a upload `Request` using the default `SessionManager` from the specified `urlRequest` for
+/// Creates a `UploadRequest` using the default `SessionManager` from the specified `urlRequest` for
 /// uploading the `file`.
 ///
 /// - parameter file:       The file to upload.
 /// - parameter urlRequest: The URL request.
 ///
-/// - returns: The created upload `Request`.
+/// - returns: The created `UploadRequest`.
 @discardableResult
-public func upload(_ fileURL: URL, with urlRequest: URLRequestConvertible) -> Request {
+public func upload(_ fileURL: URL, with urlRequest: URLRequestConvertible) -> UploadRequest {
     return SessionManager.default.upload(fileURL, with: urlRequest)
 }
 
 // MARK: Data
 
-/// Creates an upload `Request` using the default `SessionManager` from the specified `method`, `urlString`
+/// Creates an `UploadRequest` using the default `SessionManager` from the specified `method`, `urlString`
 /// and `headers` for uploading the `data`.
 ///
 /// - parameter data:      The data to upload.
@@ -249,33 +258,33 @@ public func upload(_ fileURL: URL, with urlRequest: URLRequestConvertible) -> Re
 /// - parameter method:    The HTTP method.
 /// - parameter headers:   The HTTP headers. `nil` by default.
 ///
-/// - returns: The created upload `Request`.
+/// - returns: The created `UploadRequest`.
 @discardableResult
 public func upload(
     _ data: Data,
     to urlString: URLStringConvertible,
     withMethod method: HTTPMethod,
     headers: [String: String]? = nil)
-    -> Request
+    -> UploadRequest
 {
     return SessionManager.default.upload(data, to: urlString, withMethod: method, headers: headers)
 }
 
-/// Creates an upload `Request` using the default `SessionManager` from the specified `urlRequest` for
+/// Creates an `UploadRequest` using the default `SessionManager` from the specified `urlRequest` for
 /// uploading the `data`.
 ///
 /// - parameter data:       The data to upload.
 /// - parameter urlRequest: The URL request.
 ///
-/// - returns: The created upload `Request`.
+/// - returns: The created `UploadRequest`.
 @discardableResult
-public func upload(_ data: Data, with urlRequest: URLRequestConvertible) -> Request {
+public func upload(_ data: Data, with urlRequest: URLRequestConvertible) -> UploadRequest {
     return SessionManager.default.upload(data, with: urlRequest)
 }
 
 // MARK: InputStream
 
-/// Creates an upload `Request` using the default `SessionManager` from the specified `method`, `urlString`
+/// Creates an `UploadRequest` using the default `SessionManager` from the specified `method`, `urlString`
 /// and `headers` for uploading the `stream`.
 ///
 /// - parameter stream:    The stream to upload.
@@ -283,34 +292,34 @@ public func upload(_ data: Data, with urlRequest: URLRequestConvertible) -> Requ
 /// - parameter method:    The HTTP method.
 /// - parameter headers:   The HTTP headers. `nil` by default.
 ///
-/// - returns: The created upload `Request`.
+/// - returns: The created `UploadRequest`.
 @discardableResult
 public func upload(
     _ stream: InputStream,
     to urlString: URLStringConvertible,
     withMethod method: HTTPMethod,
     headers: [String: String]? = nil)
-    -> Request
+    -> UploadRequest
 {
     return SessionManager.default.upload(stream, to: urlString, withMethod: method, headers: headers)
 }
 
-/// Creates an upload `Request` using the default `SessionManager` from the specified `urlRequest` for
+/// Creates an `UploadRequest` using the default `SessionManager` from the specified `urlRequest` for
 /// uploading the `stream`.
 ///
 /// - parameter urlRequest: The URL request.
 /// - parameter stream:     The stream to upload.
 ///
-/// - returns: The created upload `Request`.
+/// - returns: The created `UploadRequest`.
 @discardableResult
-public func upload(_ stream: InputStream, with urlRequest: URLRequestConvertible) -> Request {
+public func upload(_ stream: InputStream, with urlRequest: URLRequestConvertible) -> UploadRequest {
     return SessionManager.default.upload(stream, with: urlRequest)
 }
 
 // MARK: MultipartFormData
 
 /// Encodes `multipartFormData` using `encodingMemoryThreshold` with the default `SessionManager` and calls
-/// `encodingCompletion` with new upload `Request` using the `method`, `urlString` and `headers`.
+/// `encodingCompletion` with new `UploadRequest` using the `method`, `urlString` and `headers`.
 ///
 /// It is important to understand the memory implications of uploading `MultipartFormData`. If the cummulative
 /// payload is small, encoding the data in-memory and directly uploading to a server is the by far the most
@@ -351,7 +360,7 @@ public func upload(
 }
 
 /// Encodes `multipartFormData` using `encodingMemoryThreshold` and the default `SessionManager` and
-/// calls `encodingCompletion` with new upload `Request` using the `urlRequest`.
+/// calls `encodingCompletion` with new `UploadRequest` using the `urlRequest`.
 ///
 /// It is important to understand the memory implications of uploading `MultipartFormData`. If the cummulative
 /// payload is small, encoding the data in-memory and directly uploading to a server is the by far the most

--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -393,3 +393,39 @@ public func upload(
         encodingCompletion: encodingCompletion
     )
 }
+
+#if !os(watchOS)
+
+// MARK: - Stream Request
+
+// MARK: Hostname and Port
+
+/// Creates a `StreamRequest` using the default `SessionManager` for bidirectional streaming with the `hostname`
+/// and `port`.
+///
+/// If `startRequestsImmediately` is `true`, the request will have `resume()` called before being returned.
+///
+/// - parameter hostName: The hostname of the server to connect to.
+/// - parameter port:     The port of the server to connect to.
+///
+/// - returns: The created `StreamRequest`.
+@discardableResult
+public func stream(withHostName hostName: String, port: Int) -> StreamRequest {
+    return SessionManager.default.stream(withHostName: hostName, port: port)
+}
+
+// MARK: NetService
+
+/// Creates a `StreamRequest` using the default `SessionManager` for bidirectional streaming with the `netService`.
+///
+/// If `startRequestsImmediately` is `true`, the request will have `resume()` called before being returned.
+///
+/// - parameter netService: The net service used to identify the endpoint.
+///
+/// - returns: The created `StreamRequest`.
+@discardableResult
+public func stream(with netService: NetService) -> StreamRequest {
+    return SessionManager.default.stream(with: netService)
+}
+
+#endif

--- a/Source/DispatchQueue+Alamofire.swift
+++ b/Source/DispatchQueue+Alamofire.swift
@@ -33,4 +33,10 @@ extension DispatchQueue {
     func after(_ delay: TimeInterval, execute closure: @escaping () -> Void) {
         asyncAfter(deadline: .now() + delay, execute: closure)
     }
+
+    func syncResult<T>(_ closure: () -> T) -> T {
+        var result: T!
+        sync { result = closure() }
+        return result
+    }
 }

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -178,18 +178,18 @@ open class Request {
         return self
     }
 
-    /// Returns a base64 encoded basic authentication credential as an authorization header dictionary.
+    /// Returns a base64 encoded basic authentication credential as an authorization header tuple.
     ///
     /// - parameter user:     The user.
     /// - parameter password: The password.
     ///
-    /// - returns: A dictionary with Authorization key and credential value or empty dictionary if encoding fails.
-    open static func authorizationHeaderFrom(user: String, password: String) -> [String: String] {
-        guard let data = "\(user):\(password)".data(using: String.Encoding.utf8) else { return [:] }
+    /// - returns: A tuple with Authorization header and credential value if encoding succeeds, `nil` otherwise.
+    open static func authorizationHeaderFrom(user: String, password: String) -> (key: String, value: String)? {
+        guard let data = "\(user):\(password)".data(using: .utf8) else { return nil }
 
         let credential = data.base64EncodedString(options: [])
 
-        return ["Authorization": "Basic \(credential)"]
+        return (key: "Authorization", value: "Basic \(credential)")
     }
 
     // MARK: Progress

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -577,7 +577,7 @@ open class UploadRequest: DataRequest {
 /// Specific type of `Request` that manages an underlying `URLSessionStreamTask`.
 open class StreamRequest: Request {
     enum Streamable: TaskConvertible {
-        case stream(String, Int)
+        case stream(hostName: String, port: Int)
         case netService(NetService)
 
         func task(session: URLSession, adapter: RequestAdapter?, queue: DispatchQueue) -> URLSessionTask {

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -331,15 +331,12 @@ open class DataRequest: Request {
 
     // MARK: Helper Types
 
-    enum Requestable: TaskConvertible {
-        case request(URLRequest)
+    struct Requestable: TaskConvertible {
+        let urlRequest: URLRequest
 
         func task(session: URLSession, adapter: RequestAdapter?, queue: DispatchQueue) -> URLSessionTask {
-            switch self {
-            case let .request(urlRequest):
-                let urlRequest = urlRequest.adapt(using: adapter)
-                return queue.syncResult { session.dataTask(with: urlRequest) }
-            }
+            let urlRequest = self.urlRequest.adapt(using: adapter)
+            return queue.syncResult { session.dataTask(with: urlRequest) }
         }
     }
 

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -168,7 +168,7 @@ open class Request {
     /// - parameter password: The password.
     ///
     /// - returns: A tuple with Authorization header and credential value if encoding succeeds, `nil` otherwise.
-    open static func authorizationHeaderFrom(user: String, password: String) -> (key: String, value: String)? {
+    open static func authorizationHeader(user: String, password: String) -> (key: String, value: String)? {
         guard let data = "\(user):\(password)".data(using: .utf8) else { return nil }
 
         let credential = data.base64EncodedString(options: [])

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -335,15 +335,11 @@ open class DataRequest: Request {
         case request(URLRequest)
 
         func task(session: URLSession, adapter: RequestAdapter?, queue: DispatchQueue) -> URLSessionTask {
-            var task: URLSessionTask!
-
             switch self {
             case let .request(urlRequest):
                 let urlRequest = urlRequest.adapt(using: adapter)
-                queue.sync { task = session.dataTask(with: urlRequest) }
+                return queue.syncResult { session.dataTask(with: urlRequest) }
             }
-
-            return task
         }
     }
 
@@ -415,14 +411,14 @@ open class DownloadRequest: Request {
         case resumeData(Data)
 
         func task(session: URLSession, adapter: RequestAdapter?, queue: DispatchQueue) -> URLSessionTask {
-            var task: URLSessionTask!
+            let task: URLSessionTask
 
             switch self {
             case let .request(urlRequest):
                 let urlRequest = urlRequest.adapt(using: adapter)
-                queue.sync { task = session.downloadTask(with: urlRequest) }
+                task = queue.syncResult { session.downloadTask(with: urlRequest) }
             case let .resumeData(resumeData):
-                queue.sync { task = session.downloadTask(withResumeData: resumeData) }
+                task = queue.syncResult { session.downloadTask(withResumeData: resumeData) }
             }
 
             return task
@@ -517,18 +513,18 @@ open class UploadRequest: DataRequest {
         case stream(InputStream, URLRequest)
 
         func task(session: URLSession, adapter: RequestAdapter?, queue: DispatchQueue) -> URLSessionTask {
-            var task: URLSessionTask!
+            let task: URLSessionTask
 
             switch self {
             case let .data(data, urlRequest):
                 let urlRequest = urlRequest.adapt(using: adapter)
-                queue.sync { task = session.uploadTask(with: urlRequest, from: data) }
+                task = queue.syncResult { session.uploadTask(with: urlRequest, from: data) }
             case let .file(url, urlRequest):
                 let urlRequest = urlRequest.adapt(using: adapter)
-                queue.sync { task = session.uploadTask(with: urlRequest, fromFile: url) }
+                task = queue.syncResult { session.uploadTask(with: urlRequest, fromFile: url) }
             case let .stream(_, urlRequest):
                 let urlRequest = urlRequest.adapt(using: adapter)
-                queue.sync { task = session.uploadTask(withStreamedRequest: urlRequest) }
+                task = queue.syncResult { session.uploadTask(withStreamedRequest: urlRequest) }
             }
 
             return task
@@ -588,18 +584,18 @@ open class StreamRequest: Request {
         case netService(NetService)
 
         func task(session: URLSession, adapter: RequestAdapter?, queue: DispatchQueue) -> URLSessionTask {
-            var task: URLSessionTask!
+            let task: URLSessionTask
 
             switch self {
             case let .stream(hostName, port):
-                queue.sync { task = session.streamTask(withHostName: hostName, port: port) }
+                task = queue.syncResult { session.streamTask(withHostName: hostName, port: port) }
             case let .netService(netService):
-                queue.sync { task = session.streamTask(with: netService) }
+                task = queue.syncResult { session.streamTask(with: netService) }
             }
-            
+
             return task
         }
     }
 }
-    
+
 #endif

--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -117,7 +117,7 @@ open class SessionDelegate: NSObject {
     open var streamTaskBetterRouteDiscovered: ((URLSession, URLSessionStreamTask) -> Void)?
 
     /// Overrides default behavior for URLSessionStreamDelegate method `urlSession(_:streamTask:didBecome:outputStream:)`.
-    open var streamTaskDidBecomeInputStream: ((URLSession, URLSessionStreamTask, InputStream, OutputStream) -> Void)?
+    open var streamTaskDidBecomeInputAndOutputStreams: ((URLSession, URLSessionStreamTask, InputStream, OutputStream) -> Void)?
 
 #endif
 
@@ -162,6 +162,21 @@ open class SessionDelegate: NSObject {
         #if !os(OSX)
             if selector == #selector(URLSessionDelegate.urlSessionDidFinishEvents(forBackgroundURLSession:)) {
                 return sessionDidFinishEventsForBackgroundURLSession != nil
+            }
+        #endif
+
+        #if !os(watchOS)
+            switch selector {
+            case #selector(URLSessionStreamDelegate.urlSession(_:readClosedFor:)):
+                return streamTaskReadClosed != nil
+            case #selector(URLSessionStreamDelegate.urlSession(_:writeClosedFor:)):
+                return streamTaskWriteClosed != nil
+            case #selector(URLSessionStreamDelegate.urlSession(_:betterRouteDiscoveredFor:)):
+                return streamTaskBetterRouteDiscovered != nil
+            case #selector(URLSessionStreamDelegate.urlSession(_:streamTask:didBecome:outputStream:)):
+                return streamTaskDidBecomeInputAndOutputStreams != nil
+            default:
+                break
             }
         #endif
 
@@ -644,7 +659,7 @@ extension SessionDelegate: URLSessionStreamDelegate {
         didBecome inputStream: InputStream,
         outputStream: OutputStream)
     {
-        streamTaskDidBecomeInputStream?(session, streamTask, inputStream, outputStream)
+        streamTaskDidBecomeInputAndOutputStreams?(session, streamTask, inputStream, outputStream)
     }
 }
 

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -179,7 +179,7 @@ open class SessionManager {
     /// `nil` by default.
     open var backgroundCompletionHandler: (() -> Void)?
 
-    let queue = DispatchQueue(label: "Alamofire Session Manager Queue")
+    let queue = DispatchQueue(label: "org.alamofire.session-manager." + NSUUID().uuidString)
 
     // MARK: - Lifecycle
 

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -241,7 +241,7 @@ open class SessionManager {
         var task: URLSessionDataTask!
         queue.sync { task = self.session.dataTask(with: adaptedRequest) }
 
-        let originalTask = DataRequest.Requestable.request(originalRequest)
+        let originalTask = DataRequest.Requestable(urlRequest: originalRequest)
         let request = DataRequest(session: session, task: task, originalTask: originalTask)
 
         delegate[request.delegate.task] = request

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -139,7 +139,7 @@ open class SessionManager {
     /// `nil` by default.
     open var backgroundCompletionHandler: (() -> Void)?
 
-    let queue = DispatchQueue(label: "org.alamofire.session-manager." + NSUUID().uuidString)
+    let queue = DispatchQueue(label: "org.alamofire.session-manager." + UUID().uuidString)
 
     // MARK: - Lifecycle
 

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -638,7 +638,7 @@ open class SessionManager {
     /// - returns: The created `StreamRequest`.
     @discardableResult
     open func stream(withHostName hostName: String, port: Int) -> StreamRequest {
-        return stream(.stream(hostName, port))
+        return stream(.stream(hostName: hostName, port: port))
     }
 
     // MARK: NetService

--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -172,7 +172,7 @@ class DataTaskDelegate: TaskDelegate, URLSessionDataDelegate {
 
     // MARK: Properties
 
-    var dataTask: URLSessionDataTask? { return task as? URLSessionDataTask }
+    var dataTask: URLSessionDataTask { return task as! URLSessionDataTask }
 
     override var data: Data? {
         if dataStream != nil {
@@ -286,7 +286,7 @@ class DownloadTaskDelegate: TaskDelegate, URLSessionDownloadDelegate {
 
     // MARK: Properties
 
-    var downloadTask: URLSessionDownloadTask? { return task as? URLSessionDownloadTask }
+    var downloadTask: URLSessionDownloadTask { return task as! URLSessionDownloadTask }
     var downloadProgress: ((Int64, Int64, Int64) -> Void)?
 
     var resumeData: Data?
@@ -367,7 +367,7 @@ class UploadTaskDelegate: DataTaskDelegate {
 
     // MARK: Properties
 
-    var uploadTask: URLSessionUploadTask? { return task as? URLSessionUploadTask }
+    var uploadTask: URLSessionUploadTask { return task as! URLSessionUploadTask }
     var uploadProgress: ((Int64, Int64, Int64) -> Void)!
 
     // MARK: URLSessionTaskDelegate

--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -185,7 +185,7 @@ class DataTaskDelegate: TaskDelegate, URLSessionDataDelegate {
     var progressHandler: (closure: Request.ProgressHandler, queue: DispatchQueue)?
     var progressDebugHandler: (closure: Request.DownloadProgressHandler, queue: DispatchQueue)?
 
-    var dataStream: ((_ data: Data) -> Void)? // this should use handler pattern also
+    var dataStream: ((_ data: Data) -> Void)?
 
     private var totalBytesReceived: Int64 = 0
     private var mutableData: Data

--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -125,9 +125,14 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
 
     func testHiddenHTTPBasicAuthentication() {
         // Given
-        let authorizationHeader = Request.authorizationHeaderFrom(user: user, password: password)
         let urlString = "http://httpbin.org/hidden-basic-auth/\(user)/\(password)"
         let expectation = self.expectation(description: "\(urlString) 200")
+
+        var headers: [String: String]?
+
+        if let authorizationHeader = Request.authorizationHeaderFrom(user: user, password: password) {
+            headers = [authorizationHeader.key: authorizationHeader.value]
+        }
 
         var request: URLRequest?
         var response: HTTPURLResponse?
@@ -135,7 +140,7 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString, withMethod: .get, headers: authorizationHeader)
+        manager.request(urlString, withMethod: .get, headers: headers)
             .response { responseRequest, responseResponse, responseData, responseError in
                 request = responseRequest
                 response = responseResponse

--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -130,7 +130,7 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
 
         var headers: [String: String]?
 
-        if let authorizationHeader = Request.authorizationHeaderFrom(user: user, password: password) {
+        if let authorizationHeader = Request.authorizationHeader(user: user, password: password) {
             headers = [authorizationHeader.key: authorizationHeader.value]
         }
 

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -33,7 +33,7 @@ class DownloadInitializationTestCase: BaseTestCase {
     func testDownloadClassMethodWithMethodURLAndDestination() {
         // Given
         let urlString = "https://httpbin.org/"
-        let destination = Request.suggestedDownloadDestination(for: searchPathDirectory, in: searchPathDomain)
+        let destination = DownloadRequest.suggestedDownloadDestination(for: searchPathDirectory, in: searchPathDomain)
 
         // When
         let request = Alamofire.download(urlString, to: destination, withMethod: .get)
@@ -49,7 +49,7 @@ class DownloadInitializationTestCase: BaseTestCase {
         // Given
         let urlString = "https://httpbin.org/"
         let headers = ["Authorization": "123456"]
-        let destination = Request.suggestedDownloadDestination(for: searchPathDirectory, in: searchPathDomain)
+        let destination = DownloadRequest.suggestedDownloadDestination(for: searchPathDirectory, in: searchPathDomain)
 
         // When
         let request = Alamofire.download(urlString, to: destination, withMethod: .get, headers: headers)
@@ -87,7 +87,7 @@ class DownloadResponseTestCase: BaseTestCase {
         // Given
         let numberOfLines = 100
         let urlString = "https://httpbin.org/stream/\(numberOfLines)"
-        let destination = Alamofire.Request.suggestedDownloadDestination(for: searchPathDirectory, in: searchPathDomain)
+        let destination = DownloadRequest.suggestedDownloadDestination(for: searchPathDirectory, in: searchPathDomain)
 
         let expectation = self.expectation(description: "Download request should download data to file: \(urlString)")
 
@@ -253,7 +253,7 @@ class DownloadResponseTestCase: BaseTestCase {
         let fileURL = randomCachesFileURL
         let urlString = "https://httpbin.org/get"
         let parameters = ["foo": "bar"]
-        let destination: Request.DownloadFileDestination = { _, _ in fileURL }
+        let destination: DownloadRequest.DownloadFileDestination = { _, _ in fileURL }
 
         let expectation = self.expectation(description: "Download request should download data to file: \(fileURL)")
 
@@ -295,7 +295,7 @@ class DownloadResponseTestCase: BaseTestCase {
         let fileURL = randomCachesFileURL
         let urlString = "https://httpbin.org/get"
         let headers = ["Authorization": "123456"]
-        let destination: Request.DownloadFileDestination = { _, _ in fileURL }
+        let destination: DownloadRequest.DownloadFileDestination = { _, _ in fileURL }
 
         let expectation = self.expectation(description: "Download request should download data to file: \(fileURL)")
 
@@ -337,11 +337,11 @@ class DownloadResponseTestCase: BaseTestCase {
 
 class DownloadResumeDataTestCase: BaseTestCase {
     let urlString = "https://upload.wikimedia.org/wikipedia/commons/6/69/NASA-HS201427a-HubbleUltraDeepField2014-20140603.jpg"
-    let destination: Request.DownloadFileDestination = {
+    let destination: DownloadRequest.DownloadFileDestination = {
         let searchPathDirectory: FileManager.SearchPathDirectory = .cachesDirectory
         let searchPathDomain: FileManager.SearchPathDomainMask = .userDomainMask
 
-        return Request.suggestedDownloadDestination(for: searchPathDirectory, in: searchPathDomain)
+        return DownloadRequest.suggestedDownloadDestination(for: searchPathDirectory, in: searchPathDomain)
     }()
 
     func testThatImmediatelyCancelledDownloadDoesNotHaveResumeDataAvailable() {

--- a/Tests/SessionManagerTests.swift
+++ b/Tests/SessionManagerTests.swift
@@ -270,7 +270,7 @@ class SessionManagerTestCase: BaseTestCase {
         sessionManager.startRequestsImmediately = false
 
         // When
-        let destination = Request.suggestedDownloadDestination()
+        let destination = DownloadRequest.suggestedDownloadDestination()
         let request = sessionManager.download("https://httpbin.org/get", to: destination, withMethod: .get)
 
         // Then

--- a/Tests/SessionManagerTests.swift
+++ b/Tests/SessionManagerTests.swift
@@ -55,8 +55,8 @@ class SessionManagerTestCase: BaseTestCase {
             adaptedCount += 1
 
             if shouldApplyAuthorizationHeader && adaptedCount > 1 {
-                Request.authorizationHeaderFrom(user: "user", password: "password").forEach { header, value in
-                    urlRequest.setValue(value, forHTTPHeaderField: header)
+                if let header = Request.authorizationHeaderFrom(user: "user", password: "password") {
+                    urlRequest.setValue(header.value, forHTTPHeaderField: header.key)
                 }
             }
 

--- a/Tests/SessionManagerTests.swift
+++ b/Tests/SessionManagerTests.swift
@@ -55,7 +55,7 @@ class SessionManagerTestCase: BaseTestCase {
             adaptedCount += 1
 
             if shouldApplyAuthorizationHeader && adaptedCount > 1 {
-                if let header = Request.authorizationHeaderFrom(user: "user", password: "password") {
+                if let header = Request.authorizationHeader(user: "user", password: "password") {
                     urlRequest.setValue(header.value, forHTTPHeaderField: header.key)
                 }
             }

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -242,7 +242,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
 
                 let task: URLSessionDataTask = queue.syncResult { session.dataTask(with: adaptedRequest) }
 
-                let originalTask = DataRequest.Requestable.request(originalRequest)
+                let originalTask = DataRequest.Requestable(urlRequest: originalRequest)
                 let request = MockRequest(session: session, task: task, originalTask: originalTask)
 
                 delegate[request.delegate.task] = request

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -240,8 +240,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
                 let originalRequest = urlRequest.urlRequest
                 let adaptedRequest = originalRequest.adapt(using: adapter)
 
-                var task: URLSessionDataTask!
-                queue.sync { task = self.session.dataTask(with: adaptedRequest) }
+                let task: URLSessionDataTask = queue.syncResult { session.dataTask(with: adaptedRequest) }
 
                 let originalTask = DataRequest.Requestable.request(originalRequest)
                 let request = MockRequest(session: session, task: task, originalTask: originalTask)


### PR DESCRIPTION
This PR splits up the `Request` class into `DataRequest`, `DownloadRequest`, `UploadRequest` and `StreamRequest` subclasses.

## Motivation

There were several reasons why the `Request` class could greatly benefit from being split up. 

### Progress

The first reason is that the progress APIs were stomping on each other and were confusing the users. For example, the upload progress behavior was very ambiguous considering that the same `Progress` instance was used to report both upload progress and then download progress after the upload was complete.

### Session Manager Duplication

The `feature/adapter-and-retrier` PR added the `TaskConvertible` enumeration to the `Request` class. Unfortunately, there is a large amount of duplication between the `TaskConvertible` implementation and the `Downloadable`, `Uploadable` and `Streamable` enumerations inside the `SessionManager`. Not only is there duplication, but the `Downloadable`, `Uploadable` and `Streamable` enumerations don't really belong in the `SessionManager` anyways. They're really the pieces required to construct a concrete `Request`.

By splitting up the `Request` into subclasses, we could move the `Downloadable`, `Uploadable` and `Streamable` implementations into their respective subclass and eliminate the duplication with the `TaskConvertible` enumeration in the `Request` class.

In the previous PR where the `TaskConvertible` enumeration was added, the `Downloadable`, `Uploadable` and `Streamable` enumerations

### Response Serializers

Another awesome reason for splitting up the `Request` class is to associate response serializers with a particular request type. For example, right now you can chain a `responseData` closure onto a `Request` that is backed by a `URLSessionDownloadTask` or a `ULRSessionStreamTask`. However, if you do this, what's the behavior? It currently gets really weird in all these cases when you start to consider resume data. 

Also, how does one get the destination URL of a download? Great question, right now it is WAY more difficult than it should be. By splitting up the `Request`, we can extend only certain subclasses to support specific response serializers that are tailored to the underlying type of task. These changes will be coming in a future PR.

## Solution

So now that we have some background as to why these changes would be useful, let's dig into what had to change to make this work.

### TaskConvertible

By pulling the `Downloadable`, `Uploadable` and `Streamable` enumerations into their respective subclasses and adding a `Requestable` enumeration to the `DataRequest` subclass, I was able to get rid of the `TaskConvertible` enumeration and make it a protocol. The protocol now creates a `URLSessionTask` from a session, adapter and queue. This allows the subclassed enumerations to construct the tasks directly without having to do this in the `SessionManager`. This greatly simplifies the `SessionManager.retry` method.

### Progress

The progress APIs have been completely rebuilt from scratch. You can now monitor `downloadProgress` on data, download and upload requests. You can also monitor `uploadProgress` on an upload request. There are variants for both the `Progress` object and the broken out `Int64` values. Each variant can also call the progress closure on a specified queue.

Here's a quick example of how you can use the new APIs.

```swift
Alamofire.upload(data, to: urlString, withMethod: .post)
    .uploadProgress { progress in
        // Called on main dispatch queue by default
        print("upload progress: \(progress.fractionCompleted)")
    }
    .uploadProgress(queue: DispatchQueue.utility) { bytesSent, totalBytesSent, totalBytesExpectedToSend in
        // Can customize the dispatch queue for background operations if needed
        print("Sent: \(bytesSent), Total Sent: \(totalBytesSent), Total Expected: \(totalBytesExpectedToSend)")
    }
    .downloadProgress { progress in
        // Called on main dispatch queue by default
        print("download progress: \(progress.fractionCompleted)")
    }
    .downloadProgress { bytesRead, totalBytesRead, totalBytesExpectedToRead in
        // Called on main dispatch queue by default
        print("Read: \(bytesRead), Total Read: \(totalBytesRead), Total Expected: \(totalBytesExpectedToRead)")
    }
    .response { response in
        debugPrint(response)
    }
```

#### Download Progress

The download progress is now being tracked in the `DataTaskDelegate`. This allows the data, download and upload requests to leverage it. I debated for a long time as to whether to call this `progress` or `downloadProgress`. I would rather error on the side of verbosity here I think. I ultimately decided upon `downloadProgress` because `progress` is REALLY ambiguous when it comes to an upload request.

> If anyone strongly disagrees here, please voice your concerns. I'm still on the fence on this one, but right now lean towards `downloadProgress` and `uploadProgress` APIs to completely avoid ambiguity.

#### Upload Progress

The upload progress is all managed by the `UploadTaskDelegate` and is only exposed publicly through the upload request subclass. The stream request cannot chain `downloadProgress` or `uploadProgress` APIs because it no longer inherits them.

### Top-Level Stream APIs

I added the top-level stream APIs to `Alamofire.swift` because they were missing. Just wanted to callout that this random change made its way into this PR as well.

---

## Summary

These changes vastly improve the `progress` APIs and open up the ability to greatly specialize the available chained methods for each subclass. This will help avoid confusion and will allow for better customization for each request type.