### PR TITLE
Fix - SessionManager Retry Delay

### DIFF
--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -471,10 +471,10 @@ extension SessionDelegate: URLSessionTaskDelegate {
         /// If an error occurred and the retrier is set, asynchronously ask the retrier if the request
         /// should be retried. Otherwise, complete the task by notifying the task delegate.
         if let retrier = retrier, let error = error {
-            retrier.should(sessionManager, retry: request, with: error) { [weak self] shouldRetry, delay in
+            retrier.should(sessionManager, retry: request, with: error) { [weak self] shouldRetry, timeDelay in
                 guard shouldRetry else { completeTask(session, task, error) ; return }
 
-                DispatchQueue.utility.after(delay) { [weak self] in
+                DispatchQueue.utility.after(timeDelay) { [weak self] in
                     guard let strongSelf = self else { return }
 
                     let retrySucceeded = strongSelf.sessionManager?.retry(request) ?? false

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -874,12 +874,16 @@ open class SessionManager {
                     return
                 }
 
-                let retrySucceeded = strongSelf.retry(request)
+                DispatchQueue.utility.after(timeDelay) {
+                    guard let strongSelf = self else { return }
 
-                if retrySucceeded, let task = request.task {
-                    strongSelf.delegate[task] = request
-                } else {
-                    if strongSelf.startRequestsImmediately { request.resume() }
+                    let retrySucceeded = strongSelf.retry(request)
+
+                    if retrySucceeded, let task = request.task {
+                        strongSelf.delegate[task] = request
+                    } else {
+                        if strongSelf.startRequestsImmediately { request.resume() }
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR addresses the issue pointed out in #1853 where the `SessionManager` internal retry logic for `AdaptError` instances was not respecting the time delay. This small change now respects the delay returned by the retrier.