### PR TITLE
Fixes bugs in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,7 +630,7 @@ You can also provide a `DownloadFileDestination` closure to move the file from t
 ```swift
 let destination: DownloadRequest.DownloadFileDestination = { _, _ in
 	let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-	let fileURL = documentsURL.appendPathComponent("pig.png")
+	let fileURL = documentsURL.appendingPathComponent("pig.png")
 
     return (fileURL, [.removePreviousFile, .createIntermediateDirectories])
 }
@@ -699,7 +699,7 @@ class ImageRequestor {
 
 		let destination: DownloadRequest.DownloadFileDestination = { _, _ in
 			let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-			let fileURL = documentsURL.appendPathComponent("pig.png")
+			let fileURL = documentsURL.appendingPathComponent("pig.png")
 
 		    return (fileURL, [.removePreviousFile, .createIntermediateDirectories])
 		}


### PR DESCRIPTION
`URL.appendPathComponent` is mutating; the example is set up to use the generating version `URL.appendingPathComponent`.