### PR TITLE
Add request/download methods allowing query/body parameter combinations

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -146,6 +146,37 @@ public func request(
     )
 }
 
+/// Creates a `DataRequest` using the default `SessionManager` to retrieve the contents of the specified `url`,
+/// `method`, `queryParameters`, `bodyParameters`, `bodyEncoding` and `headers`.
+///
+/// - parameter url:                The URL.
+/// - parameter method:             The HTTP method. `.get` by default.
+/// - parameter queryParameters:    The query parameters. `nil` by default.
+/// - parameter bodyParameters:     The body parameters. `nil` by default.
+/// - parameter encoding:           The body parameter encoding. `URLEncoding.default` by default.
+/// - parameter headers:            The HTTP headers. `nil` by default.
+///
+/// - returns: The created `DataRequest`.
+@discardableResult
+public func request(
+    _ url: URLConvertible,
+    method: HTTPMethod = .get,
+    queryParameters: Parameters?,
+    bodyParameters: Parameters? = nil,
+    bodyEncoding: ParameterEncoding = URLEncoding.default,
+    headers: HTTPHeaders? = nil)
+    -> DataRequest
+{
+    return SessionManager.default.request(
+        url,
+        method: method,
+        queryParameters: queryParameters,
+        bodyParameters: bodyParameters,
+        bodyEncoding: bodyEncoding,
+        headers: headers
+    )
+}
+
 /// Creates a `DataRequest` using the default `SessionManager` to retrieve the contents of a URL based on the
 /// specified `urlRequest`.
 ///

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -231,12 +231,44 @@ open class SessionManager {
         headers: HTTPHeaders? = nil)
         -> DataRequest
     {
+        return request(
+            url,
+            method: method,
+            queryParameters: nil,
+            bodyParameters: parameters,
+            bodyEncoding: encoding,
+            headers: headers
+        )
+    }
+
+    /// Creates a `DataRequest` to retrieve the contents of the specified `url`, `method`, `queryParameters`,
+    /// `bodyParameters`, `bodyEncoding` and `headers`.
+    ///
+    /// - parameter url:                The URL.
+    /// - parameter method:             The HTTP method. `.get` by default.
+    /// - parameter queryParameters:    The query parameters. `nil` by default.
+    /// - parameter bodyParameters:     The body parameters. `nil` by default.
+    /// - parameter encoding:           The body parameter encoding. `URLEncoding.default` by default.
+    /// - parameter headers:            The HTTP headers. `nil` by default.
+    ///
+    /// - returns: The created `DataRequest`.
+    @discardableResult
+    open func request(
+        _ url: URLConvertible,
+        method: HTTPMethod = .get,
+        queryParameters: Parameters?,
+        bodyParameters: Parameters? = nil,
+        bodyEncoding: ParameterEncoding = URLEncoding.default,
+        headers: HTTPHeaders? = nil)
+        -> DataRequest
+    {
         var originalRequest: URLRequest?
 
         do {
             originalRequest = try URLRequest(url: url, method: method, headers: headers)
-            let encodedURLRequest = try encoding.encode(originalRequest!, with: parameters)
-            return request(encodedURLRequest)
+            let queryEncodedURLRequest = try URLEncoding.default.encode(originalRequest!, with: queryParameters)
+            let queryAndBodyEncodedURLRequest = try bodyEncoding.encode(queryEncodedURLRequest, with: bodyParameters)
+            return request(queryAndBodyEncodedURLRequest)
         } catch {
             return request(originalRequest, failedWith: error)
         }


### PR DESCRIPTION
This is a follow-up on #1883 and implements my second approach explained in https://github.com/Alamofire/Alamofire/pull/1883#issuecomment-269853832.

Progress:
- [x] Add new request method which accepts both query and body parameters
- [x] Make the existing request method a convenience method for the new one
- [ ] Add new download method which accepts both query and body parameters
- [ ] Make existing download method a convenience method for the new one
- [ ] Add tests to cover the new method use cases
- [ ] Document the new method in the README