### PR TITLE
Added missing charset to JSONEncoding.encode()

### DIFF
--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -267,7 +267,7 @@ public struct URLEncoding: ParameterEncoding {
 // MARK: -
 
 /// Uses `JSONSerialization` to create a JSON representation of the parameters object, which is set as the body of the
-/// request. The `Content-Type` HTTP header field of an encoded request is set to `application/json`.
+/// request. The `Content-Type` HTTP header field of an encoded request is set to `application/json; charset=utf-8`.
 public struct JSONEncoding: ParameterEncoding {
 
     // MARK: Properties
@@ -311,7 +311,7 @@ public struct JSONEncoding: ParameterEncoding {
             let data = try JSONSerialization.data(withJSONObject: parameters, options: options)
 
             if urlRequest.value(forHTTPHeaderField: "Content-Type") == nil {
-                urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                urlRequest.setValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
             }
 
             urlRequest.httpBody = data
@@ -339,7 +339,7 @@ public struct JSONEncoding: ParameterEncoding {
             let data = try JSONSerialization.data(withJSONObject: jsonObject, options: options)
 
             if urlRequest.value(forHTTPHeaderField: "Content-Type") == nil {
-                urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                urlRequest.setValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
             }
 
             urlRequest.httpBody = data


### PR DESCRIPTION
The charset is needed to make sure, that the server uses the correct charset for decoding.