### PR TITLE
Fix README example in the "POST Request with Parameters" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,9 +445,9 @@ let parameters: Parameters = [
 ]
 
 // All three of these calls are equivalent
-Alamofire.request("https://httpbin.org/post", parameters: parameters)
-Alamofire.request("https://httpbin.org/post", parameters: parameters, encoding: URLEncoding.default)
-Alamofire.request("https://httpbin.org/post", parameters: parameters, encoding: URLEncoding.httpBody)
+Alamofire.request("https://httpbin.org/post", method: .post, parameters: parameters)
+Alamofire.request("https://httpbin.org/post", method: .post, parameters: parameters, encoding: URLEncoding.default)
+Alamofire.request("https://httpbin.org/post", method: .post, parameters: parameters, encoding: URLEncoding.httpBody)
 
 // HTTP body: foo=bar&baz[]=a&baz[]=1&qux[x]=1&qux[y]=2&qux[z]=3
 ```


### PR DESCRIPTION
In the `README.md` the usage example for `POST Request with Parameters` doesn't include the parameter `method: .post`.

If the method is not included in the `request` it will default to `.get`