### PR TITLE
Feature - Destinations Closures, Download Options and Top-Level APIs

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -106,7 +106,7 @@ extension URLRequest {
 /// specified `urlString`, `method`, `parameters`, `encoding` and `headers`.
 ///
 /// - parameter urlString:  The URL string.
-/// - parameter method:     The HTTP method.
+/// - parameter method:     The HTTP method. `.get` by default.
 /// - parameter parameters: The parameters. `nil` by default.
 /// - parameter encoding:   The parameter encoding. `.url` by default.
 /// - parameter headers:    The HTTP headers. `nil` by default.
@@ -115,7 +115,7 @@ extension URLRequest {
 @discardableResult
 public func request(
     _ urlString: URLStringConvertible,
-    withMethod method: HTTPMethod,
+    method: HTTPMethod = .get,
     parameters: [String: Any]? = nil,
     encoding: ParameterEncoding = .url,
     headers: [String: String]? = nil)
@@ -123,7 +123,7 @@ public func request(
 {
     return SessionManager.default.request(
         urlString,
-        withMethod: method,
+        method: method,
         parameters: parameters,
         encoding: encoding,
         headers: headers
@@ -137,8 +137,8 @@ public func request(
 ///
 /// - returns: The created `DataRequest`.
 @discardableResult
-public func request(_ urlRequest: URLRequestConvertible) -> DataRequest {
-    return SessionManager.default.request(urlRequest.urlRequest)
+public func request(resource urlRequest: URLRequestConvertible) -> DataRequest {
+    return SessionManager.default.request(resource: urlRequest)
 }
 
 // MARK: - Download Request
@@ -229,8 +229,8 @@ public func download(
 /// and `headers` for uploading the `file`.
 ///
 /// - parameter file:      The file to upload.
-/// - parameter method:    The HTTP method.
 /// - parameter urlString: The URL string.
+/// - parameter method:    The HTTP method. `.post` by default.
 /// - parameter headers:   The HTTP headers. `nil` by default.
 ///
 /// - returns: The created `UploadRequest`.
@@ -238,11 +238,11 @@ public func download(
 public func upload(
     _ fileURL: URL,
     to urlString: URLStringConvertible,
-    withMethod method: HTTPMethod,
+    method: HTTPMethod = .post,
     headers: [String: String]? = nil)
     -> UploadRequest
 {
-    return SessionManager.default.upload(fileURL, to: urlString, withMethod: method, headers: headers)
+    return SessionManager.default.upload(fileURL, to: urlString, method: method, headers: headers)
 }
 
 /// Creates a `UploadRequest` using the default `SessionManager` from the specified `urlRequest` for
@@ -264,7 +264,7 @@ public func upload(_ fileURL: URL, with urlRequest: URLRequestConvertible) -> Up
 ///
 /// - parameter data:      The data to upload.
 /// - parameter urlString: The URL string.
-/// - parameter method:    The HTTP method.
+/// - parameter method:    The HTTP method. `.post` by default.
 /// - parameter headers:   The HTTP headers. `nil` by default.
 ///
 /// - returns: The created `UploadRequest`.
@@ -272,11 +272,11 @@ public func upload(_ fileURL: URL, with urlRequest: URLRequestConvertible) -> Up
 public func upload(
     _ data: Data,
     to urlString: URLStringConvertible,
-    withMethod method: HTTPMethod,
+    method: HTTPMethod = .post,
     headers: [String: String]? = nil)
     -> UploadRequest
 {
-    return SessionManager.default.upload(data, to: urlString, withMethod: method, headers: headers)
+    return SessionManager.default.upload(data, to: urlString, method: method, headers: headers)
 }
 
 /// Creates an `UploadRequest` using the default `SessionManager` from the specified `urlRequest` for
@@ -298,7 +298,7 @@ public func upload(_ data: Data, with urlRequest: URLRequestConvertible) -> Uplo
 ///
 /// - parameter stream:    The stream to upload.
 /// - parameter urlString: The URL string.
-/// - parameter method:    The HTTP method.
+/// - parameter method:    The HTTP method. `.post` by default.
 /// - parameter headers:   The HTTP headers. `nil` by default.
 ///
 /// - returns: The created `UploadRequest`.
@@ -306,11 +306,11 @@ public func upload(_ data: Data, with urlRequest: URLRequestConvertible) -> Uplo
 public func upload(
     _ stream: InputStream,
     to urlString: URLStringConvertible,
-    withMethod method: HTTPMethod,
+    method: HTTPMethod = .post,
     headers: [String: String]? = nil)
     -> UploadRequest
 {
-    return SessionManager.default.upload(stream, to: urlString, withMethod: method, headers: headers)
+    return SessionManager.default.upload(stream, to: urlString, method: method, headers: headers)
 }
 
 /// Creates an `UploadRequest` using the default `SessionManager` from the specified `urlRequest` for
@@ -347,14 +347,14 @@ public func upload(_ stream: InputStream, with urlRequest: URLRequestConvertible
 /// - parameter encodingMemoryThreshold: The encoding memory threshold in bytes.
 ///                                      `multipartFormDataEncodingMemoryThreshold` by default.
 /// - parameter urlString:               The URL string.
-/// - parameter method:                  The HTTP method.
+/// - parameter method:                  The HTTP method. `.post` by default.
 /// - parameter headers:                 The HTTP headers. `nil` by default.
 /// - parameter encodingCompletion:      The closure called when the `MultipartFormData` encoding is complete.
 public func upload(
     multipartFormData: @escaping (MultipartFormData) -> Void,
     usingThreshold encodingMemoryThreshold: UInt64 = SessionManager.multipartFormDataEncodingMemoryThreshold,
     to urlString: URLStringConvertible,
-    withMethod method: HTTPMethod,
+    method: HTTPMethod = .post,
     headers: [String: String]? = nil,
     encodingCompletion: ((SessionManager.MultipartFormDataEncodingResult) -> Void)?)
 {
@@ -362,7 +362,7 @@ public func upload(
         multipartFormData: multipartFormData,
         usingThreshold: encodingMemoryThreshold,
         to: urlString,
-        withMethod: method,
+        method: method,
         headers: headers,
         encodingCompletion: encodingCompletion
     )

--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -149,7 +149,7 @@ public func request(resource urlRequest: URLRequestConvertible) -> DataRequest {
 /// specified `urlString`, `method`, `parameters`, `encoding`, `headers` and save them to the `destination`.
 ///
 /// If `destination` is not specified, the contents will remain in the temporary location determined by the
-/// URL session.
+/// underlying URL session.
 ///
 /// - parameter urlString:   The URL string.
 /// - parameter method:      The HTTP method. `.get` by default.
@@ -183,7 +183,7 @@ public func download(
 /// specified `urlRequest` and save them to the `destination`.
 ///
 /// If `destination` is not specified, the contents will remain in the temporary location determined by the
-/// URL session.
+/// underlying URL session.
 ///
 /// - parameter urlRequest:  The URL request.
 /// - parameter destination: The closure used to determine the destination of the downloaded file. `nil` by default.
@@ -204,7 +204,7 @@ public func download(
 /// previous request cancellation to retrieve the contents of the original request and save them to the `destination`.
 ///
 /// If `destination` is not specified, the contents will remain in the temporary location determined by the
-/// URL session.
+/// underlying URL session.
 ///
 /// - parameter resumeData:  The resume data. This is an opaque data blob produced by `URLSessionDownloadTask`
 ///                          when a task is cancelled. See `URLSession -downloadTask(withResumeData:)` for additional

--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -148,48 +148,54 @@ public func request(_ urlRequest: URLRequestConvertible) -> DataRequest {
 /// Creates a `DownloadRequest` using the default `SessionManager` to retrieve the contents of a URL based on the
 /// specified `urlString`, `method`, `parameters`, `encoding`, `headers` and save them to the `destination`.
 ///
+/// If `destination` is not specified, the contents will remain in the temporary location determined by the
+/// URL session.
+///
 /// - parameter urlString:   The URL string.
-/// - parameter destination: The closure used to determine the destination of the downloaded file.
-/// - parameter method:      The HTTP method.
+/// - parameter method:      The HTTP method. `.get` by default.
 /// - parameter parameters:  The parameters. `nil` by default.
 /// - parameter encoding:    The parameter encoding. `.url` by default.
 /// - parameter headers:     The HTTP headers. `nil` by default.
+/// - parameter destination: The closure used to determine the destination of the downloaded file. `nil` by default.
 ///
 /// - returns: The created `DownloadRequest`.
 @discardableResult
 public func download(
     _ urlString: URLStringConvertible,
-    to destination: DownloadRequest.DownloadFileDestination,
-    withMethod method: HTTPMethod,
+    method: HTTPMethod = .get,
     parameters: [String: Any]? = nil,
     encoding: ParameterEncoding = .url,
-    headers: [String: String]? = nil)
+    headers: [String: String]? = nil,
+    to destination: DownloadRequest.DownloadFileDestination? = nil)
     -> DownloadRequest
 {
     return SessionManager.default.download(
         urlString,
-        to: destination,
-        withMethod: method,
+        method: method,
         parameters: parameters,
         encoding: encoding,
-        headers: headers
+        headers: headers,
+        to: destination
     )
 }
 
 /// Creates a `DownloadRequest` using the default `SessionManager` to retrieve the contents of a URL based on the
 /// specified `urlRequest` and save them to the `destination`.
 ///
+/// If `destination` is not specified, the contents will remain in the temporary location determined by the
+/// URL session.
+///
 /// - parameter urlRequest:  The URL request.
-/// - parameter destination: The closure used to determine the destination of the downloaded file.
+/// - parameter destination: The closure used to determine the destination of the downloaded file. `nil` by default.
 ///
 /// - returns: The created `DownloadRequest`.
 @discardableResult
 public func download(
-    _ urlRequest: URLRequestConvertible,
-    to destination: DownloadRequest.DownloadFileDestination)
+    resource urlRequest: URLRequestConvertible,
+    to destination: DownloadRequest.DownloadFileDestination? = nil)
     -> DownloadRequest
 {
-    return SessionManager.default.download(urlRequest, to: destination)
+    return SessionManager.default.download(resource: urlRequest, to: destination)
 }
 
 // MARK: Resume Data
@@ -197,16 +203,19 @@ public func download(
 /// Creates a `DownloadRequest` using the default `SessionManager` from the `resumeData` produced from a
 /// previous request cancellation to retrieve the contents of the original request and save them to the `destination`.
 ///
+/// If `destination` is not specified, the contents will remain in the temporary location determined by the
+/// URL session.
+///
 /// - parameter resumeData:  The resume data. This is an opaque data blob produced by `URLSessionDownloadTask`
 ///                          when a task is cancelled. See `URLSession -downloadTask(withResumeData:)` for additional
 ///                          information.
-/// - parameter destination: The closure used to determine the destination of the downloaded file.
+/// - parameter destination: The closure used to determine the destination of the downloaded file. `nil` by default.
 ///
 /// - returns: The created `DownloadRequest`.
 @discardableResult
 public func download(
     resourceWithin resumeData: Data,
-    to destination: DownloadRequest.DownloadFileDestination)
+    to destination: DownloadRequest.DownloadFileDestination? = nil)
     -> DownloadRequest
 {
     return SessionManager.default.download(resourceWithin: resumeData, to: destination)

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -401,29 +401,23 @@ open class DownloadRequest: Request {
     /// A collection of options to be executed prior to moving a downloaded file from the temporary URL to the
     /// destination URL.
     public struct DownloadOptions: OptionSet {
-        /// Defines the `RawValue` type as `UInt` to satisfy the `RawRepresentable` protocol.
-        public typealias RawValue = UInt
-
         /// Returns the raw bitmask value of the option and satisfies the `RawRepresentable` protocol.
-        public let rawValue: RawValue
-
-        private static let createIntermediateDirectoriesBitmask: RawValue = 1 << 0
-        private static let removePreviousFileBitmask: RawValue            = 1 << 1
+        public let rawValue: UInt
 
         /// A `DownloadOptions` flag that creates intermediate directories for the destination URL if specified.
-        public static let createIntermediateDirectories = DownloadOptions(rawValue: createIntermediateDirectoriesBitmask)
+        public static let createIntermediateDirectories = DownloadOptions(rawValue: 1 << 0)
 
         /// A `DownloadOptions` flag that removes a previous file from the destination URL if specified.
-        public static let removePreviousFile = DownloadOptions(rawValue: removePreviousFileBitmask)
-
-        // MARK: Initialization Methods
+        public static let removePreviousFile = DownloadOptions(rawValue: 1 << 1)
 
         /// Creates a `DownloadFileDestinationOptions` instance with the specified raw value.
         ///
         /// - parameter rawValue: The raw bitmask value for the option.
         ///
         /// - returns: A new log level instance.
-        public init(rawValue: RawValue) { self.rawValue = rawValue }
+        public init(rawValue: UInt) {
+            self.rawValue = rawValue
+        }
     }
 
     /// A closure executed once a download request has successfully completed in order to determine where to move the 

--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -92,7 +92,7 @@ extension DataResponse: CustomStringConvertible, CustomDebugStringConvertible {
     }
 
     /// The debug textual representation used when written to an output stream, which includes the URL request, the URL
-    /// response, the server data and the response serialization result.
+    /// response, the server data, the response serialization result and the timeline.
     public var debugDescription: String {
         var output: [String] = []
 
@@ -116,7 +116,10 @@ public struct DefaultDownloadResponse {
     /// The server's response to the URL request.
     public let response: HTTPURLResponse?
 
-    /// The final destination URL of the data returned from the server.
+    /// The temporary destination URL of the data returned from the server.
+    public let temporaryURL: URL?
+
+    /// The final destination URL of the data returned from the server if it was moved.
     public let destinationURL: URL?
 
     /// The resume data generated if the request was cancelled.
@@ -136,7 +139,10 @@ public struct DownloadResponse<Value> {
     /// The server's response to the URL request.
     public let response: HTTPURLResponse?
 
-    /// The final destination URL of the data returned from the server.
+    /// The temporary destination URL of the data returned from the server.
+    public let temporaryURL: URL?
+
+    /// The final destination URL of the data returned from the server if it was moved.
     public let destinationURL: URL?
 
     /// The resume data generated if the request was cancelled.
@@ -152,7 +158,8 @@ public struct DownloadResponse<Value> {
     ///
     /// - parameter request:        The URL request sent to the server.
     /// - parameter response:       The server's response to the URL request.
-    /// - parameter destinationURL: The final destination URL of the data returned from the server.
+    /// - parameter temporaryURL:   The temporary destination URL of the data returned from the server.
+    /// - parameter destinationURL: The final destination URL of the data returned from the server if it was moved.
     /// - parameter resumeData:     The resume data generated if the request was cancelled.
     /// - parameter result:         The result of response serialization.
     /// - parameter timeline:       The timeline of the complete lifecycle of the `Request`. Defaults to `Timeline()`.
@@ -161,6 +168,7 @@ public struct DownloadResponse<Value> {
     public init(
         request: URLRequest?,
         response: HTTPURLResponse?,
+        temporaryURL: URL?,
         destinationURL: URL?,
         resumeData: Data?,
         result: Result<Value>,
@@ -168,6 +176,7 @@ public struct DownloadResponse<Value> {
     {
         self.request = request
         self.response = response
+        self.temporaryURL = temporaryURL
         self.destinationURL = destinationURL
         self.resumeData = resumeData
         self.result = result
@@ -185,12 +194,14 @@ extension DownloadResponse: CustomStringConvertible, CustomDebugStringConvertibl
     }
 
     /// The debug textual representation used when written to an output stream, which includes the URL request, the URL
-    /// response, the server data and the response serialization result.
+    /// response, the temporary and destination URLs, the resume data, the response serialization result and the 
+    /// timeline.
     public var debugDescription: String {
         var output: [String] = []
 
         output.append(request != nil ? "[Request]: \(request!)" : "[Request]: nil")
         output.append(response != nil ? "[Response]: \(response!)" : "[Response]: nil")
+        output.append("[TemporaryURL]: \(temporaryURL?.path ?? "nil")")
         output.append("[DestinationURL]: \(destinationURL?.path ?? "nil")")
         output.append("[ResumeData]: \(resumeData?.count ?? 0) bytes")
         output.append("[Result]: \(result.debugDescription)")

--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -177,7 +177,7 @@ public struct DownloadResponse<Value> {
 
 // MARK: -
 
-extension DownloadResponse: CustomStringConvertible {
+extension DownloadResponse: CustomStringConvertible, CustomDebugStringConvertible {
     /// The textual representation used when written to an output stream, which includes whether the result was a
     /// success or failure.
     public var description: String {

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -209,7 +209,7 @@ extension DownloadRequest {
             let result = responseSerializer.serializeResponse(
                 self.request,
                 self.response,
-                self.downloadDelegate.destinationURL,
+                self.downloadDelegate.fileURL,
                 self.downloadDelegate.error
             )
 

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -177,6 +177,7 @@ extension DownloadRequest {
                 let downloadResponse = DefaultDownloadResponse(
                     request: self.request,
                     response: self.response,
+                    temporaryURL: self.downloadDelegate.temporaryURL,
                     destinationURL: self.downloadDelegate.destinationURL,
                     resumeData: self.downloadDelegate.resumeData,
                     error: self.downloadDelegate.error
@@ -225,6 +226,7 @@ extension DownloadRequest {
             let response = DownloadResponse<T.SerializedObject>(
                 request: self.request,
                 response: self.response,
+                temporaryURL: self.downloadDelegate.temporaryURL,
                 destinationURL: self.downloadDelegate.destinationURL,
                 resumeData: self.downloadDelegate.resumeData,
                 result: result,
@@ -233,7 +235,7 @@ extension DownloadRequest {
 
             (queue ?? DispatchQueue.main).async { completionHandler(response) }
         }
-        
+
         return self
     }
 }

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -255,45 +255,51 @@ open class SessionManager {
     /// Creates a `DownloadRequest` to retrieve the contents of a URL based on the specified `urlString`, `method`,
     /// `parameters`, `encoding`, `headers` and save them to the `destination`.
     ///
+    /// If `destination` is not specified, the contents will remain in the temporary location determined by the
+    /// URL session.
+    /// 
     /// If `startRequestsImmediately` is `true`, the request will have `resume()` called before being returned.
     ///
     /// - parameter urlString:   The URL string.
-    /// - parameter destination: The closure used to determine the destination of the downloaded file.
-    /// - parameter method:      The HTTP method.
+    /// - parameter method:      The HTTP method. `.get` by default.
     /// - parameter parameters:  The parameters. `nil` by default.
     /// - parameter encoding:    The parameter encoding. `.url` by default.
     /// - parameter headers:     The HTTP headers. `nil` by default.
+    /// - parameter destination: The closure used to determine the destination of the downloaded file. `nil` by default.
     ///
     /// - returns: The created `DownloadRequest`.
     @discardableResult
     open func download(
         _ urlString: URLStringConvertible,
-        to destination: DownloadRequest.DownloadFileDestination,
-        withMethod method: HTTPMethod,
+        method: HTTPMethod = .get,
         parameters: [String: Any]? = nil,
         encoding: ParameterEncoding = .url,
-        headers: [String: String]? = nil)
+        headers: [String: String]? = nil,
+        to destination: DownloadRequest.DownloadFileDestination? = nil)
         -> DownloadRequest
     {
         let urlRequest = URLRequest(urlString: urlString, method: method, headers: headers)
         let encodedURLRequest = encoding.encode(urlRequest, parameters: parameters).0
 
-        return download(encodedURLRequest, to: destination)
+        return download(resource: encodedURLRequest, to: destination)
     }
 
     /// Creates a `DownloadRequest` to retrieve the contents of a URL based on the specified `urlRequest` and save
     /// them to the `destination`.
     ///
+    /// If `destination` is not specified, the contents will remain in the temporary location determined by the
+    /// URL session.
+    ///
     /// If `startRequestsImmediately` is `true`, the request will have `resume()` called before being returned.
     ///
     /// - parameter urlRequest:  The URL request
-    /// - parameter destination: The closure used to determine the destination of the downloaded file.
+    /// - parameter destination: The closure used to determine the destination of the downloaded file. `nil` by default.
     ///
     /// - returns: The created `DownloadRequest`.
     @discardableResult
     open func download(
-        _ urlRequest: URLRequestConvertible,
-        to destination: DownloadRequest.DownloadFileDestination)
+        resource urlRequest: URLRequestConvertible,
+        to destination: DownloadRequest.DownloadFileDestination? = nil)
         -> DownloadRequest
     {
         return download(.request(urlRequest.urlRequest), to: destination)
@@ -304,18 +310,21 @@ open class SessionManager {
     /// Creates a `DownloadRequest` from the `resumeData` produced from a previous request cancellation to retrieve
     /// the contents of the original request and save them to the `destination`.
     ///
+    /// If `destination` is not specified, the contents will remain in the temporary location determined by the
+    /// URL session.
+    ///
     /// If `startRequestsImmediately` is `true`, the request will have `resume()` called before being returned.
     ///
     /// - parameter resumeData:  The resume data. This is an opaque data blob produced by `URLSessionDownloadTask`
     ///                          when a task is cancelled. See `URLSession -downloadTask(withResumeData:)` for
     ///                          additional information.
-    /// - parameter destination: The closure used to determine the destination of the downloaded file.
+    /// - parameter destination: The closure used to determine the destination of the downloaded file. `nil` by default.
     ///
     /// - returns: The created `DownloadRequest`.
     @discardableResult
     open func download(
         resourceWithin resumeData: Data,
-        to destination: DownloadRequest.DownloadFileDestination)
+        to destination: DownloadRequest.DownloadFileDestination? = nil)
         -> DownloadRequest
     {
         return download(.resumeData(resumeData), to: destination)
@@ -325,15 +334,13 @@ open class SessionManager {
 
     private func download(
         _ downloadable: DownloadRequest.Downloadable,
-        to destination: DownloadRequest.DownloadFileDestination)
+        to destination: DownloadRequest.DownloadFileDestination?)
         -> DownloadRequest
     {
         let task = downloadable.task(session: session, adapter: adapter, queue: queue)
         let request = DownloadRequest(session: session, task: task, originalTask: downloadable)
 
-        request.downloadDelegate.downloadTaskDidFinishDownloadingToURL = { session, task, URL in
-            return destination(URL, task.response as! HTTPURLResponse)
-        }
+        request.downloadDelegate.destination = destination
 
         delegate[request.delegate.task] = request
 

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -256,7 +256,7 @@ open class SessionManager {
     /// `parameters`, `encoding`, `headers` and save them to the `destination`.
     ///
     /// If `destination` is not specified, the contents will remain in the temporary location determined by the
-    /// URL session.
+    /// underlying URL session.
     /// 
     /// If `startRequestsImmediately` is `true`, the request will have `resume()` called before being returned.
     ///
@@ -288,7 +288,7 @@ open class SessionManager {
     /// them to the `destination`.
     ///
     /// If `destination` is not specified, the contents will remain in the temporary location determined by the
-    /// URL session.
+    /// underlying URL session.
     ///
     /// If `startRequestsImmediately` is `true`, the request will have `resume()` called before being returned.
     ///
@@ -311,7 +311,7 @@ open class SessionManager {
     /// the contents of the original request and save them to the `destination`.
     ///
     /// If `destination` is not specified, the contents will remain in the temporary location determined by the
-    /// URL session.
+    /// underlying URL session.
     ///
     /// If `startRequestsImmediately` is `true`, the request will have `resume()` called before being returned.
     ///

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -206,7 +206,7 @@ open class SessionManager {
     /// `parameters`, `encoding` and `headers`.
     ///
     /// - parameter urlString:  The URL string.
-    /// - parameter method:     The HTTP method.
+    /// - parameter method:     The HTTP method. `.get` by default.
     /// - parameter parameters: The parameters. `nil` by default.
     /// - parameter encoding:   The parameter encoding. `.url` by default.
     /// - parameter headers:    The HTTP headers. `nil` by default.
@@ -215,7 +215,7 @@ open class SessionManager {
     @discardableResult
     open func request(
         _ urlString: URLStringConvertible,
-        withMethod method: HTTPMethod,
+        method: HTTPMethod = .get,
         parameters: [String: Any]? = nil,
         encoding: ParameterEncoding = .url,
         headers: [String: String]? = nil)
@@ -224,17 +224,17 @@ open class SessionManager {
         let urlRequest = URLRequest(urlString: urlString, method: method, headers: headers)
         let encodedURLRequest = encoding.encode(urlRequest, parameters: parameters).0
 
-        return request(encodedURLRequest)
+        return request(resource: encodedURLRequest)
     }
 
     /// Creates a `DataRequest` to retrieve the contents of a URL based on the specified `urlRequest`.
     ///
     /// If `startRequestsImmediately` is `true`, the request will have `resume()` called before being returned.
     ///
-    /// - parameter urlRequest: The URL request
+    /// - parameter urlRequest: The URL request.
     ///
     /// - returns: The created `DataRequest`.
-    open func request(_ urlRequest: URLRequestConvertible) -> DataRequest {
+    open func request(resource urlRequest: URLRequestConvertible) -> DataRequest {
         let originalRequest = urlRequest.urlRequest
         let originalTask = DataRequest.Requestable(urlRequest: originalRequest)
 
@@ -358,8 +358,8 @@ open class SessionManager {
     /// If `startRequestsImmediately` is `true`, the request will have `resume()` called before being returned.
     ///
     /// - parameter file:      The file to upload.
-    /// - parameter method:    The HTTP method.
     /// - parameter urlString: The URL string.
+    /// - parameter method:    The HTTP method. `.post` by default.
     /// - parameter headers:   The HTTP headers. `nil` by default.
     ///
     /// - returns: The created `UploadRequest`.
@@ -367,7 +367,7 @@ open class SessionManager {
     open func upload(
         _ fileURL: URL,
         to urlString: URLStringConvertible,
-        withMethod method: HTTPMethod,
+        method: HTTPMethod = .post,
         headers: [String: String]? = nil)
         -> UploadRequest
     {
@@ -396,7 +396,7 @@ open class SessionManager {
     ///
     /// - parameter data:      The data to upload.
     /// - parameter urlString: The URL string.
-    /// - parameter method:    The HTTP method.
+    /// - parameter method:    The HTTP method. `.post` by default.
     /// - parameter headers:   The HTTP headers. `nil` by default.
     ///
     /// - returns: The created `UploadRequest`.
@@ -404,7 +404,7 @@ open class SessionManager {
     open func upload(
         _ data: Data,
         to urlString: URLStringConvertible,
-        withMethod method: HTTPMethod,
+        method: HTTPMethod = .post,
         headers: [String: String]? = nil)
         -> UploadRequest
     {
@@ -433,7 +433,7 @@ open class SessionManager {
     ///
     /// - parameter stream:    The stream to upload.
     /// - parameter urlString: The URL string.
-    /// - parameter method:    The HTTP method.
+    /// - parameter method:    The HTTP method. `.post` by default.
     /// - parameter headers:   The HTTP headers. `nil` by default.
     ///
     /// - returns: The created `UploadRequest`.
@@ -441,7 +441,7 @@ open class SessionManager {
     open func upload(
         _ stream: InputStream,
         to urlString: URLStringConvertible,
-        withMethod method: HTTPMethod,
+        method: HTTPMethod = .post,
         headers: [String: String]? = nil)
         -> UploadRequest
     {
@@ -486,14 +486,14 @@ open class SessionManager {
     /// - parameter encodingMemoryThreshold: The encoding memory threshold in bytes.
     ///                                      `multipartFormDataEncodingMemoryThreshold` by default.
     /// - parameter urlString:               The URL string.
-    /// - parameter method:                  The HTTP method.
+    /// - parameter method:                  The HTTP method. `.post` by default.
     /// - parameter headers:                 The HTTP headers. `nil` by default.
     /// - parameter encodingCompletion:      The closure called when the `MultipartFormData` encoding is complete.
     open func upload(
         multipartFormData: @escaping (MultipartFormData) -> Void,
         usingThreshold encodingMemoryThreshold: UInt64 = SessionManager.multipartFormDataEncodingMemoryThreshold,
         to urlString: URLStringConvertible,
-        withMethod method: HTTPMethod,
+        method: HTTPMethod = .post,
         headers: [String: String]? = nil,
         encodingCompletion: ((MultipartFormDataEncodingResult) -> Void)?)
     {

--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -317,6 +317,8 @@ class DownloadTaskDelegate: TaskDelegate, URLSessionDownloadDelegate {
     var temporaryURL: URL?
     var destinationURL: URL?
 
+    var fileURL: URL? { return destination != nil ? destinationURL : temporaryURL }
+
     // MARK: Lifecycle
 
     override init(task: URLSessionTask) {

--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -275,8 +275,8 @@ extension DownloadRequest {
     /// - returns: The request.
     @discardableResult
     public func validate<S: Sequence>(contentType acceptableContentTypes: S) -> Self where S.Iterator.Element == String {
-        return validate { _, response, temporaryURL, destinationURL in
-            let fileURL = self.downloadDelegate.destination != nil ? destinationURL : temporaryURL
+        return validate { _, response, _, _ in
+            let fileURL = self.downloadDelegate.fileURL
 
             guard let validFileURL = fileURL else {
                 return .failure(AFError.responseValidationFailed(reason: .dataFileNil))

--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -222,7 +222,7 @@ extension DataRequest {
 extension DownloadRequest {
     /// A closure used to validate a request that takes a URL request, a URL response, a temporary URL and a 
     /// destination URL, and returns whether the request was valid.
-    public typealias Validation = (URLRequest?, HTTPURLResponse, _ temporary: URL?, _ destination: URL?) -> ValidationResult
+    public typealias Validation = (_ request: URLRequest?, _ response: HTTPURLResponse, _ temporary: URL?, _ destination: URL?) -> ValidationResult
 
     /// Validates the request, using the specified closure.
     ///

--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -68,7 +68,7 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .authenticate(user: "invalid", password: "credentials")
             .response { resp in
                 response = resp
@@ -92,7 +92,7 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .authenticate(user: user, password: password)
             .response { resp in
                 response = resp
@@ -123,7 +123,7 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString, withMethod: .get, headers: headers)
+        manager.request(urlString, headers: headers)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -157,7 +157,7 @@ class HTTPDigestAuthenticationTestCase: AuthenticationTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .authenticate(user: "invalid", password: "credentials")
             .response { resp in
                 response = resp
@@ -181,7 +181,7 @@ class HTTPDigestAuthenticationTestCase: AuthenticationTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .authenticate(user: user, password: password)
             .response { resp in
                 response = resp

--- a/Tests/BaseTestCase.swift
+++ b/Tests/BaseTestCase.swift
@@ -32,13 +32,13 @@ class BaseTestCase: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        FileManager.removeAllItemsInsideDirectory(atPath: FileManager.applicationSupportDirectory)
-        FileManager.removeAllItemsInsideDirectory(atPath: FileManager.cachesDirectory)
-        FileManager.removeAllItemsInsideDirectory(atPath: FileManager.documentsDirectory)
+        FileManager.removeAllItemsInsideDirectory(atPath: FileManager.applicationSupportDirectoryPath)
+        FileManager.removeAllItemsInsideDirectory(atPath: FileManager.cachesDirectoryPath)
+        FileManager.removeAllItemsInsideDirectory(atPath: FileManager.documentsDirectoryPath)
 
-        FileManager.createDirectory(atPath: FileManager.applicationSupportDirectory)
-        FileManager.createDirectory(atPath: FileManager.cachesDirectory)
-        FileManager.createDirectory(atPath: FileManager.documentsDirectory)
+        FileManager.createDirectory(atPath: FileManager.applicationSupportDirectoryPath)
+        FileManager.createDirectory(atPath: FileManager.cachesDirectoryPath)
+        FileManager.createDirectory(atPath: FileManager.documentsDirectoryPath)
     }
 
     func url(forResource fileName: String, withExtension ext: String) -> URL {

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -210,7 +210,7 @@ class DownloadResponseTestCase: BaseTestCase {
         var response: DefaultDownloadResponse?
 
         // When
-        Alamofire.download(urlString, method: .get, headers: headers, to: destination)
+        Alamofire.download(urlString, headers: headers, to: destination)
             .response { resp in
                 response = resp
                 expectation.fulfill()

--- a/Tests/FileManager+AlamofireTests.swift
+++ b/Tests/FileManager+AlamofireTests.swift
@@ -28,24 +28,44 @@ extension FileManager {
 
     // MARK: - Common Directories
 
-    static var documentsDirectory: String {
+    static var documentsDirectoryPath: String {
         return NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
     }
 
-    static var libraryDirectory: String {
+    static var documentsDirectoryURL: URL {
+        return URL(fileURLWithPath: FileManager.documentsDirectoryPath, isDirectory: true)
+    }
+
+    static var libraryDirectoryPath: String {
         return NSSearchPathForDirectoriesInDomains(.libraryDirectory, .userDomainMask, true)[0]
     }
 
-    static var applicationSupportDirectory: String {
+    static var libraryDirectoryURL: URL {
+        return URL(fileURLWithPath: FileManager.libraryDirectoryPath, isDirectory: true)
+    }
+
+    static var applicationSupportDirectoryPath: String {
         return NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true)[0]
     }
 
-    static var cachesDirectory: String {
+    static var applicationSupportDirectoryURL: URL {
+        return URL(fileURLWithPath: FileManager.applicationSupportDirectoryPath, isDirectory: true)
+    }
+
+    static var cachesDirectoryPath: String {
         return NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true)[0]
     }
 
-    static var temporaryDirectory: String {
+    static var cachesDirectoryURL: URL {
+        return URL(fileURLWithPath: FileManager.cachesDirectoryPath, isDirectory: true)
+    }
+
+    static var temporaryDirectoryPath: String {
         return NSTemporaryDirectory()
+    }
+
+    static var temporaryDirectoryURL: URL {
+        return URL(fileURLWithPath: FileManager.temporaryDirectoryPath, isDirectory: true)
     }
 
     // MARK: - File System Modification

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -32,7 +32,7 @@ class RequestInitializationTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/"
 
         // When
-        let request = Alamofire.request(urlString, withMethod: .get)
+        let request = Alamofire.request(urlString)
 
         // Then
         XCTAssertNotNil(request.request)
@@ -46,7 +46,7 @@ class RequestInitializationTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
 
         // When
-        let request = Alamofire.request(urlString, withMethod: .get, parameters: ["foo": "bar"])
+        let request = Alamofire.request(urlString, parameters: ["foo": "bar"])
 
         // Then
         XCTAssertNotNil(request.request)
@@ -62,7 +62,7 @@ class RequestInitializationTestCase: BaseTestCase {
         let headers = ["Authorization": "123456"]
 
         // When
-        let request = Alamofire.request(urlString, withMethod: .get, parameters: ["foo": "bar"], headers: headers)
+        let request = Alamofire.request(urlString, parameters: ["foo": "bar"], headers: headers)
 
         // Then
         XCTAssertNotNil(request.request)
@@ -86,7 +86,7 @@ class RequestResponseTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        Alamofire.request(urlString, withMethod: .get, parameters: ["foo": "bar"])
+        Alamofire.request(urlString, parameters: ["foo": "bar"])
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -113,7 +113,7 @@ class RequestResponseTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        Alamofire.request(urlString, withMethod: .get)
+        Alamofire.request(urlString)
             .downloadProgress { progress in
                 progressValues.append((progress.completedUnitCount, progress.totalUnitCount))
             }
@@ -168,7 +168,7 @@ class RequestResponseTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        Alamofire.request(urlString, withMethod: .get)
+        Alamofire.request(urlString)
             .downloadProgress { progress in
                 progressValues.append((progress.completedUnitCount, progress.totalUnitCount))
             }
@@ -230,7 +230,7 @@ class RequestResponseTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        Alamofire.request(urlString, withMethod: .post, parameters: parameters)
+        Alamofire.request(urlString, method: .post, parameters: parameters)
             .responseJSON { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -282,7 +282,7 @@ class RequestResponseTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        Alamofire.request(urlString, withMethod: .post, parameters: parameters)
+        Alamofire.request(urlString, method: .post, parameters: parameters)
             .responseJSON { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -337,7 +337,7 @@ class RequestExtensionTestCase: BaseTestCase {
         var responses: [String] = []
 
         // When
-        Alamofire.request(urlString, withMethod: .get)
+        Alamofire.request(urlString)
             .preValidate {
                 responses.append("preValidate")
             }
@@ -369,7 +369,7 @@ class RequestDescriptionTestCase: BaseTestCase {
     func testRequestDescription() {
         // Given
         let urlString = "https://httpbin.org/get"
-        let request = Alamofire.request(urlString, withMethod: .get)
+        let request = Alamofire.request(urlString)
         let initialRequestDescription = request.description
 
         let expectation = self.expectation(description: "Request description should update: \(urlString)")
@@ -445,7 +445,7 @@ class RequestDebugDescriptionTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
 
         // When
-        let request = manager.request(urlString, withMethod: .get)
+        let request = manager.request(urlString)
         let components = cURLCommandComponents(for: request)
 
         // Then
@@ -460,7 +460,7 @@ class RequestDebugDescriptionTestCase: BaseTestCase {
 
         // When
         let headers = [ "Accept-Language": "en-GB" ]
-        let request = managerWithAcceptLanguageHeader.request(urlString, withMethod: .get, headers: headers)
+        let request = managerWithAcceptLanguageHeader.request(urlString, headers: headers)
         let components = cURLCommandComponents(for: request)
 
         // Then
@@ -479,7 +479,7 @@ class RequestDebugDescriptionTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/post"
 
         // When
-        let request = manager.request(urlString, withMethod: .post)
+        let request = manager.request(urlString, method: .post)
         let components = cURLCommandComponents(for: request)
 
         // Then
@@ -499,7 +499,7 @@ class RequestDebugDescriptionTestCase: BaseTestCase {
         ]
 
         // When
-        let request = manager.request(urlString, withMethod: .post, parameters: parameters, encoding: .json)
+        let request = manager.request(urlString, method: .post, parameters: parameters, encoding: .json)
         let components = cURLCommandComponents(for: request)
 
         // Then
@@ -530,7 +530,7 @@ class RequestDebugDescriptionTestCase: BaseTestCase {
         manager.session.configuration.httpCookieStorage?.setCookie(cookie)
 
         // When
-        let request = manager.request(urlString, withMethod: .post)
+        let request = manager.request(urlString, method: .post)
         let components = cURLCommandComponents(for: request)
 
         // Then
@@ -555,7 +555,7 @@ class RequestDebugDescriptionTestCase: BaseTestCase {
         managerDisallowingCookies.session.configuration.httpCookieStorage?.setCookie(cookie)
 
         // When
-        let request = managerDisallowingCookies.request(urlString, withMethod: .post)
+        let request = managerDisallowingCookies.request(urlString, method: .post)
         let components = cURLCommandComponents(for: request)
 
         // Then
@@ -578,7 +578,6 @@ class RequestDebugDescriptionTestCase: BaseTestCase {
                 multipartFormData.append(japaneseData, withName: "japanese")
             },
             to: urlString,
-            withMethod: .post,
             encodingCompletion: { result in
                 switch result {
                 case .success(let upload, _, _):
@@ -612,7 +611,7 @@ class RequestDebugDescriptionTestCase: BaseTestCase {
         let urlString = "invalid_url"
 
         // When
-        let request = manager.request(urlString, withMethod: .get)
+        let request = manager.request(urlString)
         let debugDescription = request.debugDescription
 
         // Then

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -35,7 +35,7 @@ class ResponseDataTestCase: BaseTestCase {
         var response: DataResponse<Data>?
 
         // When
-        Alamofire.request(urlString, withMethod: .get, parameters: ["foo": "bar"])
+        Alamofire.request(urlString, parameters: ["foo": "bar"])
             .responseData { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -62,7 +62,7 @@ class ResponseDataTestCase: BaseTestCase {
         var response: DataResponse<Data>?
 
         // When
-        Alamofire.request(urlString, withMethod: .get, parameters: ["foo": "bar"])
+        Alamofire.request(urlString, parameters: ["foo": "bar"])
             .responseData { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -93,7 +93,7 @@ class ResponseStringTestCase: BaseTestCase {
         var response: DataResponse<String>?
 
         // When
-        Alamofire.request(urlString, withMethod: .get, parameters: ["foo": "bar"])
+        Alamofire.request(urlString, parameters: ["foo": "bar"])
             .responseString { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -120,7 +120,7 @@ class ResponseStringTestCase: BaseTestCase {
         var response: DataResponse<String>?
 
         // When
-        Alamofire.request(urlString, withMethod: .get, parameters: ["foo": "bar"])
+        Alamofire.request(urlString, parameters: ["foo": "bar"])
             .responseString { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -151,7 +151,7 @@ class ResponseJSONTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        Alamofire.request(urlString, withMethod: .get, parameters: ["foo": "bar"])
+        Alamofire.request(urlString, parameters: ["foo": "bar"])
             .responseJSON { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -178,7 +178,7 @@ class ResponseJSONTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        Alamofire.request(urlString, withMethod: .get, parameters: ["foo": "bar"])
+        Alamofire.request(urlString, parameters: ["foo": "bar"])
             .responseJSON { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -205,7 +205,7 @@ class ResponseJSONTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        Alamofire.request(urlString, withMethod: .get, parameters: ["foo": "bar"])
+        Alamofire.request(urlString, parameters: ["foo": "bar"])
             .responseJSON { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -240,7 +240,7 @@ class ResponseJSONTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        Alamofire.request(urlString, withMethod: .post, parameters: ["foo": "bar"])
+        Alamofire.request(urlString, method: .post, parameters: ["foo": "bar"])
             .responseJSON { closureResponse in
                 response = closureResponse
                 expectation.fulfill()

--- a/Tests/SessionDelegateTests.swift
+++ b/Tests/SessionDelegateTests.swift
@@ -76,7 +76,7 @@ class SessionDelegateTestCase: BaseTestCase {
         }
 
         // When
-        manager.request("https://httpbin.org/get", withMethod: .get).responseJSON { closureResponse in
+        manager.request("https://httpbin.org/get").responseJSON { closureResponse in
             response = closureResponse.response
             expectation.fulfill()
         }
@@ -101,7 +101,7 @@ class SessionDelegateTestCase: BaseTestCase {
         }
 
         // When
-        manager.request("https://httpbin.org/get", withMethod: .get).responseJSON { closureResponse in
+        manager.request("https://httpbin.org/get").responseJSON { closureResponse in
             response = closureResponse.response
             expectation.fulfill()
         }
@@ -125,7 +125,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -153,7 +153,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -188,7 +188,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -223,7 +223,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -258,7 +258,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -293,7 +293,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -337,7 +337,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -383,7 +383,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -435,7 +435,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        manager.request(urlString, withMethod: .get, headers: headers)
+        manager.request(urlString, headers: headers)
             .responseJSON { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -470,7 +470,7 @@ class SessionDelegateTestCase: BaseTestCase {
         }
 
         // When
-        manager.request("https://httpbin.org/get", withMethod: .get).responseJSON { closureResponse in
+        manager.request("https://httpbin.org/get").responseJSON { closureResponse in
             response = closureResponse.response
             expectation.fulfill()
         }
@@ -495,7 +495,7 @@ class SessionDelegateTestCase: BaseTestCase {
         }
 
         // When
-        manager.request("https://httpbin.org/get", withMethod: .get).responseJSON { closureResponse in
+        manager.request("https://httpbin.org/get").responseJSON { closureResponse in
             response = closureResponse.response
             expectation.fulfill()
         }

--- a/Tests/SessionManagerTests.swift
+++ b/Tests/SessionManagerTests.swift
@@ -255,7 +255,7 @@ class SessionManagerTestCase: BaseTestCase {
         sessionManager.startRequestsImmediately = false
 
         // When
-        let request = sessionManager.request("https://httpbin.org/get", withMethod: .get)
+        let request = sessionManager.request("https://httpbin.org/get")
 
         // Then
         XCTAssertEqual(request.task.originalRequest?.httpMethod, adapter.method.rawValue)
@@ -286,7 +286,7 @@ class SessionManagerTestCase: BaseTestCase {
         sessionManager.startRequestsImmediately = false
 
         // When
-        let request = sessionManager.upload("data".data(using: .utf8)!, to: "https://httpbin.org/post", withMethod: .post)
+        let request = sessionManager.upload("data".data(using: .utf8)!, to: "https://httpbin.org/post")
 
         // Then
         XCTAssertEqual(request.task.originalRequest?.httpMethod, adapter.method.rawValue)
@@ -302,7 +302,7 @@ class SessionManagerTestCase: BaseTestCase {
 
         // When
         let fileURL = URL(fileURLWithPath: "/path/to/some/file.txt")
-        let request = sessionManager.upload(fileURL, to: "https://httpbin.org/post", withMethod: .post)
+        let request = sessionManager.upload(fileURL, to: "https://httpbin.org/post")
 
         // Then
         XCTAssertEqual(request.task.originalRequest?.httpMethod, adapter.method.rawValue)
@@ -318,7 +318,7 @@ class SessionManagerTestCase: BaseTestCase {
 
         // When
         let inputStream = InputStream(data: "data".data(using: .utf8)!)
-        let request = sessionManager.upload(inputStream, to: "https://httpbin.org/post", withMethod: .post)
+        let request = sessionManager.upload(inputStream, to: "https://httpbin.org/post")
 
         // Then
         XCTAssertEqual(request.task.originalRequest?.httpMethod, adapter.method.rawValue)
@@ -338,7 +338,7 @@ class SessionManagerTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        sessionManager.request("https://httpbin.org/basic-auth/user/password", withMethod: .get)
+        sessionManager.request("https://httpbin.org/basic-auth/user/password")
             .validate()
             .responseJSON { jsonResponse in
                 response = jsonResponse
@@ -366,7 +366,7 @@ class SessionManagerTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        sessionManager.request("https://httpbin.org/basic-auth/user/password", withMethod: .get)
+        sessionManager.request("https://httpbin.org/basic-auth/user/password")
             .validate()
             .responseJSON { jsonResponse in
                 response = jsonResponse
@@ -436,7 +436,7 @@ class SessionManagerConfigurationHeadersTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        manager.request("https://httpbin.org/headers", withMethod: .get)
+        manager.request("https://httpbin.org/headers")
             .responseJSON { closureResponse in
                 response = closureResponse
                 expectation.fulfill()

--- a/Tests/SessionManagerTests.swift
+++ b/Tests/SessionManagerTests.swift
@@ -271,7 +271,7 @@ class SessionManagerTestCase: BaseTestCase {
 
         // When
         let destination = DownloadRequest.suggestedDownloadDestination()
-        let request = sessionManager.download("https://httpbin.org/get", to: destination, withMethod: .get)
+        let request = sessionManager.download("https://httpbin.org/get", to: destination)
 
         // Then
         XCTAssertEqual(request.task.originalRequest?.httpMethod, adapter.method.rawValue)

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -84,7 +84,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -116,7 +116,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -152,7 +152,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -192,7 +192,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -226,7 +226,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -254,7 +254,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -282,7 +282,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -312,7 +312,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -346,7 +346,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -374,7 +374,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -402,7 +402,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -428,7 +428,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -460,7 +460,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -490,7 +490,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString, withMethod: .get)
+        manager.request(urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -33,7 +33,7 @@ class UploadFileInitializationTestCase: BaseTestCase {
         let imageURL = url(forResource: "rainbow", withExtension: "jpg")
 
         // When
-        let request = Alamofire.upload(imageURL, to: urlString, withMethod: .post)
+        let request = Alamofire.upload(imageURL, to: urlString)
 
         // Then
         XCTAssertNotNil(request.request, "request should not be nil")
@@ -49,7 +49,7 @@ class UploadFileInitializationTestCase: BaseTestCase {
         let imageURL = url(forResource: "rainbow", withExtension: "jpg")
 
         // When
-        let request = Alamofire.upload(imageURL, to: urlString, withMethod: .post, headers: headers)
+        let request = Alamofire.upload(imageURL, to: urlString, method: .post, headers: headers)
 
         // Then
         XCTAssertNotNil(request.request, "request should not be nil")
@@ -71,7 +71,7 @@ class UploadDataInitializationTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/"
 
         // When
-        let request = Alamofire.upload(Data(), to: urlString, withMethod: .post)
+        let request = Alamofire.upload(Data(), to: urlString)
 
         // Then
         XCTAssertNotNil(request.request, "request should not be nil")
@@ -86,7 +86,7 @@ class UploadDataInitializationTestCase: BaseTestCase {
         let headers = ["Authorization": "123456"]
 
         // When
-        let request = Alamofire.upload(Data(), to: urlString, withMethod: .post, headers: headers)
+        let request = Alamofire.upload(Data(), to: urlString, headers: headers)
 
         // Then
         XCTAssertNotNil(request.request, "request should not be nil")
@@ -110,7 +110,7 @@ class UploadStreamInitializationTestCase: BaseTestCase {
         let imageStream = InputStream(url: imageURL)!
 
         // When
-        let request = Alamofire.upload(imageStream, to: urlString, withMethod: .post)
+        let request = Alamofire.upload(imageStream, to: urlString)
 
         // Then
         XCTAssertNotNil(request.request, "request should not be nil")
@@ -127,7 +127,7 @@ class UploadStreamInitializationTestCase: BaseTestCase {
         let imageStream = InputStream(url: imageURL)!
 
         // When
-        let request = Alamofire.upload(imageStream, to: urlString, withMethod: .post, headers: headers)
+        let request = Alamofire.upload(imageStream, to: urlString, headers: headers)
 
         // Then
         XCTAssertNotNil(request.request, "request should not be nil")
@@ -153,7 +153,7 @@ class UploadDataTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        Alamofire.upload(data, to: urlString, withMethod: .post)
+        Alamofire.upload(data, to: urlString)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -190,7 +190,7 @@ class UploadDataTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        Alamofire.upload(data, to: urlString, withMethod: .post)
+        Alamofire.upload(data, to: urlString)
             .uploadProgress { progress in
                 uploadProgressValues.append((progress.completedUnitCount, progress.totalUnitCount))
             }
@@ -282,7 +282,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
                 formData = multipartFormData
             },
             to: urlString,
-            withMethod: .post,
+            method: .post,
             encodingCompletion: { result in
                 switch result {
                 case .success(let upload, _, _):
@@ -331,7 +331,6 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
                 multipartFormData.append(japaneseData, withName: "japanese")
             },
             to: urlString,
-            withMethod: .post,
             encodingCompletion: { result in
                 switch result {
                 case .success(let upload, _, _):
@@ -380,7 +379,6 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
                 multipartFormData.append(japaneseData, withName: "japanese")
             },
             to: urlString,
-            withMethod: .post,
             encodingCompletion: { result in
                 switch result {
                 case let .success(upload, uploadStreamingFromDisk, uploadStreamFileURL):
@@ -425,7 +423,6 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
                 formData = multipartFormData
             },
             to: urlString,
-            withMethod: .post,
             encodingCompletion: { result in
                 switch result {
                 case let .success(upload, uploadStreamingFromDisk, _):
@@ -480,7 +477,6 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
             },
             usingThreshold: 0,
             to: urlString,
-            withMethod: .post,
             encodingCompletion: { result in
                 switch result {
                 case let .success(upload, uploadStreamingFromDisk, uploadStreamFileURL):
@@ -530,7 +526,6 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
             },
             usingThreshold: 0,
             to: urlString,
-            withMethod: .post,
             encodingCompletion: { result in
                 switch result {
                 case let .success(upload, uploadStreamingFromDisk, _):
@@ -670,7 +665,6 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
             },
             usingThreshold: streamFromDisk ? 0 : 100_000_000,
             to: urlString,
-            withMethod: .post,
             encodingCompletion: { result in
                 switch result {
                 case .success(let upload, _, _):

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -282,7 +282,6 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
                 formData = multipartFormData
             },
             to: urlString,
-            method: .post,
             encodingCompletion: { result in
                 switch result {
                 case .success(let upload, _, _):

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -360,12 +360,9 @@ class ContentTypeValidationTestCase: BaseTestCase {
                 -> DownloadRequest
             {
                 let originalRequest = urlRequest.urlRequest
-                let adaptedRequest = originalRequest.adapt(using: adapter)
-
-                var task: URLSessionDownloadTask!
-                queue.sync { task = self.session.downloadTask(with: adaptedRequest) }
-
                 let originalTask = DownloadRequest.Downloadable.request(originalRequest)
+
+                let task = originalTask.task(session: session, adapter: adapter, queue: queue)
                 let request = MockDownloadRequest(session: session, task: task, originalTask: originalTask)
 
                 request.downloadDelegate.downloadTaskDidFinishDownloadingToURL = { session, task, URL in

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -38,7 +38,7 @@ class StatusCodeValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlString, withMethod: .get)
+        Alamofire.request(urlString)
             .validate(statusCode: 200..<300)
             .response { resp in
                 requestError = resp.error
@@ -70,7 +70,7 @@ class StatusCodeValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlString, withMethod: .get)
+        Alamofire.request(urlString)
             .validate(statusCode: [200])
             .response { resp in
                 requestError = resp.error
@@ -111,7 +111,7 @@ class StatusCodeValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlString, withMethod: .get)
+        Alamofire.request(urlString)
             .validate(statusCode: [])
             .response { resp in
                 requestError = resp.error
@@ -156,7 +156,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlString, withMethod: .get)
+        Alamofire.request(urlString)
             .validate(contentType: ["application/json"])
             .validate(contentType: ["application/json;charset=utf8"])
             .validate(contentType: ["application/json;q=0.8;charset=utf8"])
@@ -192,7 +192,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlString, withMethod: .get)
+        Alamofire.request(urlString)
             .validate(contentType: ["*/*"])
             .validate(contentType: ["application/*"])
             .validate(contentType: ["*/json"])
@@ -228,7 +228,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlString, withMethod: .get)
+        Alamofire.request(urlString)
             .validate(contentType: ["application/octet-stream"])
             .response { resp in
                 requestError = resp.error
@@ -270,7 +270,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlString, withMethod: .get)
+        Alamofire.request(urlString)
             .validate(contentType: [])
             .response { resp in
                 requestError = resp.error
@@ -312,7 +312,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlString, withMethod: .get)
+        Alamofire.request(urlString)
             .validate(contentType: [])
             .response { resp in
                 requestError = resp.error
@@ -336,7 +336,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
     func testThatValidationForRequestWithAcceptableWildcardContentTypeResponseSucceedsWhenResponseIsNil() {
         // Given
         class MockManager: SessionManager {
-            override func request(_ urlRequest: URLRequestConvertible) -> DataRequest {
+            override func request(resource urlRequest: URLRequestConvertible) -> DataRequest {
                 let originalRequest = urlRequest.urlRequest
                 let adaptedRequest = originalRequest.adapt(using: adapter)
 
@@ -419,7 +419,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
         var downloadResponse: DefaultDownloadResponse?
 
         // When
-        manager.request(urlString, withMethod: .delete)
+        manager.request(urlString, method: .delete)
             .validate(contentType: ["*/*"])
             .response { resp in
                 requestResponse = resp
@@ -467,7 +467,7 @@ class MultipleValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlString, withMethod: .get)
+        Alamofire.request(urlString)
             .validate(statusCode: 200..<300)
             .validate(contentType: ["application/json"])
             .response { resp in
@@ -501,7 +501,7 @@ class MultipleValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlString, withMethod: .get)
+        Alamofire.request(urlString)
             .validate(statusCode: 400..<600)
             .validate(contentType: ["application/octet-stream"])
             .response { resp in
@@ -544,7 +544,7 @@ class MultipleValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlString, withMethod: .get)
+        Alamofire.request(urlString)
             .validate(contentType: ["application/octet-stream"])
             .validate(statusCode: 400..<600)
             .response { resp in
@@ -594,7 +594,7 @@ class AutomaticValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlRequest)
+        Alamofire.request(resource: urlRequest)
             .validate()
             .response { resp in
                 requestError = resp.error
@@ -626,7 +626,7 @@ class AutomaticValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlString, withMethod: .get)
+        Alamofire.request(urlString)
             .validate()
             .response { resp in
                 requestError = resp.error
@@ -669,7 +669,7 @@ class AutomaticValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlRequest)
+        Alamofire.request(resource: urlRequest)
             .validate()
             .response { resp in
                 requestError = resp.error
@@ -705,7 +705,7 @@ class AutomaticValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlRequest)
+        Alamofire.request(resource: urlRequest)
             .validate()
             .response { resp in
                 requestError = resp.error
@@ -739,7 +739,7 @@ class AutomaticValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlRequest)
+        Alamofire.request(resource: urlRequest)
             .validate()
             .response { resp in
                 requestError = resp.error
@@ -825,7 +825,7 @@ class CustomValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlString, withMethod: .get)
+        Alamofire.request(urlString)
             .validate { request, response, data in
                 guard data != nil else { return .failure(ValidationError.missingData) }
                 return .success
@@ -869,7 +869,7 @@ class CustomValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlString, withMethod: .get)
+        Alamofire.request(urlString)
             .validate { _, _, _ in .failure(ValidationError.missingData) }
             .validate { _, _, _ in .failure(ValidationError.missingFile) } // should be ignored
             .response { resp in
@@ -903,7 +903,7 @@ class CustomValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlString, withMethod: .get)
+        Alamofire.request(urlString)
             .validateDataExists()
             .response { resp in
                 requestError = resp.error
@@ -935,7 +935,7 @@ class CustomValidationTestCase: BaseTestCase {
         var downloadError: Error?
 
         // When
-        Alamofire.request(urlString, withMethod: .get)
+        Alamofire.request(urlString)
             .validate(with: ValidationError.missingData)
             .validate(with: ValidationError.missingFile) // should be ignored
             .response { resp in

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -26,8 +26,6 @@
 import Foundation
 import XCTest
 
-private let fileURL = URL(fileURLWithPath: FileManager.documentsDirectory + "/test_response.json")
-
 class StatusCodeValidationTestCase: BaseTestCase {
     func testThatValidationForRequestWithAcceptableStatusCodeResponseSucceeds() {
         // Given
@@ -47,12 +45,12 @@ class StatusCodeValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        Alamofire.download(urlString, to: { _, _ in fileURL }, withMethod: .get)
+        Alamofire.download(urlString)
             .validate(statusCode: 200..<300)
             .response { resp in
                 downloadError = resp.error
                 expectation2.fulfill()
-        }
+            }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
@@ -79,7 +77,7 @@ class StatusCodeValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        Alamofire.download(urlString, to: { _, _ in fileURL }, withMethod: .get)
+        Alamofire.download(urlString)
             .validate(statusCode: [200])
             .response { resp in
                 downloadError = resp.error
@@ -120,7 +118,7 @@ class StatusCodeValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        Alamofire.download(urlString, to: { _, _ in fileURL }, withMethod: .get)
+        Alamofire.download(urlString)
             .validate(statusCode: [])
             .response { resp in
                 downloadError = resp.error
@@ -167,7 +165,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        Alamofire.download(urlString, to: { _, _ in fileURL }, withMethod: .get)
+        Alamofire.download(urlString)
             .validate(contentType: ["application/json"])
             .validate(contentType: ["application/json;charset=utf8"])
             .validate(contentType: ["application/json;q=0.8;charset=utf8"])
@@ -203,7 +201,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        Alamofire.download(urlString, to: { _, _ in fileURL }, withMethod: .get)
+        Alamofire.download(urlString)
             .validate(contentType: ["*/*"])
             .validate(contentType: ["application/*"])
             .validate(contentType: ["*/json"])
@@ -237,7 +235,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        Alamofire.download(urlString, to: { _, _ in fileURL }, withMethod: .get)
+        Alamofire.download(urlString)
             .validate(contentType: ["application/octet-stream"])
             .response { resp in
                 downloadError = resp.error
@@ -279,7 +277,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        Alamofire.download(urlString, to: { _, _ in fileURL }, withMethod: .get)
+        Alamofire.download(urlString)
             .validate(contentType: [])
             .response { resp in
                 downloadError = resp.error
@@ -321,7 +319,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        Alamofire.download(urlString, to: { _, _ in fileURL }, withMethod: .get)
+        Alamofire.download(urlString)
             .validate(contentType: [])
             .response { resp in
                 downloadError = resp.error
@@ -355,8 +353,8 @@ class ContentTypeValidationTestCase: BaseTestCase {
             }
 
             override func download(
-                _ urlRequest: URLRequestConvertible,
-                to destination: DownloadRequest.DownloadFileDestination)
+                resource urlRequest: URLRequestConvertible,
+                to destination: DownloadRequest.DownloadFileDestination? = nil)
                 -> DownloadRequest
             {
                 let originalRequest = urlRequest.urlRequest
@@ -365,9 +363,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
                 let task = originalTask.task(session: session, adapter: adapter, queue: queue)
                 let request = MockDownloadRequest(session: session, task: task, originalTask: originalTask)
 
-                request.downloadDelegate.downloadTaskDidFinishDownloadingToURL = { session, task, URL in
-                    return destination(URL, task.response as! HTTPURLResponse)
-                }
+                request.downloadDelegate.destination = destination
 
                 delegate[request.delegate.task] = request
 
@@ -430,7 +426,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        manager.download(urlString, to: { _, _ in fileURL }, withMethod: .delete)
+        manager.download(urlString, method: .delete)
             .validate(contentType: ["*/*"])
             .response { resp in
                 downloadResponse = resp
@@ -448,7 +444,8 @@ class ContentTypeValidationTestCase: BaseTestCase {
         XCTAssertNil(requestResponse?.response?.mimeType)
 
         XCTAssertNotNil(downloadResponse?.response)
-        XCTAssertNotNil(downloadResponse?.destinationURL)
+        XCTAssertNotNil(downloadResponse?.temporaryURL)
+        XCTAssertNil(downloadResponse?.destinationURL)
         XCTAssertNil(downloadResponse?.error)
 
         XCTAssertEqual(downloadResponse?.response?.statusCode, 204)
@@ -478,7 +475,7 @@ class MultipleValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        Alamofire.download(urlString, to: { _, _ in fileURL }, withMethod: .get)
+        Alamofire.download(urlString)
             .validate(statusCode: 200..<300)
             .validate(contentType: ["application/json"])
             .response { resp in
@@ -512,7 +509,7 @@ class MultipleValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        Alamofire.download(urlString, to: { _, _ in fileURL }, withMethod: .get)
+        Alamofire.download(urlString)
             .validate(statusCode: 400..<600)
             .validate(contentType: ["application/octet-stream"])
             .response { resp in
@@ -555,7 +552,7 @@ class MultipleValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        Alamofire.download(urlString, to: { _, _ in fileURL }, withMethod: .get)
+        Alamofire.download(urlString)
             .validate(contentType: ["application/octet-stream"])
             .validate(statusCode: 400..<600)
             .response { resp in
@@ -604,7 +601,7 @@ class AutomaticValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        Alamofire.download(urlRequest, to: { _, _ in fileURL })
+        Alamofire.download(resource: urlRequest)
             .validate()
             .response { resp in
                 downloadError = resp.error
@@ -636,7 +633,7 @@ class AutomaticValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        Alamofire.download(urlString, to: { _, _ in fileURL }, withMethod: .get)
+        Alamofire.download(urlString)
             .validate()
             .response { resp in
                 downloadError = resp.error
@@ -679,7 +676,7 @@ class AutomaticValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        Alamofire.download(urlRequest, to: { _, _ in fileURL })
+        Alamofire.download(resource: urlRequest)
             .validate()
             .response { resp in
                 downloadError = resp.error
@@ -715,7 +712,7 @@ class AutomaticValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        Alamofire.download(urlRequest, to: { _, _ in fileURL })
+        Alamofire.download(resource: urlRequest)
             .validate()
             .response { resp in
                 downloadError = resp.error
@@ -749,7 +746,7 @@ class AutomaticValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        Alamofire.download(urlRequest, to: { _, _ in fileURL })
+        Alamofire.download(resource: urlRequest)
             .validate()
             .response { resp in
                 downloadError = resp.error
@@ -795,11 +792,13 @@ extension DataRequest {
 
 extension DownloadRequest {
     func validateDataExists() -> Self {
-        return validate { request, response, fileURL in
-            guard let fileURL = fileURL else { return .failure(ValidationError.missingFile) }
+        return validate { request, response, temporaryURL, destinationURL in
+            let fileURL = self.downloadDelegate.destination != nil ? destinationURL : temporaryURL
+
+            guard let validFileURL = fileURL else { return .failure(ValidationError.missingFile) }
 
             do {
-                let _ = try Data(contentsOf: fileURL)
+                let _ = try Data(contentsOf: validFileURL)
                 return .success
             } catch {
                 return .failure(ValidationError.fileReadFailed)
@@ -808,7 +807,7 @@ extension DownloadRequest {
     }
 
     func validate(with error: Error) -> Self {
-        return validate { _, _, _ in .failure(error) }
+        return validate { _, _, _, _ in .failure(error) }
     }
 }
 
@@ -836,9 +835,9 @@ class CustomValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        Alamofire.download(urlString, to: { _, _ in fileURL }, withMethod: .get)
-            .validate { request, response, fileURL in
-                guard let fileURL = fileURL else { return .failure(ValidationError.missingFile) }
+        Alamofire.download(urlString)
+            .validate { request, response, temporaryURL, destinationURL in
+                guard let fileURL = temporaryURL else { return .failure(ValidationError.missingFile) }
 
                 do {
                     let _ = try Data(contentsOf: fileURL)
@@ -878,9 +877,9 @@ class CustomValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        Alamofire.download(urlString, to: { _, _ in fileURL }, withMethod: .get)
-            .validate { _, _, _ in .failure(ValidationError.missingFile) }
-            .validate { _, _, _ in .failure(ValidationError.fileReadFailed) } // should be ignored
+        Alamofire.download(urlString)
+            .validate { _, _, _, _ in .failure(ValidationError.missingFile) }
+            .validate { _, _, _, _ in .failure(ValidationError.fileReadFailed) } // should be ignored
             .response { resp in
                 downloadError = resp.error
                 expectation2.fulfill()
@@ -911,7 +910,7 @@ class CustomValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
         }
 
-        Alamofire.download(urlString, to: { _, _ in fileURL }, withMethod: .get)
+        Alamofire.download(urlString)
             .validateDataExists()
             .response { resp in
                 downloadError = resp.error
@@ -944,7 +943,7 @@ class CustomValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        Alamofire.download(urlString, to: { _, _ in fileURL }, withMethod: .get)
+        Alamofire.download(urlString)
             .validate(with: ValidationError.missingFile)
             .validate(with: ValidationError.fileReadFailed) // should be ignored
             .response { resp in

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -792,8 +792,8 @@ extension DataRequest {
 
 extension DownloadRequest {
     func validateDataExists() -> Self {
-        return validate { request, response, temporaryURL, destinationURL in
-            let fileURL = self.downloadDelegate.destination != nil ? destinationURL : temporaryURL
+        return validate { request, response, _, _ in
+            let fileURL = self.downloadDelegate.fileURL
 
             guard let validFileURL = fileURL else { return .failure(ValidationError.missingFile) }
 


### PR DESCRIPTION
This PR refactors the download destination system as well as the top-level APIs for constructing requests.

## Motivation

Up until now, the `DownloadFileDestination` closures have been too limiting. They "force" you to move the file from the temporary URL to some other URL. Even if you don't want to move it, you still have to implement a destination closure and return the temp URL.

A bigger issue is that you have to do all your preparation of the file system up front. You cannot modify the file system at the time the destination closure is called. For example, let's say I have an avatar image at `$Sandbox/Documents/avatar.jpg` and I want to update it. Right now, you have to either delete the `avatar.jpg` file before making the request or move it to a different location. Otherwise you'll get a file system error when trying to move the file because a file already exists at the destination url. But you don't want to delete it before you make the request because you don't know that the request will actually succeed.

On a different note, we've wanted to remove the `with` portion of the `withMethod` external parameter name in the top-level APIs. We've also wanted to figure out how add default values for the method without introducing ambiguity.

## Solution

### Download File Destination Closure

The first major change in this PR is to make the `destination` closure optional in all the top-level APIs. You no longer have to move the file if you don't want to. It's now perfectly acceptable to do the following:

```swift
Alamofire.download("https://httpbin.org/get").responseJSON { response in
    debugPrint(response)
}
```

If you do this, the file will stay in the temporary location. If you want to move it somewhere else, you'll need to handle that on your own.

> It's important to note that you should always move the file out of the temporary location if you are going to need access to it at a later time.

Now if you do want to move the file to a different destination, you'll need to use the `DownloadFileDestination` closure which is a bit different.

```swift
public typealias DownloadFileDestination = (
    _ temporaryURL: URL,
    _ response: HTTPURLResponse)
    -> (destinationURL: URL, options: DownloadOptions)
```

You'll notice that the typealias is the same as it was before with the exception of the `DownloadOptions` in the return type.

### Download Options

The `DownloadOptions` struct is an `OptionSet` that comes with a couple cool new features.

* `.createIntermediateDirectories` - creates all intermediate directories to the destination url if specified
* `.removePreviousFile` - removes a previous file at the destination url if it exists right before moving the temp file to the destination url

These options allow you to customize the file system behavior right before the temp file is moved to the final destination url. Here's an example of what it looks like to use the new destination closure system.

```swift
let destination: DownloadRequest.DownloadFileDestination = { _, _ in 
    return (fileURL, [.removePreviousFile, .createIntermediateDirectories]) 
}

Alamofire.download(urlString, to: destination).response { response in
    debugPrint(response)
}
```

### DownloadResponse

The `DownloadResponse` has been modified to support both the `temporaryURL` and `destinationURL` properties. The `temporaryURL` will always be set if the file was successfully downloaded. The `destinationURL` will be set if the file was successfully downloaded and the `destination` closure was set. Make sure to check whether the `Result` was a success though to know the file was able to be copied to the `destinationURL`. If the move operation fails, an error is generated, but `destinationURL` is not `nil`. I designed it this way so that when an error occurs, you have as much information as possible to debug what happened.

### Download Request Validation

The `Validation` typealias for a `DownloadRequest` has been modified to support both the `temporaryURL` and `destinationURL`.

```swift
public typealias Validation = (URLRequest?, HTTPURLResponse, _ temporary: URL?, _ destination: URL?) -> ValidationResult
```

### Top-Level APIs

The goal of the top-level API changes was to set `method` defaults and get rid of the `with` portion of the `withMethod` external parameter name. The results are pretty awesome. You can now do the following:

```swift
Alamofire.request("https://httpbin.org/get") // defaults to `.get`
Alamofire.download("https://httpbin.org/get") // defaults to `.get`
Alamofire.upload("https://httpbin.org/post") // defaults to `.post`
```

Since this is certainly the majority of the use cases, this makes the call sights much more concise. If you do need to specify the `method`, it's now just `method` instead of `withMethod`.

```swift
Alamofire.request("https://httpbin.org/delete", method: .delete)
```

In order to disambiguate the `request` APIs, we had to add the external `resource` parameter name to the `URLRequestConvertible` variant.

```swift
Alamofire.request(resource: urlRequest)
Alamofire.download(resource: urlRequest, to: destination)
```

The reason for this is that `URLRequest` conforms to both `URLStringConvertible` and `URLRequestConvertible`. Rather than going down the route of removing conforms, I decided to just remove the potential of ambiguity altogether. Otherwise users could add their own extensions to types that would re-introduce ambiguity. And as well all know, ambiguous errors suck to debug.

One thing that I think is still open is whether we add the `resource` name to the upload APIs.

```swift
// Current
Alamofire.upload(fileURL, to: urlString)
Alamofire.upload(fileURL, with: urlRequest)

// Possible Improvements
Alamofire.upload(fileURL, to: urlRequest)
Alamofire.upload(fileURL, toResource: urlRequest)
```

Thoughts here?

---

## Summary

These changes greatly improve the functionality and usefulness of download requests by allowing them to support all the potential use cases. In the event that the `DownloadOptions` don't offer you enough flexibility, you can alway fall back to moving the file on your own in the response serializer. The top-level API changes are a huge improvement and make the common usage cases very concise.





