### PR TITLE
Feature - Throwing Adapt Error Calls Retrier

### DIFF
--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -132,6 +132,19 @@ public enum AFError: Error {
     case responseSerializationFailed(reason: ResponseSerializationFailureReason)
 }
 
+// MARK: - Adapt Error
+
+struct AdaptError: Error {
+    let error: Error
+}
+
+extension Error {
+    var extractedAdaptError: Error {
+        guard let error = self as? AdaptError else { return self }
+        return error.error
+    }
+}
+
 // MARK: - Error Booleans
 
 extension AFError {

--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -139,10 +139,7 @@ struct AdaptError: Error {
 }
 
 extension Error {
-    var extractedAdaptError: Error {
-        guard let error = self as? AdaptError else { return self }
-        return error.error
-    }
+    var underlyingAdaptError: Error? { return (self as? AdaptError)?.error }
 }
 
 // MARK: - Error Booleans

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -354,8 +354,12 @@ open class DataRequest: Request {
         let urlRequest: URLRequest
 
         func task(session: URLSession, adapter: RequestAdapter?, queue: DispatchQueue) throws -> URLSessionTask {
-            let urlRequest = try self.urlRequest.adapt(using: adapter)
-            return queue.syncResult { session.dataTask(with: urlRequest) }
+            do {
+                let urlRequest = try self.urlRequest.adapt(using: adapter)
+                return queue.syncResult { session.dataTask(with: urlRequest) }
+            } catch {
+                throw AdaptError(error: error)
+            }
         }
     }
 

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -539,21 +539,25 @@ open class UploadRequest: DataRequest {
         case stream(InputStream, URLRequest)
 
         func task(session: URLSession, adapter: RequestAdapter?, queue: DispatchQueue) throws -> URLSessionTask {
-            let task: URLSessionTask
+            do {
+                let task: URLSessionTask
 
-            switch self {
-            case let .data(data, urlRequest):
-                let urlRequest = try urlRequest.adapt(using: adapter)
-                task = queue.syncResult { session.uploadTask(with: urlRequest, from: data) }
-            case let .file(url, urlRequest):
-                let urlRequest = try urlRequest.adapt(using: adapter)
-                task = queue.syncResult { session.uploadTask(with: urlRequest, fromFile: url) }
-            case let .stream(_, urlRequest):
-                let urlRequest = try urlRequest.adapt(using: adapter)
-                task = queue.syncResult { session.uploadTask(withStreamedRequest: urlRequest) }
+                switch self {
+                case let .data(data, urlRequest):
+                    let urlRequest = try urlRequest.adapt(using: adapter)
+                    task = queue.syncResult { session.uploadTask(with: urlRequest, from: data) }
+                case let .file(url, urlRequest):
+                    let urlRequest = try urlRequest.adapt(using: adapter)
+                    task = queue.syncResult { session.uploadTask(with: urlRequest, fromFile: url) }
+                case let .stream(_, urlRequest):
+                    let urlRequest = try urlRequest.adapt(using: adapter)
+                    task = queue.syncResult { session.uploadTask(withStreamedRequest: urlRequest) }
+                }
+
+                return task
+            } catch {
+                throw AdaptError(error: error)
             }
-
-            return task
         }
     }
 

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -445,17 +445,21 @@ open class DownloadRequest: Request {
         case resumeData(Data)
 
         func task(session: URLSession, adapter: RequestAdapter?, queue: DispatchQueue) throws -> URLSessionTask {
-            let task: URLSessionTask
+            do {
+                let task: URLSessionTask
 
-            switch self {
-            case let .request(urlRequest):
-                let urlRequest = try urlRequest.adapt(using: adapter)
-                task = queue.syncResult { session.downloadTask(with: urlRequest) }
-            case let .resumeData(resumeData):
-                task = queue.syncResult { session.downloadTask(withResumeData: resumeData) }
+                switch self {
+                case let .request(urlRequest):
+                    let urlRequest = try urlRequest.adapt(using: adapter)
+                    task = queue.syncResult { session.downloadTask(with: urlRequest) }
+                case let .resumeData(resumeData):
+                    task = queue.syncResult { session.downloadTask(withResumeData: resumeData) }
+                }
+
+                return task
+            } catch {
+                throw AdaptError(error: error)
             }
-
-            return task
         }
     }
 

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -806,7 +806,7 @@ open class SessionManager {
         DispatchQueue.utility.async { [weak self] in
             guard let strongSelf = self else { return }
 
-            retrier.should(strongSelf, retry: request, with: error) { [weak self] shouldRetry, timeDelay in
+            retrier.should(strongSelf, retry: request, with: error) { shouldRetry, timeDelay in
                 guard let strongSelf = self else { return }
 
                 guard shouldRetry else {

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -279,12 +279,10 @@ open class SessionManager {
             requestTask = .data(originalTask, nil)
         }
 
-        let isAdaptError = error is AdaptError
-        let error = error.extractedAdaptError
+        let underlyingError = error.underlyingAdaptError ?? error
+        let request = DataRequest(session: session, requestTask: requestTask, error: underlyingError)
 
-        let request = DataRequest(session: session, requestTask: requestTask, error: error)
-
-        if let retrier = retrier, isAdaptError {
+        if let retrier = retrier, error is AdaptError {
             allowRetrier(retrier, toRetry: request, with: error)
         } else {
             if startRequestsImmediately { request.resume() }
@@ -425,13 +423,12 @@ open class SessionManager {
             downloadTask = .download(downloadable, nil)
         }
 
-        let isAdaptError = error is AdaptError
-        let error = error.extractedAdaptError
+        let underlyingError = error.underlyingAdaptError ?? error
 
-        let download = DownloadRequest(session: session, requestTask: downloadTask, error: error)
+        let download = DownloadRequest(session: session, requestTask: downloadTask, error: underlyingError)
         download.downloadDelegate.destination = destination
 
-        if let retrier = retrier, isAdaptError {
+        if let retrier = retrier, error is AdaptError {
             allowRetrier(retrier, toRetry: download, with: error)
         } else {
             if startRequestsImmediately { download.resume() }
@@ -743,12 +740,10 @@ open class SessionManager {
             uploadTask = .upload(uploadable, nil)
         }
 
-        let isAdaptError = error is AdaptError
-        let error = error.extractedAdaptError
+        let underlyingError = error.underlyingAdaptError ?? error
+        let upload = UploadRequest(session: session, requestTask: uploadTask, error: underlyingError)
 
-        let upload = UploadRequest(session: session, requestTask: uploadTask, error: error)
-
-        if let retrier = retrier, isAdaptError {
+        if let retrier = retrier, error is AdaptError {
             allowRetrier(retrier, toRetry: upload, with: error)
         } else {
             if startRequestsImmediately { upload.resume() }
@@ -833,7 +828,7 @@ open class SessionManager {
 
             return true
         } catch {
-            request.delegate.error = error.extractedAdaptError
+            request.delegate.error = error.underlyingAdaptError ?? error
             return false
         }
     }

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -362,7 +362,7 @@ class DownloadResponseTestCase: BaseTestCase {
             .response { resp in
                 response = resp
                 expectation.fulfill()
-        }
+            }
 
         waitForExpectations(timeout: timeout, handler: nil)
 


### PR DESCRIPTION
This PR was created to allow errors thrown in the adapter to call the retrier before starting up the request's internal dispatch queue. 
## Problem

The reason this is necessary is if you want to be able to throw an `ExpiredAccessToken` type of `Error` in your `RequestAdapter`. This would allow you to do things like preemptively refresh you token before sending any requests to the server even though the public APIs had already started up the request. The adapter would be able to intervene.

> See #1674 for the a more in-depth explanation of the issue.
## Solution

Okay everyone (especially @jshier), I need a sanity check here. I don't think this is too hackish, but I want to make sure everyone else agrees. This was really tricky to implement since there are so many different things going on.

The biggest decision was whether or not to wrap the errors in the `AdaptError` or not. It all boils down to whether we should call the retrier for things like invalid URLs and parameter encoding failures. IMO, we should not. I feel like calling the retrier in those scenarios could cause all sorts of problems where people are accidentally getting themselves into endless retry scenarios without realizing it.

Instead, I created an `AdaptError` to wrap any `Error` that's thrown by the `RequestAdapter`. This is only used internally by Alamofire to figure out whether the encountered error was actually thrown by the `adapter` or not. If it is an `AdaptError`, extract the underlying `Error` and call the `retrier`. If it isn't an `AdaptError`, then the request isn't going to succeed and just start up the request queue.

We could instead actually expose an `AFError.adaptError` that people are required to throw to get this behavior, but that seems a bit odd and easy to misuse. Instead, I think people are going to want to throw all types of errors from the adapter and we should just wrap them up internally to figure out whether or not we should call the retrier. Once we make that decision, we extract the underlying error and continue on.

I haven't actually built any tests around this yet because I wanted to get everyone's thoughts first. I've dug into the download and upload requests a bit and this is definitely possible to support in a similar manner.

Thoughts?
