### PR TITLE
Fixed calling second request after server return 401

### DIFF
--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -122,6 +122,8 @@ open class TaskDelegate: NSObject {
 
                 if credential != nil {
                     disposition = .useCredential
+                } else {
+                    disposition = .cancelAuthenticationChallenge
                 }
             }
         }


### PR DESCRIPTION
Regarding this issue - https://github.com/Alamofire/Alamofire/issues/1425
After server return 401, request calling second time and only after second call it stops. It behaves the same with previous Alamofire version.

After investigation I find that challenge.previousFailureCount still 0 after first 401 error. 
I try code suggected by @cnoon but it doesn't change anything, the code is:
```
let delegate = Alamofire.SessionManager.shared.delegate

delegate.taskDidReceiveChallengeWithCompletion = { session, task, challenge, completion in
    completion(.performDefaultHandling, nil)
}
```
Only this little fix suggested in this PR helps me. After first 401 error if credential is nil I cancel authentication challenge. If this is doesn't brake anything for you please apply this PR.

I call my request like this:
```
let aReq = Alamofire.request(myRequest)
aReq.responseJSON { response in
    //do something with response
}
```

Login and password inside myRequest parameters. If they wrong server return 401. I didn't store they in URLCredentialStorage and I didn't use .authenticate Alamofire closure(because my server require sending login and password in parameters). 

![screen shot 2016-09-23 at 10 22 22](https://cloud.githubusercontent.com/assets/8593066/18779183/2c8825e4-8178-11e6-8336-73683f149d9b.png)