### PR TITLE
Properly handle nil Data from HEAD requests

### DIFF
--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -109,7 +109,7 @@ public enum AFError: Error {
     /// The underlying reason the response serialization error occurred.
     ///
     /// - inputDataNil:                    The server response contained no data.
-    /// - inputDataNilOrZeroLength:        The server response contained no data or the data was zero length.
+    /// - inputDataZeroLength:             The server response data was zero length.
     /// - inputFileNil:                    The file containing the server response did not exist.
     /// - inputFileReadFailed:             The file containing the server response could not be read.
     /// - stringSerializationFailed:       String serialization failed using the provided `String.Encoding`.
@@ -117,7 +117,7 @@ public enum AFError: Error {
     /// - propertyListSerializationFailed: Property list serialization failed with an underlying system error.
     public enum ResponseSerializationFailureReason {
         case inputDataNil
-        case inputDataNilOrZeroLength
+        case inputDataZeroLength
         case inputFileNil
         case inputFileReadFailed(at: URL)
         case stringSerializationFailed(encoding: String.Encoding)
@@ -420,8 +420,8 @@ extension AFError.ResponseSerializationFailureReason {
         switch self {
         case .inputDataNil:
             return "Response could not be serialized, input data was nil."
-        case .inputDataNilOrZeroLength:
-            return "Response could not be serialized, input data was nil or zero length."
+        case .inputDataZeroLength:
+            return "Response could not be serialized, input data was zero length."
         case .inputFileNil:
             return "Response could not be serialized, input file was nil."
         case .inputFileReadFailed(let url):

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -261,7 +261,7 @@ extension Request {
     /// - returns: The result data type.
     public static func serializeResponseData(request: URLRequest?, response: HTTPURLResponse?, data: Data?, error: Error?) -> Result<Data> {
         guard error == nil else { return .failure(error!) }
-        
+
         guard let validData = data else {
             return isValidNoDataResponse(request: request, response: response) ?
                 .success(Data()) :
@@ -363,13 +363,13 @@ extension Request {
         -> Result<String>
     {
         guard error == nil else { return .failure(error!) }
-        
+
         guard let validData = data else {
             return isValidNoDataResponse(request: request, response: response) ?
                 .success("") :
                 .failure(AFError.responseSerializationFailed(reason: .inputDataNil))
         }
-        
+
         var convertedEncoding = encoding
 
         if let encodingName = response?.textEncodingName as CFString!, convertedEncoding == nil {
@@ -495,13 +495,13 @@ extension Request {
         -> Result<Any>
     {
         guard error == nil else { return .failure(error!) }
-        
+
         guard let validData = data else {
             return isValidNoDataResponse(request: request, response: response) ?
                 .success(NSNull()) :
                 .failure(AFError.responseSerializationFailed(reason: .inputDataNil))
         }
-        
+
         guard !validData.isEmpty else {
             return .failure(AFError.responseSerializationFailed(reason: .inputDataZeroLength))
         }
@@ -622,13 +622,13 @@ extension Request {
         -> Result<Any>
     {
         guard error == nil else { return .failure(error!) }
-        
+
         guard let validData = data else {
             return isValidNoDataResponse(request: request, response: response) ?
                 .success(NSNull()) :
                 .failure(AFError.responseSerializationFailed(reason: .inputDataNil))
         }
-        
+
         guard !validData.isEmpty else {
             return .failure(AFError.responseSerializationFailed(reason: .inputDataZeroLength))
         }
@@ -732,12 +732,12 @@ extension DownloadRequest {
 extension Request {
     /// A set of HTTP response status code that do not contain response data.
     fileprivate static let emptyDataStatusCodes: Set<Int> = [204, 205]
-    
-    
+
+
     /// A set of `HTTPMethod`s that are not required to contained response data.
     fileprivate static let emptyDataHTTPMethods: Set<HTTPMethod> = [.head]
-    
-    
+
+
     /// Determines whether it's valid for the request / response combination to have empty response data.
     ///
     /// - Parameters:
@@ -748,11 +748,11 @@ extension Request {
         if let response = response {
             return emptyDataStatusCodes.contains(response.statusCode)
         }
-        
+
         if let rawHTTPMethod = request?.httpMethod, let method = HTTPMethod(rawValue: rawHTTPMethod) {
             return emptyDataHTTPMethods.contains(method)
         }
-        
+
         return false
     }
 }

--- a/Tests/AFError+AlamofireTests.swift
+++ b/Tests/AFError+AlamofireTests.swift
@@ -117,8 +117,8 @@ extension AFError {
         return false
     }
 
-    var isInputDataNilOrZeroLength: Bool {
-        if case let .responseSerializationFailed(reason) = self, reason.isInputDataNilOrZeroLength { return true }
+    var isInputDataZeroLength: Bool {
+        if case let .responseSerializationFailed(reason) = self, reason.isInputDataZeroLength { return true }
         return false
     }
 
@@ -271,8 +271,8 @@ extension AFError.ResponseSerializationFailureReason {
         return false
     }
 
-    var isInputDataNilOrZeroLength: Bool {
-        if case .inputDataNilOrZeroLength = self { return true }
+    var isInputDataZeroLength: Bool {
+        if case .inputDataZeroLength = self { return true }
         return false
     }
 

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -73,14 +73,14 @@ class DataResponseSerializationTestCase: BaseTestCase {
             XCTFail("error should not be nil")
         }
     }
-    
+
     func testThatDataResponseSerializerSucceedsWhenDataIsEmpty() {
         // Given
         let serializer = DataRequest.dataResponseSerializer()
-        
+
         // When
         let result = serializer.serializeResponse(nil, nil, Data(), nil)
-        
+
         // Then
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(result.value)
@@ -143,16 +143,16 @@ class DataResponseSerializationTestCase: BaseTestCase {
             XCTAssertEqual(data.count, 0)
         }
     }
-    
+
     func testThatDataResponseSerializerSucceedsWhenDataIsNilWithEmptyRequestMethod() {
         // Given
         let serializer = DataRequest.dataResponseSerializer()
         var request = URLRequest(url: URL(string: "https://httpbin.org/head")!)
         request.httpMethod = HTTPMethod.head.rawValue
-        
+
         // When
         let result = serializer.serializeResponse(request, nil, nil, nil)
-        
+
         // Then
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(result.value)
@@ -330,16 +330,16 @@ class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertNil(result.error)
         XCTAssertEqual(result.value, "")
     }
-    
+
     func testThatStringResponseSerializerSucceedsWhenDataIsNilWithEmptyRequestMethod() {
         // Given
         let serializer = DataRequest.stringResponseSerializer()
         var request = URLRequest(url: URL(string: "https://httpbin.org/head")!)
         request.httpMethod = HTTPMethod.head.rawValue
-        
+
         // When
         let result = serializer.serializeResponse(request, nil, nil, nil)
-        
+
         // Then
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(result.value)
@@ -478,21 +478,21 @@ class DataResponseSerializationTestCase: BaseTestCase {
             XCTAssertEqual(json, NSNull())
         }
     }
-    
+
     func testThatJSONResponseSerializerSucceedsWhenDataIsNilWithEmptyRequestMethod() {
         // Given
         let serializer = DataRequest.jsonResponseSerializer()
         var request = URLRequest(url: URL(string: "https://httpbin.org/head")!)
         request.httpMethod = HTTPMethod.head.rawValue
-        
+
         // When
         let result = serializer.serializeResponse(request, nil, nil, nil)
-        
+
         // Then
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(result.value)
         XCTAssertNil(result.error)
-        
+
         if let json = result.value as? NSNull {
             XCTAssertEqual(json, NSNull())
         }
@@ -629,21 +629,21 @@ class DataResponseSerializationTestCase: BaseTestCase {
             XCTAssertEqual(plist, NSNull())
         }
     }
-    
+
     func testThatPropertyListResponseSerializerSucceedsWhenDataIsNilWithEmptyRequestMethod() {
         // Given
         let serializer = DataRequest.propertyListResponseSerializer()
         var request = URLRequest(url: URL(string: "https://httpbin.org/head")!)
         request.httpMethod = HTTPMethod.head.rawValue
-        
+
         // When
         let result = serializer.serializeResponse(request, nil, nil, nil)
-        
+
         // Then
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(result.value)
         XCTAssertNil(result.error)
-        
+
         if let plist = result.value as? NSNull {
             XCTAssertEqual(plist, NSNull())
         }

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -73,6 +73,19 @@ class DataResponseSerializationTestCase: BaseTestCase {
             XCTFail("error should not be nil")
         }
     }
+    
+    func testThatDataResponseSerializerSucceedsWhenDataIsEmpty() {
+        // Given
+        let serializer = DataRequest.dataResponseSerializer()
+        
+        // When
+        let result = serializer.serializeResponse(nil, nil, Data(), nil)
+        
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertNotNil(result.value)
+        XCTAssertNil(result.error)
+    }
 
     func testThatDataResponseSerializerFailsWhenErrorIsNotNil() {
         // Given
@@ -129,6 +142,22 @@ class DataResponseSerializationTestCase: BaseTestCase {
         if let data = result.value {
             XCTAssertEqual(data.count, 0)
         }
+    }
+    
+    func testThatDataResponseSerializerSucceedsWhenDataIsNilWithEmptyRequestMethod() {
+        // Given
+        let serializer = DataRequest.dataResponseSerializer()
+        var request = URLRequest(url: URL(string: "https://httpbin.org/head")!)
+        request.httpMethod = HTTPMethod.head.rawValue
+        
+        // When
+        let result = serializer.serializeResponse(request, nil, nil, nil)
+        
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertNotNil(result.value)
+        XCTAssertNil(result.error)
+        XCTAssertEqual(result.value, Data())
     }
 
     // MARK: Tests - String Response Serializer
@@ -299,10 +328,23 @@ class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(result.value)
         XCTAssertNil(result.error)
-
-        if let string = result.value {
-            XCTAssertEqual(string, "")
-        }
+        XCTAssertEqual(result.value, "")
+    }
+    
+    func testThatStringResponseSerializerSucceedsWhenDataIsNilWithEmptyRequestMethod() {
+        // Given
+        let serializer = DataRequest.stringResponseSerializer()
+        var request = URLRequest(url: URL(string: "https://httpbin.org/head")!)
+        request.httpMethod = HTTPMethod.head.rawValue
+        
+        // When
+        let result = serializer.serializeResponse(request, nil, nil, nil)
+        
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertNotNil(result.value)
+        XCTAssertNil(result.error)
+        XCTAssertEqual(result.value, "")
     }
 
     // MARK: Tests - JSON Response Serializer
@@ -320,7 +362,7 @@ class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error)
 
         if let error = result.error as? AFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
+            XCTAssertTrue(error.isInputDataNil)
         } else {
             XCTFail("error should not be nil")
         }
@@ -339,7 +381,7 @@ class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error)
 
         if let error = result.error as? AFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
+            XCTAssertTrue(error.isInputDataZeroLength)
         } else {
             XCTFail("error should not be nil")
         }
@@ -413,7 +455,7 @@ class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error)
 
         if let error = result.error as? AFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
+            XCTAssertTrue(error.isInputDataNil)
         } else {
             XCTFail("error should not be nil")
         }
@@ -436,6 +478,25 @@ class DataResponseSerializationTestCase: BaseTestCase {
             XCTAssertEqual(json, NSNull())
         }
     }
+    
+    func testThatJSONResponseSerializerSucceedsWhenDataIsNilWithEmptyRequestMethod() {
+        // Given
+        let serializer = DataRequest.jsonResponseSerializer()
+        var request = URLRequest(url: URL(string: "https://httpbin.org/head")!)
+        request.httpMethod = HTTPMethod.head.rawValue
+        
+        // When
+        let result = serializer.serializeResponse(request, nil, nil, nil)
+        
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertNotNil(result.value)
+        XCTAssertNil(result.error)
+        
+        if let json = result.value as? NSNull {
+            XCTAssertEqual(json, NSNull())
+        }
+    }
 
     // MARK: Tests - Property List Response Serializer
 
@@ -452,7 +513,7 @@ class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error)
 
         if let error = result.error as? AFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
+            XCTAssertTrue(error.isInputDataNil)
         } else {
             XCTFail("error should not be nil")
         }
@@ -471,7 +532,7 @@ class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error)
 
         if let error = result.error as? AFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
+            XCTAssertTrue(error.isInputDataZeroLength)
         } else {
             XCTFail("error should not be nil")
         }
@@ -545,7 +606,7 @@ class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error)
 
         if let error = result.error as? AFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
+            XCTAssertTrue(error.isInputDataNil)
         } else {
             XCTFail("error should not be nil")
         }
@@ -564,6 +625,25 @@ class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.value)
         XCTAssertNil(result.error)
 
+        if let plist = result.value as? NSNull {
+            XCTAssertEqual(plist, NSNull())
+        }
+    }
+    
+    func testThatPropertyListResponseSerializerSucceedsWhenDataIsNilWithEmptyRequestMethod() {
+        // Given
+        let serializer = DataRequest.propertyListResponseSerializer()
+        var request = URLRequest(url: URL(string: "https://httpbin.org/head")!)
+        request.httpMethod = HTTPMethod.head.rawValue
+        
+        // When
+        let result = serializer.serializeResponse(request, nil, nil, nil)
+        
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertNotNil(result.value)
+        XCTAssertNil(result.error)
+        
         if let plist = result.value as? NSNull {
             XCTAssertEqual(plist, NSNull())
         }
@@ -607,7 +687,7 @@ class DownloadResponseSerializationTestCase: BaseTestCase {
         XCTAssertNil(result.error)
     }
 
-    func testThatDataResponseSerializerSucceedsWhenFileDataIsNil() {
+    func testThatDataResponseSerializerSucceedsWhenFileDataIsEmpty() {
         // Given
         let serializer = DownloadRequest.dataResponseSerializer()
 
@@ -957,7 +1037,7 @@ class DownloadResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error)
 
         if let error = result.error as? AFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
+            XCTAssertTrue(error.isInputDataZeroLength)
         } else {
             XCTFail("error should not be nil")
         }
@@ -1029,7 +1109,7 @@ class DownloadResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error)
 
         if let error = result.error as? AFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
+            XCTAssertTrue(error.isInputDataNil)
         } else {
             XCTFail("error should not be nil")
         }
@@ -1106,7 +1186,7 @@ class DownloadResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error)
 
         if let error = result.error as? AFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
+            XCTAssertTrue(error.isInputDataZeroLength)
         } else {
             XCTFail("error should not be nil")
         }
@@ -1178,7 +1258,7 @@ class DownloadResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error)
 
         if let error = result.error as? AFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
+            XCTAssertTrue(error.isInputDataNil)
         } else {
             XCTFail("error should not be nil")
         }

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -294,7 +294,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-    #if os(iOS) || (macOS)
+    #if os(iOS) || os(macOS)
         if #available(iOS 10.0, macOS 10.12.0, *) {
             XCTAssertNotNil(error, "error should not be nil")
         } else {
@@ -422,7 +422,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-    #if os(iOS) || (macOS)
+    #if os(iOS) || os(macOS)
         if #available(iOS 10.0, macOS 10.12.0, *) {
             XCTAssertNotNil(error, "error should not be nil")
         } else {

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -294,7 +294,15 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
+    #if os(iOS) || (macOS)
+        if #available(iOS 10.0, macOS 10.12.0, *) {
+            XCTAssertNotNil(error, "error should not be nil")
+        } else {
+            XCTAssertNil(error, "error should be nil")
+        }
+    #else
         XCTAssertNil(error, "error should be nil")
+    #endif
     }
 
     // MARK: Server Trust Policy - Public Key Pinning Tests
@@ -414,7 +422,15 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
+    #if os(iOS) || (macOS)
+        if #available(iOS 10.0, macOS 10.12.0, *) {
+            XCTAssertNotNil(error, "error should not be nil")
+        } else {
+            XCTAssertNil(error, "error should be nil")
+        }
+    #else
         XCTAssertNil(error, "error should be nil")
+    #endif
     }
 
     // MARK: Server Trust Policy - Disabling Evaluation Tests

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -295,7 +295,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
         // Then
     #if os(iOS) || os(macOS)
-        if #available(iOS 10.0, macOS 10.12.0, *) {
+        if #available(iOS 10.1, macOS 10.12.0, *) {
             XCTAssertNotNil(error, "error should not be nil")
         } else {
             XCTAssertNil(error, "error should be nil")
@@ -423,7 +423,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
         // Then
     #if os(iOS) || os(macOS)
-        if #available(iOS 10.0, macOS 10.12.0, *) {
+        if #available(iOS 10.1, macOS 10.12.0, *) {
             XCTAssertNotNil(error, "error should not be nil")
         } else {
             XCTAssertNil(error, "error should be nil")


### PR DESCRIPTION
This PR adds support for treating `HEAD` requests as successful when they have `nil` response data. It also refactors our existing treatment of `nil` data response codes and adds tests for this new behavior.