### PR TITLE
Fix URLRequest not always being available publicly

### DIFF
--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -139,7 +139,7 @@ struct AdaptError: Error {
 }
 
 extension Error {
-    var underlyingAdaptError: Error? { return (self as? AdaptError)?.error }
+    public var underlyingAdaptError: Error? { return (self as? AdaptError)?.error }
 }
 
 // MARK: - Error Booleans

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -365,6 +365,13 @@ open class DataRequest: Request {
 
     // MARK: Properties
 
+    open override var request: URLRequest? {
+        if let request = super.request { return request }
+        if let requestable = originalTask as? Requestable { return requestable.urlRequest }
+
+        return nil
+    }
+
     /// The progress of fetching the response data from the server for the request.
     open var progress: Progress { return dataDelegate.progress }
 
@@ -465,6 +472,16 @@ open class DownloadRequest: Request {
 
     // MARK: Properties
 
+    open override var request: URLRequest? {
+        if let request = super.request { return request }
+
+        if let downloadable = originalTask as? Downloadable, case .request(let urlRequest) = downloadable {
+            return urlRequest
+        }
+
+        return nil
+    }
+
     /// The resume data of the underlying download task if available after a failure.
     open var resumeData: Data? { return downloadDelegate.resumeData }
 
@@ -562,6 +579,19 @@ open class UploadRequest: DataRequest {
     }
 
     // MARK: Properties
+
+    open override var request: URLRequest? {
+        if let request = super.request { return request }
+
+        guard let uploadable = originalTask as? Uploadable else { return nil }
+
+        switch uploadable {
+        case .data(_, let urlRequest),
+             .file(_, let urlRequest),
+             .stream(_, let urlRequest):
+            return urlRequest
+        }
+    }
 
     /// The progress of uploading the payload to the server for the upload request.
     open var uploadProgress: Progress { return uploadDelegate.uploadProgress }


### PR DESCRIPTION
This PR aims to resolve #1785 by first trying to return the `URLRequest` from the task. If it’s `nil` we’ll attempt to return `URLRequest` associated with the `originalTask`, if there is one. As per the https://github.com/Alamofire/Alamofire/issues/1785#issuecomment-261284279.

I’ve also made `Error.underlyingAdaptError` public so that request re-triers can check any underlying adapt errors. I opted to not make the error type public as it might add confusion of what type of error `RequestAdapter`s should throw.

Hopefully this is in line with Alamofire’s style and with what you where thinking @cnoon. Let me know if you want me to make any changes.

🧀🍷