### PR TITLE
better update for request

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -122,7 +122,7 @@ public func request(
     -> DataRequest
 {
     return SessionManager.default.request(
-        urlString,
+        url: urlString,
         method: method,
         parameters: parameters,
         encoding: encoding,

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -224,7 +224,7 @@ open class SessionManager {
     /// - returns: The created `DataRequest`.
     @discardableResult
     open func request(
-        _ urlString: URLStringConvertible,
+        url urlString: URLStringConvertible,
         method: HTTPMethod = .get,
         parameters: Parameters? = nil,
         encoding: ParameterEncoding = URLEncoding.default,

--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -68,7 +68,7 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .authenticate(user: "invalid", password: "credentials")
             .response { resp in
                 response = resp
@@ -92,7 +92,7 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .authenticate(user: user, password: password)
             .response { resp in
                 response = resp
@@ -123,7 +123,7 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString, headers: headers)
+        manager.request(url: urlString, headers: headers)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -157,7 +157,7 @@ class HTTPDigestAuthenticationTestCase: AuthenticationTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .authenticate(user: "invalid", password: "credentials")
             .response { resp in
                 response = resp
@@ -181,7 +181,7 @@ class HTTPDigestAuthenticationTestCase: AuthenticationTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .authenticate(user: user, password: password)
             .response { resp in
                 response = resp

--- a/Tests/CacheTests.swift
+++ b/Tests/CacheTests.swift
@@ -187,7 +187,7 @@ class CacheTestCase: BaseTestCase {
         -> URLRequest
     {
         let urlRequest = self.urlRequest(cacheControl: cacheControl, cachePolicy: cachePolicy)
-        let request = manager.request(urlRequest)
+        let request = manager.request(resource: urlRequest)
 
         request.response(
             queue: queue,

--- a/Tests/SessionDelegateTests.swift
+++ b/Tests/SessionDelegateTests.swift
@@ -76,7 +76,7 @@ class SessionDelegateTestCase: BaseTestCase {
         }
 
         // When
-        manager.request("https://httpbin.org/get").responseJSON { closureResponse in
+        manager.request(url: "https://httpbin.org/get").responseJSON { closureResponse in
             response = closureResponse.response
             expectation.fulfill()
         }
@@ -101,7 +101,7 @@ class SessionDelegateTestCase: BaseTestCase {
         }
 
         // When
-        manager.request("https://httpbin.org/get").responseJSON { closureResponse in
+        manager.request(url: "https://httpbin.org/get").responseJSON { closureResponse in
             response = closureResponse.response
             expectation.fulfill()
         }
@@ -125,7 +125,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -153,7 +153,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -188,7 +188,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -223,7 +223,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -258,7 +258,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -293,7 +293,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -337,7 +337,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -383,7 +383,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -435,7 +435,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        manager.request(urlString, headers: headers)
+        manager.request(url: urlString, headers: headers)
             .responseJSON { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -470,7 +470,7 @@ class SessionDelegateTestCase: BaseTestCase {
         }
 
         // When
-        manager.request("https://httpbin.org/get").responseJSON { closureResponse in
+        manager.request(url: "https://httpbin.org/get").responseJSON { closureResponse in
             response = closureResponse.response
             expectation.fulfill()
         }
@@ -495,7 +495,7 @@ class SessionDelegateTestCase: BaseTestCase {
         }
 
         // When
-        manager.request("https://httpbin.org/get").responseJSON { closureResponse in
+        manager.request(url: "https://httpbin.org/get").responseJSON { closureResponse in
             response = closureResponse.response
             expectation.fulfill()
         }

--- a/Tests/SessionManagerTests.swift
+++ b/Tests/SessionManagerTests.swift
@@ -235,7 +235,7 @@ class SessionManagerTestCase: BaseTestCase {
         var response: HTTPURLResponse?
 
         // When
-        manager.request(urlRequest)
+        manager.request(resource: urlRequest)
             .response { resp in
                 response = resp.response
                 expectation.fulfill()
@@ -260,7 +260,7 @@ class SessionManagerTestCase: BaseTestCase {
         let urlRequest = URLRequest(url: url)
 
         // When
-        let request = manager?.request(urlRequest)
+        let request = manager?.request(resource: urlRequest)
         manager = nil
 
         // Then
@@ -277,7 +277,7 @@ class SessionManagerTestCase: BaseTestCase {
         let urlRequest = URLRequest(url: url)
 
         // When
-        let request = manager!.request(urlRequest)
+        let request = manager!.request(resource: urlRequest)
         request.cancel()
         manager = nil
 
@@ -298,7 +298,7 @@ class SessionManagerTestCase: BaseTestCase {
         sessionManager.startRequestsImmediately = false
 
         // When
-        let request = sessionManager.request("https://httpbin.org/get")
+        let request = sessionManager.request(url: "https://httpbin.org/get")
 
         // Then
         XCTAssertEqual(request.task.originalRequest?.httpMethod, adapter.method.rawValue)
@@ -381,7 +381,7 @@ class SessionManagerTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        sessionManager.request("https://httpbin.org/basic-auth/user/password")
+        sessionManager.request(url: "https://httpbin.org/basic-auth/user/password")
             .validate()
             .responseJSON { jsonResponse in
                 response = jsonResponse
@@ -409,7 +409,7 @@ class SessionManagerTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        sessionManager.request("https://httpbin.org/basic-auth/user/password")
+        sessionManager.request(url: "https://httpbin.org/basic-auth/user/password")
             .validate()
             .responseJSON { jsonResponse in
                 response = jsonResponse
@@ -479,7 +479,7 @@ class SessionManagerConfigurationHeadersTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        manager.request("https://httpbin.org/headers")
+        manager.request(url: "https://httpbin.org/headers")
             .responseJSON { closureResponse in
                 response = closureResponse
                 expectation.fulfill()

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -84,7 +84,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -119,7 +119,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -155,7 +155,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -195,7 +195,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -229,7 +229,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -257,7 +257,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -285,7 +285,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -315,7 +315,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -349,7 +349,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -377,7 +377,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -405,7 +405,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -431,7 +431,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -463,7 +463,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()
@@ -493,7 +493,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         var error: Error?
 
         // When
-        manager.request(urlString)
+        manager.request(url: urlString)
             .response { resp in
                 error = resp.error
                 expectation?.fulfill()

--- a/Tests/URLProtocolTests.swift
+++ b/Tests/URLProtocolTests.swift
@@ -150,7 +150,7 @@ class URLProtocolTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlRequest)
+        manager.request(resource: urlRequest)
             .response { resp in
                 response = resp
                 expectation.fulfill()

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -419,7 +419,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
         var downloadResponse: DefaultDownloadResponse?
 
         // When
-        manager.request(urlString, method: .delete)
+        manager.request(url: urlString, method: .delete)
             .validate(contentType: ["*/*"])
             .response { resp in
                 requestResponse = resp


### PR DESCRIPTION
using `_` causes any existing code that called `request(urlRequest)` to
compile but potentially fail. because it needs to be updated to
`request(resource: request)` but this is not caught by the compiler
because `URLRequest` apparently conforms to `URLStringConvertible`.

This issue is evident in some of the tests, which compiled and actually
passed, but were in fact calling the wrong `request`. 

I added a test that would fail if the wrong `request` is called to
illustrate this point.