### PR TITLE
Add the request method to debugDescription.

### DIFF
--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -111,7 +111,7 @@ extension DataResponse: CustomStringConvertible, CustomDebugStringConvertible {
     public var debugDescription: String {
         var output: [String] = []
 
-        output.append(request != nil ? "[Request]: \(request!)" : "[Request]: nil")
+        output.append(request != nil ? "[Request]: \(request!.httpMethod!) \(request!)" : "[Request]: nil")
         output.append(response != nil ? "[Response]: \(response!)" : "[Response]: nil")
         output.append("[Data]: \(data?.count ?? 0) bytes")
         output.append("[Result]: \(result.debugDescription)")
@@ -239,7 +239,7 @@ extension DownloadResponse: CustomStringConvertible, CustomDebugStringConvertibl
     public var debugDescription: String {
         var output: [String] = []
 
-        output.append(request != nil ? "[Request]: \(request!)" : "[Request]: nil")
+        output.append(request != nil ? "[Request]: \(request!.httpMethod!) \(request!)" : "[Request]: nil")
         output.append(response != nil ? "[Response]: \(response!)" : "[Response]: nil")
         output.append("[TemporaryURL]: \(temporaryURL?.path ?? "nil")")
         output.append("[DestinationURL]: \(destinationURL?.path ?? "nil")")


### PR DESCRIPTION
This PR adds the request method to the `DataResponse` and `DownloadResponse` `debugDescriptions`.