### PR TITLE
Updated podspec targets to use SWIFT_VERSION 3

### DIFF
--- a/Alamofire.podspec
+++ b/Alamofire.podspec
@@ -12,6 +12,10 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.11'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
+  
+  s.pod_target_xcconfig = {
+  'SWIFT_VERSION' => '3.0',
+ }
 
   s.source_files = 'Source/*.swift'
 end


### PR DESCRIPTION
This fixes the problem where Xcode pops a warning that it needs to convert the project source into Swift 3, since it isn't sure that the code's been converted already.