### PR TITLE
Changes default in SessionManager to allow it to be overridden.

### DIFF
--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -24,11 +24,43 @@
 
 import Foundation
 
+public protocol SessionManagerProtocol {
+
+    associatedtype DefaultType
+    
+    static var `default`:DefaultType {get}
+
+    init(configuration: URLSessionConfiguration,// = URLSessionConfiguration.default,
+        delegate: SessionDelegate,// = SessionDelegate(),
+        serverTrustPolicyManager: ServerTrustPolicyManager?)
+    
+}
+
+public extension SessionManagerProtocol {
+
+    /// A default instance of `SessionManager`, used by top-level Alamofire request methods, and suitable for use
+    /// directly for any ad hoc requests.
+    public static var `default`: SessionManager {
+        let configuration = URLSessionConfiguration.default
+        configuration.httpAdditionalHeaders = SessionManager.defaultHTTPHeaders
+        
+        return SessionManager(configuration: configuration,
+                              delegate: SessionDelegate(),
+                              serverTrustPolicyManager: nil)
+    }
+
+}
+
+
+
+
 /// Responsible for creating and managing `Request` objects, as well as their underlying `NSURLSession`.
-open class SessionManager {
+open class SessionManager: SessionManagerProtocol {
 
-    // MARK: - Helper Types
-
+    public typealias DefaultType = SessionManager
+    
+    // MARK: - Helper Types    
+    
     /// Defines whether the `MultipartFormData` encoding was successful and contains result of the encoding as
     /// associated values.
     ///
@@ -42,15 +74,6 @@ open class SessionManager {
     }
 
     // MARK: - Properties
-
-    /// A default instance of `SessionManager`, used by top-level Alamofire request methods, and suitable for use
-    /// directly for any ad hoc requests.
-    open static let `default`: SessionManager = {
-        let configuration = URLSessionConfiguration.default
-        configuration.httpAdditionalHeaders = SessionManager.defaultHTTPHeaders
-
-        return SessionManager(configuration: configuration)
-    }()
 
     /// Creates default values for the "Accept-Encoding", "Accept-Language" and "User-Agent" headers.
     open static let defaultHTTPHeaders: HTTPHeaders = {
@@ -163,10 +186,9 @@ open class SessionManager {
     ///                                       challenges. `nil` by default.
     ///
     /// - returns: The new `SessionManager` instance.
-    public init(
-        configuration: URLSessionConfiguration = URLSessionConfiguration.default,
-        delegate: SessionDelegate = SessionDelegate(),
-        serverTrustPolicyManager: ServerTrustPolicyManager? = nil)
+    public required init(configuration: URLSessionConfiguration = URLSessionConfiguration.default,
+                         delegate: SessionDelegate = SessionDelegate(),
+                         serverTrustPolicyManager: ServerTrustPolicyManager? = nil)
     {
         self.delegate = delegate
         self.session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)


### PR DESCRIPTION
Current default variable in SessionManager access is set to open which made me think that i [could override its behaviour](http://stackoverflow.com/q/40725354/999817), while some @robertmryan at [stackoverflow](http://stackoverflow.com/a/40747649/999817) was quick to point out, that default implementation of class shouldnt be overriden. I do think that part of Alamofire helper methods revolve around the default property. Therefore i think it would be appropriate to be able to override this property in either a subclass or an extension to set TrustPolicy objects, custom delegates, or even just a custom configuration object.

After playing around a little longer with alamofire, i created this small extension which allows to either subclass SessionManager or extend it in a category and continue to use helper methods in Alamofire.swift or even use SessionManager.default, as for me as user default should be something that 'suits the needs of my my app'.

Therefore i wonder if this extension is something that could be of use to comunity and something we could integrate in Alamofire. Please let me know.
