### PR TITLE
Feature - Robust Validation

### DIFF
--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -25,6 +25,11 @@
 import Foundation
 
 extension Request {
+
+    // MARK: Helper Types
+
+    fileprivate typealias ErrorReason = AFError.ValidationFailureReason
+
     /// Used to represent whether validation was successful or encountered an error resulting in a failure.
     ///
     /// - success: The validation was successful.
@@ -34,57 +39,7 @@ extension Request {
         case failure(Error)
     }
 
-    /// A closure used to validate a request that takes a URL request and URL response, and returns whether the
-    /// request was valid.
-    public typealias Validation = (URLRequest?, HTTPURLResponse) -> ValidationResult
-
-    /// Validates the request, using the specified closure.
-    ///
-    /// If validation fails, subsequent calls to response handlers will have an associated error.
-    ///
-    /// - parameter validation: A closure to validate the request.
-    ///
-    /// - returns: The request.
-    @discardableResult
-    public func validate(_ validation: Validation) -> Self {
-        let validationExecution: () -> Void = {
-            if
-                let response = self.response,
-                self.delegate.error == nil,
-                case let .failure(error) = validation(self.request, response)
-            {
-                self.delegate.error = error
-            }
-        }
-
-        validations.append(validationExecution)
-
-        return self
-    }
-
-    // MARK: - Status Code
-
-    /// Validates that the response has a status code in the specified range.
-    ///
-    /// If validation fails, subsequent calls to response handlers will have an associated error.
-    ///
-    /// - parameter range: The range of acceptable status codes.
-    ///
-    /// - returns: The request.
-    @discardableResult
-    public func validate<S: Sequence>(statusCode acceptableStatusCode: S) -> Self where S.Iterator.Element == Int {
-        return validate { _, response in
-            if acceptableStatusCode.contains(response.statusCode) {
-                return .success
-            } else {
-                return .failure(AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: response.statusCode)))
-            }
-        }
-    }
-
-    // MARK: - Content-Type
-
-    private struct MIMEType {
+    fileprivate struct MIMEType {
         let type: String
         let subtype: String
 
@@ -113,7 +68,128 @@ extension Request {
         }
     }
 
-    /// Validates that the response has a content type in the specified array.
+    // MARK: Properties
+
+    fileprivate var acceptableStatusCodes: [Int] { return Array(200..<300) }
+
+    fileprivate var acceptableContentTypes: [String] {
+        if let accept = request?.value(forHTTPHeaderField: "Accept") {
+            return accept.components(separatedBy: ",")
+        }
+
+        return ["*/*"]
+    }
+
+    // MARK: Status Code
+
+    fileprivate func validate<S: Sequence>(
+        statusCode acceptableStatusCodes: S,
+        response: HTTPURLResponse)
+        -> ValidationResult
+        where S.Iterator.Element == Int
+    {
+        if acceptableStatusCodes.contains(response.statusCode) {
+            return .success
+        } else {
+            let reason: ErrorReason = .unacceptableStatusCode(code: response.statusCode)
+            return .failure(AFError.responseValidationFailed(reason: reason))
+        }
+    }
+
+    // MARK: Content Type
+
+    fileprivate func validate<S: Sequence>(
+        contentType acceptableContentTypes: S,
+        response: HTTPURLResponse,
+        data: Data?)
+        -> ValidationResult
+        where S.Iterator.Element == String
+    {
+        guard let data = data, data.count > 0 else { return .success }
+
+        guard
+            let responseContentType = response.mimeType,
+            let responseMIMEType = MIMEType(responseContentType)
+        else {
+            for contentType in acceptableContentTypes {
+                if let mimeType = MIMEType(contentType), mimeType.type == "*" && mimeType.subtype == "*" {
+                    return .success
+                }
+            }
+
+            let error: AFError = {
+                let reason: ErrorReason = .missingContentType(acceptableContentTypes: Array(acceptableContentTypes))
+                return AFError.responseValidationFailed(reason: reason)
+            }()
+
+            return .failure(error)
+        }
+
+        for contentType in acceptableContentTypes {
+            if let acceptableMIMEType = MIMEType(contentType), acceptableMIMEType.matches(responseMIMEType) {
+                return .success
+            }
+        }
+
+        let error: AFError = {
+            let reason: ErrorReason = .unacceptableContentType(
+                acceptableContentTypes: Array(acceptableContentTypes),
+                responseContentType: responseContentType
+            )
+
+            return AFError.responseValidationFailed(reason: reason)
+        }()
+        
+        return .failure(error)
+    }
+}
+
+// MARK: -
+
+extension DataRequest {
+    /// A closure used to validate a request that takes a URL request, a URL response and data, and returns whether the
+    /// request was valid.
+    public typealias Validation = (URLRequest?, HTTPURLResponse, Data?) -> ValidationResult
+
+    /// Validates the request, using the specified closure.
+    ///
+    /// If validation fails, subsequent calls to response handlers will have an associated error.
+    ///
+    /// - parameter validation: A closure to validate the request.
+    ///
+    /// - returns: The request.
+    @discardableResult
+    public func validate(_ validation: Validation) -> Self {
+        let validationExecution: () -> Void = {
+            if
+                let response = self.response,
+                self.delegate.error == nil,
+                case let .failure(error) = validation(self.request, response, self.delegate.data)
+            {
+                self.delegate.error = error
+            }
+        }
+
+        validations.append(validationExecution)
+
+        return self
+    }
+
+    /// Validates that the response has a status code in the specified sequence.
+    ///
+    /// If validation fails, subsequent calls to response handlers will have an associated error.
+    ///
+    /// - parameter range: The range of acceptable status codes.
+    ///
+    /// - returns: The request.
+    @discardableResult
+    public func validate<S: Sequence>(statusCode acceptableStatusCodes: S) -> Self where S.Iterator.Element == Int {
+        return validate { _, response, _ in
+            return self.validate(statusCode: acceptableStatusCodes, response: response)
+        }
+    }
+
+    /// Validates that the response has a content type in the specified sequence.
     ///
     /// If validation fails, subsequent calls to response handlers will have an associated error.
     ///
@@ -122,34 +198,10 @@ extension Request {
     /// - returns: The request.
     @discardableResult
     public func validate<S: Sequence>(contentType acceptableContentTypes: S) -> Self where S.Iterator.Element == String {
-        return validate { _, response in
-            guard let validData = self.delegate.data, validData.count > 0 else { return .success }
-
-            guard
-                let responseContentType = response.mimeType,
-                let responseMIMEType = MIMEType(responseContentType) else {
-                for contentType in acceptableContentTypes {
-                    if let mimeType = MIMEType(contentType), mimeType.type == "*" && mimeType.subtype == "*" {
-                        return .success
-                    }
-                }
-
-                return .failure(AFError.responseValidationFailed(reason: .missingContentType(acceptableContentTypes: Array(acceptableContentTypes))))
-            }
-
-            for contentType in acceptableContentTypes {
-                if let acceptableMIMEType = MIMEType(contentType), acceptableMIMEType.matches(responseMIMEType) {
-                    return .success
-                }
-            }
-
-            let error = AFError.responseValidationFailed(reason: .unacceptableContentType(acceptableContentTypes: Array(acceptableContentTypes), responseContentType: responseContentType))
-
-            return .failure(error)
+        return validate { _, response, data in
+            return self.validate(contentType: acceptableContentTypes, response: response, data: data)
         }
     }
-
-    // MARK: - Automatic
 
     /// Validates that the response has a status code in the default acceptable range of 200...299, and that the content
     /// type matches any specified in the Accept HTTP header field.
@@ -159,15 +211,86 @@ extension Request {
     /// - returns: The request.
     @discardableResult
     public func validate() -> Self {
-        let acceptableStatusCodes: CountableRange<Int> = 200..<300
-        let acceptableContentTypes: [String] = {
-            if let accept = request?.value(forHTTPHeaderField: "Accept") {
-                return accept.components(separatedBy: ",")
+        return validate(statusCode: self.acceptableStatusCodes).validate(contentType: self.acceptableContentTypes)
+    }
+}
+
+// MARK: -
+
+extension DownloadRequest {
+    /// A closure used to validate a request that takes a URL request, a URL response and destination URL, and returns
+    /// whether the request was valid.
+    public typealias Validation = (URLRequest?, HTTPURLResponse, URL?) -> ValidationResult
+
+    /// Validates the request, using the specified closure.
+    ///
+    /// If validation fails, subsequent calls to response handlers will have an associated error.
+    ///
+    /// - parameter validation: A closure to validate the request.
+    ///
+    /// - returns: The request.
+    @discardableResult
+    public func validate(_ validation: Validation) -> Self {
+        let validationExecution: () -> Void = {
+            if
+                let response = self.response,
+                self.delegate.error == nil,
+                case let .failure(error) = validation(self.request, response, self.downloadDelegate.destinationURL)
+            {
+                self.delegate.error = error
+            }
+        }
+
+        validations.append(validationExecution)
+
+        return self
+    }
+
+    /// Validates that the response has a status code in the specified sequence.
+    ///
+    /// If validation fails, subsequent calls to response handlers will have an associated error.
+    ///
+    /// - parameter range: The range of acceptable status codes.
+    ///
+    /// - returns: The request.
+    @discardableResult
+    public func validate<S: Sequence>(statusCode acceptableStatusCodes: S) -> Self where S.Iterator.Element == Int {
+        return validate { _, response, _ in
+            return self.validate(statusCode: acceptableStatusCodes, response: response)
+        }
+    }
+
+    /// Validates that the response has a content type in the specified sequence.
+    ///
+    /// If validation fails, subsequent calls to response handlers will have an associated error.
+    ///
+    /// - parameter contentType: The acceptable content types, which may specify wildcard types and/or subtypes.
+    ///
+    /// - returns: The request.
+    @discardableResult
+    public func validate<S: Sequence>(contentType acceptableContentTypes: S) -> Self where S.Iterator.Element == String {
+        return validate { _, response, fileURL in
+            guard let fileURL = fileURL else {
+                return .failure(AFError.responseValidationFailed(reason: .dataFileNil))
             }
 
-            return ["*/*"]
-        }()
+            do {
+                let data = try Data(contentsOf: fileURL)
+                return self.validate(contentType: acceptableContentTypes, response: response, data: data)
+            } catch {
+                return .failure(AFError.responseValidationFailed(reason: .dataFileReadFailed(at: fileURL)))
+            }
+        }
+    }
 
-        return validate(statusCode: acceptableStatusCodes).validate(contentType: acceptableContentTypes)
+    /// Validates that the response has a status code in the default acceptable range of 200...299, and that the content
+    /// type matches any specified in the Accept HTTP header field.
+    ///
+    /// If validation fails, subsequent calls to response handlers will have an associated error.
+    ///
+    /// - returns: The request.
+    @discardableResult
+    public func validate() -> Self {
+        return validate(statusCode: self.acceptableStatusCodes).validate(contentType: self.acceptableContentTypes)
     }
 }

--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -43,9 +43,11 @@ extension Request {
         let type: String
         let subtype: String
 
+        var isWildcard: Bool { return type == "*" && subtype == "*" }
+
         init?(_ string: String) {
             let components: [String] = {
-                let stripped = string.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+                let stripped = string.trimmingCharacters(in: .whitespacesAndNewlines)
                 let split = stripped.substring(to: stripped.range(of: ";")?.lowerBound ?? stripped.endIndex)
                 return split.components(separatedBy: "/")
             }()
@@ -112,7 +114,7 @@ extension Request {
             let responseMIMEType = MIMEType(responseContentType)
         else {
             for contentType in acceptableContentTypes {
-                if let mimeType = MIMEType(contentType), mimeType.type == "*" && mimeType.subtype == "*" {
+                if let mimeType = MIMEType(contentType), mimeType.isWildcard {
                     return .success
                 }
             }

--- a/Tests/AFError+AlamofireTests.swift
+++ b/Tests/AFError+AlamofireTests.swift
@@ -25,6 +25,9 @@
 import Alamofire
 
 extension AFError {
+
+    // MultipartEncodingFailureReason
+
     var isBodyPartURLInvalid: Bool {
         if case let .multipartEncodingFailed(reason) = self, reason.isBodyPartURLInvalid { return true }
         return false
@@ -128,6 +131,16 @@ extension AFError {
     }
 
     // ValidationFailureReason
+
+    var isDataFileNil: Bool {
+        if case let .responseValidationFailed(reason) = self, reason.isDataFileNil { return true }
+        return false
+    }
+
+    var isDataFileReadFailed: Bool {
+        if case let .responseValidationFailed(reason) = self, reason.isDataFileReadFailed { return true }
+        return false
+    }
 
     var isMissingContentType: Bool {
         if case let .responseValidationFailed(reason) = self, reason.isMissingContentType { return true }
@@ -256,6 +269,16 @@ extension AFError.SerializationFailureReason {
 // MARK: -
 
 extension AFError.ValidationFailureReason {
+    var isDataFileNil: Bool {
+        if case .dataFileNil = self { return true }
+        return false
+    }
+
+    var isDataFileReadFailed: Bool {
+        if case .dataFileReadFailed = self { return true }
+        return false
+    }
+
     var isMissingContentType: Bool {
         if case .missingContentType = self { return true }
         return false


### PR DESCRIPTION
This PR splits up validation between `Request` subclasses and adds `Data?` or `URL?` parameters to the `Validation` closure.

## Motivation

Previously, the Validation closure only exposed the optional request and response parameters making it difficult to customize validations in inline closures that were not custom extensions in the `Request` class. You didn’t have access to the actual response data. This was limiting in certain cases where you want to create a custom validation error that includes the error message buried in the server data. The only way you could do this previously was to write an extension on `Request`.

Another limitation was that the `Validation` closure did not expose the `destinationURL` for a `DownloadRequest` incase you needed to inspect the data in some special scenario.

One final reason to change up the design was that all `validate` methods could be chained on any `Request`. This doesn't make sense for `StreamRequest` types.

## Solution

Modifying the validation system to accomplish all the goals stated above meant rethinking the majority of the design and splitting it up between subclasses.

### Data Request

The `Validation` closure exposed on the `DataRequest` class is now as follows:

```swift
extension DataRequest {
    public typealias Validation = (URLRequest?, HTTPURLResponse, Data?) -> ValidationResult
}
```

By exposing the `Data?` property directly in the closure, you no longer have to write an extension on `Request` to access it. Now you can do something like this:

```swift
let urlString = "https://httpbin.org/get"

// When
Alamofire.request("https://httpbin.org/get", withMethod: .get)
    .validate { request, response, data in
        guard data != nil else { return .failure(ValidationError.missingData) }
        return .success
    }
    .response { response in
        debugPrint(response)
    }
```

> This will be helpful in those cases where you would like to create a custom error that includes the error message from the server that's buried in the `data`.

### Download Request

The `Validation` closure exposed on the `DownloadRequest` class is now as follows:

```swift
extension DownloadRequest {
    public typealias Validation = (URLRequest?, HTTPURLResponse, URL?) -> ValidationResult
}
```

The `URL?` parameter allows you to access the response data downloaded from the server and stored in the `destinationURL`. This allows you to inspect the data inside the file if you've determined you need to in order to create a custom error.

```swift
let fileURL = URL(fileURLWithPath: FileManager.documentsDirectory + "/test_response.json")

Alamofire.download(urlString, to: { _, _ in fileURL }, withMethod: .get)
    .validate { request, response, fileURL in
        guard let fileURL = fileURL else { return .failure(ValidationError.missingFile) }

        do {
            let _ = try Data(contentsOf: fileURL)
            return .success
        } catch {
            return .failure(ValidationError.fileReadFailed)
        }
    }
    .response { response in
        debugPrint(response)
    }
```

### DRY by Design

Since the default validation methods supported in AF are the same between data and download requests, I decided to DRY things up by pulling the validation logic out into a `fileprivate` set of extensions on `Request`. This is very similar to how the response serialization logic was DRY'd up as well.

## Session Manager

I also snuck in commit c46bc01f into this PR that updates the `SessionManager` to leverage the new `TaskConvertible` conformance to generate the `URLSessionTask` instances. This cleans up a bunch of duplicated logic that I should have caught in the earlier PRs. This commit doesn't change any functionality, just DRYs things up a bit.

---

## Summary

These changes allow inline validation closures to be much more powerful, eliminates chaining validation APIs on `StreamRequest` instances, and exposes the `destinationURL` directly to the inline closure. We'll want to update the Validation section of the README to include examples of best practices here.

> We need to make sure people understand they shouldn't parse the response data unless they know they're in a failure case where they want to dig the error message out.