### PR TITLE
fix error of a unescaped logging for symbol "$" in headers

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -327,7 +327,8 @@ extension Request: CustomDebugStringConvertible {
         }
 
         for (field, value) in headers {
-            components.append("-H \"\(field): \(value)\"")
+            let escapedValue = "\(value)".replacingOccurrences(of: "$", with: "\\$")
+            components.append("-H \"\(field): \(escapedValue)\"")
         }
 
         if let httpBodyData = request.httpBody, let httpBody = String(data: httpBodyData, encoding: .utf8) {


### PR DESCRIPTION
if request header contains "$" symbol, then debugDescription (cUrlRepresentation)  returns incorrect value: header contains not escaping value for this symbol, and on server we have header with incorrect value (it includes only part before "$" symbol).