### PR TITLE
Fix Response Data handler sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Alamofire.request("https://httpbin.org/get").response { response in
     print("Response: \(response.response)")
     print("Error: \(response.data)")
 
-    if let data = data, let utf8Text = String(data: data, encoding: .utf8) {
+    if let data = response.data, let utf8Text = String(data: data, encoding: .utf8) {
     	print("Data: \(utf8Text)")
     }
 }


### PR DESCRIPTION
While learning Alamofire 4.0 with Swift 3.0 from the README samples, I encountered a minor bug in the [Response Handler](https://github.com/Alamofire/Alamofire#response-handler) section.

`Error: Use of unresolved identifier data`

Looks like code section should be 

```
if let data = response.data, let utf8Text = String(data: data, encoding: .utf8) {
                print("Data: \(utf8Text)")
            }
```

instead of 

```
if let data = data, let utf8Text = String(data: data, encoding: .utf8) {
                print("Data: \(utf8Text)")
            }
```

<img width="1232" alt="screen shot 2016-09-24 at 4 34 50 pm" src="https://cloud.githubusercontent.com/assets/8782776/18811892/e5bd9528-8275-11e6-9f44-73c2ba7422aa.png">


Thanks!