### PR TITLE
Use HTTP header's Host to validate if existed

### DIFF
--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -229,7 +229,7 @@ extension SessionDelegate: URLSessionDelegate {
         if let sessionDidReceiveChallenge = sessionDidReceiveChallenge {
             (disposition, credential) = sessionDidReceiveChallenge(session, challenge)
         } else if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust {
-            let host = challenge.protectionSpace.host
+            let host = (session.configuration.httpAdditionalHeaders?["Host"] as? String) ?? challenge.protectionSpace.host
 
             if
                 let serverTrustPolicy = session.serverTrustPolicyManager?.serverTrustPolicy(forHost: host),

--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -102,8 +102,8 @@ open class TaskDelegate: NSObject {
         if let taskDidReceiveChallenge = taskDidReceiveChallenge {
             (disposition, credential) = taskDidReceiveChallenge(session, task, challenge)
         } else if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust {
-            let host = challenge.protectionSpace.host
-
+            let host = (session.configuration.httpAdditionalHeaders?["Host"] as? String) ?? challenge.protectionSpace.host
+            
             if
                 let serverTrustPolicy = session.serverTrustPolicyManager?.serverTrustPolicy(forHost: host),
                 let serverTrust = challenge.protectionSpace.serverTrust


### PR DESCRIPTION
In a https connection, when the host in requested URL is an *IP address*, the host can’t match with domain during certificate validation, which leads to failure of SSL/TLS hand shake. it’s better to allow user define Host in HTTPS header and this would be helpful for httpdns.

```
IP: 192.168.0.1
Certificate domain: *.example.com

request: https://192.168.0.1/

let serverTrustPolicies: [String: ServerTrustPolicy] = [
    "test.example.com": .performDefaultEvaluation(validateHost: true)
]
```