### PR TITLE
Fix response validation sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ By default, Alamofire treats any completed request to be successful, regardless 
 Alamofire.request("https://httpbin.org/get")
     .validate(statusCode: 200..<300)
     .validate(contentType: ["application/json"])
-    .response { response in
+    .responseData { response in
 	    switch response.result {
 	    case .success:
     	    print("Validation Successful")


### PR DESCRIPTION
Alamofire 4.0.1 with Swift 3.0 
one more minor bug in the [Response Validation](https://github.com/Alamofire/Alamofire#manual-validation) section.

**Error**: Value of type 'DefaultDataResponse' has no member 'result'.

Looks like code section should be using responseData / responseJSON / other response handlers which provides access to the `result` member on `response` object like below:

```
Alamofire.request("https://httpbin.org/get")
    .validate(statusCode: 200..<300)
    .validate(contentType: ["application/json"])
    .responseData { response in
        switch response.result {
        case .success:
            print("Validation Successful")
        case .failure(let error):
            print(error)
        }
    }
```

<img width="1207" alt="screen shot 2016-09-25 at 12 20 17 am" src="https://cloud.githubusercontent.com/assets/8782776/18813675/db5751a0-82b6-11e6-94f7-9fc308cb7768.png">

Thanks!