### PR TITLE
Feature - Opening up Default Response Initializers

### DIFF
--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -87,6 +87,12 @@ public struct DataResponse<Value> {
     /// The timeline of the complete lifecycle of the request.
     public let timeline: Timeline
 
+    /// Returns the associated value of the result if it is a success, `nil` otherwise.
+    public var value: Value? { return result.value }
+
+    /// Returns the associated error value if the result if it is a failure, `nil` otherwise.
+    public var error: Error? { return result.error }
+
     var _metrics: AnyObject?
 
     /// Creates a `DataResponse` instance with the specified parameters derived from response serialization.
@@ -219,6 +225,12 @@ public struct DownloadResponse<Value> {
 
     /// The timeline of the complete lifecycle of the request.
     public let timeline: Timeline
+
+    /// Returns the associated value of the result if it is a success, `nil` otherwise.
+    public var value: Value? { return result.value }
+
+    /// Returns the associated error value if the result if it is a failure, `nil` otherwise.
+    public var error: Error? { return result.error }
 
     var _metrics: AnyObject?
 

--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -43,7 +43,23 @@ public struct DefaultDataResponse {
 
     var _metrics: AnyObject?
 
-    init(request: URLRequest?, response: HTTPURLResponse?, data: Data?, error: Error?, timeline: Timeline = Timeline()) {
+    /// Creates a `DefaultDataResponse` instance from the specified parameters.
+    ///
+    /// - Parameters:
+    ///   - request:  The URL request sent to the server.
+    ///   - response: The server's response to the URL request.
+    ///   - data:     The data returned by the server.
+    ///   - error:    The error encountered while executing or validating the request.
+    ///   - timeline: The timeline of the complete lifecycle of the request. `Timeline()` by default.
+    ///   - metrics:  The task metrics containing the request / response statistics. `nil` by default.
+    public init(
+        request: URLRequest?,
+        response: HTTPURLResponse?,
+        data: Data?,
+        error: Error?,
+        timeline: Timeline = Timeline(),
+        metrics: AnyObject? = nil)
+    {
         self.request = request
         self.response = response
         self.data = data
@@ -148,14 +164,26 @@ public struct DefaultDownloadResponse {
 
     var _metrics: AnyObject?
 
-    init(
+    /// Creates a `DefaultDownloadResponse` instance from the specified parameters.
+    ///
+    /// - Parameters:
+    ///   - request:        The URL request sent to the server.
+    ///   - response:       The server's response to the URL request.
+    ///   - temporaryURL:   The temporary destination URL of the data returned from the server.
+    ///   - destinationURL: The final destination URL of the data returned from the server if it was moved.
+    ///   - resumeData:     The resume data generated if the request was cancelled.
+    ///   - error:          The error encountered while executing or validating the request.
+    ///   - timeline:       The timeline of the complete lifecycle of the request. `Timeline()` by default.
+    ///   - metrics:        The task metrics containing the request / response statistics. `nil` by default.
+    public init(
         request: URLRequest?,
         response: HTTPURLResponse?,
         temporaryURL: URL?,
         destinationURL: URL?,
         resumeData: Data?,
         error: Error?,
-        timeline: Timeline = Timeline())
+        timeline: Timeline = Timeline(),
+        metrics: AnyObject? = nil)
     {
         self.request = request
         self.response = response


### PR DESCRIPTION
This PR modifies the `DefaultDataResponse` and `DefaultDownloadResponse` initializers to be `public` instead of `internal`. This allows you to rebuild the responses if necessary in client code to do things like wrap the `error` in your own custom error or modify the server data or possibly inject a missing header, etc. The main use case is to wrap the `error`.

This PR also adds convenience properties to the `DataResponse` and `DownloadResponse` structs for accessing the `value` and `error` in the result. Both of these computed properties are merely for convenience.