### PR TITLE
Remove redundant optional unwrap

### DIFF
--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -462,8 +462,8 @@ extension SessionDelegate: URLSessionTaskDelegate {
         // Determine whether an error has occurred
         var error: Error? = error
 
-        if let taskDelegate = self[task]?.delegate, taskDelegate.error != nil {
-            error = taskDelegate.error
+        if request.delegate.error != nil {
+            error = request.delegate.error
         }
 
         /// If an error occurred and the retrier is set, asynchronously ask the retrier if the request


### PR DESCRIPTION
`self[task]` [is guarded a few lines above to not be `nil`](https://github.com/Alamofire/Alamofire/blob/b03b43cc381ec02eb9855085427186ef89055eef/Source/SessionDelegate.swift#L454) (and captured in `request` variable), so [checking again whether it is `nil` a few lines later](https://github.com/Alamofire/Alamofire/blob/b03b43cc381ec02eb9855085427186ef89055eef/Source/SessionDelegate.swift#L465) is confusing because it suggests that it could be `nil`, which cannot be the case however.

This is based on the assumption that [validations run a few lines above](https://github.com/Alamofire/Alamofire/blob/b03b43cc381ec02eb9855085427186ef89055eef/Source/SessionDelegate.swift#L460) do not set the delegate of the `request` to `nil`.