### PR TITLE
Empty bodies for GET, HEAD and DELETE methods.

### DIFF
--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -125,16 +125,9 @@ public struct URLEncoding: ParameterEncoding {
 
         guard let parameters = parameters else { return urlRequest }
 
-        if let method = HTTPMethod(rawValue: urlRequest.httpMethod ?? "GET"), encodesParametersInURL(with: method) {
-            guard let url = urlRequest.url else {
-                throw AFError.parameterEncodingFailed(reason: .missingURL)
-            }
-
-            if var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false), !parameters.isEmpty {
-                let percentEncodedQuery = (urlComponents.percentEncodedQuery.map { $0 + "&" } ?? "") + query(parameters)
-                urlComponents.percentEncodedQuery = percentEncodedQuery
-                urlRequest.url = urlComponents.url
-            }
+        if let method = HTTPMethod(rawValue: urlRequest.httpMethod ?? "GET"),
+            encodesParametersInURL(with: method), (destination == Destination.methodDependent || destination == Destination.queryString) {
+            urlRequest.url = try encode(parameters: parameters, inRequestUrl: urlRequest.url)
         } else {
             if urlRequest.value(forHTTPHeaderField: "Content-Type") == nil {
                 urlRequest.setValue("application/x-www-form-urlencoded; charset=utf-8", forHTTPHeaderField: "Content-Type")
@@ -145,91 +138,7 @@ public struct URLEncoding: ParameterEncoding {
 
         return urlRequest
     }
-
-    /// Creates percent-escaped, URL encoded query string components from the given key-value pair using recursion.
-    ///
-    /// - parameter key:   The key of the query component.
-    /// - parameter value: The value of the query component.
-    ///
-    /// - returns: The percent-escaped, URL encoded query string components.
-    public func queryComponents(fromKey key: String, value: Any) -> [(String, String)] {
-        var components: [(String, String)] = []
-
-        if let dictionary = value as? [String: Any] {
-            for (nestedKey, value) in dictionary {
-                components += queryComponents(fromKey: "\(key)[\(nestedKey)]", value: value)
-            }
-        } else if let array = value as? [Any] {
-            for value in array {
-                components += queryComponents(fromKey: "\(key)[]", value: value)
-            }
-        } else if let value = value as? NSNumber {
-            if value.isBool {
-                components.append((escape(key), escape((value.boolValue ? "1" : "0"))))
-            } else {
-                components.append((escape(key), escape("\(value)")))
-            }
-        } else if let bool = value as? Bool {
-            components.append((escape(key), escape((bool ? "1" : "0"))))
-        } else {
-            components.append((escape(key), escape("\(value)")))
-        }
-
-        return components
-    }
-
-    /// Returns a percent-escaped string following RFC 3986 for a query string key or value.
-    ///
-    /// RFC 3986 states that the following characters are "reserved" characters.
-    ///
-    /// - General Delimiters: ":", "#", "[", "]", "@", "?", "/"
-    /// - Sub-Delimiters: "!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "="
-    ///
-    /// In RFC 3986 - Section 3.4, it states that the "?" and "/" characters should not be escaped to allow
-    /// query strings to include a URL. Therefore, all "reserved" characters with the exception of "?" and "/"
-    /// should be percent-escaped in the query string.
-    ///
-    /// - parameter string: The string to be percent-escaped.
-    ///
-    /// - returns: The percent-escaped string.
-    public func escape(_ string: String) -> String {
-        let generalDelimitersToEncode = ":#[]@" // does not include "?" or "/" due to RFC 3986 - Section 3.4
-        let subDelimitersToEncode = "!$&'()*+,;="
-
-        var allowedCharacterSet = CharacterSet.urlQueryAllowed
-        allowedCharacterSet.remove(charactersIn: "\(generalDelimitersToEncode)\(subDelimitersToEncode)")
-
-        return string.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) ?? string
-    }
-
-    private func query(_ parameters: [String: Any]) -> String {
-        var components: [(String, String)] = []
-
-        for key in parameters.keys.sorted(by: <) {
-            let value = parameters[key]!
-            components += queryComponents(fromKey: key, value: value)
-        }
-
-        return components.map { "\($0)=\($1)" }.joined(separator: "&")
-    }
-
-    private func encodesParametersInURL(with method: HTTPMethod) -> Bool {
-        switch destination {
-        case .queryString:
-            return true
-        case .httpBody:
-            return false
-        default:
-            break
-        }
-
-        switch method {
-        case .get, .head, .delete:
-            return true
-        default:
-            return false
-        }
-    }
+    
 }
 
 // MARK: -
@@ -275,16 +184,20 @@ public struct JSONEncoding: ParameterEncoding {
 
         guard let parameters = parameters else { return urlRequest }
 
-        do {
-            let data = try JSONSerialization.data(withJSONObject: parameters, options: options)
+        if let method = HTTPMethod(rawValue: urlRequest.httpMethod ?? "GET"), encodesParametersInURL(with: method) {
+            urlRequest.url = try encode(parameters: parameters, inRequestUrl: urlRequest.url)
+        } else {
+            do {
+                let data = try JSONSerialization.data(withJSONObject: parameters, options: options)
 
-            if urlRequest.value(forHTTPHeaderField: "Content-Type") == nil {
-                urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                if urlRequest.value(forHTTPHeaderField: "Content-Type") == nil {
+                    urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                }
+
+                urlRequest.httpBody = data
+            } catch {
+                throw AFError.parameterEncodingFailed(reason: .jsonEncodingFailed(error: error))
             }
-
-            urlRequest.httpBody = data
-        } catch {
-            throw AFError.parameterEncodingFailed(reason: .jsonEncodingFailed(error: error))
         }
 
         return urlRequest
@@ -346,20 +259,24 @@ public struct PropertyListEncoding: ParameterEncoding {
 
         guard let parameters = parameters else { return urlRequest }
 
-        do {
-            let data = try PropertyListSerialization.data(
-                fromPropertyList: parameters,
-                format: format,
-                options: options
-            )
+        if let method = HTTPMethod(rawValue: urlRequest.httpMethod ?? "GET"), encodesParametersInURL(with: method) {
+            urlRequest.url = try encode(parameters: parameters, inRequestUrl: urlRequest.url)
+        } else {
+            do {
+                let data = try PropertyListSerialization.data(
+                    fromPropertyList: parameters,
+                    format: format,
+                    options: options
+                )
 
-            if urlRequest.value(forHTTPHeaderField: "Content-Type") == nil {
-                urlRequest.setValue("application/x-plist", forHTTPHeaderField: "Content-Type")
+                if urlRequest.value(forHTTPHeaderField: "Content-Type") == nil {
+                    urlRequest.setValue("application/x-plist", forHTTPHeaderField: "Content-Type")
+                }
+
+                urlRequest.httpBody = data
+            } catch {
+                throw AFError.parameterEncodingFailed(reason: .propertyListEncodingFailed(error: error))
             }
-
-            urlRequest.httpBody = data
-        } catch {
-            throw AFError.parameterEncodingFailed(reason: .propertyListEncodingFailed(error: error))
         }
 
         return urlRequest
@@ -370,4 +287,99 @@ public struct PropertyListEncoding: ParameterEncoding {
 
 extension NSNumber {
     fileprivate var isBool: Bool { return CFBooleanGetTypeID() == CFGetTypeID(self) }
+}
+
+extension ParameterEncoding {
+    
+    fileprivate func encode(parameters: Parameters, inRequestUrl requestUrl: URL?) throws -> URL? {
+        
+        guard let url = requestUrl else {
+            throw AFError.parameterEncodingFailed(reason: .missingURL)
+        }
+        
+        if var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false), !parameters.isEmpty {
+            let percentEncodedQuery = (urlComponents.percentEncodedQuery.map { $0 + "&" } ?? "") + query(parameters)
+            urlComponents.percentEncodedQuery = percentEncodedQuery
+            return urlComponents.url
+        } else {
+            return requestUrl
+        }
+    }
+    
+    /// Creates percent-escaped, URL encoded query string components from the given key-value pair using recursion.
+    ///
+    /// - parameter key:   The key of the query component.
+    /// - parameter value: The value of the query component.
+    ///
+    /// - returns: The percent-escaped, URL encoded query string components.
+    public func queryComponents(fromKey key: String, value: Any) -> [(String, String)] {
+        var components: [(String, String)] = []
+        
+        if let dictionary = value as? [String: Any] {
+            for (nestedKey, value) in dictionary {
+                components += queryComponents(fromKey: "\(key)[\(nestedKey)]", value: value)
+            }
+        } else if let array = value as? [Any] {
+            for value in array {
+                components += queryComponents(fromKey: "\(key)[]", value: value)
+            }
+        } else if let value = value as? NSNumber {
+            if value.isBool {
+                components.append((escape(key), escape((value.boolValue ? "1" : "0"))))
+            } else {
+                components.append((escape(key), escape("\(value)")))
+            }
+        } else if let bool = value as? Bool {
+            components.append((escape(key), escape((bool ? "1" : "0"))))
+        } else {
+            components.append((escape(key), escape("\(value)")))
+        }
+        
+        return components
+    }
+    
+    /// Returns a percent-escaped string following RFC 3986 for a query string key or value.
+    ///
+    /// RFC 3986 states that the following characters are "reserved" characters.
+    ///
+    /// - General Delimiters: ":", "#", "[", "]", "@", "?", "/"
+    /// - Sub-Delimiters: "!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "="
+    ///
+    /// In RFC 3986 - Section 3.4, it states that the "?" and "/" characters should not be escaped to allow
+    /// query strings to include a URL. Therefore, all "reserved" characters with the exception of "?" and "/"
+    /// should be percent-escaped in the query string.
+    ///
+    /// - parameter string: The string to be percent-escaped.
+    ///
+    /// - returns: The percent-escaped string.
+    public func escape(_ string: String) -> String {
+        let generalDelimitersToEncode = ":#[]@" // does not include "?" or "/" due to RFC 3986 - Section 3.4
+        let subDelimitersToEncode = "!$&'()*+,;="
+        
+        var allowedCharacterSet = CharacterSet.urlQueryAllowed
+        allowedCharacterSet.remove(charactersIn: "\(generalDelimitersToEncode)\(subDelimitersToEncode)")
+        
+        return string.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) ?? string
+    }
+    
+    fileprivate func query(_ parameters: [String: Any]) -> String {
+        var components: [(String, String)] = []
+        
+        for key in parameters.keys.sorted(by: <) {
+            let value = parameters[key]!
+            components += queryComponents(fromKey: key, value: value)
+        }
+        
+        return components.map { "\($0)=\($1)" }.joined(separator: "&")
+    }
+    
+    fileprivate func encodesParametersInURL(with method: HTTPMethod) -> Bool {
+        switch method {
+        case .get, .head, .delete:
+            return true
+        default:
+            return false
+        }
+    }
+    
 }

--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -27,7 +27,11 @@ import Foundation
 import XCTest
 
 class ParameterEncodingTestCase: BaseTestCase {
-    let urlRequest = URLRequest(url: URL(string: "https://example.com/")!)
+    func createUrlRequest(method: HTTPMethod, url: String = "https://example.com/") -> URLRequest {
+        var request = URLRequest(url: URL(string: url)!)
+        request.httpMethod = method.rawValue
+        return request
+    }
 }
 
 // MARK: -
@@ -43,7 +47,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
     func testURLParameterEncodeNilParameters() {
         do {
             // Given, When
-            let urlRequest = try encoding.encode(self.urlRequest, with: nil)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: nil)
 
             // Then
             XCTAssertNil(urlRequest.url?.query)
@@ -58,7 +62,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters: [String: Any] = [:]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertNil(urlRequest.url?.query)
@@ -73,7 +77,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["foo": "bar"]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "foo=bar")
@@ -85,15 +89,15 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
     func testURLParameterEncodeOneStringKeyStringValueParameterAppendedToQuery() {
         do {
             // Given
-            var mutableURLRequest = self.urlRequest
-            var urlComponents = URLComponents(url: mutableURLRequest.url!, resolvingAgainstBaseURL: false)!
+            var request = self.createUrlRequest(method: .get)
+            var urlComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)!
             urlComponents.query = "baz=qux"
-            mutableURLRequest.url = urlComponents.url
+            request.url = urlComponents.url
 
             let parameters = ["foo": "bar"]
 
             // When
-            let urlRequest = try encoding.encode(mutableURLRequest, with: parameters)
+            let urlRequest = try encoding.encode(request, with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "baz=qux&foo=bar")
@@ -108,7 +112,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["foo": "bar", "baz": "qux"]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "baz=qux&foo=bar")
@@ -123,7 +127,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["foo": NSNumber(value: 25)]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "foo=25")
@@ -138,7 +142,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["foo": NSNumber(value: false)]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "foo=0")
@@ -153,7 +157,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["foo": 1]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "foo=1")
@@ -168,7 +172,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["foo": 1.1]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "foo=1.1")
@@ -183,7 +187,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["foo": true]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "foo=1")
@@ -198,7 +202,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["foo": ["a", 1, true]]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "foo%5B%5D=a&foo%5B%5D=1&foo%5B%5D=1")
@@ -213,7 +217,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["foo": ["bar": 1]]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "foo%5Bbar%5D=1")
@@ -228,7 +232,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["foo": ["bar": ["baz": 1]]]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "foo%5Bbar%5D%5Bbaz%5D=1")
@@ -243,7 +247,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["foo": ["bar": ["baz": ["a", 1, true]]]]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             let expectedQuery = "foo%5Bbar%5D%5Bbaz%5D%5B%5D=a&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1"
@@ -263,7 +267,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["reserved": "\(generalDelimiters)\(subDelimiters)"]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             let expectedQuery = "reserved=%3A%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D"
@@ -279,7 +283,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["reserved": "?/"]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "reserved=?/")
@@ -294,7 +298,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["numbers": "0123456789"]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "numbers=0123456789")
@@ -309,7 +313,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["lowercase": "abcdefghijklmnopqrstuvwxyz"]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "lowercase=abcdefghijklmnopqrstuvwxyz")
@@ -324,7 +328,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["uppercase": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "uppercase=ABCDEFGHIJKLMNOPQRSTUVWXYZ")
@@ -339,7 +343,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["illegal": " \"#%<>[]\\^`{}|"]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             let expectedQuery = "illegal=%20%22%23%25%3C%3E%5B%5D%5C%5E%60%7B%7D%7C"
@@ -357,7 +361,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["foo&bar": "baz&qux", "foobar": "bazqux"]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "foo%26bar=baz%26qux&foobar=bazqux")
@@ -372,7 +376,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["?foo?": "?bar?"]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "?foo?=?bar?")
@@ -387,7 +391,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["foo": "/bar/baz/qux"]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "foo=/bar/baz/qux")
@@ -402,7 +406,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = [" foo ": " bar "]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "%20foo%20=%20bar%20")
@@ -417,7 +421,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["+foo+": "+bar+"]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "%2Bfoo%2B=%2Bbar%2B")
@@ -432,7 +436,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             let parameters = ["percent": "%25"]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "percent=%2525")
@@ -452,7 +456,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             ]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: parameters)
 
             // Then
             let expectedParameterValues = [
@@ -529,7 +533,7 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
     func testThatURLParameterEncodingEncodesGETParametersInURL() {
         do {
             // Given
-            var mutableURLRequest = self.urlRequest
+            var mutableURLRequest = self.createUrlRequest(method: .get)
             mutableURLRequest.httpMethod = HTTPMethod.get.rawValue
             let parameters = ["foo": 1, "bar": 2]
 
@@ -548,12 +552,11 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
     func testThatURLParameterEncodingEncodesPOSTParametersInHTTPBody() {
         do {
             // Given
-            var mutableURLRequest = self.urlRequest
-            mutableURLRequest.httpMethod = HTTPMethod.post.rawValue
+            let request = self.createUrlRequest(method: .post)
             let parameters = ["foo": 1, "bar": 2]
 
             // When
-            let urlRequest = try encoding.encode(mutableURLRequest, with: parameters)
+            let urlRequest = try encoding.encode(request, with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded; charset=utf-8")
@@ -572,12 +575,11 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
     func testThatURLEncodedInURLParameterEncodingEncodesPOSTParametersInURL() {
         do {
             // Given
-            var mutableURLRequest = self.urlRequest
-            mutableURLRequest.httpMethod = HTTPMethod.post.rawValue
+            let request = self.createUrlRequest(method: .get)
             let parameters = ["foo": 1, "bar": 2]
 
             // When
-            let urlRequest = try URLEncoding.queryString.encode(mutableURLRequest, with: parameters)
+            let urlRequest = try URLEncoding.queryString.encode(request, with: parameters)
 
             // Then
             XCTAssertEqual(urlRequest.url?.query, "bar=2&foo=1")
@@ -601,7 +603,7 @@ class JSONParameterEncodingTestCase: ParameterEncodingTestCase {
     func testJSONParameterEncodeNilParameters() {
         do {
             // Given, When
-            let URLRequest = try encoding.encode(self.urlRequest, with: nil)
+            let URLRequest = try encoding.encode(self.createUrlRequest(method: .post), with: nil)
 
             // Then
             XCTAssertNil(URLRequest.url?.query, "query should be nil")
@@ -626,7 +628,7 @@ class JSONParameterEncodingTestCase: ParameterEncodingTestCase {
             ]
 
             // When
-            let URLRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let URLRequest = try encoding.encode(self.createUrlRequest(method: .post), with: parameters)
 
             // Then
             XCTAssertNil(URLRequest.url?.query)
@@ -657,7 +659,7 @@ class JSONParameterEncodingTestCase: ParameterEncodingTestCase {
     func testJSONParameterEncodeParametersRetainsCustomContentType() {
         do {
             // Given
-            var mutableURLRequest = URLRequest(url: URL(string: "https://example.com/")!)
+            var mutableURLRequest = self.createUrlRequest(method: .post)
             mutableURLRequest.setValue("application/custom-json-type+json", forHTTPHeaderField: "Content-Type")
 
             let parameters = ["foo": "bar"]
@@ -687,7 +689,7 @@ class PropertyListParameterEncodingTestCase: ParameterEncodingTestCase {
     func testPropertyListParameterEncodeNilParameters() {
         do {
             // Given, When
-            let urlRequest = try encoding.encode(self.urlRequest, with: nil)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .get), with: nil)
 
             // Then
             XCTAssertNil(urlRequest.url?.query)
@@ -712,7 +714,7 @@ class PropertyListParameterEncodingTestCase: ParameterEncodingTestCase {
             ]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .post), with: parameters)
 
             // Then
             XCTAssertNil(urlRequest.url?.query)
@@ -750,7 +752,7 @@ class PropertyListParameterEncodingTestCase: ParameterEncodingTestCase {
             ]
 
             // When
-            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            let urlRequest = try encoding.encode(self.createUrlRequest(method: .post), with: parameters)
 
             // Then
             XCTAssertNil(urlRequest.url?.query)
@@ -778,7 +780,7 @@ class PropertyListParameterEncodingTestCase: ParameterEncodingTestCase {
     func testPropertyListParameterEncodeParametersRetainsCustomContentType() {
         do {
             // Given
-            var mutableURLRequest = URLRequest(url: URL(string: "https://example.com/")!)
+            var mutableURLRequest = self.createUrlRequest(method: .post)
             mutableURLRequest.setValue("application/custom-plist-type+plist", forHTTPHeaderField: "Content-Type")
 
             let parameters = ["foo": "bar"]


### PR DESCRIPTION
`JSONEncoding` and `PropertyListEncoding` now consider HTTP method. 
In case of GET, HEAD or DELETE parameters are not serialised into request body.

Addressing https://github.com/Alamofire/Alamofire/issues/1530