### PR TITLE
Refactor User-Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,14 @@ Alamofire.request(.GET, "https://httpbin.org/get", headers: headers)
          }
 ```
 
+Alamofire provides a common set of headers for every request. These include:
+
+* `Accept-Encoding`, which defaults to `gzip;q=1.0, compress;q=0.5`, per [RFC7230](https://tools.ietf.org/html/rfc7230#section-4.2.3).
+* `Accept-Language`, which defaults to up to the top 6 preferred languages on the system, formatted like `en;q=1.0`, per [RFC7231](https://tools.ietf.org/html/rfc7231#section-5.3.5).
+* `User-Agent`, which contains versioning information about the current app. For example: `iOS Example/1.0 (com.alamofire.iOS-Example; build:1; iOS 9.3.0) Alamofire/3.4.2`, per [RFC7231](https://tools.ietf.org/html/rfc7231#section-5.5.3).
+
+Customizing these headers, since they need to be added to every request, should be done by creating a customized `Manager` instance and modifying the `defaultHTTPHeaders` dictionary, as shown in [our documentation](https://github.com/Alamofire/Alamofire#modifying-session-configuration).
+
 ### Caching
 
 Caching is handled on the system framework level by [`NSURLCache`](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSURLCache_Class/Reference/Reference.html#//apple_ref/occ/cl/NSURLCache).

--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -56,6 +56,7 @@ public class Manager {
         }.joinWithSeparator(", ")
 
         // User-Agent Header; see https://tools.ietf.org/html/rfc7231#section-5.5.3
+        // Example: `iOS Example/1.0 (com.alamofire.iOS-Example; build:1; iOS 9.3.0) Alamofire/3.4.2`
         let userAgent: String = {
             if let info = NSBundle.mainBundle().infoDictionary {
                 let executable = info[kCFBundleExecutableKey as String] as? String ?? "Unknown"
@@ -92,7 +93,16 @@ public class Manager {
                     return "\(osName) \(versionString)"
                 }()
 
-                return "\(executable)/\(bundle) (\(appVersion)/\(appBuild)); \(osNameVersion))"
+                let alamofireVersion: String = {
+                    guard
+                        let afInfo = NSBundle(forClass: Manager.self).infoDictionary,
+                        build = afInfo["CFBundleShortVersionString"]
+                    else { return "Unknown" }
+
+                    return "Alamofire/\(build)"
+                }()
+
+                return "\(executable)/\(appVersion) (\(bundle); build:\(appBuild); \(osNameVersion)) \(alamofireVersion)"
             }
 
             return "Alamofire"

--- a/Tests/ManagerTests.swift
+++ b/Tests/ManagerTests.swift
@@ -40,6 +40,53 @@ class ManagerTestCase: BaseTestCase {
         XCTAssertNil(manager.session.serverTrustPolicyManager, "session server trust policy manager should be nil")
     }
 
+    func testDefaultUserAgentHeader() {
+        // Given
+        let userAgent = Manager.defaultHTTPHeaders["User-Agent"]
+
+        // When
+        let osNameVersion: String = {
+            let versionString: String
+
+            if #available(OSX 10.10, *) {
+                let version = NSProcessInfo.processInfo().operatingSystemVersion
+                versionString = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+            } else {
+                versionString = "10.9"
+            }
+
+            let osName: String = {
+                #if os(iOS)
+                    return "iOS"
+                #elseif os(watchOS)
+                    return "watchOS"
+                #elseif os(tvOS)
+                    return "tvOS"
+                #elseif os(OSX)
+                    return "OS X"
+                #elseif os(Linux)
+                    return "Linux"
+                #else
+                    return "Unknown"
+                #endif
+            }()
+
+            return "\(osName) \(versionString)"
+        }()
+        let alamofireVersion: String = {
+            guard
+                let afInfo = NSBundle(forClass: Manager.self).infoDictionary,
+                build = afInfo["CFBundleShortVersionString"]
+            else { return "Unknown" }
+
+            return "Alamofire/\(build)"
+        }()
+
+        // Then
+        let expectedUserAgent = "Unknown/Unknown (Unknown; build:Unknown; \(osNameVersion)) \(alamofireVersion)"
+        XCTAssertEqual(userAgent, expectedUserAgent, "default user agent should match expected user agent")
+    }
+
     func testInitializerWithSpecifiedArguments() {
         // Given
         let configuration = NSURLSessionConfiguration.defaultSessionConfiguration()


### PR DESCRIPTION
Fixes #1452 

This PR updates our `User-Agent` string generation to not only fix the issue reported but bring it more in line with [RFC7231](https://tools.ietf.org/html/rfc7231#section-5.5.3) in regards to where the various bits of information live. It now looks something like this: `iOS Example/1.0 (com.alamofire.iOS-Example; build:1; iOS 9.3.0) Alamofire/3.4.2`. This more closely matches the `User-Agent` strings returned by browsers and now includes the Alamofire version.