### PR TITLE
Fixed a markdown error in the Manual install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,13 +143,13 @@ If you prefer not to use either of the aforementioned dependency managers, you c
 
 - Open up Terminal, `cd` into your top-level project directory, and run the following command "if" your project is not initialized as a git repository:
 
-  ```bash
+```bash
 $ git init
 ```
 
 - Add Alamofire as a git [submodule](http://git-scm.com/docs/git-submodule) by running the following command:
 
-  ```bash
+```bash
 $ git submodule add https://github.com/Alamofire/Alamofire.git
 ```
 


### PR DESCRIPTION
The markdown in the Manual Installation section had an error that messed up the formatting of command and regular text. This commit fixes it.

I know this is a simple PR; but I am excited because this is my first one!