### PR TITLE
Update custom encoding section of Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ struct JSONStringArrayEncoding: ParameterEncoding {
     }
 
     func encode(_ urlRequest: URLRequestConvertible, with parameters: Parameters?) throws -> URLRequest {
-        var urlRequest = urlRequest.urlRequest
+        var urlRequest = try urlRequest.asURLRequest()
 
         let data = try JSONSerialization.data(withJSONObject: array, options: [])
 


### PR DESCRIPTION
urlRequest property of URLRequestConvertible is optional, so you have to unwrap it or make non-optional.