### PR TITLE
Feature - Task Metrics

### DIFF
--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -97,12 +97,14 @@ extension DataRequest {
     public func response(queue: DispatchQueue? = nil, completionHandler: @escaping (DefaultDataResponse) -> Void) -> Self {
         delegate.queue.addOperation {
             (queue ?? DispatchQueue.main).async {
-                let dataResponse = DefaultDataResponse(
+                var dataResponse = DefaultDataResponse(
                     request: self.request,
                     response: self.response,
                     data: self.delegate.data,
                     error: self.delegate.error
                 )
+
+                dataResponse.add(self.delegate.metrics)
 
                 completionHandler(dataResponse)
             }
@@ -144,7 +146,7 @@ extension DataRequest {
                 serializationCompletedTime: CFAbsoluteTimeGetCurrent()
             )
 
-            let response = DataResponse<T.SerializedObject>(
+            var dataResponse = DataResponse<T.SerializedObject>(
                 request: self.request,
                 response: self.response,
                 data: self.delegate.data,
@@ -152,7 +154,9 @@ extension DataRequest {
                 timeline: timeline
             )
 
-            (queue ?? DispatchQueue.main).async { completionHandler(response) }
+            dataResponse.add(self.delegate.metrics)
+
+            (queue ?? DispatchQueue.main).async { completionHandler(dataResponse) }
         }
 
         return self
@@ -174,7 +178,7 @@ extension DownloadRequest {
     {
         delegate.queue.addOperation {
             (queue ?? DispatchQueue.main).async {
-                let downloadResponse = DefaultDownloadResponse(
+                var downloadResponse = DefaultDownloadResponse(
                     request: self.request,
                     response: self.response,
                     temporaryURL: self.downloadDelegate.temporaryURL,
@@ -182,6 +186,8 @@ extension DownloadRequest {
                     resumeData: self.downloadDelegate.resumeData,
                     error: self.downloadDelegate.error
                 )
+
+                downloadResponse.add(self.delegate.metrics)
 
                 completionHandler(downloadResponse)
             }
@@ -223,7 +229,7 @@ extension DownloadRequest {
                 serializationCompletedTime: CFAbsoluteTimeGetCurrent()
             )
 
-            let response = DownloadResponse<T.SerializedObject>(
+            var downloadResponse = DownloadResponse<T.SerializedObject>(
                 request: self.request,
                 response: self.response,
                 temporaryURL: self.downloadDelegate.temporaryURL,
@@ -233,7 +239,9 @@ extension DownloadRequest {
                 timeline: timeline
             )
 
-            (queue ?? DispatchQueue.main).async { completionHandler(response) }
+            downloadResponse.add(self.delegate.metrics)
+
+            (queue ?? DispatchQueue.main).async { completionHandler(downloadResponse) }
         }
 
         return self

--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -374,6 +374,21 @@ extension SessionDelegate: URLSessionTaskDelegate {
         }
     }
 
+#if !os(watchOS)
+
+    /// Tells the delegate that the session finished collecting metrics for the task.
+    ///
+    /// - parameter session: The session collecting the metrics.
+    /// - parameter task:    The task whose metrics have been collected.
+    /// - parameter metrics: The collected metrics.
+    @available(iOS 10.0, macOS 10.12, tvOS 10.0, *)
+    @objc(URLSession:task:didFinishCollectingMetrics:)
+    open func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        self[task]?.delegate.metrics = metrics
+    }
+
+#endif
+
     /// Tells the delegate that the task finished transferring data.
     ///
     /// - parameter session: The session containing the task whose request finished transferring data.

--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -42,6 +42,7 @@ open class TaskDelegate: NSObject {
 
     var initialResponseTime: CFAbsoluteTime?
     var credential: URLCredential?
+    var metrics: AnyObject? // URLSessionTaskMetrics
 
     // MARK: Lifecycle
 

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -26,6 +26,62 @@ import Alamofire
 import Foundation
 import XCTest
 
+class ResponseTestCase: BaseTestCase {
+    func testThatResponseReturnsSuccessResultWithValidData() {
+        // Given
+        let urlString = "https://httpbin.org/get"
+        let expectation = self.expectation(description: "request should succeed")
+
+        var response: DefaultDataResponse?
+
+        // When
+        Alamofire.request(urlString, parameters: ["foo": "bar"]).response { resp in
+            response = resp
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertNil(response?.error)
+
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            XCTAssertNotNil(response?.metrics)
+        }
+    }
+
+    func testThatResponseReturnsFailureResultWithOptionalDataAndError() {
+        // Given
+        let urlString = "https://invalid-url-here.org/this/does/not/exist"
+        let expectation = self.expectation(description: "request should fail with 404")
+
+        var response: DefaultDataResponse?
+
+        // When
+        Alamofire.request(urlString, parameters: ["foo": "bar"]).response { resp in
+            response = resp
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertNotNil(response?.request)
+        XCTAssertNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertNotNil(response?.error)
+
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            XCTAssertNotNil(response?.metrics)
+        }
+    }
+}
+
+// MARK: -
+
 class ResponseDataTestCase: BaseTestCase {
     func testThatResponseDataReturnsSuccessResultWithValidData() {
         // Given
@@ -35,22 +91,22 @@ class ResponseDataTestCase: BaseTestCase {
         var response: DataResponse<Data>?
 
         // When
-        Alamofire.request(urlString, parameters: ["foo": "bar"])
-            .responseData { closureResponse in
-                response = closureResponse
-                expectation.fulfill()
-            }
+        Alamofire.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
+            response = resp
+            expectation.fulfill()
+        }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        if let response = response {
-            XCTAssertNotNil(response.request, "request should not be nil")
-            XCTAssertNotNil(response.response, "response should not be nil")
-            XCTAssertNotNil(response.data, "data should not be nil")
-            XCTAssertTrue(response.result.isSuccess, "result should be success")
-        } else {
-            XCTFail("response should not be nil")
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertNotNil(response?.data)
+        XCTAssertEqual(response?.result.isSuccess, true)
+
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            XCTAssertNotNil(response?.metrics)
         }
     }
 
@@ -62,22 +118,21 @@ class ResponseDataTestCase: BaseTestCase {
         var response: DataResponse<Data>?
 
         // When
-        Alamofire.request(urlString, parameters: ["foo": "bar"])
-            .responseData { closureResponse in
-                response = closureResponse
-                expectation.fulfill()
-            }
+        Alamofire.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
+            response = resp
+            expectation.fulfill()
+        }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        if let response = response {
-            XCTAssertNotNil(response.request, "request should not be nil")
-            XCTAssertNil(response.response, "response should be nil")
-            XCTAssertNotNil(response.data, "data should not be nil")
-            XCTAssertTrue(response.result.isFailure, "result should be failure")
-        } else {
-            XCTFail("response should not be nil")
+        XCTAssertNotNil(response?.request)
+        XCTAssertNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertEqual(response?.result.isFailure, true)
+
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            XCTAssertNotNil(response?.metrics)
         }
     }
 }
@@ -93,22 +148,22 @@ class ResponseStringTestCase: BaseTestCase {
         var response: DataResponse<String>?
 
         // When
-        Alamofire.request(urlString, parameters: ["foo": "bar"])
-            .responseString { closureResponse in
-                response = closureResponse
-                expectation.fulfill()
-            }
+        Alamofire.request(urlString, parameters: ["foo": "bar"]).responseString { resp in
+            response = resp
+            expectation.fulfill()
+        }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        if let response = response {
-            XCTAssertNotNil(response.request, "request should not be nil")
-            XCTAssertNotNil(response.response, "response should not be nil")
-            XCTAssertNotNil(response.data, "data should not be nil")
-            XCTAssertTrue(response.result.isSuccess, "result should be success")
-        } else {
-            XCTFail("response should not be nil")
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertNotNil(response?.data)
+        XCTAssertEqual(response?.result.isSuccess, true)
+
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            XCTAssertNotNil(response?.metrics)
         }
     }
 
@@ -120,22 +175,21 @@ class ResponseStringTestCase: BaseTestCase {
         var response: DataResponse<String>?
 
         // When
-        Alamofire.request(urlString, parameters: ["foo": "bar"])
-            .responseString { closureResponse in
-                response = closureResponse
-                expectation.fulfill()
-            }
+        Alamofire.request(urlString, parameters: ["foo": "bar"]).responseString { resp in
+            response = resp
+            expectation.fulfill()
+        }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        if let response = response {
-            XCTAssertNotNil(response.request, "request should not be nil")
-            XCTAssertNil(response.response, "response should be nil")
-            XCTAssertNotNil(response.data, "data should not be nil")
-            XCTAssertTrue(response.result.isFailure, "result should be failure")
-        } else {
-            XCTFail("response should not be nil")
+        XCTAssertNotNil(response?.request)
+        XCTAssertNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertEqual(response?.result.isFailure, true)
+
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            XCTAssertNotNil(response?.metrics)
         }
     }
 }
@@ -151,22 +205,22 @@ class ResponseJSONTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        Alamofire.request(urlString, parameters: ["foo": "bar"])
-            .responseJSON { closureResponse in
-                response = closureResponse
-                expectation.fulfill()
-            }
+        Alamofire.request(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
+            response = resp
+            expectation.fulfill()
+        }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        if let response = response {
-            XCTAssertNotNil(response.request, "request should not be nil")
-            XCTAssertNotNil(response.response, "response should not be nil")
-            XCTAssertNotNil(response.data, "data should not be nil")
-            XCTAssertTrue(response.result.isSuccess, "result should be success")
-        } else {
-            XCTFail("response should not be nil")
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertNotNil(response?.data)
+        XCTAssertEqual(response?.result.isSuccess, true)
+
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            XCTAssertNotNil(response?.metrics)
         }
     }
 
@@ -178,22 +232,21 @@ class ResponseJSONTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        Alamofire.request(urlString, parameters: ["foo": "bar"])
-            .responseJSON { closureResponse in
-                response = closureResponse
-                expectation.fulfill()
-            }
+        Alamofire.request(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
+            response = resp
+            expectation.fulfill()
+        }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        if let response = response {
-            XCTAssertNotNil(response.request, "request should not be nil")
-            XCTAssertNil(response.response, "response should be nil")
-            XCTAssertNotNil(response.data, "data should not be nil")
-            XCTAssertTrue(response.result.isFailure, "result should be failure")
-        } else {
-            XCTFail("response should not be nil")
+        XCTAssertNotNil(response?.request)
+        XCTAssertNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertEqual(response?.result.isFailure, true)
+
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            XCTAssertNotNil(response?.metrics)
         }
     }
 
@@ -205,30 +258,30 @@ class ResponseJSONTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        Alamofire.request(urlString, parameters: ["foo": "bar"])
-            .responseJSON { closureResponse in
-                response = closureResponse
-                expectation.fulfill()
-            }
+        Alamofire.request(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
+            response = resp
+            expectation.fulfill()
+        }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        if let response = response {
-            XCTAssertNotNil(response.request, "request should not be nil")
-            XCTAssertNotNil(response.response, "response should not be nil")
-            XCTAssertNotNil(response.data, "data should not be nil")
-            XCTAssertTrue(response.result.isSuccess, "result should be success")
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertNotNil(response?.data)
+        XCTAssertEqual(response?.result.isSuccess, true)
 
-            // The `as NSString` cast is necessary due to a compiler bug. See the following rdar for more info.
-            // - https://openradar.appspot.com/radar?id=5517037090635776
-            if let args = (response.result.value as AnyObject?)?["args" as NSString] as? [String: String] {
-                XCTAssertEqual(args, ["foo": "bar"], "args should match parameters")
-            } else {
-                XCTFail("args should not be nil")
-            }
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            XCTAssertNotNil(response?.metrics)
+        }
+
+        // The `as NSString` cast is necessary due to a compiler bug. See the following rdar for more info.
+        // - https://openradar.appspot.com/radar?id=5517037090635776
+        if let args = (response?.result.value as AnyObject?)?["args" as NSString] as? [String: String] {
+            XCTAssertEqual(args, ["foo": "bar"], "args should match parameters")
         } else {
-            XCTFail("response should not be nil")
+            XCTFail("args should not be nil")
         }
     }
 
@@ -240,30 +293,30 @@ class ResponseJSONTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        Alamofire.request(urlString, method: .post, parameters: ["foo": "bar"])
-            .responseJSON { closureResponse in
-                response = closureResponse
-                expectation.fulfill()
-            }
+        Alamofire.request(urlString, method: .post, parameters: ["foo": "bar"]).responseJSON { resp in
+            response = resp
+            expectation.fulfill()
+        }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        if let response = response {
-            XCTAssertNotNil(response.request, "request should not be nil")
-            XCTAssertNotNil(response.response, "response should not be nil")
-            XCTAssertNotNil(response.data, "data should not be nil")
-            XCTAssertTrue(response.result.isSuccess, "result should be success")
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertNotNil(response?.data)
+        XCTAssertEqual(response?.result.isSuccess, true)
 
-            // The `as NSString` cast is necessary due to a compiler bug. See the following rdar for more info.
-            // - https://openradar.appspot.com/radar?id=5517037090635776
-            if let form = (response.result.value as AnyObject?)?["form" as NSString] as? [String: String] {
-                XCTAssertEqual(form, ["foo": "bar"], "form should match parameters")
-            } else {
-                XCTFail("form should not be nil")
-            }
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            XCTAssertNotNil(response?.metrics)
+        }
+
+        // The `as NSString` cast is necessary due to a compiler bug. See the following rdar for more info.
+        // - https://openradar.appspot.com/radar?id=5517037090635776
+        if let form = (response?.result.value as AnyObject?)?["form" as NSString] as? [String: String] {
+            XCTAssertEqual(form, ["foo": "bar"], "form should match parameters")
         } else {
-            XCTFail("response should not be nil")
+            XCTFail("form should not be nil")
         }
     }
 }


### PR DESCRIPTION
This PR adds support for the awesome new `URLSessionTaskMetric` statistical tracking. This is essentially what we always wanted the `Timeline` to be, but we didn't have access to the same internal APIs to compute all these data points. Thanks Apple!

> For the time being, it makes sense to keep the `Timeline` around for watchOS and earlier versions of the platforms that don't support the new APIs.

This shouldn't be a difficult feature to build, but it most definitely was due to the complexity of compiling against 4 platforms with only three of the latest actually supporting new APIs. Therefore, I had to get pretty creative with the new `Response` protocol and extension in combination with `AnyObject` abstraction while moving the metrics through the various objects.

Overall, I'm VERY happy with how this turned out. I wish it wasn't so complicated to support so many platforms, but unfortunately, it is. I abstracted the complexity away into the single `Response` protocol and implementation, so that certainly helps isolate all the platform complexity to a single area.