### PR TITLE
Fix filename comment in TaskDelegate header

### DIFF
--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -1,5 +1,5 @@
 //
-//  Error.swift
+//  TaskDelegate.swift
 //
 //  Copyright (c) 2014-2016 Alamofire Software Foundation (http://alamofire.org/)
 //


### PR DESCRIPTION
The file was likely renamed without the comment being updated. Comment used to report:
```
//  Error.swift
```