### PR TITLE
Updated README for RequestRetrier example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1291,8 +1291,8 @@ class OAuth2Handler: RequestAdapter, RequestRetrier {
             .responseJSON { [weak self] response in
                 guard let strongSelf = self else { return }
 
-                if let json = response.result.value as? [String: String] {
-                    completion(true, json["access_token"], json["refresh_token"])
+                if let json = response.result.value as? [String: Any], let accessToken = json["access_token"] as? String, let refreshToken = json["refresh_token"] as? String {
+                    completion(true, accessToken, refreshToken)
                 } else {
                     completion(false, nil, nil)
                 }


### PR DESCRIPTION
This PR fixes improves the README for the `RequestRetrier`. Some OAuth services returns a result that is not convertable to [String:String]. E.g. some services returns an `expire` timestamp as an integer:

```
{
	"token_type": "Bearer",
	"refresh_token": "******************************",
	"access_token": "******************************",
	"expires_in": 36000,
	"scope": "write read"
}
```

Copying the old example from the README would result in an unsuccessful result when refreshing the access token. 