### PR TITLE
Add QueryURL wrapper class and test for url/body parameter combination

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -64,6 +64,37 @@ extension URLComponents: URLConvertible {
     }
 }
 
+/// Wrapper around URLConvertible to force-include query parameters on body-enabled requests.
+/// Use this if you want to pass body parameters and query paramters in one request.
+public class QueryURL: URLConvertible {
+    let url: URLConvertible
+    let parameters: Parameters
+
+    /// Creates a new QueryURL object with given url and query parameters.
+    ///
+    /// - parameter url:        The URL.
+    /// - parameter parameters: The parameters to be included into the URL as query params.
+    public init(url: URLConvertible, parameters: Parameters) {
+        self.url = url
+        self.parameters = parameters
+    }
+}
+
+extension QueryURL {
+    /// Returns a URL that conforms to RFC 2396 or throws an `Error`.
+    ///
+    /// - throws: An `Error` if the type cannot be converted to a `URL`.
+    ///
+    /// - returns: A URL or throws an `Error`.
+    public func asURL() throws -> URL {
+        let url = try self.url.asURL()
+        let fakeUrlRequest = URLRequest(url: url)
+        let queryFakeUrlRequest = try URLEncoding.default.encode(fakeUrlRequest, with: self.parameters)
+        guard let queryUrl = queryFakeUrlRequest.url else { throw AFError.invalidURL(url: self) }
+        return queryUrl
+    }
+}
+
 // MARK: -
 
 /// Types adopting the `URLRequestConvertible` protocol can be used to construct URL requests.

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -56,6 +56,37 @@ class RequestInitializationTestCase: BaseTestCase {
         XCTAssertNil(request.response)
     }
 
+    func testRequestClassMethodWithMethodAndQueryURLAndParameters() {
+        // Given
+        let urlString = "https://httpbin.org/"
+
+        // When
+        let queryUrl = QueryURL(url: urlString, parameters: ["lorem": "ipsum"])
+        let bodyParameters = ["foo": "bar"]
+        let request = Alamofire.request(queryUrl, method: .post, parameters: bodyParameters, encoding: JSONEncoding.default)
+
+        // Then
+        XCTAssertNotNil(request.request)
+        XCTAssertEqual(request.request?.httpMethod, "POST")
+        XCTAssertNotEqual(request.request?.url?.absoluteString, urlString)
+        XCTAssertEqual(request.request?.url?.query, "lorem=ipsum")
+        XCTAssertNotNil(request.request?.httpBody)
+
+        if let httpBody = request.request?.httpBody {
+            do {
+                let json = try JSONSerialization.jsonObject(with: httpBody, options: .allowFragments)
+
+                if let json = json as? NSObject {
+                    XCTAssertEqual(json, bodyParameters as NSObject)
+                } else {
+                    XCTFail("json should be an NSObject")
+                }
+            } catch {
+                XCTFail("json should not be nil")
+            }
+        }
+    }
+
     func testRequestClassMethodWithMethodURLParametersAndHeaders() {
         // Given
         let urlString = "https://httpbin.org/get"


### PR DESCRIPTION
This adds the feature requested in #374 to Alamofire in a backwards-compatible and (hopefully) clean way. I'd love to hear feedback on this approach. The usage would be as simple as this:

```swift
let queryUrl = QueryURL(url: urlString, parameters: ["lorem": "ipsum"])
let bodyParameters = ["foo": "bar"]
Alamofire.request(queryUrl, method: .post, parameters: bodyParameters, encoding: JSONEncoding.default).response // ...
```

Progress:

- [x] Implement support for both query and body parameters
- [x] Write test to ensure the feature survives future changes
- [ ] Add a section to the README explaining this feature