### PR TITLE
Feature - Parameter Encoding Safety

### DIFF
--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -31,6 +31,12 @@ import Foundation
 /// - responseValidationFailed:    Returned when a `validate()` call fails.
 /// - responseSerializationFailed: Returned when a response serializer encounters an error in the serialization process.
 public enum AFError: Error {
+    // TODO: Need docstring...also need above!
+    public enum ParameterEncodingFailureReason {
+        case jsonSerializationFailed(error: Error)
+        case propertyListSerializationFailed(error: Error)
+    }
+
     /// The underlying reason the multipart encoding error occurred.
     ///
     /// - bodyPartURLInvalid:                   The `fileURL` provided for reading an encodable body part isn't a
@@ -110,6 +116,7 @@ public enum AFError: Error {
         case propertyListSerializationFailed(error: Error)
     }
 
+    case parameterEncodingFailed(reason: ParameterEncodingFailureReason)
     case multipartEncodingFailed(reason: MultipartEncodingFailureReason)
     case responseValidationFailed(reason: ValidationFailureReason)
     case responseSerializationFailed(reason: SerializationFailureReason)
@@ -286,12 +293,25 @@ extension AFError.SerializationFailureReason {
 extension AFError: LocalizedError {
     public var errorDescription: String? {
         switch self {
+        case .parameterEncodingFailed(let reason):
+            return reason.localizedDescription
         case .multipartEncodingFailed(let reason):
             return reason.localizedDescription
         case .responseValidationFailed(let reason):
             return reason.localizedDescription
         case .responseSerializationFailed(let reason):
             return reason.localizedDescription
+        }
+    }
+}
+
+extension AFError.ParameterEncodingFailureReason {
+    var localizedDescription: String {
+        switch self {
+        case .jsonSerializationFailed(let error):
+            return "JSON could not be serialized because of error:\n\(error.localizedDescription)"
+        case .propertyListSerializationFailed(let error):
+            return "PropertyList could not be serialized because of error:\n\(error.localizedDescription)"
         }
     }
 }

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -232,9 +232,15 @@ open class SessionManager {
         -> DataRequest
     {
         let urlRequest = URLRequest(urlString: urlString, method: method, headers: headers)
-        let encodedURLRequest = encoding.encode(urlRequest, parameters: parameters).0
 
-        return request(resource: encodedURLRequest)
+        do {
+            let encodedURLRequest = try encoding.encode(urlRequest, with: parameters)
+            return request(resource: encodedURLRequest)
+        } catch {
+            let request = self.request(resource: urlRequest)
+            request.delegate.error = error
+            return request
+        }
     }
 
     /// Creates a `DataRequest` to retrieve the contents of a URL based on the specified `urlRequest`.
@@ -289,9 +295,15 @@ open class SessionManager {
         -> DownloadRequest
     {
         let urlRequest = URLRequest(urlString: urlString, method: method, headers: headers)
-        let encodedURLRequest = encoding.encode(urlRequest, parameters: parameters).0
 
-        return download(resource: encodedURLRequest, to: destination)
+        do {
+            let encodedURLRequest = try encoding.encode(urlRequest, with: parameters)
+            return download(resource: encodedURLRequest, to: destination)
+        } catch {
+            let request = download(resource: urlRequest, to: destination)
+            request.delegate.error = error
+            return request
+        }
     }
 
     /// Creates a `DownloadRequest` to retrieve the contents of a URL based on the specified `urlRequest` and save

--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -149,7 +149,7 @@ open class TaskDelegate: NSObject {
             taskDidCompleteWithError(session, task, error)
         } else {
             if let error = error {
-                self.error = error
+                if self.error == nil { self.error = error }
 
                 if
                     let downloadDelegate = self as? DownloadTaskDelegate,

--- a/Tests/CacheTests.swift
+++ b/Tests/CacheTests.swift
@@ -171,7 +171,11 @@ class CacheTestCase: BaseTestCase {
         var urlRequest = URLRequest(url: url, cachePolicy: cachePolicy, timeoutInterval: requestTimeout)
         urlRequest.httpMethod = HTTPMethod.get.rawValue
 
-        return ParameterEncoding.url.encode(urlRequest, parameters: parameters).0
+        do {
+            return try ParameterEncoding.url.encode(urlRequest, with: parameters)
+        } catch {
+            return urlRequest
+        }
     }
 
     @discardableResult

--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -41,402 +41,524 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
     // MARK: Tests - Parameter Types
 
     func testURLParameterEncodeNilParameters() {
-        // Given, When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: nil)
+        do {
+            // Given, When
+            let urlRequest = try encoding.encode(self.urlRequest, with: nil)
 
-        // Then
-        XCTAssertNil(urlRequest.url?.query, "query should be nil")
+            // Then
+            XCTAssertNil(urlRequest.url?.query, "query should be nil")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeEmptyDictionaryParameter() {
-        // Given
-        let parameters: [String: Any] = [:]
+        do {
+            // Given
+            let parameters: [String: Any] = [:]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertNil(urlRequest.url?.query, "query should be nil")
+            // Then
+            XCTAssertNil(urlRequest.url?.query, "query should be nil")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeOneStringKeyStringValueParameter() {
-        // Given
-        let parameters = ["foo": "bar"]
+        do {
+            // Given
+            let parameters = ["foo": "bar"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "foo=bar", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=bar", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeOneStringKeyStringValueParameterAppendedToQuery() {
-        // Given
-        var mutableURLRequest = self.urlRequest.urlRequest
-        var urlComponents = URLComponents(url: mutableURLRequest.url!, resolvingAgainstBaseURL: false)!
-        urlComponents.query = "baz=qux"
-        mutableURLRequest.url = urlComponents.url
+        do {
+            // Given
+            var mutableURLRequest = self.urlRequest.urlRequest
+            var urlComponents = URLComponents(url: mutableURLRequest.url!, resolvingAgainstBaseURL: false)!
+            urlComponents.query = "baz=qux"
+            mutableURLRequest.url = urlComponents.url
 
-        let parameters = ["foo": "bar"]
+            let parameters = ["foo": "bar"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(mutableURLRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(mutableURLRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "baz=qux&foo=bar", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "baz=qux&foo=bar", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeTwoStringKeyStringValueParameters() {
-        // Given
-        let parameters = ["foo": "bar", "baz": "qux"]
+        do {
+            // Given
+            let parameters = ["foo": "bar", "baz": "qux"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "baz=qux&foo=bar", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "baz=qux&foo=bar", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringKeyIntegerValueParameter() {
-        // Given
-        let parameters = ["foo": 1]
+        do {
+            // Given
+            let parameters = ["foo": 1]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "foo=1", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=1", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringKeyDoubleValueParameter() {
-        // Given
-        let parameters = ["foo": 1.1]
+        do {
+            // Given
+            let parameters = ["foo": 1.1]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "foo=1.1", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=1.1", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringKeyBoolValueParameter() {
-        // Given
-        let parameters = ["foo": true]
+        do {
+            // Given
+            let parameters = ["foo": true]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "foo=1", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=1", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringKeyArrayValueParameter() {
-        // Given
-        let parameters = ["foo": ["a", 1, true]]
+        do {
+            // Given
+            let parameters = ["foo": ["a", 1, true]]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "foo%5B%5D=a&foo%5B%5D=1&foo%5B%5D=1", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "foo%5B%5D=a&foo%5B%5D=1&foo%5B%5D=1", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringKeyDictionaryValueParameter() {
-        // Given
-        let parameters = ["foo": ["bar": 1]]
+        do {
+            // Given
+            let parameters = ["foo": ["bar": 1]]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "foo%5Bbar%5D=1", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "foo%5Bbar%5D=1", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringKeyNestedDictionaryValueParameter() {
-        // Given
-        let parameters = ["foo": ["bar": ["baz": 1]]]
+        do {
+            // Given
+            let parameters = ["foo": ["bar": ["baz": 1]]]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "foo%5Bbar%5D%5Bbaz%5D=1", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "foo%5Bbar%5D%5Bbaz%5D=1", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringKeyNestedDictionaryArrayValueParameter() {
-        // Given
-        let parameters = ["foo": ["bar": ["baz": ["a", 1, true]]]]
+        do {
+            // Given
+            let parameters = ["foo": ["bar": ["baz": ["a", 1, true]]]]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        let expectedQuery = "foo%5Bbar%5D%5Bbaz%5D%5B%5D=a&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1"
-        XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+            // Then
+            let expectedQuery = "foo%5Bbar%5D%5Bbaz%5D%5B%5D=a&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1"
+            XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     // MARK: Tests - All Reserved / Unreserved / Illegal Characters According to RFC 3986
 
     func testThatReservedCharactersArePercentEscapedMinusQuestionMarkAndForwardSlash() {
-        // Given
-        let generalDelimiters = ":#[]@"
-        let subDelimiters = "!$&'()*+,;="
-        let parameters = ["reserved": "\(generalDelimiters)\(subDelimiters)"]
+        do {
+            // Given
+            let generalDelimiters = ":#[]@"
+            let subDelimiters = "!$&'()*+,;="
+            let parameters = ["reserved": "\(generalDelimiters)\(subDelimiters)"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        let expectedQuery = "reserved=%3A%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D"
-        XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+            // Then
+            let expectedQuery = "reserved=%3A%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D"
+            XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testThatReservedCharactersQuestionMarkAndForwardSlashAreNotPercentEscaped() {
-        // Given
-        let parameters = ["reserved": "?/"]
+        do {
+            // Given
+            let parameters = ["reserved": "?/"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "reserved=?/", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "reserved=?/", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testThatUnreservedNumericCharactersAreNotPercentEscaped() {
-        // Given
-        let parameters = ["numbers": "0123456789"]
+        do {
+            // Given
+            let parameters = ["numbers": "0123456789"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "numbers=0123456789", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "numbers=0123456789", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testThatUnreservedLowercaseCharactersAreNotPercentEscaped() {
-        // Given
-        let parameters = ["lowercase": "abcdefghijklmnopqrstuvwxyz"]
+        do {
+            // Given
+            let parameters = ["lowercase": "abcdefghijklmnopqrstuvwxyz"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "lowercase=abcdefghijklmnopqrstuvwxyz", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "lowercase=abcdefghijklmnopqrstuvwxyz", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testThatUnreservedUppercaseCharactersAreNotPercentEscaped() {
-        // Given
-        let parameters = ["uppercase": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"]
+        do {
+            // Given
+            let parameters = ["uppercase": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "uppercase=ABCDEFGHIJKLMNOPQRSTUVWXYZ", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "uppercase=ABCDEFGHIJKLMNOPQRSTUVWXYZ", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testThatIllegalASCIICharactersArePercentEscaped() {
-        // Given
-        let parameters = ["illegal": " \"#%<>[]\\^`{}|"]
+        do {
+            // Given
+            let parameters = ["illegal": " \"#%<>[]\\^`{}|"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        let expectedQuery = "illegal=%20%22%23%25%3C%3E%5B%5D%5C%5E%60%7B%7D%7C"
-        XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+            // Then
+            let expectedQuery = "illegal=%20%22%23%25%3C%3E%5B%5D%5C%5E%60%7B%7D%7C"
+            XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     // MARK: Tests - Special Character Queries
 
     func testURLParameterEncodeStringWithAmpersandKeyStringWithAmpersandValueParameter() {
-        // Given
-        let parameters = ["foo&bar": "baz&qux", "foobar": "bazqux"]
+        do {
+            // Given
+            let parameters = ["foo&bar": "baz&qux", "foobar": "bazqux"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "foo%26bar=baz%26qux&foobar=bazqux", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "foo%26bar=baz%26qux&foobar=bazqux", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringWithQuestionMarkKeyStringWithQuestionMarkValueParameter() {
-        // Given
-        let parameters = ["?foo?": "?bar?"]
+        do {
+            // Given
+            let parameters = ["?foo?": "?bar?"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "?foo?=?bar?", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "?foo?=?bar?", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringWithSlashKeyStringWithQuestionMarkValueParameter() {
-        // Given
-        let parameters = ["foo": "/bar/baz/qux"]
+        do {
+            // Given
+            let parameters = ["foo": "/bar/baz/qux"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "foo=/bar/baz/qux", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=/bar/baz/qux", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringWithSpaceKeyStringWithSpaceValueParameter() {
-        // Given
-        let parameters = [" foo ": " bar "]
+        do {
+            // Given
+            let parameters = [" foo ": " bar "]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "%20foo%20=%20bar%20", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "%20foo%20=%20bar%20", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringWithPlusKeyStringWithPlusValueParameter() {
-        // Given
-        let parameters = ["+foo+": "+bar+"]
+        do {
+            // Given
+            let parameters = ["+foo+": "+bar+"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "%2Bfoo%2B=%2Bbar%2B", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "%2Bfoo%2B=%2Bbar%2B", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringKeyPercentEncodedStringValueParameter() {
-        // Given
-        let parameters = ["percent": "%25"]
+        do {
+            // Given
+            let parameters = ["percent": "%25"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "percent=%2525", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "percent=%2525", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringKeyNonLatinStringValueParameter() {
-        // Given
-        let parameters = [
-            "french": "français",
-            "japanese": "日本語",
-            "arabic": "العربية",
-            "emoji": "😃"
-        ]
+        do {
+            // Given
+            let parameters = [
+                "french": "français",
+                "japanese": "日本語",
+                "arabic": "العربية",
+                "emoji": "😃"
+            ]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        let expectedParameterValues = [
-            "arabic=%D8%A7%D9%84%D8%B9%D8%B1%D8%A8%D9%8A%D8%A9",
-            "emoji=%F0%9F%98%83",
-            "french=fran%C3%A7ais",
-            "japanese=%E6%97%A5%E6%9C%AC%E8%AA%9E"
-        ]
+            // Then
+            let expectedParameterValues = [
+                "arabic=%D8%A7%D9%84%D8%B9%D8%B1%D8%A8%D9%8A%D8%A9",
+                "emoji=%F0%9F%98%83",
+                "french=fran%C3%A7ais",
+                "japanese=%E6%97%A5%E6%9C%AC%E8%AA%9E"
+            ]
 
-        let expectedQuery = expectedParameterValues.joined(separator: "&")
-        XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+            let expectedQuery = expectedParameterValues.joined(separator: "&")
+            XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringForRequestWithPrecomposedQuery() {
-        // Given
-        let url = URL(string: "https://example.com/movies?hd=[1]")!
-        let parameters = ["page": "0"]
+        do {
+            // Given
+            let url = URL(string: "https://example.com/movies?hd=[1]")!
+            let parameters = ["page": "0"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(URLRequest(url: url), parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(URLRequest(url: url), with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "hd=%5B1%5D&page=0", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "hd=%5B1%5D&page=0", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringWithPlusKeyStringWithPlusValueParameterForRequestWithPrecomposedQuery() {
-        // Given
-        let url = URL(string: "https://example.com/movie?hd=[1]")!
-        let parameters = ["+foo+": "+bar+"]
+        do {
+            // Given
+            let url = URL(string: "https://example.com/movie?hd=[1]")!
+            let parameters = ["+foo+": "+bar+"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(URLRequest(url: url), parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(URLRequest(url: url), with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "hd=%5B1%5D&%2Bfoo%2B=%2Bbar%2B", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "hd=%5B1%5D&%2Bfoo%2B=%2Bbar%2B", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringWithThousandsOfChineseCharacters() {
-        // Given
-        let repeatedCount = 2_000
-        let url = URL(string: "https://example.com/movies")!
-        let parameters = ["chinese": String(count: repeatedCount, repeatedString: "一二三四五六七八九十")]
+        do {
+            // Given
+            let repeatedCount = 2_000
+            let url = URL(string: "https://example.com/movies")!
+            let parameters = ["chinese": String(count: repeatedCount, repeatedString: "一二三四五六七八九十")]
 
-        // When
-        let (urlRequest, _) = encoding.encode(URLRequest(url: url), parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(URLRequest(url: url), with: parameters)
 
-        // Then
-        var expected = "chinese="
-        for _ in 0..<repeatedCount {
-            expected += "%E4%B8%80%E4%BA%8C%E4%B8%89%E5%9B%9B%E4%BA%94%E5%85%AD%E4%B8%83%E5%85%AB%E4%B9%9D%E5%8D%81"
+            // Then
+            var expected = "chinese="
+
+            for _ in 0..<repeatedCount {
+                expected += "%E4%B8%80%E4%BA%8C%E4%B8%89%E5%9B%9B%E4%BA%94%E5%85%AD%E4%B8%83%E5%85%AB%E4%B9%9D%E5%8D%81"
+            }
+
+            XCTAssertEqual(urlRequest.url?.query ?? "", expected, "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
         }
-        XCTAssertEqual(urlRequest.url?.query ?? "", expected, "query is incorrect")
     }
 
     // MARK: Tests - Varying HTTP Methods
 
     func testThatURLParameterEncodingEncodesGETParametersInURL() {
-        // Given
-        var mutableURLRequest = self.urlRequest.urlRequest
-        mutableURLRequest.httpMethod = HTTPMethod.get.rawValue
-        let parameters = ["foo": 1, "bar": 2]
+        do {
+            // Given
+            var mutableURLRequest = self.urlRequest.urlRequest
+            mutableURLRequest.httpMethod = HTTPMethod.get.rawValue
+            let parameters = ["foo": 1, "bar": 2]
 
-        // When
-        let (urlRequest, _) = encoding.encode(mutableURLRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(mutableURLRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "bar=2&foo=1", "query is incorrect")
-        XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
-        XCTAssertNil(urlRequest.httpBody, "HTTPBody should be nil")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "bar=2&foo=1", "query is incorrect")
+            XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
+            XCTAssertNil(urlRequest.httpBody, "HTTPBody should be nil")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testThatURLParameterEncodingEncodesPOSTParametersInHTTPBody() {
-        // Given
-        var mutableURLRequest = self.urlRequest.urlRequest
-        mutableURLRequest.httpMethod = HTTPMethod.post.rawValue
-        let parameters = ["foo": 1, "bar": 2]
+        do {
+            // Given
+            var mutableURLRequest = self.urlRequest.urlRequest
+            mutableURLRequest.httpMethod = HTTPMethod.post.rawValue
+            let parameters = ["foo": 1, "bar": 2]
 
-        // When
-        let (urlRequest, _) = encoding.encode(mutableURLRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(mutableURLRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(
-            urlRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
-            "application/x-www-form-urlencoded; charset=utf-8",
-            "Content-Type should be application/x-www-form-urlencoded"
-        )
-        XCTAssertNotNil(urlRequest.httpBody, "HTTPBody should not be nil")
+            // Then
+            XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded; charset=utf-8")
+            XCTAssertNotNil(urlRequest.httpBody, "HTTPBody should not be nil")
 
-        if
-            let httpBody = urlRequest.httpBody,
-            let decodedHTTPBody = String(data: httpBody, encoding: String.Encoding.utf8)
-        {
-            XCTAssertEqual(decodedHTTPBody, "bar=2&foo=1", "HTTPBody is incorrect")
-        } else {
-            XCTFail("decoded http body should not be nil")
+            if
+                let httpBody = urlRequest.httpBody,
+                let decodedHTTPBody = String(data: httpBody, encoding: String.Encoding.utf8)
+            {
+                XCTAssertEqual(decodedHTTPBody, "bar=2&foo=1", "HTTPBody is incorrect")
+            } else {
+                XCTFail("decoded http body should not be nil")
+            }
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
         }
     }
 
     func testThatURLEncodedInURLParameterEncodingEncodesPOSTParametersInURL() {
-        // Given
-        var mutableURLRequest = self.urlRequest.urlRequest
-        mutableURLRequest.httpMethod = HTTPMethod.post.rawValue
-        let parameters = ["foo": 1, "bar": 2]
+        do {
+            // Given
+            var mutableURLRequest = self.urlRequest.urlRequest
+            mutableURLRequest.httpMethod = HTTPMethod.post.rawValue
+            let parameters = ["foo": 1, "bar": 2]
 
-        // When
-        let (urlRequest, _) = ParameterEncoding.urlEncodedInURL.encode(mutableURLRequest, parameters: parameters)
+            // When
+            let urlRequest = try ParameterEncoding.urlEncodedInURL.encode(mutableURLRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "bar=2&foo=1", "query is incorrect")
-        XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
-        XCTAssertNil(urlRequest.httpBody, "HTTPBody should be nil")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "bar=2&foo=1", "query is incorrect")
+            XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
+            XCTAssertNil(urlRequest.httpBody, "HTTPBody should be nil")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 }
 
@@ -450,73 +572,82 @@ class JSONParameterEncodingTestCase: ParameterEncodingTestCase {
     // MARK: Tests
 
     func testJSONParameterEncodeNilParameters() {
-        // Given, When
-        let (URLRequest, error) = encoding.encode(self.urlRequest, parameters: nil)
+        do {
+            // Given, When
+            let URLRequest = try encoding.encode(self.urlRequest, with: nil)
 
-        // Then
-        XCTAssertNil(error, "error should be nil")
-        XCTAssertNil(URLRequest.url?.query, "query should be nil")
-        XCTAssertNil(URLRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
-        XCTAssertNil(URLRequest.httpBody, "HTTPBody should be nil")
+            // Then
+            XCTAssertNil(URLRequest.url?.query, "query should be nil")
+            XCTAssertNil(URLRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
+            XCTAssertNil(URLRequest.httpBody, "HTTPBody should be nil")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testJSONParameterEncodeComplexParameters() {
-        // Given
-        let parameters: [String: Any] = [
-            "foo": "bar",
-            "baz": ["a", 1, true],
-            "qux": [
-                "a": 1,
-                "b": [2, 2],
-                "c": [3, 3, 3]
+        do {
+            // Given
+            let parameters: [String: Any] = [
+                "foo": "bar",
+                "baz": ["a", 1, true],
+                "qux": [
+                    "a": 1,
+                    "b": [2, 2],
+                    "c": [3, 3, 3]
+                ]
             ]
-        ]
 
-        // When
-        let (URLRequest, error) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let URLRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertNil(error, "error should be nil")
-        XCTAssertNil(URLRequest.url?.query, "query should be nil")
-        XCTAssertNotNil(URLRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should not be nil")
-        XCTAssertEqual(
-            URLRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
-            "application/json",
-            "Content-Type should be application/json"
-        )
-        XCTAssertNotNil(URLRequest.httpBody, "HTTPBody should not be nil")
+            // Then
+            XCTAssertNil(URLRequest.url?.query, "query should be nil")
+            XCTAssertNotNil(URLRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should not be nil")
+            XCTAssertEqual(
+                URLRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
+                "application/json",
+                "Content-Type should be application/json"
+            )
+            XCTAssertNotNil(URLRequest.httpBody, "HTTPBody should not be nil")
 
-        if let HTTPBody = URLRequest.httpBody {
-            do {
-                let JSON = try JSONSerialization.jsonObject(with: HTTPBody, options: .allowFragments)
+            if let HTTPBody = URLRequest.httpBody {
+                do {
+                    let JSON = try JSONSerialization.jsonObject(with: HTTPBody, options: .allowFragments)
 
-                if let JSON = JSON as? NSObject {
-                    XCTAssertEqual(JSON, parameters as NSObject, "HTTPBody JSON does not equal parameters")
-                } else {
-                    XCTFail("JSON should be an NSObject")
+                    if let JSON = JSON as? NSObject {
+                        XCTAssertEqual(JSON, parameters as NSObject, "HTTPBody JSON does not equal parameters")
+                    } else {
+                        XCTFail("JSON should be an NSObject")
+                    }
+                } catch {
+                    XCTFail("JSON should not be nil")
                 }
-            } catch {
+            } else {
                 XCTFail("JSON should not be nil")
             }
-        } else {
-            XCTFail("JSON should not be nil")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
         }
     }
 
     func testJSONParameterEncodeParametersRetainsCustomContentType() {
-        // Given
-        var mutableURLRequest = URLRequest(url: URL(string: "https://example.com/")!)
-        mutableURLRequest.setValue("application/custom-json-type+json", forHTTPHeaderField: "Content-Type")
+        do {
+            // Given
+            var mutableURLRequest = URLRequest(url: URL(string: "https://example.com/")!)
+            mutableURLRequest.setValue("application/custom-json-type+json", forHTTPHeaderField: "Content-Type")
 
-        let parameters = ["foo": "bar"]
+            let parameters = ["foo": "bar"]
 
-        // When
-        let (urlRequest, error) = encoding.encode(mutableURLRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(mutableURLRequest, with: parameters)
 
-        // Then
-        XCTAssertNil(error)
-        XCTAssertNil(urlRequest.url?.query)
-        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/custom-json-type+json")
+            // Then
+            XCTAssertNil(urlRequest.url?.query)
+            XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/custom-json-type+json")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 }
 
@@ -530,117 +661,129 @@ class PropertyListParameterEncodingTestCase: ParameterEncodingTestCase {
     // MARK: Tests
 
     func testPropertyListParameterEncodeNilParameters() {
-        // Given, When
-        let (URLRequest, error) = encoding.encode(self.urlRequest, parameters: nil)
+        do {
+            // Given, When
+            let urlRequest = try encoding.encode(self.urlRequest, with: nil)
 
-        // Then
-        XCTAssertNil(error, "error should be nil")
-        XCTAssertNil(URLRequest.url?.query, "query should be nil")
-        XCTAssertNil(URLRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
-        XCTAssertNil(URLRequest.httpBody, "HTTPBody should be nil")
+            // Then
+            XCTAssertNil(urlRequest.url?.query, "query should be nil")
+            XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
+            XCTAssertNil(urlRequest.httpBody, "HTTPBody should be nil")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testPropertyListParameterEncodeComplexParameters() {
-        // Given
-        let parameters: [String: Any] = [
-            "foo": "bar",
-            "baz": ["a", 1, true],
-            "qux": [
-                "a": 1,
-                "b": [2, 2],
-                "c": [3, 3, 3]
+        do {
+            // Given
+            let parameters: [String: Any] = [
+                "foo": "bar",
+                "baz": ["a", 1, true],
+                "qux": [
+                    "a": 1,
+                    "b": [2, 2],
+                    "c": [3, 3, 3]
+                ]
             ]
-        ]
 
-        // When
-        let (URLRequest, error) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertNil(error, "error should be nil")
-        XCTAssertNil(URLRequest.url?.query, "query should be nil")
-        XCTAssertNotNil(URLRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should not be nil")
-        XCTAssertEqual(
-            URLRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
-            "application/x-plist",
-            "Content-Type should be application/x-plist"
-        )
-        XCTAssertNotNil(URLRequest.httpBody, "HTTPBody should not be nil")
+            // Then
+            XCTAssertNil(urlRequest.url?.query, "query should be nil")
+            XCTAssertNotNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should not be nil")
+            XCTAssertEqual(
+                urlRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
+                "application/x-plist",
+                "Content-Type should be application/x-plist"
+            )
+            XCTAssertNotNil(urlRequest.httpBody, "HTTPBody should not be nil")
 
-        if let HTTPBody = URLRequest.httpBody {
-            do {
-                let plist = try PropertyListSerialization.propertyList(
-                    from: HTTPBody,
-                    options: PropertyListSerialization.MutabilityOptions(),
-                    format: nil
-                )
+            if let HTTPBody = urlRequest.httpBody {
+                do {
+                    let plist = try PropertyListSerialization.propertyList(
+                        from: HTTPBody,
+                        options: PropertyListSerialization.MutabilityOptions(),
+                        format: nil
+                    )
 
-                if let plist = plist as? NSObject {
-                    XCTAssertEqual(plist, parameters as NSObject, "HTTPBody plist does not equal parameters")
-                } else {
-                    XCTFail("plist should be an NSObject")
+                    if let plist = plist as? NSObject {
+                        XCTAssertEqual(plist, parameters as NSObject, "HTTPBody plist does not equal parameters")
+                    } else {
+                        XCTFail("plist should be an NSObject")
+                    }
+                } catch {
+                    XCTFail("plist should not be nil")
                 }
-            } catch {
-                XCTFail("plist should not be nil")
             }
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
         }
     }
 
     func testPropertyListParameterEncodeDateAndDataParameters() {
-        // Given
-        let date: Date = Date()
-        let data: Data = "data".data(using: String.Encoding.utf8, allowLossyConversion: false)!
+        do {
+            // Given
+            let date: Date = Date()
+            let data: Data = "data".data(using: String.Encoding.utf8, allowLossyConversion: false)!
 
-        let parameters: [String: Any] = [
-            "date": date,
-            "data": data
-        ]
+            let parameters: [String: Any] = [
+                "date": date,
+                "data": data
+            ]
 
-        // When
-        let (urlRequest, error) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertNil(error, "error should be nil")
-        XCTAssertNil(urlRequest.url?.query, "query should be nil")
-        XCTAssertNotNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should not be nil")
-        XCTAssertEqual(
-            urlRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
-            "application/x-plist",
-            "Content-Type should be application/x-plist"
-        )
-        XCTAssertNotNil(urlRequest.httpBody, "HTTPBody should not be nil")
+            // Then
+            XCTAssertNil(urlRequest.url?.query, "query should be nil")
+            XCTAssertNotNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should not be nil")
+            XCTAssertEqual(
+                urlRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
+                "application/x-plist",
+                "Content-Type should be application/x-plist"
+            )
+            XCTAssertNotNil(urlRequest.httpBody, "HTTPBody should not be nil")
 
-        if let HTTPBody = urlRequest.httpBody {
-            do {
-                let plist = try PropertyListSerialization.propertyList(
-                    from: HTTPBody,
-                    options: PropertyListSerialization.MutabilityOptions(),
-                    format: nil
-                ) as AnyObject
+            if let HTTPBody = urlRequest.httpBody {
+                do {
+                    let plist = try PropertyListSerialization.propertyList(
+                        from: HTTPBody,
+                        options: PropertyListSerialization.MutabilityOptions(),
+                        format: nil
+                        ) as AnyObject
 
-                XCTAssertTrue(plist.value(forKey: "date") is Date, "date is not Date")
-                XCTAssertTrue(plist.value(forKey: "data") is Data, "data is not Data")
-            } catch {
-                XCTFail("plist should not be nil")
+                    XCTAssertTrue(plist.value(forKey: "date") is Date, "date is not Date")
+                    XCTAssertTrue(plist.value(forKey: "data") is Data, "data is not Data")
+                } catch {
+                    XCTFail("plist should not be nil")
+                }
+            } else {
+                XCTFail("HTTPBody should not be nil")
             }
-        } else {
-            XCTFail("HTTPBody should not be nil")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
         }
     }
 
     func testPropertyListParameterEncodeParametersRetainsCustomContentType() {
-        // Given
-        var mutableURLRequest = URLRequest(url: URL(string: "https://example.com/")!)
-        mutableURLRequest.setValue("application/custom-plist-type+plist", forHTTPHeaderField: "Content-Type")
+        do {
+            // Given
+            var mutableURLRequest = URLRequest(url: URL(string: "https://example.com/")!)
+            mutableURLRequest.setValue("application/custom-plist-type+plist", forHTTPHeaderField: "Content-Type")
 
-        let parameters = ["foo": "bar"]
+            let parameters = ["foo": "bar"]
 
-        // When
-        let (urlRequest, error) = encoding.encode(mutableURLRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(mutableURLRequest, with: parameters)
 
-        // Then
-        XCTAssertNil(error)
-        XCTAssertNil(urlRequest.url?.query)
-        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/custom-plist-type+plist")
+            // Then
+            XCTAssertNil(urlRequest.url?.query)
+            XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/custom-plist-type+plist")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 }
 
@@ -651,29 +794,33 @@ class CustomParameterEncodingTestCase: ParameterEncodingTestCase {
     // MARK: Tests
 
     func testCustomParameterEncode() {
-        // Given
-        let encodingClosure: (URLRequestConvertible, [String: Any]?) -> (URLRequest, Error?) = { urlRequest, parameters in
-            guard let parameters = parameters else { return (urlRequest.urlRequest, nil) }
+        do {
+            // Given
+            let encodingClosure: (URLRequestConvertible, [String: Any]?) throws -> URLRequest = { urlRequest, parameters in
+                guard let parameters = parameters else { return urlRequest.urlRequest }
 
-            var urlString = urlRequest.urlRequest.urlString + "?"
+                var urlString = urlRequest.urlRequest.urlString + "?"
 
-            parameters.forEach { urlString += "\($0)=\($1)" }
+                parameters.forEach { urlString += "\($0)=\($1)" }
 
-            var mutableURLRequest = urlRequest.urlRequest
-            mutableURLRequest.url = URL(string: urlString)!
+                var mutableURLRequest = urlRequest.urlRequest
+                mutableURLRequest.url = URL(string: urlString)!
 
-            return (mutableURLRequest, nil)
+                return mutableURLRequest
+            }
+
+            // When
+            let encoding: ParameterEncoding = .custom(encodingClosure)
+
+            // Then
+            let url = URL(string: "https://example.com")!
+            let urlRequest = URLRequest(url: url)
+            let parameters = ["foo": "bar"]
+            
+            let result = try encoding.encode(urlRequest, with: parameters)
+            XCTAssertEqual(result.urlString, "https://example.com?foo=bar")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
         }
-
-        // When
-        let encoding: ParameterEncoding = .custom(encodingClosure)
-
-        // Then
-        let url = URL(string: "https://example.com")!
-        let urlRequest = URLRequest(url: url)
-        let parameters = ["foo": "bar"]
-
-        let result = encoding.encode(urlRequest, parameters: parameters)
-        XCTAssertEqual(result.0.urlString, "https://example.com?foo=bar")
     }
 }

--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -46,7 +46,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: nil)
 
             // Then
-            XCTAssertNil(urlRequest.url?.query, "query should be nil")
+            XCTAssertNil(urlRequest.url?.query)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -61,7 +61,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertNil(urlRequest.url?.query, "query should be nil")
+            XCTAssertNil(urlRequest.url?.query)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -76,7 +76,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=bar", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "foo=bar")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -96,7 +96,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(mutableURLRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "baz=qux&foo=bar", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "baz=qux&foo=bar")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -111,7 +111,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "baz=qux&foo=bar", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "baz=qux&foo=bar")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -126,7 +126,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=1", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "foo=1")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -141,7 +141,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=1.1", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "foo=1.1")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -156,7 +156,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=1", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "foo=1")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -171,7 +171,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "foo%5B%5D=a&foo%5B%5D=1&foo%5B%5D=1", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "foo%5B%5D=a&foo%5B%5D=1&foo%5B%5D=1")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -186,7 +186,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "foo%5Bbar%5D=1", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "foo%5Bbar%5D=1")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -201,7 +201,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "foo%5Bbar%5D%5Bbaz%5D=1", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "foo%5Bbar%5D%5Bbaz%5D=1")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -217,7 +217,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
 
             // Then
             let expectedQuery = "foo%5Bbar%5D%5Bbaz%5D%5B%5D=a&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1"
-            XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, expectedQuery)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -237,7 +237,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
 
             // Then
             let expectedQuery = "reserved=%3A%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D"
-            XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, expectedQuery)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -252,7 +252,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "reserved=?/", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "reserved=?/")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -267,7 +267,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "numbers=0123456789", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "numbers=0123456789")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -282,7 +282,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "lowercase=abcdefghijklmnopqrstuvwxyz", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "lowercase=abcdefghijklmnopqrstuvwxyz")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -297,7 +297,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "uppercase=ABCDEFGHIJKLMNOPQRSTUVWXYZ", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "uppercase=ABCDEFGHIJKLMNOPQRSTUVWXYZ")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -313,7 +313,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
 
             // Then
             let expectedQuery = "illegal=%20%22%23%25%3C%3E%5B%5D%5C%5E%60%7B%7D%7C"
-            XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, expectedQuery)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -330,7 +330,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "foo%26bar=baz%26qux&foobar=bazqux", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "foo%26bar=baz%26qux&foobar=bazqux")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -345,7 +345,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "?foo?=?bar?", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "?foo?=?bar?")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -360,7 +360,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=/bar/baz/qux", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "foo=/bar/baz/qux")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -375,7 +375,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "%20foo%20=%20bar%20", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "%20foo%20=%20bar%20")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -390,7 +390,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "%2Bfoo%2B=%2Bbar%2B", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "%2Bfoo%2B=%2Bbar%2B")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -405,7 +405,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "percent=%2525", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "percent=%2525")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -433,7 +433,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             ]
 
             let expectedQuery = expectedParameterValues.joined(separator: "&")
-            XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, expectedQuery)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -449,7 +449,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(URLRequest(url: url), with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "hd=%5B1%5D&page=0", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "hd=%5B1%5D&page=0")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -465,7 +465,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(URLRequest(url: url), with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "hd=%5B1%5D&%2Bfoo%2B=%2Bbar%2B", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "hd=%5B1%5D&%2Bfoo%2B=%2Bbar%2B")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -488,7 +488,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
                 expected += "%E4%B8%80%E4%BA%8C%E4%B8%89%E5%9B%9B%E4%BA%94%E5%85%AD%E4%B8%83%E5%85%AB%E4%B9%9D%E5%8D%81"
             }
 
-            XCTAssertEqual(urlRequest.url?.query ?? "", expected, "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, expected)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -507,7 +507,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(mutableURLRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "bar=2&foo=1", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "bar=2&foo=1")
             XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
             XCTAssertNil(urlRequest.httpBody, "HTTPBody should be nil")
         } catch {
@@ -529,11 +529,8 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded; charset=utf-8")
             XCTAssertNotNil(urlRequest.httpBody, "HTTPBody should not be nil")
 
-            if
-                let httpBody = urlRequest.httpBody,
-                let decodedHTTPBody = String(data: httpBody, encoding: String.Encoding.utf8)
-            {
-                XCTAssertEqual(decodedHTTPBody, "bar=2&foo=1", "HTTPBody is incorrect")
+            if let httpBody = urlRequest.httpBody, let decodedHTTPBody = String(data: httpBody, encoding: .utf8) {
+                XCTAssertEqual(decodedHTTPBody, "bar=2&foo=1")
             } else {
                 XCTFail("decoded http body should not be nil")
             }
@@ -553,8 +550,8 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try ParameterEncoding.urlEncodedInURL.encode(mutableURLRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "bar=2&foo=1", "query is incorrect")
-            XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
+            XCTAssertEqual(urlRequest.url?.query, "bar=2&foo=1")
+            XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"))
             XCTAssertNil(urlRequest.httpBody, "HTTPBody should be nil")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
@@ -578,7 +575,7 @@ class JSONParameterEncodingTestCase: ParameterEncodingTestCase {
 
             // Then
             XCTAssertNil(URLRequest.url?.query, "query should be nil")
-            XCTAssertNil(URLRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
+            XCTAssertNil(URLRequest.value(forHTTPHeaderField: "Content-Type"))
             XCTAssertNil(URLRequest.httpBody, "HTTPBody should be nil")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
@@ -602,29 +599,25 @@ class JSONParameterEncodingTestCase: ParameterEncodingTestCase {
             let URLRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertNil(URLRequest.url?.query, "query should be nil")
-            XCTAssertNotNil(URLRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should not be nil")
-            XCTAssertEqual(
-                URLRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
-                "application/json",
-                "Content-Type should be application/json"
-            )
-            XCTAssertNotNil(URLRequest.httpBody, "HTTPBody should not be nil")
+            XCTAssertNil(URLRequest.url?.query)
+            XCTAssertNotNil(URLRequest.value(forHTTPHeaderField: "Content-Type"))
+            XCTAssertEqual(URLRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
+            XCTAssertNotNil(URLRequest.httpBody)
 
-            if let HTTPBody = URLRequest.httpBody {
+            if let httpBody = URLRequest.httpBody {
                 do {
-                    let JSON = try JSONSerialization.jsonObject(with: HTTPBody, options: .allowFragments)
+                    let json = try JSONSerialization.jsonObject(with: httpBody, options: .allowFragments)
 
-                    if let JSON = JSON as? NSObject {
-                        XCTAssertEqual(JSON, parameters as NSObject, "HTTPBody JSON does not equal parameters")
+                    if let json = json as? NSObject {
+                        XCTAssertEqual(json, parameters as NSObject)
                     } else {
-                        XCTFail("JSON should be an NSObject")
+                        XCTFail("json should be an NSObject")
                     }
                 } catch {
-                    XCTFail("JSON should not be nil")
+                    XCTFail("json should not be nil")
                 }
             } else {
-                XCTFail("JSON should not be nil")
+                XCTFail("json should not be nil")
             }
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
@@ -666,9 +659,9 @@ class PropertyListParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: nil)
 
             // Then
-            XCTAssertNil(urlRequest.url?.query, "query should be nil")
-            XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
-            XCTAssertNil(urlRequest.httpBody, "HTTPBody should be nil")
+            XCTAssertNil(urlRequest.url?.query)
+            XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"))
+            XCTAssertNil(urlRequest.httpBody)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -691,25 +684,17 @@ class PropertyListParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertNil(urlRequest.url?.query, "query should be nil")
-            XCTAssertNotNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should not be nil")
-            XCTAssertEqual(
-                urlRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
-                "application/x-plist",
-                "Content-Type should be application/x-plist"
-            )
-            XCTAssertNotNil(urlRequest.httpBody, "HTTPBody should not be nil")
+            XCTAssertNil(urlRequest.url?.query)
+            XCTAssertNotNil(urlRequest.value(forHTTPHeaderField: "Content-Type"))
+            XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/x-plist")
+            XCTAssertNotNil(urlRequest.httpBody)
 
-            if let HTTPBody = urlRequest.httpBody {
+            if let httpBody = urlRequest.httpBody {
                 do {
-                    let plist = try PropertyListSerialization.propertyList(
-                        from: HTTPBody,
-                        options: PropertyListSerialization.MutabilityOptions(),
-                        format: nil
-                    )
+                    let plist = try PropertyListSerialization.propertyList(from: httpBody, options: [], format: nil)
 
                     if let plist = plist as? NSObject {
-                        XCTAssertEqual(plist, parameters as NSObject, "HTTPBody plist does not equal parameters")
+                        XCTAssertEqual(plist, parameters as NSObject)
                     } else {
                         XCTFail("plist should be an NSObject")
                     }
@@ -737,25 +722,17 @@ class PropertyListParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertNil(urlRequest.url?.query, "query should be nil")
-            XCTAssertNotNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should not be nil")
-            XCTAssertEqual(
-                urlRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
-                "application/x-plist",
-                "Content-Type should be application/x-plist"
-            )
-            XCTAssertNotNil(urlRequest.httpBody, "HTTPBody should not be nil")
+            XCTAssertNil(urlRequest.url?.query)
+            XCTAssertNotNil(urlRequest.value(forHTTPHeaderField: "Content-Type"))
+            XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/x-plist")
+            XCTAssertNotNil(urlRequest.httpBody)
 
-            if let HTTPBody = urlRequest.httpBody {
+            if let httpBody = urlRequest.httpBody {
                 do {
-                    let plist = try PropertyListSerialization.propertyList(
-                        from: HTTPBody,
-                        options: PropertyListSerialization.MutabilityOptions(),
-                        format: nil
-                        ) as AnyObject
+                    let plist = try PropertyListSerialization.propertyList(from: httpBody, options: [], format: nil) as AnyObject
 
-                    XCTAssertTrue(plist.value(forKey: "date") is Date, "date is not Date")
-                    XCTAssertTrue(plist.value(forKey: "data") is Data, "data is not Data")
+                    XCTAssertTrue(plist.value(forKey: "date") is Date)
+                    XCTAssertTrue(plist.value(forKey: "data") is Data)
                 } catch {
                     XCTFail("plist should not be nil")
                 }
@@ -816,7 +793,7 @@ class CustomParameterEncodingTestCase: ParameterEncodingTestCase {
             let url = URL(string: "https://example.com")!
             let urlRequest = URLRequest(url: url)
             let parameters = ["foo": "bar"]
-            
+
             let result = try encoding.encode(urlRequest, with: parameters)
             XCTAssertEqual(result.urlString, "https://example.com?foo=bar")
         } catch {

--- a/Tests/URLProtocolTests.swift
+++ b/Tests/URLProtocolTests.swift
@@ -61,7 +61,11 @@ class ProxyURLProtocol: URLProtocol {
 
     override class func canonicalRequest(for request: URLRequest) -> URLRequest {
         if let headers = request.allHTTPHeaderFields {
-            return ParameterEncoding.url.encode(request, parameters: headers).0
+            do {
+                return try ParameterEncoding.url.encode(request, with: headers)
+            } catch {
+                return request
+            }
         }
 
         return request


### PR DESCRIPTION
This PR is a work in progress (WIP). I switched the `ParameterEncoding` `encode` API over to properly throwing an AFError if encoding fails. I'll write up more details tomorrow, but long story short this change throws a parameter encoding error that gets pushed all the way down into the `TaskDelegate` which will bubble out the end after the request completes.

@jshier I'm looking for a rough nod from you that this approach seems viable before I finish it up. Right now I think all that's missing are some updated docstrings and the AFError extensions in the test suite.