### PR TITLE
Make completion of RequestRetrier escaping

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -52,7 +52,7 @@ public protocol RequestRetrier {
     /// - parameter request:    The request that failed due to the encountered error.
     /// - parameter error:      The error encountered when executing the request.
     /// - parameter completion: The completion closure to be executed when retry decision has been determined.
-    func should(_ manager: SessionManager, retry request: Request, with error: Error, completion: RequestRetryCompletion)
+    func should(_ manager: SessionManager, retry request: Request, with error: Error, completion: @escaping RequestRetryCompletion)
 }
 
 // MARK: -


### PR DESCRIPTION
Allows the `RequestRetrier` to perform async work before executing the `completion` closure.

I’m in need of this since I’m using this a point to handle 401 errors and kick off re-authentication (refreshing the access token). Having those requests re-tried automatically once the access token has arrived. As such the `completion` closure needs to be “stored away” for a bit.