### PR TITLE
Add README entry about installing through SPM.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,18 @@ github "Alamofire/Alamofire" ~> 4.0
 
 Run `carthage update` to build the framework and drag the built `Alamofire.framework` into your Xcode project.
 
+### Swift Pacakge Manager
+
+The [Swift Pacakage Manager](https://swift.org/package-manager/) is a tool for automating the distribution of Swift code and is integrated into the `swift` compiler. It is in early development, but Alamofire does support its use on supported platforms. 
+
+Once you have your Swift package set up, adding Alamofire as a dependency is as easy as adding it to the `dependencies` value of your `Package.swift`.
+
+```swift
+dependencies: [
+    .Package(url: "https://github.com/Alamofire/Alamofire.git", majorVersion: 4)
+]
+```
+
 ### Manually
 
 If you prefer not to use either of the aforementioned dependency managers, you can integrate Alamofire into your project manually.


### PR DESCRIPTION
This PR adds a README entry about installing through SPM. The current `Package.swift` file didn't need any changes to build as a dependency of another SPM package.