### PR TITLE
Added Request retryCount property to support RequestRetrier

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -110,6 +110,9 @@ open class Request {
     /// The response received from the server, if any.
     open var response: HTTPURLResponse? { return task?.response as? HTTPURLResponse }
 
+    /// The number of times the request has been retried.
+    open internal(set) var retryCount: UInt = 0
+
     let originalTask: TaskConvertible?
 
     var startTime: CFAbsoluteTime?

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -769,6 +769,7 @@ open class SessionManager {
 
             request.delegate.task = task // resets all task delegate data
 
+            request.retryCount += 1
             request.startTime = CFAbsoluteTimeGetCurrent()
             request.endTime = nil
 

--- a/Tests/SessionManagerTests.swift
+++ b/Tests/SessionManagerTests.swift
@@ -562,7 +562,7 @@ class SessionManagerTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        sessionManager.request("https://httpbin.org/basic-auth/user/password")
+        let request = sessionManager.request("https://httpbin.org/basic-auth/user/password")
             .validate()
             .responseJSON { jsonResponse in
                 response = jsonResponse
@@ -574,6 +574,7 @@ class SessionManagerTestCase: BaseTestCase {
         // Then
         XCTAssertEqual(handler.adaptedCount, 2)
         XCTAssertEqual(handler.retryCount, 2)
+        XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, false)
     }
 
@@ -590,7 +591,7 @@ class SessionManagerTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        sessionManager.request("https://httpbin.org/basic-auth/user/password")
+        let request = sessionManager.request("https://httpbin.org/basic-auth/user/password")
             .validate()
             .responseJSON { jsonResponse in
                 response = jsonResponse
@@ -602,6 +603,7 @@ class SessionManagerTestCase: BaseTestCase {
         // Then
         XCTAssertEqual(handler.adaptedCount, 2)
         XCTAssertEqual(handler.retryCount, 1)
+        XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, true)
     }
 
@@ -618,7 +620,7 @@ class SessionManagerTestCase: BaseTestCase {
         var response: DataResponse<Any>?
 
         // When
-        sessionManager.request("https://httpbin.org/basic-auth/user/password")
+        let request = sessionManager.request("https://httpbin.org/basic-auth/user/password")
             .validate()
             .responseJSON { jsonResponse in
                 response = jsonResponse
@@ -630,6 +632,7 @@ class SessionManagerTestCase: BaseTestCase {
         // Then
         XCTAssertEqual(handler.adaptedCount, 1)
         XCTAssertEqual(handler.retryCount, 1)
+        XCTAssertEqual(request.retryCount, 0)
         XCTAssertEqual(response?.result.isSuccess, false)
 
         if let error = response?.result.error as? AFError {


### PR DESCRIPTION
This PR adds a `retryCount` property to a `Request`, updates the `SessionManager` to increment the count and also adds the appropriate tests.

By adding the `retryCount` to the `Request`, the `RequestRetrier` protocol can use the `retryCount` to determine whether to continue to retry the `Request`.

> More details can be found in #1672.