### PR TITLE
add LICENSE Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1851,4 +1851,4 @@ The community adoption of the ASF libraries has been amazing. We are greatly hum
 
 ## License
 
-Alamofire is released under the MIT license. See LICENSE for details.
+Alamofire is released under the MIT license. [See LICENSE](https://github.com/Alamofire/Alamofire/blob/master/LICENSE) for details.


### PR DESCRIPTION
Part of License is `See LICENCE for details' in README.

But It's not uncomfortable and unkind

I added LICENSE link.