### PR TITLE
Functional extensions for Result, DataResponse, DownloadResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1401,7 +1401,7 @@ Response mapping is a good fit for your custom completion handlers:
 
 ```swift
 @discardableResult
-func loadUser(completionHandler: @escaping (DataResponse<User>) -> Void) {
+func loadUser(completionHandler: @escaping (DataResponse<User>) -> Void) -> Alamofire.DataRequest {
     return Alamofire.request("https://example.com/users/mattt").responseJSON { response in
         let userResponse = response.flatMap { json in
             try User(json: json)
@@ -1421,7 +1421,7 @@ When the map/flatMap closure may process a big amount of data, make sure you exe
 
 ```swift
 @discardableResult
-func loadUser(completionHandler: @escaping (DataResponse<User>) -> Void) {
+func loadUser(completionHandler: @escaping (DataResponse<User>) -> Void) -> Alamofire.DataRequest {
     let utilityQueue = DispatchQueue.global(qos: .utility)
     return Alamofire.request("https://example.com/users/mattt").responseJSON(queue: utilityQueue) { response in
         let userResponse = response.flatMap { json in

--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -145,6 +145,61 @@ extension DataResponse: CustomStringConvertible, CustomDebugStringConvertible {
 
 // MARK: -
 
+extension DataResponse {
+    /// Evaluates the given closure when the result of this `DataResponse` is a
+    /// success, passing the unwrapped result value as a parameter.
+    ///
+    /// Use the `map` method with a closure that does not throw. For example:
+    ///
+    ///     let possibleData: DataResponse<Data> = ...
+    ///     let possibleInt = possibleData.map { $0.count }
+    ///
+    /// - parameter transform: A closure that takes the success value of
+    ///   the instance's result.
+    /// - returns: A `DataResponse` whose result wraps the value returned by the
+    ///   given closure. If this instance's result is a failure, returns a
+    ///   response wrapping the same failure.
+    func map<T>(_ transform: (Value) -> T) -> DataResponse<T> {
+        var response = DataResponse<T>(
+            request: request,
+            response: self.response,
+            data: data,
+            result: result.map(transform),
+            timeline: timeline)
+        response._metrics = _metrics
+        return response
+    }
+    
+    /// Evaluates the given closure when the result of this `DataResponse` is a
+    /// success, passing the unwrapped result value as a parameter.
+    ///
+    /// Use the `flatMap` method with a closure that may throw an error.
+    /// For example:
+    ///
+    ///     let possibleData: DataResponse<Data> = ...
+    ///     let possibleObject = possibleData.flatMap {
+    ///         try JSONSerialization.jsonObject(with: $0)
+    ///     }
+    ///
+    /// - parameter transform: A closure that takes the success value of
+    ///   the instance's result.
+    /// - returns: A success or failure `DataResponse` depending on the result
+    ///   of the given closure. If this instance's result is a failure, returns
+    ///   the same failure.
+    func flatMap<T>(_ transform: (Value) throws -> T) -> DataResponse<T> {
+        var response = DataResponse<T>(
+            request: request,
+            response: self.response,
+            data: data,
+            result: result.flatMap(transform),
+            timeline: timeline)
+        response._metrics = _metrics
+        return response
+    }
+}
+
+// MARK: -
+
 /// Used to store all data associated with an non-serialized response of a download request.
 public struct DefaultDownloadResponse {
     /// The URL request sent to the server.
@@ -288,6 +343,65 @@ extension DownloadResponse: CustomStringConvertible, CustomDebugStringConvertibl
         output.append("[Timeline]: \(timeline.debugDescription)")
 
         return output.joined(separator: "\n")
+    }
+}
+
+// MARK: -
+
+extension DownloadResponse {
+    /// Evaluates the given closure when the result of this `DownloadResponse`
+    /// is a success, passing the unwrapped result value as a parameter.
+    ///
+    /// Use the `map` method with a closure that does not throw. For example:
+    ///
+    ///     let possibleData: DownloadResponse<Data> = ...
+    ///     let possibleInt = possibleData.map { $0.count }
+    ///
+    /// - parameter transform: A closure that takes the success value of
+    ///   the instance's result.
+    /// - returns: A `DownloadResponse` whose result wraps the value returned by the
+    ///   given closure. If this instance's result is a failure, returns a
+    ///   response wrapping the same failure.
+    func map<T>(_ transform: (Value) -> T) -> DownloadResponse<T> {
+        var response = DownloadResponse<T>(
+            request: request,
+            response: self.response,
+            temporaryURL: temporaryURL,
+            destinationURL: destinationURL,
+            resumeData: resumeData,
+            result: result.map(transform),
+            timeline: timeline)
+        response._metrics = _metrics
+        return response
+    }
+    
+    /// Evaluates the given closure when the result of this `DownloadResponse`
+    /// is a success, passing the unwrapped result value as a parameter.
+    ///
+    /// Use the `flatMap` method with a closure that may throw an error.
+    /// For example:
+    ///
+    ///     let possibleData: DownloadResponse<Data> = ...
+    ///     let possibleObject = possibleData.flatMap {
+    ///         try JSONSerialization.jsonObject(with: $0)
+    ///     }
+    ///
+    /// - parameter transform: A closure that takes the success value of
+    ///   the instance's result.
+    /// - returns: A success or failure `DownloadResponse` depending on the result
+    ///   of the given closure. If this instance's result is a failure, returns
+    ///   the same failure.
+    func flatMap<T>(_ transform: (Value) throws -> T) -> DownloadResponse<T> {
+        var response = DownloadResponse<T>(
+            request: request,
+            response: self.response,
+            temporaryURL: temporaryURL,
+            destinationURL: destinationURL,
+            resumeData: resumeData,
+            result: result.flatMap(transform),
+            timeline: timeline)
+        response._metrics = _metrics
+        return response
     }
 }
 

--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -159,7 +159,7 @@ extension DataResponse {
     /// - returns: A `DataResponse` whose result wraps the value returned by the
     ///   given closure. If this instance's result is a failure, returns a
     ///   response wrapping the same failure.
-    func map<T>(_ transform: (Value) -> T) -> DataResponse<T> {
+    public func map<T>(_ transform: (Value) -> T) -> DataResponse<T> {
         var response = DataResponse<T>(
             request: request,
             response: self.response,
@@ -186,7 +186,7 @@ extension DataResponse {
     /// - returns: A success or failure `DataResponse` depending on the result
     ///   of the given closure. If this instance's result is a failure, returns
     ///   the same failure.
-    func flatMap<T>(_ transform: (Value) throws -> T) -> DataResponse<T> {
+    public func flatMap<T>(_ transform: (Value) throws -> T) -> DataResponse<T> {
         var response = DataResponse<T>(
             request: request,
             response: self.response,
@@ -362,7 +362,7 @@ extension DownloadResponse {
     /// - returns: A `DownloadResponse` whose result wraps the value returned by the
     ///   given closure. If this instance's result is a failure, returns a
     ///   response wrapping the same failure.
-    func map<T>(_ transform: (Value) -> T) -> DownloadResponse<T> {
+    public func map<T>(_ transform: (Value) -> T) -> DownloadResponse<T> {
         var response = DownloadResponse<T>(
             request: request,
             response: self.response,
@@ -391,7 +391,7 @@ extension DownloadResponse {
     /// - returns: A success or failure `DownloadResponse` depending on the result
     ///   of the given closure. If this instance's result is a failure, returns
     ///   the same failure.
-    func flatMap<T>(_ transform: (Value) throws -> T) -> DownloadResponse<T> {
+    public func flatMap<T>(_ transform: (Value) throws -> T) -> DownloadResponse<T> {
         var response = DownloadResponse<T>(
             request: request,
             response: self.response,

--- a/Source/Result.swift
+++ b/Source/Result.swift
@@ -104,6 +104,26 @@ extension Result: CustomDebugStringConvertible {
 // MARK: - Functional Tools
 
 extension Result {
+    /// Creates a Result from the result of a closure: a failure when the
+    /// closure throws, and a success when the closure succeeds without error.
+    ///
+    ///     func someString() throws -> String { ... }
+    ///     let result = Result(value: {
+    ///         return try someString()
+    ///     })
+    ///     // The type of result is Result<String>
+    ///
+    /// The trailing closure syntax is supported:
+    ///
+    ///     let result = Result { try someString() }
+    public init(value: () throws -> Value) {
+        do {
+            self = try .success(value())
+        } catch {
+            self = .failure(error)
+        }
+    }
+    
     /// Returns the success value, or throws the failure error.
     ///
     ///     let possibleString: Result<String> = .success("success")
@@ -113,7 +133,7 @@ extension Result {
     ///     let noString: Result<String> = .failure(error)
     ///     try print(noString.unwrap())
     ///     // Throws error
-    func unwrap() throws -> Value {
+    public func unwrap() throws -> Value {
         switch self {
         case .success(let value):
             return value
@@ -141,7 +161,7 @@ extension Result {
     ///   the instance.
     /// - returns: A `Result` containing the result of the given closure. If
     ///   this instance is a failure, returns the same failure.
-    func map<T>(_ transform: (Value) -> T) -> Result<T> {
+    public func map<T>(_ transform: (Value) -> T) -> Result<T> {
         switch self {
         case .success(let value):
             return .success(transform(value))
@@ -166,7 +186,7 @@ extension Result {
     /// - returns: A success or failure `Result` depending on the result of the
     ///   given closure. If this instance is a failure, returns the`
     ///   same failure.
-    func flatMap<T>(_ transform: (Value) throws -> T) -> Result<T> {
+    public func flatMap<T>(_ transform: (Value) throws -> T) -> Result<T> {
         switch self {
         case .success(let value):
             do {

--- a/Source/Result.swift
+++ b/Source/Result.swift
@@ -100,3 +100,82 @@ extension Result: CustomDebugStringConvertible {
         }
     }
 }
+
+// MARK: - Functional Tools
+
+extension Result {
+    /// Returns the success value, or throws the failure error.
+    ///
+    ///     let possibleString: Result<String> = .success("success")
+    ///     try print(possibleString.unwrap())
+    ///     // Prints "success"
+    ///
+    ///     let noString: Result<String> = .failure(error)
+    ///     try print(noString.unwrap())
+    ///     // Throws error
+    func unwrap() throws -> Value {
+        switch self {
+        case .success(let value):
+            return value
+        case .failure(let error):
+            throw error
+        }
+    }
+    
+    /// Evaluates the given closure when this `Result` is a success, passing the
+    /// unwrapped value as a parameter.
+    ///
+    /// Use the `map` method with a closure that does not throw. For example:
+    ///
+    ///     let possibleData: Result<Data> = .success(Data())
+    ///     let possibleInt = possibleData.map { $0.count }
+    ///     try print(possibleInt.unwrap())
+    ///     // Prints "0"
+    ///
+    ///     let noData: Result<Data> = .failure(error)
+    ///     let noInt = noData.map { $0.count }
+    ///     try print(noInt.unwrap())
+    ///     // Throws error
+    ///
+    /// - parameter transform: A closure that takes the success value of
+    ///   the instance.
+    /// - returns: A `Result` containing the result of the given closure. If
+    ///   this instance is a failure, returns the same failure.
+    func map<T>(_ transform: (Value) -> T) -> Result<T> {
+        switch self {
+        case .success(let value):
+            return .success(transform(value))
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+    
+    /// Evaluates the given closure when this `Result` is a success, passing the
+    /// unwrapped value as a parameter.
+    ///
+    /// Use the `flatMap` method with a closure that may throw an error.
+    /// For example:
+    ///
+    ///     let possibleData: Result<Data> = .success(Data(...))
+    ///     let possibleObject = possibleData.flatMap {
+    ///         try JSONSerialization.jsonObject(with: $0)
+    ///     }
+    ///
+    /// - parameter transform: A closure that takes the success value of
+    ///   the instance.
+    /// - returns: A success or failure `Result` depending on the result of the
+    ///   given closure. If this instance is a failure, returns the`
+    ///   same failure.
+    func flatMap<T>(_ transform: (Value) throws -> T) -> Result<T> {
+        switch self {
+        case .success(let value):
+            do {
+                return try .success(transform(value))
+            } catch {
+                return .failure(error)
+            }
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+}

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -543,3 +543,180 @@ class DownloadResumeDataTestCase: BaseTestCase {
         progressValues.forEach { XCTAssertGreaterThanOrEqual($0, 0.4) }
     }
 }
+
+// MARK: -
+
+class DownloadResponseMapTestCase: BaseTestCase {
+    func testThatMapTransformsSuccessValue() {
+        // Given
+        let urlString = "https://httpbin.org/get"
+        let expectation = self.expectation(description: "request should succeed")
+        
+        var response: DownloadResponse<String>?
+        
+        // When
+        Alamofire.download(urlString, parameters: ["foo": "bar"])
+            .responseJSON { resp in
+                response = resp.map { json in
+                    // json["args"]["foo"] is "bar": use this invariant to test the map function
+                    return ((json as! [String: Any])["args"] as! [String: Any])["foo"] as! String
+                }
+                expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        // Then
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNotNil(response?.temporaryURL)
+        XCTAssertNil(response?.destinationURL)
+        XCTAssertNil(response?.resumeData)
+        XCTAssertNil(response?.error)
+        XCTAssertEqual(response?.result.value, "bar")
+        
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            XCTAssertNotNil(response?.metrics)
+        }
+    }
+    
+    func testThatMapPreservesFailureError() {
+        // Given
+        let urlString = "https://invalid-url-here.org/this/does/not/exist"
+        let expectation = self.expectation(description: "request should fail with 404")
+        
+        var response: DownloadResponse<String>?
+        
+        // When
+        Alamofire.download(urlString, parameters: ["foo": "bar"])
+            .responseJSON { resp in
+                response = resp.map { json in
+                    fatalError("should not run")
+                }
+                expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        // Then
+        XCTAssertNotNil(response?.request)
+        XCTAssertNil(response?.response)
+        XCTAssertNil(response?.temporaryURL)
+        XCTAssertNil(response?.destinationURL)
+        XCTAssertNil(response?.resumeData)
+        XCTAssertNotNil(response?.error)
+        XCTAssertEqual(response?.result.isFailure, true)
+        
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            XCTAssertNotNil(response?.metrics)
+        }
+    }
+}
+
+// MARK: -
+
+class DownloadResponseFlatMapTestCase: BaseTestCase {
+    func testThatFlatMapTransformsSuccessValue() {
+        // Given
+        let urlString = "https://httpbin.org/get"
+        let expectation = self.expectation(description: "request should succeed")
+        
+        var response: DownloadResponse<String>?
+        
+        // When
+        Alamofire.download(urlString, parameters: ["foo": "bar"])
+            .responseJSON { resp in
+                response = resp.flatMap { json in
+                    // json["args"]["foo"] is "bar": use this invariant to test the map function
+                    return ((json as! [String: Any])["args"] as! [String: Any])["foo"] as! String
+                }
+                expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        // Then
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNotNil(response?.temporaryURL)
+        XCTAssertNil(response?.destinationURL)
+        XCTAssertNil(response?.resumeData)
+        XCTAssertNil(response?.error)
+        XCTAssertEqual(response?.result.value, "bar")
+        
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            XCTAssertNotNil(response?.metrics)
+        }
+    }
+    
+    func testThatFlatMapCatchesTransformationError() {
+        // Given
+        let urlString = "https://httpbin.org/get"
+        let expectation = self.expectation(description: "request should succeed")
+        
+        var response: DownloadResponse<String>?
+        
+        // When
+        struct TransformError : Error { }
+        Alamofire.download(urlString, parameters: ["foo": "bar"])
+            .responseJSON { resp in
+                response = resp.flatMap { json in
+                    throw TransformError()
+                }
+                expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        // Then
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNotNil(response?.temporaryURL)
+        XCTAssertNil(response?.destinationURL)
+        XCTAssertNil(response?.resumeData)
+        if let error = response?.result.error {
+            XCTAssertTrue(
+                error is TransformError,
+                "flatMap should catch the transformation error"
+            )
+        } else {
+            XCTFail("flatMap should catch the transformation error")
+        }
+        
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            XCTAssertNotNil(response?.metrics)
+        }
+    }
+    
+    func testThatFlatMapPreservesFailureError() {
+        // Given
+        let urlString = "https://invalid-url-here.org/this/does/not/exist"
+        let expectation = self.expectation(description: "request should fail with 404")
+        
+        var response: DownloadResponse<String>?
+        
+        // When
+        Alamofire.download(urlString, parameters: ["foo": "bar"])
+            .responseJSON { resp in
+                response = resp.flatMap { json in
+                    fatalError("should not run")
+                }
+                expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        // Then
+        XCTAssertNotNil(response?.request)
+        XCTAssertNil(response?.response)
+        XCTAssertNil(response?.temporaryURL)
+        XCTAssertNil(response?.destinationURL)
+        XCTAssertNil(response?.resumeData)
+        XCTAssertNotNil(response?.error)
+        XCTAssertEqual(response?.result.isFailure, true)
+        
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            XCTAssertNotNil(response?.metrics)
+        }
+    }
+}

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -590,9 +590,7 @@ class DownloadResponseMapTestCase: BaseTestCase {
         // When
         Alamofire.download(urlString, parameters: ["foo": "bar"])
             .responseJSON { resp in
-                response = resp.map { json in
-                    fatalError("should not run")
-                }
+                response = resp.map { json in "ignored" }
                 expectation.fulfill()
         }
         
@@ -698,9 +696,7 @@ class DownloadResponseFlatMapTestCase: BaseTestCase {
         // When
         Alamofire.download(urlString, parameters: ["foo": "bar"])
             .responseJSON { resp in
-                response = resp.flatMap { json in
-                    fatalError("should not run")
-                }
+                response = resp.flatMap { json in "ignored" }
                 expectation.fulfill()
         }
         

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -363,9 +363,7 @@ class ResponseMapTestCase: BaseTestCase {
         
         // When
         Alamofire.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
-            response = resp.map { json in
-                fatalError("should not run")
-            }
+            response = resp.map { json in "ignored" }
             expectation.fulfill()
         }
         
@@ -462,9 +460,7 @@ class ResponseFlatMapTestCase: BaseTestCase {
         
         // When
         Alamofire.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
-            response = resp.flatMap { json in
-                fatalError("should not run")
-            }
+            response = resp.flatMap { json in "ignored" }
             expectation.fulfill()
         }
         

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -382,3 +382,102 @@ class ResponseMapTestCase: BaseTestCase {
         }
     }
 }
+
+// MARK: -
+
+class ResponseFlatMapTestCase: BaseTestCase {
+    func testThatFlatMapTransformsSuccessValue() {
+        // Given
+        let urlString = "https://httpbin.org/get"
+        let expectation = self.expectation(description: "request should succeed")
+        
+        var response: DataResponse<String>?
+        
+        // When
+        Alamofire.request(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
+            response = resp.flatMap { json in
+                // json["args"]["foo"] is "bar": use this invariant to test the flatMap function
+                return ((json as! [String: Any])["args"] as! [String: Any])["foo"] as! String
+            }
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        // Then
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertEqual(response?.result.isSuccess, true)
+        XCTAssertEqual(response?.result.value, "bar")
+        
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            XCTAssertNotNil(response?.metrics)
+        }
+    }
+    
+    func testThatFlatMapCatchesTransformationError() {
+        // Given
+        let urlString = "https://httpbin.org/get"
+        let expectation = self.expectation(description: "request should succeed")
+        
+        var response: DataResponse<String>?
+        
+        // When
+        struct TransformError : Error { }
+        Alamofire.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
+            response = resp.flatMap { json in
+                throw TransformError()
+            }
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        // Then
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertEqual(response?.result.isFailure, true)
+        if let error = response?.result.error {
+            XCTAssertTrue(
+                error is TransformError,
+                "flatMap should catch the transformation error"
+            )
+        } else {
+            XCTFail("flatMap should catch the transformation error")
+        }
+        
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            XCTAssertNotNil(response?.metrics)
+        }
+    }
+    
+    func testThatFlatMapPreservesFailureError() {
+        // Given
+        let urlString = "https://invalid-url-here.org/this/does/not/exist"
+        let expectation = self.expectation(description: "request should fail with 404")
+        
+        var response: DataResponse<String>?
+        
+        // When
+        Alamofire.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
+            response = resp.flatMap { json in
+                fatalError("should not run")
+            }
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        // Then
+        XCTAssertNotNil(response?.request)
+        XCTAssertNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertEqual(response?.result.isFailure, true)
+        
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            XCTAssertNotNil(response?.metrics)
+        }
+    }
+}

--- a/Tests/ResultTests.swift
+++ b/Tests/ResultTests.swift
@@ -214,7 +214,7 @@ class ResultTestCase: BaseTestCase {
         let result = Result<String>.success("success value")
         
         // Then
-        let mappedResult = result.map { $0.characters.count }
+        let mappedResult = result.flatMap { $0.characters.count }
         XCTAssertEqual(
             mappedResult.value ?? 0,
             13,

--- a/Tests/ResultTests.swift
+++ b/Tests/ResultTests.swift
@@ -145,6 +145,34 @@ class ResultTestCase: BaseTestCase {
         )
     }
     
+    // MARK: - Initializer from throwing closure Tests
+    
+    func testThatInitializerFromThrowingClosureStoresResultAsASuccess() {
+        // Given, When
+        let value = "success value"
+        let result1 = Result(value: { value })  // syntax 1
+        let result2 = Result { value }          // syntax 2
+        
+        // Then
+        for result in [result1, result2] {
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertEqual(result.value, value)
+        }
+    }
+    
+    func testThatInitializerFromThrowingClosureCatchesErrorAsAFailure() {
+        // Given, When
+        struct ResultError : Error { }
+        let result1 = Result(value: { throw ResultError() })    // syntax 1
+        let result2 = Result { throw ResultError() }            // syntax 2
+        
+        // Then
+        for result in [result1, result2] {
+            XCTAssertTrue(result.isFailure)
+            XCTAssertTrue(result.error! is ResultError)
+        }
+    }
+    
     // MARK: - Unwrap Tests
     
     func testThatUnwrapReturnsSuccessValue() {

--- a/Tests/ResultTests.swift
+++ b/Tests/ResultTests.swift
@@ -144,4 +144,116 @@ class ResultTestCase: BaseTestCase {
             "result debug description should match expected value for failure case"
         )
     }
+    
+    // MARK: - Unwrap Tests
+    
+    func testThatUnwrapReturnsSuccessValue() {
+        // Given, When
+        let result = Result<String>.success("success value")
+        
+        // Then
+        XCTAssertEqual(
+            try result.unwrap(),
+            "success value",
+            "result unwrapping should return the success value"
+        )
+    }
+    
+    func testThatUnwrapThrowsFailureError() {
+        // Given, When
+        struct ResultError : Error { }
+        let result = Result<String>.failure(ResultError())
+        
+        // Then
+        do {
+            _ = try result.unwrap()
+            XCTFail("result unwrapping should throw the failure error")
+        } catch {
+            XCTAssert(
+                error is ResultError,
+                "result unwrapping should throw the failure error")
+        }
+    }
+    
+    // MARK: - Map Tests
+    
+    func testThatMapTransformsSuccessValue() {
+        // Given, When
+        let result = Result<String>.success("success value")
+        
+        // Then
+        let mappedResult = result.map { $0.characters.count }
+        XCTAssertEqual(
+            mappedResult.value ?? 0,
+            13,
+            "map should transform the success value"
+        )
+    }
+    
+    func testThatMapPreservesFailureError() {
+        // Given, When
+        struct ResultError : Error { }
+        let result = Result<String>.failure(ResultError())
+        
+        // Then
+        let mappedResult = result.map { $0.characters.count }
+        if let error = mappedResult.error {
+            XCTAssertTrue(
+                error is ResultError,
+                "map should preserve the failure error"
+            )
+        } else {
+            XCTFail("map should preserve the failure error")
+        }
+    }
+    
+    // MARK: - FlatMap Tests
+    
+    func testThatFlatMapTransformsSuccessValue() {
+        // Given, When
+        let result = Result<String>.success("success value")
+        
+        // Then
+        let mappedResult = result.map { $0.characters.count }
+        XCTAssertEqual(
+            mappedResult.value ?? 0,
+            13,
+            "flatMap should transform the success value"
+        )
+    }
+    
+    func testThatFlatMapCatchesTransformationError() {
+        // Given, When
+        let result = Result<String>.success("success value")
+        
+        // Then
+        struct TransformError : Error { }
+        let mappedResult = result.flatMap { _ in throw TransformError() }
+        if let error = mappedResult.error {
+            XCTAssertTrue(
+                error is TransformError,
+                "flatMap should catch the transformation error"
+            )
+        } else {
+            XCTFail("flatMap should catch the transformation error")
+        }
+    }
+    
+    func testThatFlatMapPreservesFailureError() {
+        // Given, When
+        struct ResultError : Error { }
+        let result = Result<String>.failure(ResultError())
+        
+        // Then
+        struct TransformError : Error { }
+        let mappedResult = result.flatMap { _ in throw TransformError() }
+        if let error = mappedResult.error {
+            XCTAssertTrue(
+                error is ResultError,
+                "flatMap should preserve the failure error"
+            )
+        } else {
+            XCTFail("flatMap should preserve the failure error")
+        }
+    }
 }


### PR DESCRIPTION
Hello,

This pull request addresses #1072.

It contains:

- Three new Result methods: `unwrap`, `map`, and `flatMap`.
- Two new DataResponse and DownloadResponse methods: `map` and `flatMap`.
- Tests for Result
- Inline documentation

It does not contain:

- Tests for DataResponse and DownloadResponse, because I don't quite know where to put them
- Documentation in README.md, because I prefer waiting for your feedback

### Result.unwrap

`unwrap` returns a result's success value, or throws its failure error:

```swift
let result: Result<Data> = ...
try result.unwrap() // Data
```

### Result.map

`map` transforms the success value of a result, while preserving its eventual failure error. Its closure argument must not throw any error:

```swift
let result: Result<Data> = ...
result.map { $0.count } // Result<Int>
```

### Result.flatMap

`flatMap` transforms the success value of a result, while preserving its eventual failure error, and catches eventual transformation error:

```swift
let result: Result<Data> = ...
result.flatMap { try JSONSerialization.jsonObject(with: $0) } // Result<Any>
```

It is worth noting that the proposed flatMap method does not strictly follow the rules of functional programming, because its closure argument does not return another Result. Instead, its closure returns a regular value, and can throw. That's because in Swift, throwing methods are more fundamental than the `Result` type, and the sample code above looks like it is the right thing to do. Besides, users who use Result extensively can still use the unwrap method in their flatMap closures:

```swift
func f(_ data: Data) -> Result<Int> { ... }
let result: Result<Data> = ...
result.flatMap { try f($0).unwrap() } // Result<Int>
```

### DataResponse and DownloadResponse

Their `map` and `flatMap` methods apply `map` and `flatMap` to their result, while preserving all other information (requests, timelines, etc.).

They make it easier to perform ad-hoc deserializations, when extending Alamofire with a full-fledged DataResponseSerializer is not worth it.

```swift
func getStuff(_ completionHandler: @escaping (DataResponse<Stuff>) -> Void)) {
    Alamofire.request("https://httpbin.org/get").responseJSON { response in
        completionHandler(response.flatMap { JSON in
            return try Stuff(with: JSON)
        })
    }
}

getStuff { response in
    print(response.request)  // original URL request
    print(response.response) // HTTP URL response
    print(response.data)     // server data
    print(response.result)   // result of response serialization

    if let stuff = response.result.value {
        print("stuff: \(stuff)")
    }
}
```

---

What do you think?
