### PR TITLE
Rename OS X to macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ env:
   - LANG=en_US.UTF-8
   - WORKSPACE=Alamofire.xcworkspace
   - IOS_FRAMEWORK_SCHEME="Alamofire iOS"
-  - OSX_FRAMEWORK_SCHEME="Alamofire OSX"
+  - MACOS_FRAMEWORK_SCHEME="Alamofire macOS"
   - TVOS_FRAMEWORK_SCHEME="Alamofire tvOS"
   - WATCHOS_FRAMEWORK_SCHEME="Alamofire watchOS"
   - IOS_SDK=iphonesimulator10.0
-  - OSX_SDK=macosx10.12
+  - MACOS_SDK=macosx10.12
   - TVOS_SDK=appletvsimulator10.0
   - WATCHOS_SDK=watchsimulator3.0
   - EXAMPLE_SCHEME="iOS Example"
@@ -24,7 +24,7 @@ env:
     - DESTINATION="OS=10.0,name=Apple TV 1080p"    SCHEME="$TVOS_FRAMEWORK_SCHEME"    SDK="$TVOS_SDK"    RUN_TESTS="YES" BUILD_EXAMPLE="NO"  POD_LINT="NO"
     - DESTINATION="OS=9.0,name=Apple TV 1080p"     SCHEME="$TVOS_FRAMEWORK_SCHEME"    SDK="$TVOS_SDK"    RUN_TESTS="YES" BUILD_EXAMPLE="NO"  POD_LINT="NO"
 
-    - DESTINATION="arch=x86_64"                    SCHEME="$OSX_FRAMEWORK_SCHEME"     SDK="$OSX_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="NO"  POD_LINT="NO"
+    - DESTINATION="arch=x86_64"                    SCHEME="$MACOS_FRAMEWORK_SCHEME"     SDK="$MACOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="NO"  POD_LINT="NO"
 before_install:
   - gem install cocoapods --pre --no-rdoc --no-ri --no-document --quiet
 script:
@@ -34,21 +34,21 @@ script:
 
   # Build Framework in Debug and Run Tests if specified
   - if [ $RUN_TESTS == "YES" ]; then
-      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty -c;
+      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty;
     else
-      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO build | xcpretty -c;
+      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO build | xcpretty;
     fi
 
   # Build Framework in Release and Run Tests if specified
   - if [ $RUN_TESTS == "YES" ]; then
-      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty -c;
+      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty;
     else
-      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO build | xcpretty -c;
+      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO build | xcpretty;
     fi
 
   # Build Example in Debug if specified
   - if [ $BUILD_EXAMPLE == "YES" ]; then
-      xcodebuild -workspace "$WORKSPACE" -scheme "$EXAMPLE_SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO build | xcpretty -c;
+      xcodebuild -workspace "$WORKSPACE" -scheme "$EXAMPLE_SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO build | xcpretty;
     fi
 
   # Temporarily disabling pod lib lint check due to CocoaPods issue: https://github.com/CocoaPods/CocoaPods/issues/5661

--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -366,7 +366,7 @@
 		F8111E5D19A9674D0040E7D1 /* RequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestTests.swift; sourceTree = "<group>"; };
 		F8111E5E19A9674D0040E7D1 /* ResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResponseTests.swift; sourceTree = "<group>"; };
 		F8111E5F19A9674D0040E7D1 /* UploadTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UploadTests.swift; sourceTree = "<group>"; };
-		F829C6B21A7A94F100A2CD59 /* Alamofire OSX Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Alamofire OSX Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F829C6B21A7A94F100A2CD59 /* Alamofire macOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Alamofire macOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F86AEFE51AE6A282007D9C76 /* TLSEvaluationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TLSEvaluationTests.swift; sourceTree = "<group>"; };
 		F897FF4019AA800700AB5182 /* Alamofire.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Alamofire.swift; sourceTree = "<group>"; };
 		F8AE910119D28DCC0078C7B2 /* ValidationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidationTests.swift; sourceTree = "<group>"; };
@@ -682,7 +682,7 @@
 				F8111E3319A95C8B0040E7D1 /* Alamofire.framework */,
 				F8111E3E19A95C8B0040E7D1 /* Alamofire iOS Tests.xctest */,
 				4DD67C0B1A5C55C900ED2280 /* Alamofire.framework */,
-				F829C6B21A7A94F100A2CD59 /* Alamofire OSX Tests.xctest */,
+				F829C6B21A7A94F100A2CD59 /* Alamofire macOS Tests.xctest */,
 				E4202FE01B667AA100C997FB /* Alamofire.framework */,
 				4CF626EF1BA7CB3E0011A099 /* Alamofire.framework */,
 				4CF626F81BA7CB3E0011A099 /* Alamofire tvOS Tests.xctest */,
@@ -808,9 +808,9 @@
 			productReference = 4CF626F81BA7CB3E0011A099 /* Alamofire tvOS Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		4DD67C0A1A5C55C900ED2280 /* Alamofire OSX */ = {
+		4DD67C0A1A5C55C900ED2280 /* Alamofire macOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 4DD67C1E1A5C55C900ED2280 /* Build configuration list for PBXNativeTarget "Alamofire OSX" */;
+			buildConfigurationList = 4DD67C1E1A5C55C900ED2280 /* Build configuration list for PBXNativeTarget "Alamofire macOS" */;
 			buildPhases = (
 				4DD67C061A5C55C900ED2280 /* Sources */,
 				4DD67C071A5C55C900ED2280 /* Frameworks */,
@@ -821,7 +821,7 @@
 			);
 			dependencies = (
 			);
-			name = "Alamofire OSX";
+			name = "Alamofire macOS";
 			productName = AlamofireOSX;
 			productReference = 4DD67C0B1A5C55C900ED2280 /* Alamofire.framework */;
 			productType = "com.apple.product-type.framework";
@@ -880,9 +880,9 @@
 			productReference = F8111E3E19A95C8B0040E7D1 /* Alamofire iOS Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		F829C6B11A7A94F100A2CD59 /* Alamofire OSX Tests */ = {
+		F829C6B11A7A94F100A2CD59 /* Alamofire macOS Tests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F829C6BB1A7A94F100A2CD59 /* Build configuration list for PBXNativeTarget "Alamofire OSX Tests" */;
+			buildConfigurationList = F829C6BB1A7A94F100A2CD59 /* Build configuration list for PBXNativeTarget "Alamofire macOS Tests" */;
 			buildPhases = (
 				F829C6AE1A7A94F100A2CD59 /* Sources */,
 				F829C6AF1A7A94F100A2CD59 /* Frameworks */,
@@ -893,9 +893,9 @@
 			dependencies = (
 				F829C6BA1A7A94F100A2CD59 /* PBXTargetDependency */,
 			);
-			name = "Alamofire OSX Tests";
+			name = "Alamofire macOS Tests";
 			productName = "Alamofire OSX Tests";
-			productReference = F829C6B21A7A94F100A2CD59 /* Alamofire OSX Tests.xctest */;
+			productReference = F829C6B21A7A94F100A2CD59 /* Alamofire macOS Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -955,8 +955,8 @@
 			targets = (
 				F8111E3219A95C8B0040E7D1 /* Alamofire iOS */,
 				F8111E3D19A95C8B0040E7D1 /* Alamofire iOS Tests */,
-				4DD67C0A1A5C55C900ED2280 /* Alamofire OSX */,
-				F829C6B11A7A94F100A2CD59 /* Alamofire OSX Tests */,
+				4DD67C0A1A5C55C900ED2280 /* Alamofire macOS */,
+				F829C6B11A7A94F100A2CD59 /* Alamofire macOS Tests */,
 				4CF626EE1BA7CB3E0011A099 /* Alamofire tvOS */,
 				4CF626F71BA7CB3E0011A099 /* Alamofire tvOS Tests */,
 				E4202FCD1B667AA100C997FB /* Alamofire watchOS */,
@@ -1332,7 +1332,7 @@
 		};
 		F829C6BA1A7A94F100A2CD59 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 4DD67C0A1A5C55C900ED2280 /* Alamofire OSX */;
+			target = 4DD67C0A1A5C55C900ED2280 /* Alamofire macOS */;
 			targetProxy = F829C6B91A7A94F100A2CD59 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -1768,7 +1768,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		4DD67C1E1A5C55C900ED2280 /* Build configuration list for PBXNativeTarget "Alamofire OSX" */ = {
+		4DD67C1E1A5C55C900ED2280 /* Build configuration list for PBXNativeTarget "Alamofire macOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				4DD67C1F1A5C55C900ED2280 /* Debug */,
@@ -1813,7 +1813,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		F829C6BB1A7A94F100A2CD59 /* Build configuration list for PBXNativeTarget "Alamofire OSX Tests" */ = {
+		F829C6BB1A7A94F100A2CD59 /* Build configuration list for PBXNativeTarget "Alamofire macOS Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				F829C6BC1A7A94F100A2CD59 /* Debug */,

--- a/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire macOS.xcscheme
+++ b/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire macOS.xcscheme
@@ -16,7 +16,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "4DD67C0A1A5C55C900ED2280"
                BuildableName = "Alamofire.framework"
-               BlueprintName = "Alamofire OSX"
+               BlueprintName = "Alamofire macOS"
                ReferencedContainer = "container:Alamofire.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -29,8 +29,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "F829C6B11A7A94F100A2CD59"
-               BuildableName = "Alamofire OSX Tests.xctest"
-               BlueprintName = "Alamofire OSX Tests"
+               BuildableName = "Alamofire macOS Tests.xctest"
+               BlueprintName = "Alamofire macOS Tests"
                ReferencedContainer = "container:Alamofire.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -47,8 +47,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "F829C6B11A7A94F100A2CD59"
-               BuildableName = "Alamofire OSX Tests.xctest"
-               BlueprintName = "Alamofire OSX Tests"
+               BuildableName = "Alamofire macOS Tests.xctest"
+               BlueprintName = "Alamofire macOS Tests"
                ReferencedContainer = "container:Alamofire.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -58,7 +58,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4DD67C0A1A5C55C900ED2280"
             BuildableName = "Alamofire.framework"
-            BlueprintName = "Alamofire OSX"
+            BlueprintName = "Alamofire macOS"
             ReferencedContainer = "container:Alamofire.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -80,7 +80,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4DD67C0A1A5C55C900ED2280"
             BuildableName = "Alamofire.framework"
-            BlueprintName = "Alamofire OSX"
+            BlueprintName = "Alamofire macOS"
             ReferencedContainer = "container:Alamofire.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -98,7 +98,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4DD67C0A1A5C55C900ED2280"
             BuildableName = "Alamofire.framework"
-            BlueprintName = "Alamofire OSX"
+            BlueprintName = "Alamofire macOS"
             ReferencedContainer = "container:Alamofire.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Doing this helps prioritize the most common problems and requests.
 When reporting issues, please include the following:
 
 * The version of Xcode you're using
-* The version of iOS or OS X you're targeting
+* The version of iOS or macOS you're targeting
 * The full output of any stack trace or compiler error
 * A code snippet that reproduces the described behavior, if applicable
 * Any other details that would be useful in understanding the problem

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ In order to keep Alamofire focused specifically on core networking implementatio
 
 ## Requirements
 
-- iOS 9.0+ / Mac OS X 10.11+ / tvOS 9.0+ / watchOS 2.0+
+- iOS 9.0+ / macOS 10.11+ / tvOS 9.0+ / watchOS 2.0+
 - Xcode 8.0+
 - Swift 3.0+
 
@@ -1364,7 +1364,7 @@ extension DataRequest {
             // Use Alamofire's existing data serializer to extract the data, passing the error as nil, as it has
             // alreaady been handled.
             let result = Request.serializeResponseData(response: response, data: data, error: nil)
-            
+
             guard case let .success(validData) = result else {
                 return .failure(BackendError.dataSerialization(error: result.error! as! AFError))
             }
@@ -1413,7 +1413,7 @@ extension DataRequest {
 
             let jsonResponseSerializer = DataRequest.jsonResponseSerializer(options: .allowFragments)
             let result = jsonResponseSerializer.serializeResponse(request, response, data, nil)
-            
+
             guard case let .success(jsonObject) = result else {
                 return .failure(BackendError.jsonSerialization(error: result.error!))
             }
@@ -1498,7 +1498,7 @@ extension DataRequest {
 
             let jsonSerializer = DataRequest.jsonResponseSerializer(options: .allowFragments)
             let result = jsonSerializer.serializeResponse(request, response, data, nil)
-            
+
             guard case let .success(jsonObject) = result else {
                 return .failure(BackendError.jsonSerialization(error: result.error!))
             }

--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -26,7 +26,7 @@ import Foundation
 
 #if os(iOS) || os(watchOS) || os(tvOS)
 import MobileCoreServices
-#elseif os(OSX)
+#elseif os(macOS)
 import CoreServices
 #endif
 

--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -159,7 +159,7 @@ open class SessionDelegate: NSObject {
     ///
     /// - returns: `true` if the receiver implements or inherits a method that can respond to selector, otherwise `false`.
     open override func responds(to selector: Selector) -> Bool {
-        #if !os(OSX)
+        #if !os(macOS)
             if selector == #selector(URLSessionDelegate.urlSessionDidFinishEvents(forBackgroundURLSession:)) {
                 return sessionDidFinishEventsForBackgroundURLSession != nil
             }
@@ -247,7 +247,7 @@ extension SessionDelegate: URLSessionDelegate {
         completionHandler(disposition, credential)
     }
 
-#if !os(OSX)
+#if !os(macOS)
 
     /// Tells the delegate that all messages enqueued for a session have been delivered.
     ///

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -83,7 +83,7 @@ open class SessionManager {
                             return "watchOS"
                         #elseif os(tvOS)
                             return "tvOS"
-                        #elseif os(OSX)
+                        #elseif os(macOS)
                             return "OS X"
                         #elseif os(Linux)
                             return "Linux"

--- a/Tests/CacheTests.swift
+++ b/Tests/CacheTests.swift
@@ -39,8 +39,8 @@ import XCTest
 /// - Verify whether the response came from the cache or from the network
 ///     - This is determined by whether the cached response timestamp matches the new response timestamp
 ///
-/// An important thing to note is the difference in behavior between iOS and OS X. On iOS, a response with
-/// a `Cache-Control` header value of `no-store` is still written into the `NSURLCache` where on OS X, it is not.
+/// An important thing to note is the difference in behavior between iOS and macOS. On iOS, a response with
+/// a `Cache-Control` header value of `no-store` is still written into the `NSURLCache` where on macOS, it is not.
 /// The different tests below reflect and demonstrate this behavior.
 ///
 /// For information about `Cache-Control` HTTP headers, please refer to RFC 2616 - Section 14.9.

--- a/Tests/ServerTrustPolicyTests.swift
+++ b/Tests/ServerTrustPolicyTests.swift
@@ -1409,8 +1409,8 @@ class ServerTrustPolicyCertificatesInBundleTestCase: ServerTrustPolicyTestCase {
 
         // Then
         // Expectation: 19 well-formed certificates in the test bundle plus 4 invalid certificates.
-        #if os(OSX)
-            // For some reason, OSX is allowing all certificates to be considered valid. Need to file a
+        #if os(macOS)
+            // For some reason, macOS is allowing all certificates to be considered valid. Need to file a
             // rdar demonstrating this behavior.
             XCTAssertEqual(certificates.count, 23, "Expected 23 well-formed certificates")
         #else

--- a/Tests/SessionManagerTests.swift
+++ b/Tests/SessionManagerTests.swift
@@ -203,7 +203,7 @@ class SessionManagerTestCase: BaseTestCase {
                     return "watchOS"
                 #elseif os(tvOS)
                     return "tvOS"
-                #elseif os(OSX)
+                #elseif os(macOS)
                     return "OS X"
                 #elseif os(Linux)
                     return "Linux"


### PR DESCRIPTION
This is the pull request corresponding to #1506.

1. Rename target `Alamofire OSX` to `Alamofire macOS`.
2. Rename target `Alamofire OSX Tests` to `Alamofire macOS Tests`.
3. Rename scheme `Alamofire OSX` to `Alamofire macOS`.
4. Replace `os(OSX)` with `os(macOS)`.
5. Update README.md.
6. Update CONTRIBUTING.md.
7. Update .travis.yml (also change `xcpretty -c` to `xcpretty` since `-c` is the default argument).
8. User agent's OS version is NOT changed (still `OS X`). 

`AlamofireNetworkActivityIndicator`: no change needed
`AlamofireImage`: https://github.com/Alamofire/AlamofireImage/pull/181