### PR TITLE
Feature - Parameter Encoding Protocol

### DIFF
--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -31,6 +31,12 @@ import Foundation
 /// - responseValidationFailed:    Returned when a `validate()` call fails.
 /// - responseSerializationFailed: Returned when a response serializer encounters an error in the serialization process.
 public enum AFError: Error {
+    // TODO: Need docstring...also need above!
+    public enum ParameterEncodingFailureReason {
+        case jsonSerializationFailed(error: Error)
+        case propertyListSerializationFailed(error: Error)
+    }
+
     /// The underlying reason the multipart encoding error occurred.
     ///
     /// - bodyPartURLInvalid:                   The `fileURL` provided for reading an encodable body part isn't a
@@ -110,6 +116,7 @@ public enum AFError: Error {
         case propertyListSerializationFailed(error: Error)
     }
 
+    case parameterEncodingFailed(reason: ParameterEncodingFailureReason)
     case multipartEncodingFailed(reason: MultipartEncodingFailureReason)
     case responseValidationFailed(reason: ValidationFailureReason)
     case responseSerializationFailed(reason: SerializationFailureReason)
@@ -286,12 +293,25 @@ extension AFError.SerializationFailureReason {
 extension AFError: LocalizedError {
     public var errorDescription: String? {
         switch self {
+        case .parameterEncodingFailed(let reason):
+            return reason.localizedDescription
         case .multipartEncodingFailed(let reason):
             return reason.localizedDescription
         case .responseValidationFailed(let reason):
             return reason.localizedDescription
         case .responseSerializationFailed(let reason):
             return reason.localizedDescription
+        }
+    }
+}
+
+extension AFError.ParameterEncodingFailureReason {
+    var localizedDescription: String {
+        switch self {
+        case .jsonSerializationFailed(let error):
+            return "JSON could not be serialized because of error:\n\(error.localizedDescription)"
+        case .propertyListSerializationFailed(let error):
+            return "PropertyList could not be serialized because of error:\n\(error.localizedDescription)"
         }
     }
 }

--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -34,11 +34,13 @@ import Foundation
 public enum AFError: Error {
     /// The underlying reason the parameter encoding error occurred.
     ///
+    /// - missingURL:                 The URL request did not have a URL to encode.
     /// - jsonEncodingFailed:         JSON serialization failed with an underlying system error during the
     ///                               encoding process.
     /// - propertyListEncodingFailed: Property list serialization failed with an underlying system error during 
     ///                               encoding process.
     public enum ParameterEncodingFailureReason {
+        case missingURL
         case jsonEncodingFailed(error: Error)
         case propertyListEncodingFailed(error: Error)
     }
@@ -234,6 +236,8 @@ extension AFError.ParameterEncodingFailureReason {
         switch self {
         case .jsonEncodingFailed(let error), .propertyListEncodingFailed(let error):
             return error
+        default:
+            return nil
         }
     }
 }
@@ -332,6 +336,8 @@ extension AFError: LocalizedError {
 extension AFError.ParameterEncodingFailureReason {
     var localizedDescription: String {
         switch self {
+        case .missingURL:
+            return "URL request to encode was missing a URL"
         case .jsonEncodingFailed(let error):
             return "JSON could not be encoded because of error:\n\(error.localizedDescription)"
         case .propertyListEncodingFailed(let error):

--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -108,7 +108,7 @@ extension URLRequest {
 /// - parameter urlString:  The URL string.
 /// - parameter method:     The HTTP method. `.get` by default.
 /// - parameter parameters: The parameters. `nil` by default.
-/// - parameter encoding:   The parameter encoding. `.url` by default.
+/// - parameter encoding:   The parameter encoding. `URLEncoding.default` by default.
 /// - parameter headers:    The HTTP headers. `nil` by default.
 ///
 /// - returns: The created `DataRequest`.
@@ -116,8 +116,8 @@ extension URLRequest {
 public func request(
     _ urlString: URLStringConvertible,
     method: HTTPMethod = .get,
-    parameters: [String: Any]? = nil,
-    encoding: ParameterEncoding = .url,
+    parameters: Parameters? = nil,
+    encoding: ParameterEncoding = URLEncoding.default,
     headers: [String: String]? = nil)
     -> DataRequest
 {
@@ -154,7 +154,7 @@ public func request(resource urlRequest: URLRequestConvertible) -> DataRequest {
 /// - parameter urlString:   The URL string.
 /// - parameter method:      The HTTP method. `.get` by default.
 /// - parameter parameters:  The parameters. `nil` by default.
-/// - parameter encoding:    The parameter encoding. `.url` by default.
+/// - parameter encoding:    The parameter encoding. `URLEncoding.default` by default.
 /// - parameter headers:     The HTTP headers. `nil` by default.
 /// - parameter destination: The closure used to determine the destination of the downloaded file. `nil` by default.
 ///
@@ -163,8 +163,8 @@ public func request(resource urlRequest: URLRequestConvertible) -> DataRequest {
 public func download(
     _ urlString: URLStringConvertible,
     method: HTTPMethod = .get,
-    parameters: [String: Any]? = nil,
-    encoding: ParameterEncoding = .url,
+    parameters: Parameters? = nil,
+    encoding: ParameterEncoding = URLEncoding.default,
     headers: [String: String]? = nil,
     to destination: DownloadRequest.DownloadFileDestination? = nil)
     -> DownloadRequest

--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -140,10 +140,7 @@ public struct URLEncoding: ParameterEncoding {
                 urlRequest.setValue("application/x-www-form-urlencoded; charset=utf-8", forHTTPHeaderField: "Content-Type")
             }
 
-            urlRequest.httpBody = query(parameters).data(
-                using: String.Encoding.utf8,
-                allowLossyConversion: false
-            )
+            urlRequest.httpBody = query(parameters).data(using: .utf8, allowLossyConversion: false)
         }
 
         return urlRequest

--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -277,7 +277,7 @@ public struct JSONEncoding: ParameterEncoding {
 
             urlRequest.httpBody = data
         } catch {
-            throw AFError.parameterEncodingFailed(reason: .jsonSerializationFailed(error: error))
+            throw AFError.parameterEncodingFailed(reason: .jsonEncodingFailed(error: error))
         }
 
         return urlRequest
@@ -352,7 +352,7 @@ public struct PropertyListEncoding: ParameterEncoding {
 
             urlRequest.httpBody = data
         } catch {
-            throw AFError.parameterEncodingFailed(reason: .propertyListSerializationFailed(error: error))
+            throw AFError.parameterEncodingFailed(reason: .propertyListEncodingFailed(error: error))
         }
         
         return urlRequest

--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -125,11 +125,15 @@ public struct URLEncoding: ParameterEncoding {
 
         guard let parameters = parameters else { return urlRequest }
 
-        if let method = HTTPMethod(rawValue: urlRequest.httpMethod!), encodesParametersInURL(with: method) {
-            if var URLComponents = URLComponents(url: urlRequest.url!, resolvingAgainstBaseURL: false), !parameters.isEmpty {
-                let percentEncodedQuery = (URLComponents.percentEncodedQuery.map { $0 + "&" } ?? "") + query(parameters)
-                URLComponents.percentEncodedQuery = percentEncodedQuery
-                urlRequest.url = URLComponents.url
+        if let method = HTTPMethod(rawValue: urlRequest.httpMethod ?? "GET"), encodesParametersInURL(with: method) {
+            guard let url = urlRequest.url else {
+                throw AFError.parameterEncodingFailed(reason: .missingURL)
+            }
+
+            if var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false), !parameters.isEmpty {
+                let percentEncodedQuery = (urlComponents.percentEncodedQuery.map { $0 + "&" } ?? "") + query(parameters)
+                urlComponents.percentEncodedQuery = percentEncodedQuery
+                urlRequest.url = urlComponents.url
             }
         } else {
             if urlRequest.value(forHTTPHeaderField: "Content-Type") == nil {

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -232,9 +232,15 @@ open class SessionManager {
         -> DataRequest
     {
         let urlRequest = URLRequest(urlString: urlString, method: method, headers: headers)
-        let encodedURLRequest = encoding.encode(urlRequest, parameters: parameters).0
 
-        return request(resource: encodedURLRequest)
+        do {
+            let encodedURLRequest = try encoding.encode(urlRequest, with: parameters)
+            return request(resource: encodedURLRequest)
+        } catch {
+            let request = self.request(resource: urlRequest)
+            request.delegate.error = error
+            return request
+        }
     }
 
     /// Creates a `DataRequest` to retrieve the contents of a URL based on the specified `urlRequest`.
@@ -289,9 +295,15 @@ open class SessionManager {
         -> DownloadRequest
     {
         let urlRequest = URLRequest(urlString: urlString, method: method, headers: headers)
-        let encodedURLRequest = encoding.encode(urlRequest, parameters: parameters).0
 
-        return download(resource: encodedURLRequest, to: destination)
+        do {
+            let encodedURLRequest = try encoding.encode(urlRequest, with: parameters)
+            return download(resource: encodedURLRequest, to: destination)
+        } catch {
+            let request = download(resource: urlRequest, to: destination)
+            request.delegate.error = error
+            return request
+        }
     }
 
     /// Creates a `DownloadRequest` to retrieve the contents of a URL based on the specified `urlRequest` and save

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -218,7 +218,7 @@ open class SessionManager {
     /// - parameter urlString:  The URL string.
     /// - parameter method:     The HTTP method. `.get` by default.
     /// - parameter parameters: The parameters. `nil` by default.
-    /// - parameter encoding:   The parameter encoding. `.url` by default.
+    /// - parameter encoding:   The parameter encoding. `URLEncoding.default` by default.
     /// - parameter headers:    The HTTP headers. `nil` by default.
     ///
     /// - returns: The created `DataRequest`.
@@ -226,8 +226,8 @@ open class SessionManager {
     open func request(
         _ urlString: URLStringConvertible,
         method: HTTPMethod = .get,
-        parameters: [String: Any]? = nil,
-        encoding: ParameterEncoding = .url,
+        parameters: Parameters? = nil,
+        encoding: ParameterEncoding = URLEncoding.default,
         headers: [String: String]? = nil)
         -> DataRequest
     {
@@ -279,7 +279,7 @@ open class SessionManager {
     /// - parameter urlString:   The URL string.
     /// - parameter method:      The HTTP method. `.get` by default.
     /// - parameter parameters:  The parameters. `nil` by default.
-    /// - parameter encoding:    The parameter encoding. `.url` by default.
+    /// - parameter encoding:    The parameter encoding. `URLEncoding.default` by default.
     /// - parameter headers:     The HTTP headers. `nil` by default.
     /// - parameter destination: The closure used to determine the destination of the downloaded file. `nil` by default.
     ///
@@ -288,8 +288,8 @@ open class SessionManager {
     open func download(
         _ urlString: URLStringConvertible,
         method: HTTPMethod = .get,
-        parameters: [String: Any]? = nil,
-        encoding: ParameterEncoding = .url,
+        parameters: Parameters? = nil,
+        encoding: ParameterEncoding = URLEncoding.default,
         headers: [String: String]? = nil,
         to destination: DownloadRequest.DownloadFileDestination? = nil)
         -> DownloadRequest

--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -149,7 +149,7 @@ open class TaskDelegate: NSObject {
             taskDidCompleteWithError(session, task, error)
         } else {
             if let error = error {
-                self.error = error
+                if self.error == nil { self.error = error }
 
                 if
                     let downloadDelegate = self as? DownloadTaskDelegate,

--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -28,7 +28,7 @@ extension Request {
 
     // MARK: Helper Types
 
-    fileprivate typealias ErrorReason = AFError.ValidationFailureReason
+    fileprivate typealias ErrorReason = AFError.ResponseValidationFailureReason
 
     /// Used to represent whether validation was successful or encountered an error resulting in a failure.
     ///

--- a/Tests/AFError+AlamofireTests.swift
+++ b/Tests/AFError+AlamofireTests.swift
@@ -28,6 +28,11 @@ extension AFError {
 
     // ParameterEncodingFailureReason
 
+    var isMissingURLFailed: Bool {
+        if case let .parameterEncodingFailed(reason) = self, reason.isMissingURL { return true }
+        return false
+    }
+
     var isJSONEncodingFailed: Bool {
         if case let .parameterEncodingFailed(reason) = self, reason.isJSONEncodingFailed { return true }
         return false
@@ -173,6 +178,11 @@ extension AFError {
 // MARK: -
 
 extension AFError.ParameterEncodingFailureReason {
+    var isMissingURL: Bool {
+        if case .missingURL = self { return true }
+        return false
+    }
+
     var isJSONEncodingFailed: Bool {
         if case .jsonEncodingFailed = self { return true }
         return false

--- a/Tests/AFError+AlamofireTests.swift
+++ b/Tests/AFError+AlamofireTests.swift
@@ -26,6 +26,18 @@ import Alamofire
 
 extension AFError {
 
+    // ParameterEncodingFailureReason
+
+    var isJSONEncodingFailed: Bool {
+        if case let .parameterEncodingFailed(reason) = self, reason.isJSONEncodingFailed { return true }
+        return false
+    }
+
+    var isPropertyListEncodingFailed: Bool {
+        if case let .parameterEncodingFailed(reason) = self, reason.isPropertyListEncodingFailed { return true }
+        return false
+    }
+
     // MultipartEncodingFailureReason
 
     var isBodyPartURLInvalid: Bool {
@@ -93,7 +105,7 @@ extension AFError {
         return false
     }
 
-    // SerializationFailureReason
+    // ResponseSerializationFailureReason
 
     var isInputDataNil: Bool {
         if case let .responseSerializationFailed(reason) = self, reason.isInputDataNil { return true }
@@ -130,7 +142,7 @@ extension AFError {
         return false
     }
 
-    // ValidationFailureReason
+    // ResponseValidationFailureReason
 
     var isDataFileNil: Bool {
         if case let .responseValidationFailed(reason) = self, reason.isDataFileNil { return true }
@@ -154,6 +166,20 @@ extension AFError {
 
     var isUnacceptableStatusCode: Bool {
         if case let .responseValidationFailed(reason) = self, reason.isUnacceptableStatusCode { return true }
+        return false
+    }
+}
+
+// MARK: -
+
+extension AFError.ParameterEncodingFailureReason {
+    var isJSONEncodingFailed: Bool {
+        if case .jsonEncodingFailed = self { return true }
+        return false
+    }
+
+    var isPropertyListEncodingFailed: Bool {
+        if case .propertyListEncodingFailed = self { return true }
         return false
     }
 }
@@ -229,7 +255,7 @@ extension AFError.MultipartEncodingFailureReason {
 
 // MARK: -
 
-extension AFError.SerializationFailureReason {
+extension AFError.ResponseSerializationFailureReason {
     var isInputDataNil: Bool {
         if case .inputDataNil = self { return true }
         return false
@@ -268,7 +294,7 @@ extension AFError.SerializationFailureReason {
 
 // MARK: -
 
-extension AFError.ValidationFailureReason {
+extension AFError.ResponseValidationFailureReason {
     var isDataFileNil: Bool {
         if case .dataFileNil = self { return true }
         return false

--- a/Tests/CacheTests.swift
+++ b/Tests/CacheTests.swift
@@ -171,7 +171,11 @@ class CacheTestCase: BaseTestCase {
         var urlRequest = URLRequest(url: url, cachePolicy: cachePolicy, timeoutInterval: requestTimeout)
         urlRequest.httpMethod = HTTPMethod.get.rawValue
 
-        return ParameterEncoding.url.encode(urlRequest, parameters: parameters).0
+        do {
+            return try ParameterEncoding.url.encode(urlRequest, with: parameters)
+        } catch {
+            return urlRequest
+        }
     }
 
     @discardableResult

--- a/Tests/CacheTests.swift
+++ b/Tests/CacheTests.swift
@@ -172,7 +172,7 @@ class CacheTestCase: BaseTestCase {
         urlRequest.httpMethod = HTTPMethod.get.rawValue
 
         do {
-            return try ParameterEncoding.url.encode(urlRequest, with: parameters)
+            return try URLEncoding.default.encode(urlRequest, with: parameters)
         } catch {
             return urlRequest
         }

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -403,8 +403,8 @@ class DownloadResumeDataTestCase: BaseTestCase {
 
         // When
         let download = Alamofire.download(urlString)
-        download.downloadProgress { _, _, _ in
-            download.cancel()
+        download.downloadProgress { _, totalBytesReceived, _ in
+            if totalBytesReceived > 10_000 { download.cancel() }
         }
         download.response { resp in
             response = resp
@@ -420,7 +420,7 @@ class DownloadResumeDataTestCase: BaseTestCase {
         XCTAssertNotNil(response?.resumeData)
         XCTAssertNotNil(response?.error)
 
-        XCTAssertNotNil(download.resumeData, "resume data should not be nil")
+        XCTAssertNotNil(download.resumeData)
 
         if let responseResumeData = response?.resumeData, let resumeData = download.resumeData {
             XCTAssertEqual(responseResumeData, resumeData)
@@ -436,8 +436,8 @@ class DownloadResumeDataTestCase: BaseTestCase {
 
         // When
         let download = Alamofire.download(urlString)
-        download.downloadProgress { _, _, _ in
-            download.cancel()
+        download.downloadProgress { _, totalBytesReceived, _ in
+            if totalBytesReceived > 10_000 { download.cancel() }
         }
         download.responseJSON { resp in
             response = resp

--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -36,7 +36,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
 
     // MARK: Properties
 
-    let encoding: ParameterEncoding = .url
+    let encoding = URLEncoding.default
 
     // MARK: Tests - Parameter Types
 
@@ -547,7 +547,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["foo": 1, "bar": 2]
 
             // When
-            let urlRequest = try ParameterEncoding.urlEncodedInURL.encode(mutableURLRequest, with: parameters)
+            let urlRequest = try URLEncoding.queryString.encode(mutableURLRequest, with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "bar=2&foo=1")
@@ -564,7 +564,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
 class JSONParameterEncodingTestCase: ParameterEncodingTestCase {
     // MARK: Properties
 
-    let encoding: ParameterEncoding = .json
+    let encoding = JSONEncoding.default
 
     // MARK: Tests
 
@@ -649,7 +649,7 @@ class JSONParameterEncodingTestCase: ParameterEncodingTestCase {
 class PropertyListParameterEncodingTestCase: ParameterEncodingTestCase {
     // MARK: Properties
 
-    let encoding: ParameterEncoding = .propertyList(.xml, 0)
+    let encoding = PropertyListEncoding.default
 
     // MARK: Tests
 
@@ -758,44 +758,6 @@ class PropertyListParameterEncodingTestCase: ParameterEncodingTestCase {
             // Then
             XCTAssertNil(urlRequest.url?.query)
             XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/custom-plist-type+plist")
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
-    }
-}
-
-// MARK: -
-
-class CustomParameterEncodingTestCase: ParameterEncodingTestCase {
-
-    // MARK: Tests
-
-    func testCustomParameterEncode() {
-        do {
-            // Given
-            let encodingClosure: (URLRequestConvertible, [String: Any]?) throws -> URLRequest = { urlRequest, parameters in
-                guard let parameters = parameters else { return urlRequest.urlRequest }
-
-                var urlString = urlRequest.urlRequest.urlString + "?"
-
-                parameters.forEach { urlString += "\($0)=\($1)" }
-
-                var mutableURLRequest = urlRequest.urlRequest
-                mutableURLRequest.url = URL(string: urlString)!
-
-                return mutableURLRequest
-            }
-
-            // When
-            let encoding: ParameterEncoding = .custom(encodingClosure)
-
-            // Then
-            let url = URL(string: "https://example.com")!
-            let urlRequest = URLRequest(url: url)
-            let parameters = ["foo": "bar"]
-
-            let result = try encoding.encode(urlRequest, with: parameters)
-            XCTAssertEqual(result.urlString, "https://example.com?foo=bar")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }

--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -41,402 +41,524 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
     // MARK: Tests - Parameter Types
 
     func testURLParameterEncodeNilParameters() {
-        // Given, When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: nil)
+        do {
+            // Given, When
+            let urlRequest = try encoding.encode(self.urlRequest, with: nil)
 
-        // Then
-        XCTAssertNil(urlRequest.url?.query, "query should be nil")
+            // Then
+            XCTAssertNil(urlRequest.url?.query, "query should be nil")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeEmptyDictionaryParameter() {
-        // Given
-        let parameters: [String: Any] = [:]
+        do {
+            // Given
+            let parameters: [String: Any] = [:]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertNil(urlRequest.url?.query, "query should be nil")
+            // Then
+            XCTAssertNil(urlRequest.url?.query, "query should be nil")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeOneStringKeyStringValueParameter() {
-        // Given
-        let parameters = ["foo": "bar"]
+        do {
+            // Given
+            let parameters = ["foo": "bar"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "foo=bar", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=bar", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeOneStringKeyStringValueParameterAppendedToQuery() {
-        // Given
-        var mutableURLRequest = self.urlRequest.urlRequest
-        var urlComponents = URLComponents(url: mutableURLRequest.url!, resolvingAgainstBaseURL: false)!
-        urlComponents.query = "baz=qux"
-        mutableURLRequest.url = urlComponents.url
+        do {
+            // Given
+            var mutableURLRequest = self.urlRequest.urlRequest
+            var urlComponents = URLComponents(url: mutableURLRequest.url!, resolvingAgainstBaseURL: false)!
+            urlComponents.query = "baz=qux"
+            mutableURLRequest.url = urlComponents.url
 
-        let parameters = ["foo": "bar"]
+            let parameters = ["foo": "bar"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(mutableURLRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(mutableURLRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "baz=qux&foo=bar", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "baz=qux&foo=bar", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeTwoStringKeyStringValueParameters() {
-        // Given
-        let parameters = ["foo": "bar", "baz": "qux"]
+        do {
+            // Given
+            let parameters = ["foo": "bar", "baz": "qux"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "baz=qux&foo=bar", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "baz=qux&foo=bar", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringKeyIntegerValueParameter() {
-        // Given
-        let parameters = ["foo": 1]
+        do {
+            // Given
+            let parameters = ["foo": 1]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "foo=1", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=1", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringKeyDoubleValueParameter() {
-        // Given
-        let parameters = ["foo": 1.1]
+        do {
+            // Given
+            let parameters = ["foo": 1.1]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "foo=1.1", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=1.1", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringKeyBoolValueParameter() {
-        // Given
-        let parameters = ["foo": true]
+        do {
+            // Given
+            let parameters = ["foo": true]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "foo=1", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=1", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringKeyArrayValueParameter() {
-        // Given
-        let parameters = ["foo": ["a", 1, true]]
+        do {
+            // Given
+            let parameters = ["foo": ["a", 1, true]]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "foo%5B%5D=a&foo%5B%5D=1&foo%5B%5D=1", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "foo%5B%5D=a&foo%5B%5D=1&foo%5B%5D=1", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringKeyDictionaryValueParameter() {
-        // Given
-        let parameters = ["foo": ["bar": 1]]
+        do {
+            // Given
+            let parameters = ["foo": ["bar": 1]]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "foo%5Bbar%5D=1", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "foo%5Bbar%5D=1", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringKeyNestedDictionaryValueParameter() {
-        // Given
-        let parameters = ["foo": ["bar": ["baz": 1]]]
+        do {
+            // Given
+            let parameters = ["foo": ["bar": ["baz": 1]]]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "foo%5Bbar%5D%5Bbaz%5D=1", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "foo%5Bbar%5D%5Bbaz%5D=1", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringKeyNestedDictionaryArrayValueParameter() {
-        // Given
-        let parameters = ["foo": ["bar": ["baz": ["a", 1, true]]]]
+        do {
+            // Given
+            let parameters = ["foo": ["bar": ["baz": ["a", 1, true]]]]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        let expectedQuery = "foo%5Bbar%5D%5Bbaz%5D%5B%5D=a&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1"
-        XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+            // Then
+            let expectedQuery = "foo%5Bbar%5D%5Bbaz%5D%5B%5D=a&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1"
+            XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     // MARK: Tests - All Reserved / Unreserved / Illegal Characters According to RFC 3986
 
     func testThatReservedCharactersArePercentEscapedMinusQuestionMarkAndForwardSlash() {
-        // Given
-        let generalDelimiters = ":#[]@"
-        let subDelimiters = "!$&'()*+,;="
-        let parameters = ["reserved": "\(generalDelimiters)\(subDelimiters)"]
+        do {
+            // Given
+            let generalDelimiters = ":#[]@"
+            let subDelimiters = "!$&'()*+,;="
+            let parameters = ["reserved": "\(generalDelimiters)\(subDelimiters)"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        let expectedQuery = "reserved=%3A%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D"
-        XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+            // Then
+            let expectedQuery = "reserved=%3A%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D"
+            XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testThatReservedCharactersQuestionMarkAndForwardSlashAreNotPercentEscaped() {
-        // Given
-        let parameters = ["reserved": "?/"]
+        do {
+            // Given
+            let parameters = ["reserved": "?/"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "reserved=?/", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "reserved=?/", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testThatUnreservedNumericCharactersAreNotPercentEscaped() {
-        // Given
-        let parameters = ["numbers": "0123456789"]
+        do {
+            // Given
+            let parameters = ["numbers": "0123456789"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "numbers=0123456789", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "numbers=0123456789", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testThatUnreservedLowercaseCharactersAreNotPercentEscaped() {
-        // Given
-        let parameters = ["lowercase": "abcdefghijklmnopqrstuvwxyz"]
+        do {
+            // Given
+            let parameters = ["lowercase": "abcdefghijklmnopqrstuvwxyz"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "lowercase=abcdefghijklmnopqrstuvwxyz", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "lowercase=abcdefghijklmnopqrstuvwxyz", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testThatUnreservedUppercaseCharactersAreNotPercentEscaped() {
-        // Given
-        let parameters = ["uppercase": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"]
+        do {
+            // Given
+            let parameters = ["uppercase": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "uppercase=ABCDEFGHIJKLMNOPQRSTUVWXYZ", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "uppercase=ABCDEFGHIJKLMNOPQRSTUVWXYZ", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testThatIllegalASCIICharactersArePercentEscaped() {
-        // Given
-        let parameters = ["illegal": " \"#%<>[]\\^`{}|"]
+        do {
+            // Given
+            let parameters = ["illegal": " \"#%<>[]\\^`{}|"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        let expectedQuery = "illegal=%20%22%23%25%3C%3E%5B%5D%5C%5E%60%7B%7D%7C"
-        XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+            // Then
+            let expectedQuery = "illegal=%20%22%23%25%3C%3E%5B%5D%5C%5E%60%7B%7D%7C"
+            XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     // MARK: Tests - Special Character Queries
 
     func testURLParameterEncodeStringWithAmpersandKeyStringWithAmpersandValueParameter() {
-        // Given
-        let parameters = ["foo&bar": "baz&qux", "foobar": "bazqux"]
+        do {
+            // Given
+            let parameters = ["foo&bar": "baz&qux", "foobar": "bazqux"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "foo%26bar=baz%26qux&foobar=bazqux", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "foo%26bar=baz%26qux&foobar=bazqux", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringWithQuestionMarkKeyStringWithQuestionMarkValueParameter() {
-        // Given
-        let parameters = ["?foo?": "?bar?"]
+        do {
+            // Given
+            let parameters = ["?foo?": "?bar?"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "?foo?=?bar?", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "?foo?=?bar?", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringWithSlashKeyStringWithQuestionMarkValueParameter() {
-        // Given
-        let parameters = ["foo": "/bar/baz/qux"]
+        do {
+            // Given
+            let parameters = ["foo": "/bar/baz/qux"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "foo=/bar/baz/qux", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=/bar/baz/qux", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringWithSpaceKeyStringWithSpaceValueParameter() {
-        // Given
-        let parameters = [" foo ": " bar "]
+        do {
+            // Given
+            let parameters = [" foo ": " bar "]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "%20foo%20=%20bar%20", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "%20foo%20=%20bar%20", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringWithPlusKeyStringWithPlusValueParameter() {
-        // Given
-        let parameters = ["+foo+": "+bar+"]
+        do {
+            // Given
+            let parameters = ["+foo+": "+bar+"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "%2Bfoo%2B=%2Bbar%2B", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "%2Bfoo%2B=%2Bbar%2B", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringKeyPercentEncodedStringValueParameter() {
-        // Given
-        let parameters = ["percent": "%25"]
+        do {
+            // Given
+            let parameters = ["percent": "%25"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "percent=%2525", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "percent=%2525", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringKeyNonLatinStringValueParameter() {
-        // Given
-        let parameters = [
-            "french": "français",
-            "japanese": "日本語",
-            "arabic": "العربية",
-            "emoji": "😃"
-        ]
+        do {
+            // Given
+            let parameters = [
+                "french": "français",
+                "japanese": "日本語",
+                "arabic": "العربية",
+                "emoji": "😃"
+            ]
 
-        // When
-        let (urlRequest, _) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        let expectedParameterValues = [
-            "arabic=%D8%A7%D9%84%D8%B9%D8%B1%D8%A8%D9%8A%D8%A9",
-            "emoji=%F0%9F%98%83",
-            "french=fran%C3%A7ais",
-            "japanese=%E6%97%A5%E6%9C%AC%E8%AA%9E"
-        ]
+            // Then
+            let expectedParameterValues = [
+                "arabic=%D8%A7%D9%84%D8%B9%D8%B1%D8%A8%D9%8A%D8%A9",
+                "emoji=%F0%9F%98%83",
+                "french=fran%C3%A7ais",
+                "japanese=%E6%97%A5%E6%9C%AC%E8%AA%9E"
+            ]
 
-        let expectedQuery = expectedParameterValues.joined(separator: "&")
-        XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+            let expectedQuery = expectedParameterValues.joined(separator: "&")
+            XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringForRequestWithPrecomposedQuery() {
-        // Given
-        let url = URL(string: "https://example.com/movies?hd=[1]")!
-        let parameters = ["page": "0"]
+        do {
+            // Given
+            let url = URL(string: "https://example.com/movies?hd=[1]")!
+            let parameters = ["page": "0"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(URLRequest(url: url), parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(URLRequest(url: url), with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "hd=%5B1%5D&page=0", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "hd=%5B1%5D&page=0", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringWithPlusKeyStringWithPlusValueParameterForRequestWithPrecomposedQuery() {
-        // Given
-        let url = URL(string: "https://example.com/movie?hd=[1]")!
-        let parameters = ["+foo+": "+bar+"]
+        do {
+            // Given
+            let url = URL(string: "https://example.com/movie?hd=[1]")!
+            let parameters = ["+foo+": "+bar+"]
 
-        // When
-        let (urlRequest, _) = encoding.encode(URLRequest(url: url), parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(URLRequest(url: url), with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "hd=%5B1%5D&%2Bfoo%2B=%2Bbar%2B", "query is incorrect")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "hd=%5B1%5D&%2Bfoo%2B=%2Bbar%2B", "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testURLParameterEncodeStringWithThousandsOfChineseCharacters() {
-        // Given
-        let repeatedCount = 2_000
-        let url = URL(string: "https://example.com/movies")!
-        let parameters = ["chinese": String(count: repeatedCount, repeatedString: "一二三四五六七八九十")]
+        do {
+            // Given
+            let repeatedCount = 2_000
+            let url = URL(string: "https://example.com/movies")!
+            let parameters = ["chinese": String(count: repeatedCount, repeatedString: "一二三四五六七八九十")]
 
-        // When
-        let (urlRequest, _) = encoding.encode(URLRequest(url: url), parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(URLRequest(url: url), with: parameters)
 
-        // Then
-        var expected = "chinese="
-        for _ in 0..<repeatedCount {
-            expected += "%E4%B8%80%E4%BA%8C%E4%B8%89%E5%9B%9B%E4%BA%94%E5%85%AD%E4%B8%83%E5%85%AB%E4%B9%9D%E5%8D%81"
+            // Then
+            var expected = "chinese="
+
+            for _ in 0..<repeatedCount {
+                expected += "%E4%B8%80%E4%BA%8C%E4%B8%89%E5%9B%9B%E4%BA%94%E5%85%AD%E4%B8%83%E5%85%AB%E4%B9%9D%E5%8D%81"
+            }
+
+            XCTAssertEqual(urlRequest.url?.query ?? "", expected, "query is incorrect")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
         }
-        XCTAssertEqual(urlRequest.url?.query ?? "", expected, "query is incorrect")
     }
 
     // MARK: Tests - Varying HTTP Methods
 
     func testThatURLParameterEncodingEncodesGETParametersInURL() {
-        // Given
-        var mutableURLRequest = self.urlRequest.urlRequest
-        mutableURLRequest.httpMethod = HTTPMethod.get.rawValue
-        let parameters = ["foo": 1, "bar": 2]
+        do {
+            // Given
+            var mutableURLRequest = self.urlRequest.urlRequest
+            mutableURLRequest.httpMethod = HTTPMethod.get.rawValue
+            let parameters = ["foo": 1, "bar": 2]
 
-        // When
-        let (urlRequest, _) = encoding.encode(mutableURLRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(mutableURLRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "bar=2&foo=1", "query is incorrect")
-        XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
-        XCTAssertNil(urlRequest.httpBody, "HTTPBody should be nil")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "bar=2&foo=1", "query is incorrect")
+            XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
+            XCTAssertNil(urlRequest.httpBody, "HTTPBody should be nil")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testThatURLParameterEncodingEncodesPOSTParametersInHTTPBody() {
-        // Given
-        var mutableURLRequest = self.urlRequest.urlRequest
-        mutableURLRequest.httpMethod = HTTPMethod.post.rawValue
-        let parameters = ["foo": 1, "bar": 2]
+        do {
+            // Given
+            var mutableURLRequest = self.urlRequest.urlRequest
+            mutableURLRequest.httpMethod = HTTPMethod.post.rawValue
+            let parameters = ["foo": 1, "bar": 2]
 
-        // When
-        let (urlRequest, _) = encoding.encode(mutableURLRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(mutableURLRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(
-            urlRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
-            "application/x-www-form-urlencoded; charset=utf-8",
-            "Content-Type should be application/x-www-form-urlencoded"
-        )
-        XCTAssertNotNil(urlRequest.httpBody, "HTTPBody should not be nil")
+            // Then
+            XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded; charset=utf-8")
+            XCTAssertNotNil(urlRequest.httpBody, "HTTPBody should not be nil")
 
-        if
-            let httpBody = urlRequest.httpBody,
-            let decodedHTTPBody = String(data: httpBody, encoding: String.Encoding.utf8)
-        {
-            XCTAssertEqual(decodedHTTPBody, "bar=2&foo=1", "HTTPBody is incorrect")
-        } else {
-            XCTFail("decoded http body should not be nil")
+            if
+                let httpBody = urlRequest.httpBody,
+                let decodedHTTPBody = String(data: httpBody, encoding: String.Encoding.utf8)
+            {
+                XCTAssertEqual(decodedHTTPBody, "bar=2&foo=1", "HTTPBody is incorrect")
+            } else {
+                XCTFail("decoded http body should not be nil")
+            }
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
         }
     }
 
     func testThatURLEncodedInURLParameterEncodingEncodesPOSTParametersInURL() {
-        // Given
-        var mutableURLRequest = self.urlRequest.urlRequest
-        mutableURLRequest.httpMethod = HTTPMethod.post.rawValue
-        let parameters = ["foo": 1, "bar": 2]
+        do {
+            // Given
+            var mutableURLRequest = self.urlRequest.urlRequest
+            mutableURLRequest.httpMethod = HTTPMethod.post.rawValue
+            let parameters = ["foo": 1, "bar": 2]
 
-        // When
-        let (urlRequest, _) = ParameterEncoding.urlEncodedInURL.encode(mutableURLRequest, parameters: parameters)
+            // When
+            let urlRequest = try ParameterEncoding.urlEncodedInURL.encode(mutableURLRequest, with: parameters)
 
-        // Then
-        XCTAssertEqual(urlRequest.url?.query ?? "", "bar=2&foo=1", "query is incorrect")
-        XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
-        XCTAssertNil(urlRequest.httpBody, "HTTPBody should be nil")
+            // Then
+            XCTAssertEqual(urlRequest.url?.query ?? "", "bar=2&foo=1", "query is incorrect")
+            XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
+            XCTAssertNil(urlRequest.httpBody, "HTTPBody should be nil")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 }
 
@@ -450,73 +572,82 @@ class JSONParameterEncodingTestCase: ParameterEncodingTestCase {
     // MARK: Tests
 
     func testJSONParameterEncodeNilParameters() {
-        // Given, When
-        let (URLRequest, error) = encoding.encode(self.urlRequest, parameters: nil)
+        do {
+            // Given, When
+            let URLRequest = try encoding.encode(self.urlRequest, with: nil)
 
-        // Then
-        XCTAssertNil(error, "error should be nil")
-        XCTAssertNil(URLRequest.url?.query, "query should be nil")
-        XCTAssertNil(URLRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
-        XCTAssertNil(URLRequest.httpBody, "HTTPBody should be nil")
+            // Then
+            XCTAssertNil(URLRequest.url?.query, "query should be nil")
+            XCTAssertNil(URLRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
+            XCTAssertNil(URLRequest.httpBody, "HTTPBody should be nil")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testJSONParameterEncodeComplexParameters() {
-        // Given
-        let parameters: [String: Any] = [
-            "foo": "bar",
-            "baz": ["a", 1, true],
-            "qux": [
-                "a": 1,
-                "b": [2, 2],
-                "c": [3, 3, 3]
+        do {
+            // Given
+            let parameters: [String: Any] = [
+                "foo": "bar",
+                "baz": ["a", 1, true],
+                "qux": [
+                    "a": 1,
+                    "b": [2, 2],
+                    "c": [3, 3, 3]
+                ]
             ]
-        ]
 
-        // When
-        let (URLRequest, error) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let URLRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertNil(error, "error should be nil")
-        XCTAssertNil(URLRequest.url?.query, "query should be nil")
-        XCTAssertNotNil(URLRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should not be nil")
-        XCTAssertEqual(
-            URLRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
-            "application/json",
-            "Content-Type should be application/json"
-        )
-        XCTAssertNotNil(URLRequest.httpBody, "HTTPBody should not be nil")
+            // Then
+            XCTAssertNil(URLRequest.url?.query, "query should be nil")
+            XCTAssertNotNil(URLRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should not be nil")
+            XCTAssertEqual(
+                URLRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
+                "application/json",
+                "Content-Type should be application/json"
+            )
+            XCTAssertNotNil(URLRequest.httpBody, "HTTPBody should not be nil")
 
-        if let HTTPBody = URLRequest.httpBody {
-            do {
-                let JSON = try JSONSerialization.jsonObject(with: HTTPBody, options: .allowFragments)
+            if let HTTPBody = URLRequest.httpBody {
+                do {
+                    let JSON = try JSONSerialization.jsonObject(with: HTTPBody, options: .allowFragments)
 
-                if let JSON = JSON as? NSObject {
-                    XCTAssertEqual(JSON, parameters as NSObject, "HTTPBody JSON does not equal parameters")
-                } else {
-                    XCTFail("JSON should be an NSObject")
+                    if let JSON = JSON as? NSObject {
+                        XCTAssertEqual(JSON, parameters as NSObject, "HTTPBody JSON does not equal parameters")
+                    } else {
+                        XCTFail("JSON should be an NSObject")
+                    }
+                } catch {
+                    XCTFail("JSON should not be nil")
                 }
-            } catch {
+            } else {
                 XCTFail("JSON should not be nil")
             }
-        } else {
-            XCTFail("JSON should not be nil")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
         }
     }
 
     func testJSONParameterEncodeParametersRetainsCustomContentType() {
-        // Given
-        var mutableURLRequest = URLRequest(url: URL(string: "https://example.com/")!)
-        mutableURLRequest.setValue("application/custom-json-type+json", forHTTPHeaderField: "Content-Type")
+        do {
+            // Given
+            var mutableURLRequest = URLRequest(url: URL(string: "https://example.com/")!)
+            mutableURLRequest.setValue("application/custom-json-type+json", forHTTPHeaderField: "Content-Type")
 
-        let parameters = ["foo": "bar"]
+            let parameters = ["foo": "bar"]
 
-        // When
-        let (urlRequest, error) = encoding.encode(mutableURLRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(mutableURLRequest, with: parameters)
 
-        // Then
-        XCTAssertNil(error)
-        XCTAssertNil(urlRequest.url?.query)
-        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/custom-json-type+json")
+            // Then
+            XCTAssertNil(urlRequest.url?.query)
+            XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/custom-json-type+json")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 }
 
@@ -530,117 +661,129 @@ class PropertyListParameterEncodingTestCase: ParameterEncodingTestCase {
     // MARK: Tests
 
     func testPropertyListParameterEncodeNilParameters() {
-        // Given, When
-        let (URLRequest, error) = encoding.encode(self.urlRequest, parameters: nil)
+        do {
+            // Given, When
+            let urlRequest = try encoding.encode(self.urlRequest, with: nil)
 
-        // Then
-        XCTAssertNil(error, "error should be nil")
-        XCTAssertNil(URLRequest.url?.query, "query should be nil")
-        XCTAssertNil(URLRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
-        XCTAssertNil(URLRequest.httpBody, "HTTPBody should be nil")
+            // Then
+            XCTAssertNil(urlRequest.url?.query, "query should be nil")
+            XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
+            XCTAssertNil(urlRequest.httpBody, "HTTPBody should be nil")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 
     func testPropertyListParameterEncodeComplexParameters() {
-        // Given
-        let parameters: [String: Any] = [
-            "foo": "bar",
-            "baz": ["a", 1, true],
-            "qux": [
-                "a": 1,
-                "b": [2, 2],
-                "c": [3, 3, 3]
+        do {
+            // Given
+            let parameters: [String: Any] = [
+                "foo": "bar",
+                "baz": ["a", 1, true],
+                "qux": [
+                    "a": 1,
+                    "b": [2, 2],
+                    "c": [3, 3, 3]
+                ]
             ]
-        ]
 
-        // When
-        let (URLRequest, error) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertNil(error, "error should be nil")
-        XCTAssertNil(URLRequest.url?.query, "query should be nil")
-        XCTAssertNotNil(URLRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should not be nil")
-        XCTAssertEqual(
-            URLRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
-            "application/x-plist",
-            "Content-Type should be application/x-plist"
-        )
-        XCTAssertNotNil(URLRequest.httpBody, "HTTPBody should not be nil")
+            // Then
+            XCTAssertNil(urlRequest.url?.query, "query should be nil")
+            XCTAssertNotNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should not be nil")
+            XCTAssertEqual(
+                urlRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
+                "application/x-plist",
+                "Content-Type should be application/x-plist"
+            )
+            XCTAssertNotNil(urlRequest.httpBody, "HTTPBody should not be nil")
 
-        if let HTTPBody = URLRequest.httpBody {
-            do {
-                let plist = try PropertyListSerialization.propertyList(
-                    from: HTTPBody,
-                    options: PropertyListSerialization.MutabilityOptions(),
-                    format: nil
-                )
+            if let HTTPBody = urlRequest.httpBody {
+                do {
+                    let plist = try PropertyListSerialization.propertyList(
+                        from: HTTPBody,
+                        options: PropertyListSerialization.MutabilityOptions(),
+                        format: nil
+                    )
 
-                if let plist = plist as? NSObject {
-                    XCTAssertEqual(plist, parameters as NSObject, "HTTPBody plist does not equal parameters")
-                } else {
-                    XCTFail("plist should be an NSObject")
+                    if let plist = plist as? NSObject {
+                        XCTAssertEqual(plist, parameters as NSObject, "HTTPBody plist does not equal parameters")
+                    } else {
+                        XCTFail("plist should be an NSObject")
+                    }
+                } catch {
+                    XCTFail("plist should not be nil")
                 }
-            } catch {
-                XCTFail("plist should not be nil")
             }
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
         }
     }
 
     func testPropertyListParameterEncodeDateAndDataParameters() {
-        // Given
-        let date: Date = Date()
-        let data: Data = "data".data(using: String.Encoding.utf8, allowLossyConversion: false)!
+        do {
+            // Given
+            let date: Date = Date()
+            let data: Data = "data".data(using: String.Encoding.utf8, allowLossyConversion: false)!
 
-        let parameters: [String: Any] = [
-            "date": date,
-            "data": data
-        ]
+            let parameters: [String: Any] = [
+                "date": date,
+                "data": data
+            ]
 
-        // When
-        let (urlRequest, error) = encoding.encode(self.urlRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
-        // Then
-        XCTAssertNil(error, "error should be nil")
-        XCTAssertNil(urlRequest.url?.query, "query should be nil")
-        XCTAssertNotNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should not be nil")
-        XCTAssertEqual(
-            urlRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
-            "application/x-plist",
-            "Content-Type should be application/x-plist"
-        )
-        XCTAssertNotNil(urlRequest.httpBody, "HTTPBody should not be nil")
+            // Then
+            XCTAssertNil(urlRequest.url?.query, "query should be nil")
+            XCTAssertNotNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should not be nil")
+            XCTAssertEqual(
+                urlRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
+                "application/x-plist",
+                "Content-Type should be application/x-plist"
+            )
+            XCTAssertNotNil(urlRequest.httpBody, "HTTPBody should not be nil")
 
-        if let HTTPBody = urlRequest.httpBody {
-            do {
-                let plist = try PropertyListSerialization.propertyList(
-                    from: HTTPBody,
-                    options: PropertyListSerialization.MutabilityOptions(),
-                    format: nil
-                ) as AnyObject
+            if let HTTPBody = urlRequest.httpBody {
+                do {
+                    let plist = try PropertyListSerialization.propertyList(
+                        from: HTTPBody,
+                        options: PropertyListSerialization.MutabilityOptions(),
+                        format: nil
+                        ) as AnyObject
 
-                XCTAssertTrue(plist.value(forKey: "date") is Date, "date is not Date")
-                XCTAssertTrue(plist.value(forKey: "data") is Data, "data is not Data")
-            } catch {
-                XCTFail("plist should not be nil")
+                    XCTAssertTrue(plist.value(forKey: "date") is Date, "date is not Date")
+                    XCTAssertTrue(plist.value(forKey: "data") is Data, "data is not Data")
+                } catch {
+                    XCTFail("plist should not be nil")
+                }
+            } else {
+                XCTFail("HTTPBody should not be nil")
             }
-        } else {
-            XCTFail("HTTPBody should not be nil")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
         }
     }
 
     func testPropertyListParameterEncodeParametersRetainsCustomContentType() {
-        // Given
-        var mutableURLRequest = URLRequest(url: URL(string: "https://example.com/")!)
-        mutableURLRequest.setValue("application/custom-plist-type+plist", forHTTPHeaderField: "Content-Type")
+        do {
+            // Given
+            var mutableURLRequest = URLRequest(url: URL(string: "https://example.com/")!)
+            mutableURLRequest.setValue("application/custom-plist-type+plist", forHTTPHeaderField: "Content-Type")
 
-        let parameters = ["foo": "bar"]
+            let parameters = ["foo": "bar"]
 
-        // When
-        let (urlRequest, error) = encoding.encode(mutableURLRequest, parameters: parameters)
+            // When
+            let urlRequest = try encoding.encode(mutableURLRequest, with: parameters)
 
-        // Then
-        XCTAssertNil(error)
-        XCTAssertNil(urlRequest.url?.query)
-        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/custom-plist-type+plist")
+            // Then
+            XCTAssertNil(urlRequest.url?.query)
+            XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/custom-plist-type+plist")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
     }
 }
 
@@ -651,29 +794,33 @@ class CustomParameterEncodingTestCase: ParameterEncodingTestCase {
     // MARK: Tests
 
     func testCustomParameterEncode() {
-        // Given
-        let encodingClosure: (URLRequestConvertible, [String: Any]?) -> (URLRequest, Error?) = { urlRequest, parameters in
-            guard let parameters = parameters else { return (urlRequest.urlRequest, nil) }
+        do {
+            // Given
+            let encodingClosure: (URLRequestConvertible, [String: Any]?) throws -> URLRequest = { urlRequest, parameters in
+                guard let parameters = parameters else { return urlRequest.urlRequest }
 
-            var urlString = urlRequest.urlRequest.urlString + "?"
+                var urlString = urlRequest.urlRequest.urlString + "?"
 
-            parameters.forEach { urlString += "\($0)=\($1)" }
+                parameters.forEach { urlString += "\($0)=\($1)" }
 
-            var mutableURLRequest = urlRequest.urlRequest
-            mutableURLRequest.url = URL(string: urlString)!
+                var mutableURLRequest = urlRequest.urlRequest
+                mutableURLRequest.url = URL(string: urlString)!
 
-            return (mutableURLRequest, nil)
+                return mutableURLRequest
+            }
+
+            // When
+            let encoding: ParameterEncoding = .custom(encodingClosure)
+
+            // Then
+            let url = URL(string: "https://example.com")!
+            let urlRequest = URLRequest(url: url)
+            let parameters = ["foo": "bar"]
+            
+            let result = try encoding.encode(urlRequest, with: parameters)
+            XCTAssertEqual(result.urlString, "https://example.com?foo=bar")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
         }
-
-        // When
-        let encoding: ParameterEncoding = .custom(encodingClosure)
-
-        // Then
-        let url = URL(string: "https://example.com")!
-        let urlRequest = URLRequest(url: url)
-        let parameters = ["foo": "bar"]
-
-        let result = encoding.encode(urlRequest, parameters: parameters)
-        XCTAssertEqual(result.0.urlString, "https://example.com?foo=bar")
     }
 }

--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -46,7 +46,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: nil)
 
             // Then
-            XCTAssertNil(urlRequest.url?.query, "query should be nil")
+            XCTAssertNil(urlRequest.url?.query)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -61,7 +61,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertNil(urlRequest.url?.query, "query should be nil")
+            XCTAssertNil(urlRequest.url?.query)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -76,7 +76,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=bar", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "foo=bar")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -96,7 +96,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(mutableURLRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "baz=qux&foo=bar", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "baz=qux&foo=bar")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -111,7 +111,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "baz=qux&foo=bar", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "baz=qux&foo=bar")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -126,7 +126,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=1", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "foo=1")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -141,7 +141,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=1.1", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "foo=1.1")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -156,7 +156,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=1", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "foo=1")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -171,7 +171,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "foo%5B%5D=a&foo%5B%5D=1&foo%5B%5D=1", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "foo%5B%5D=a&foo%5B%5D=1&foo%5B%5D=1")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -186,7 +186,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "foo%5Bbar%5D=1", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "foo%5Bbar%5D=1")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -201,7 +201,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "foo%5Bbar%5D%5Bbaz%5D=1", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "foo%5Bbar%5D%5Bbaz%5D=1")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -217,7 +217,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
 
             // Then
             let expectedQuery = "foo%5Bbar%5D%5Bbaz%5D%5B%5D=a&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1"
-            XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, expectedQuery)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -237,7 +237,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
 
             // Then
             let expectedQuery = "reserved=%3A%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D"
-            XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, expectedQuery)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -252,7 +252,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "reserved=?/", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "reserved=?/")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -267,7 +267,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "numbers=0123456789", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "numbers=0123456789")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -282,7 +282,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "lowercase=abcdefghijklmnopqrstuvwxyz", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "lowercase=abcdefghijklmnopqrstuvwxyz")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -297,7 +297,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "uppercase=ABCDEFGHIJKLMNOPQRSTUVWXYZ", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "uppercase=ABCDEFGHIJKLMNOPQRSTUVWXYZ")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -313,7 +313,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
 
             // Then
             let expectedQuery = "illegal=%20%22%23%25%3C%3E%5B%5D%5C%5E%60%7B%7D%7C"
-            XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, expectedQuery)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -330,7 +330,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "foo%26bar=baz%26qux&foobar=bazqux", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "foo%26bar=baz%26qux&foobar=bazqux")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -345,7 +345,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "?foo?=?bar?", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "?foo?=?bar?")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -360,7 +360,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "foo=/bar/baz/qux", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "foo=/bar/baz/qux")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -375,7 +375,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "%20foo%20=%20bar%20", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "%20foo%20=%20bar%20")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -390,7 +390,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "%2Bfoo%2B=%2Bbar%2B", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "%2Bfoo%2B=%2Bbar%2B")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -405,7 +405,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "percent=%2525", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "percent=%2525")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -433,7 +433,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             ]
 
             let expectedQuery = expectedParameterValues.joined(separator: "&")
-            XCTAssertEqual(urlRequest.url?.query ?? "", expectedQuery, "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, expectedQuery)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -449,7 +449,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(URLRequest(url: url), with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "hd=%5B1%5D&page=0", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "hd=%5B1%5D&page=0")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -465,7 +465,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(URLRequest(url: url), with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "hd=%5B1%5D&%2Bfoo%2B=%2Bbar%2B", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "hd=%5B1%5D&%2Bfoo%2B=%2Bbar%2B")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -488,7 +488,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
                 expected += "%E4%B8%80%E4%BA%8C%E4%B8%89%E5%9B%9B%E4%BA%94%E5%85%AD%E4%B8%83%E5%85%AB%E4%B9%9D%E5%8D%81"
             }
 
-            XCTAssertEqual(urlRequest.url?.query ?? "", expected, "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, expected)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -507,7 +507,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(mutableURLRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "bar=2&foo=1", "query is incorrect")
+            XCTAssertEqual(urlRequest.url?.query, "bar=2&foo=1")
             XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
             XCTAssertNil(urlRequest.httpBody, "HTTPBody should be nil")
         } catch {
@@ -529,11 +529,8 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded; charset=utf-8")
             XCTAssertNotNil(urlRequest.httpBody, "HTTPBody should not be nil")
 
-            if
-                let httpBody = urlRequest.httpBody,
-                let decodedHTTPBody = String(data: httpBody, encoding: String.Encoding.utf8)
-            {
-                XCTAssertEqual(decodedHTTPBody, "bar=2&foo=1", "HTTPBody is incorrect")
+            if let httpBody = urlRequest.httpBody, let decodedHTTPBody = String(data: httpBody, encoding: .utf8) {
+                XCTAssertEqual(decodedHTTPBody, "bar=2&foo=1")
             } else {
                 XCTFail("decoded http body should not be nil")
             }
@@ -553,8 +550,8 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try ParameterEncoding.urlEncodedInURL.encode(mutableURLRequest, with: parameters)
 
             // Then
-            XCTAssertEqual(urlRequest.url?.query ?? "", "bar=2&foo=1", "query is incorrect")
-            XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
+            XCTAssertEqual(urlRequest.url?.query, "bar=2&foo=1")
+            XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"))
             XCTAssertNil(urlRequest.httpBody, "HTTPBody should be nil")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
@@ -578,7 +575,7 @@ class JSONParameterEncodingTestCase: ParameterEncodingTestCase {
 
             // Then
             XCTAssertNil(URLRequest.url?.query, "query should be nil")
-            XCTAssertNil(URLRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
+            XCTAssertNil(URLRequest.value(forHTTPHeaderField: "Content-Type"))
             XCTAssertNil(URLRequest.httpBody, "HTTPBody should be nil")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
@@ -602,29 +599,25 @@ class JSONParameterEncodingTestCase: ParameterEncodingTestCase {
             let URLRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertNil(URLRequest.url?.query, "query should be nil")
-            XCTAssertNotNil(URLRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should not be nil")
-            XCTAssertEqual(
-                URLRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
-                "application/json",
-                "Content-Type should be application/json"
-            )
-            XCTAssertNotNil(URLRequest.httpBody, "HTTPBody should not be nil")
+            XCTAssertNil(URLRequest.url?.query)
+            XCTAssertNotNil(URLRequest.value(forHTTPHeaderField: "Content-Type"))
+            XCTAssertEqual(URLRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
+            XCTAssertNotNil(URLRequest.httpBody)
 
-            if let HTTPBody = URLRequest.httpBody {
+            if let httpBody = URLRequest.httpBody {
                 do {
-                    let JSON = try JSONSerialization.jsonObject(with: HTTPBody, options: .allowFragments)
+                    let json = try JSONSerialization.jsonObject(with: httpBody, options: .allowFragments)
 
-                    if let JSON = JSON as? NSObject {
-                        XCTAssertEqual(JSON, parameters as NSObject, "HTTPBody JSON does not equal parameters")
+                    if let json = json as? NSObject {
+                        XCTAssertEqual(json, parameters as NSObject)
                     } else {
-                        XCTFail("JSON should be an NSObject")
+                        XCTFail("json should be an NSObject")
                     }
                 } catch {
-                    XCTFail("JSON should not be nil")
+                    XCTFail("json should not be nil")
                 }
             } else {
-                XCTFail("JSON should not be nil")
+                XCTFail("json should not be nil")
             }
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
@@ -666,9 +659,9 @@ class PropertyListParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: nil)
 
             // Then
-            XCTAssertNil(urlRequest.url?.query, "query should be nil")
-            XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should be nil")
-            XCTAssertNil(urlRequest.httpBody, "HTTPBody should be nil")
+            XCTAssertNil(urlRequest.url?.query)
+            XCTAssertNil(urlRequest.value(forHTTPHeaderField: "Content-Type"))
+            XCTAssertNil(urlRequest.httpBody)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
@@ -691,25 +684,17 @@ class PropertyListParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertNil(urlRequest.url?.query, "query should be nil")
-            XCTAssertNotNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should not be nil")
-            XCTAssertEqual(
-                urlRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
-                "application/x-plist",
-                "Content-Type should be application/x-plist"
-            )
-            XCTAssertNotNil(urlRequest.httpBody, "HTTPBody should not be nil")
+            XCTAssertNil(urlRequest.url?.query)
+            XCTAssertNotNil(urlRequest.value(forHTTPHeaderField: "Content-Type"))
+            XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/x-plist")
+            XCTAssertNotNil(urlRequest.httpBody)
 
-            if let HTTPBody = urlRequest.httpBody {
+            if let httpBody = urlRequest.httpBody {
                 do {
-                    let plist = try PropertyListSerialization.propertyList(
-                        from: HTTPBody,
-                        options: PropertyListSerialization.MutabilityOptions(),
-                        format: nil
-                    )
+                    let plist = try PropertyListSerialization.propertyList(from: httpBody, options: [], format: nil)
 
                     if let plist = plist as? NSObject {
-                        XCTAssertEqual(plist, parameters as NSObject, "HTTPBody plist does not equal parameters")
+                        XCTAssertEqual(plist, parameters as NSObject)
                     } else {
                         XCTFail("plist should be an NSObject")
                     }
@@ -737,25 +722,17 @@ class PropertyListParameterEncodingTestCase: ParameterEncodingTestCase {
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
 
             // Then
-            XCTAssertNil(urlRequest.url?.query, "query should be nil")
-            XCTAssertNotNil(urlRequest.value(forHTTPHeaderField: "Content-Type"), "Content-Type should not be nil")
-            XCTAssertEqual(
-                urlRequest.value(forHTTPHeaderField: "Content-Type") ?? "",
-                "application/x-plist",
-                "Content-Type should be application/x-plist"
-            )
-            XCTAssertNotNil(urlRequest.httpBody, "HTTPBody should not be nil")
+            XCTAssertNil(urlRequest.url?.query)
+            XCTAssertNotNil(urlRequest.value(forHTTPHeaderField: "Content-Type"))
+            XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/x-plist")
+            XCTAssertNotNil(urlRequest.httpBody)
 
-            if let HTTPBody = urlRequest.httpBody {
+            if let httpBody = urlRequest.httpBody {
                 do {
-                    let plist = try PropertyListSerialization.propertyList(
-                        from: HTTPBody,
-                        options: PropertyListSerialization.MutabilityOptions(),
-                        format: nil
-                        ) as AnyObject
+                    let plist = try PropertyListSerialization.propertyList(from: httpBody, options: [], format: nil) as AnyObject
 
-                    XCTAssertTrue(plist.value(forKey: "date") is Date, "date is not Date")
-                    XCTAssertTrue(plist.value(forKey: "data") is Data, "data is not Data")
+                    XCTAssertTrue(plist.value(forKey: "date") is Date)
+                    XCTAssertTrue(plist.value(forKey: "data") is Data)
                 } catch {
                     XCTFail("plist should not be nil")
                 }
@@ -816,7 +793,7 @@ class CustomParameterEncodingTestCase: ParameterEncodingTestCase {
             let url = URL(string: "https://example.com")!
             let urlRequest = URLRequest(url: url)
             let parameters = ["foo": "bar"]
-            
+
             let result = try encoding.encode(urlRequest, with: parameters)
             XCTAssertEqual(result.urlString, "https://example.com?foo=bar")
         } catch {

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -499,7 +499,7 @@ class RequestDebugDescriptionTestCase: BaseTestCase {
         ]
 
         // When
-        let request = manager.request(urlString, method: .post, parameters: parameters, encoding: .json)
+        let request = manager.request(urlString, method: .post, parameters: parameters, encoding: JSONEncoding.default)
         let components = cURLCommandComponents(for: request)
 
         // Then

--- a/Tests/URLProtocolTests.swift
+++ b/Tests/URLProtocolTests.swift
@@ -62,7 +62,7 @@ class ProxyURLProtocol: URLProtocol {
     override class func canonicalRequest(for request: URLRequest) -> URLRequest {
         if let headers = request.allHTTPHeaderFields {
             do {
-                return try ParameterEncoding.url.encode(request, with: headers)
+                return try URLEncoding.default.encode(request, with: headers)
             } catch {
                 return request
             }

--- a/Tests/URLProtocolTests.swift
+++ b/Tests/URLProtocolTests.swift
@@ -61,7 +61,11 @@ class ProxyURLProtocol: URLProtocol {
 
     override class func canonicalRequest(for request: URLRequest) -> URLRequest {
         if let headers = request.allHTTPHeaderFields {
-            return ParameterEncoding.url.encode(request, parameters: headers).0
+            do {
+                return try ParameterEncoding.url.encode(request, with: headers)
+            } catch {
+                return request
+            }
         }
 
         return request


### PR DESCRIPTION
This PR is an alternative to #1464 that goes WAY further in refactoring the `ParameterEncoding` logic into a protocol instead of an enumeration.

## Motivation

The `ParameterEncoding` enum hasn't been flexible enough to allow us to customize the behavior of a particular encoding type. For example, we had to introduce the new `.urlEncodedInURL` case just to allow users to be able to force the parameters into the query string when their backends required them to do so on a `POST` or `PUT`.

The enum also doesn't allow us to open up different writing options for the JSON and plist serializers. We can't customize plist formats, etc. The list goes on and on since we're locked to the enum that can't add extra cases or associated values in a backwards compatible manner.

## Solution

Get rid of the enumeration altogether! Now the `ParameterEncoding` type of a protocol backed by concrete `URL`, `JSON` and `PropertyList` conforming structs.

```swift
public typealias Parameters = [String: Any]

public protocol ParameterEncoding {
    func encode(_ urlRequest: URLRequestConvertible, with parameters: Parameters?) throws -> URLRequest
}
```

It was amazing after I split everything up how much sense it really makes. `ParameterEncoding` implementations are now free of the enumeration bounds and are free to customize to their own needs. 

### URLEncoding

The `.url` and `.urlEncodedInURL` cases have now been combined in the `URLEncoding` struct with some new enumerations and properties of it's own.

```swift
public struct URLEncoding: ParameterEncoding {
    public enum Destination {
        case methodDependent, queryString, httpBody
    }

    public static var `default`: URLEncoding { return URLEncoding() }
    public static var methodDependent: URLEncoding { return URLEncoding() }
    public static var queryString: URLEncoding { return URLEncoding(destination: .queryString) }
    public static var httpBody: URLEncoding { return URLEncoding(destination: .httpBody) }

    public let destination: Destination

    public init(destination: Destination = .methodDependent) {
        self.destination = destination
    }

    public func encode(_ urlRequest: URLRequestConvertible, with parameters: Parameters?) throws -> URLRequest {
        // left out for simplicity
    }
}
```

I added convenience properties for accessing instances without having to go through the initializer. This was a nice touch. We could actually hide the initializer if we wanted, but I figured that was a step too far.

### JSONEncoding

The `JSONEncoding` struct is much less complicated than the `URLEncoding` struct for obvious reasons.

> It's simpler!

```swift
public struct JSONEncoding: ParameterEncoding {
    public static var `default`: JSONEncoding { return JSONEncoding() }
    public static var prettyPrinted: JSONEncoding { return JSONEncoding(options: .prettyPrinted) }

    public let options: JSONSerialization.WritingOptions

    public init(options: JSONSerialization.WritingOptions = []) {
        self.options = options
    }

    public func encode(_ urlRequest: URLRequestConvertible, with parameters: Parameters?) throws -> URLRequest {
        // left out for simplicity
    }
}
```

### PropertyListEncoding

The `PropertyListEncoding` struct is very similar to the `JSONEncoding` struct, just with a few more properties.

```swift
public struct PropertyListEncoding: ParameterEncoding {
    public static var `default`: PropertyListEncoding { return PropertyListEncoding() }
    public static var xml: PropertyListEncoding { return PropertyListEncoding(format: .xml) }
    public static var binary: PropertyListEncoding { return PropertyListEncoding(format: .binary) }

    public let format: PropertyListSerialization.PropertyListFormat
    public let options: PropertyListSerialization.WriteOptions

    public init(
        format: PropertyListSerialization.PropertyListFormat = .xml,
        options: PropertyListSerialization.WriteOptions = 0)
    {
        self.format = format
        self.options = options
    }

    public func encode(_ urlRequest: URLRequestConvertible, with parameters: Parameters?) throws -> URLRequest {
        // left out for simplicity
    }
}
```

> If you noticed `default` and ` xml` are exact duplicate properties, bonus points for you. I wanted to follow the same `.default` property convention across all the `ParameterEncoding` types for consistency. That way at the call sight you can always use `<encoding_struct>.default` and know it will be there. _I wonder if that should be enforced in the protocol_ 🤔

### Wrapping Up Parameters with Encoding

So I tried for probably 2 hours to work the parameters and the encoding into a single type. I had `Parameters` as the protocol and `URLParameters`, `JSONParameters`, etc. and you'd create the object like `URLParameters(parameters)` and call it like so:

```swift
Alamofire.request(urlString, parameters: URLParameters(parameters)
```

Part of this was great because it got rid of the `encoding` parameter altogether which I was all for. However, it greatly increased the majority of our calls because it can't rely on the default parameter value of `.url` anymore. So we end up having to write `URLParameters(parameters)` everywhere instead of just `parameters`. Not to mention it just feels a little off.

Because of all of this, I finally decided enough was enough and it was just a square peg, round hole scenario. Once I backed away, I was able to finally land on the solution you see here.

### Throwing vs. Double Tuple

This also includes all the changes to the `encode` method itself which was part of the previous PR. These changes should definitely be adopted in AF 4. It's time to eliminate the last odd double optional case we have left! 🙌🏼🏆

---

## Summary

Overall, I think this is an awesome set of changes for AF 4. It makes it so much easier to create your own custom `ParameterEncoding` type. It also rids the world of the `.urlEncodedInURL` case that I sadly had to introduce a year ago.