### PR TITLE
Removed URLStringConvertible conformance on URLRequest

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -52,11 +52,6 @@ extension URLComponents: URLStringConvertible {
     public var urlString: String { return url!.urlString }
 }
 
-extension URLRequest: URLStringConvertible {
-    /// The URL string.
-    public var urlString: String { return url!.urlString }
-}
-
 // MARK: -
 
 /// Types adopting the `URLRequestConvertible` protocol can be used to construct URL requests.

--- a/Tests/CacheTests.swift
+++ b/Tests/CacheTests.swift
@@ -187,7 +187,7 @@ class CacheTestCase: BaseTestCase {
         -> URLRequest
     {
         let urlRequest = self.urlRequest(cacheControl: cacheControl, cachePolicy: cachePolicy)
-        let request = manager.request(urlRequest)
+        let request = manager.request(resource: urlRequest)
 
         request.response(
             queue: queue,

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -40,7 +40,7 @@ class DownloadInitializationTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request.request)
         XCTAssertEqual(request.request?.httpMethod, "GET")
-        XCTAssertEqual(request.request?.urlString, urlString)
+        XCTAssertEqual(request.request?.url?.urlString, urlString)
         XCTAssertNil(request.response)
     }
 
@@ -55,7 +55,7 @@ class DownloadInitializationTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request.request)
         XCTAssertEqual(request.request?.httpMethod, "GET")
-        XCTAssertEqual(request.request?.urlString, urlString)
+        XCTAssertEqual(request.request?.url?.urlString, urlString)
         XCTAssertEqual(request.request?.value(forHTTPHeaderField: "Authorization"), "123456")
         XCTAssertNil(request.response)
     }

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -37,7 +37,7 @@ class RequestInitializationTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request.request)
         XCTAssertEqual(request.request?.httpMethod, "GET")
-        XCTAssertEqual(request.request?.urlString, urlString)
+        XCTAssertEqual(request.request?.url?.urlString, urlString)
         XCTAssertNil(request.response)
     }
 
@@ -51,7 +51,7 @@ class RequestInitializationTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request.request)
         XCTAssertEqual(request.request?.httpMethod, "GET")
-        XCTAssertNotEqual(request.request?.urlString, urlString)
+        XCTAssertNotEqual(request.request?.url?.urlString, urlString)
         XCTAssertEqual(request.request?.url?.query, "foo=bar")
         XCTAssertNil(request.response)
     }
@@ -67,7 +67,7 @@ class RequestInitializationTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request.request)
         XCTAssertEqual(request.request?.httpMethod, "GET")
-        XCTAssertNotEqual(request.request?.urlString, urlString)
+        XCTAssertNotEqual(request.request?.url?.urlString, urlString)
         XCTAssertEqual(request.request?.url?.query, "foo=bar")
         XCTAssertEqual(request.request?.value(forHTTPHeaderField: "Authorization"), "123456")
         XCTAssertNil(request.response)

--- a/Tests/SessionManagerTests.swift
+++ b/Tests/SessionManagerTests.swift
@@ -235,7 +235,7 @@ class SessionManagerTestCase: BaseTestCase {
         var response: HTTPURLResponse?
 
         // When
-        manager.request(urlRequest)
+        manager.request(resource: urlRequest)
             .response { resp in
                 response = resp.response
                 expectation.fulfill()
@@ -260,7 +260,7 @@ class SessionManagerTestCase: BaseTestCase {
         let urlRequest = URLRequest(url: url)
 
         // When
-        let request = manager?.request(urlRequest)
+        let request = manager?.request(resource: urlRequest)
         manager = nil
 
         // Then
@@ -277,7 +277,7 @@ class SessionManagerTestCase: BaseTestCase {
         let urlRequest = URLRequest(url: url)
 
         // When
-        let request = manager!.request(urlRequest)
+        let request = manager!.request(resource: urlRequest)
         request.cancel()
         manager = nil
 

--- a/Tests/URLProtocolTests.swift
+++ b/Tests/URLProtocolTests.swift
@@ -150,7 +150,7 @@ class URLProtocolTestCase: BaseTestCase {
         var response: DefaultDataResponse?
 
         // When
-        manager.request(urlRequest)
+        manager.request(resource: urlRequest)
             .response { resp in
                 response = resp
                 expectation.fulfill()

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -38,7 +38,7 @@ class UploadFileInitializationTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request.request, "request should not be nil")
         XCTAssertEqual(request.request?.httpMethod ?? "", "POST", "request HTTP method should be POST")
-        XCTAssertEqual(request.request?.urlString ?? "", urlString, "request URL string should be equal")
+        XCTAssertEqual(request.request?.url?.urlString, urlString, "request URL string should be equal")
         XCTAssertNil(request.response, "response should be nil")
     }
 
@@ -54,7 +54,7 @@ class UploadFileInitializationTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request.request, "request should not be nil")
         XCTAssertEqual(request.request?.httpMethod ?? "", "POST", "request HTTP method should be POST")
-        XCTAssertEqual(request.request?.urlString ?? "", urlString, "request URL string should be equal")
+        XCTAssertEqual(request.request?.url?.urlString, urlString, "request URL string should be equal")
 
         let authorizationHeader = request.request?.value(forHTTPHeaderField: "Authorization") ?? ""
         XCTAssertEqual(authorizationHeader, "123456", "Authorization header is incorrect")
@@ -76,7 +76,7 @@ class UploadDataInitializationTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request.request, "request should not be nil")
         XCTAssertEqual(request.request?.httpMethod ?? "", "POST", "request HTTP method should be POST")
-        XCTAssertEqual(request.request?.urlString ?? "", urlString, "request URL string should be equal")
+        XCTAssertEqual(request.request?.url?.urlString, urlString, "request URL string should be equal")
         XCTAssertNil(request.response, "response should be nil")
     }
 
@@ -91,7 +91,7 @@ class UploadDataInitializationTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request.request, "request should not be nil")
         XCTAssertEqual(request.request?.httpMethod ?? "", "POST", "request HTTP method should be POST")
-        XCTAssertEqual(request.request?.urlString ?? "", urlString, "request URL string should be equal")
+        XCTAssertEqual(request.request?.url?.urlString, urlString, "request URL string should be equal")
 
         let authorizationHeader = request.request?.value(forHTTPHeaderField: "Authorization") ?? ""
         XCTAssertEqual(authorizationHeader, "123456", "Authorization header is incorrect")
@@ -115,7 +115,7 @@ class UploadStreamInitializationTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request.request, "request should not be nil")
         XCTAssertEqual(request.request?.httpMethod ?? "", "POST", "request HTTP method should be POST")
-        XCTAssertEqual(request.request?.urlString ?? "", urlString, "request URL string should be equal")
+        XCTAssertEqual(request.request?.url?.urlString, urlString, "request URL string should be equal")
         XCTAssertNil(request.response, "response should be nil")
     }
 
@@ -132,7 +132,7 @@ class UploadStreamInitializationTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(request.request, "request should not be nil")
         XCTAssertEqual(request.request?.httpMethod ?? "", "POST", "request HTTP method should be POST")
-        XCTAssertEqual(request.request?.urlString ?? "", urlString, "request URL string should be equal")
+        XCTAssertEqual(request.request?.url?.urlString, urlString, "request URL string should be equal")
 
         let authorizationHeader = request.request?.value(forHTTPHeaderField: "Authorization") ?? ""
         XCTAssertEqual(authorizationHeader, "123456", "Authorization header is incorrect")

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -376,7 +376,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
         class MockDataRequest: DataRequest {
             override var response: HTTPURLResponse? {
                 return MockHTTPURLResponse(
-                    url: URL(string: request!.urlString)!,
+                    url: request!.url!,
                     statusCode: 204,
                     httpVersion: "HTTP/1.1",
                     headerFields: nil
@@ -387,7 +387,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
         class MockDownloadRequest: DownloadRequest {
             override var response: HTTPURLResponse? {
                 return MockHTTPURLResponse(
-                    url: URL(string: request!.urlString)!,
+                    url: request!.url!,
                     statusCode: 204,
                     httpVersion: "HTTP/1.1",
                     headerFields: nil


### PR DESCRIPTION
This PR is an alternate approach to solving the issue identified in #1488. Overall, I think this is a better approach to solving the problem. This allows us to keep the same public APIs, but allow the compiler to catch all the places where the problem wasn't previously identified.

Overall, I don't think it is necessary to keep the `URLRequest` API conforming to `URLStringConvertible`. We don't actually use it for anything anymore and it's misleading and problematic. I actually almost removed it before but didn't have a strong reason to because I hadn't realized what @tremblay did.