### PR TITLE
Fix some warnings from Xcode 8.3.

### DIFF
--- a/Tests/MultipartFormDataTests.swift
+++ b/Tests/MultipartFormDataTests.swift
@@ -794,7 +794,7 @@ class MultipartFormDataWriteEncodedDataToDiskTestCase: BaseTestCase {
 class MultipartFormDataFailureTestCase: BaseTestCase {
     func testThatAppendingFileBodyPartWithInvalidLastPathComponentReturnsError() {
         // Given
-        let fileURL = NSURL(string: "") as! URL
+        let fileURL = NSURL(string: "")! as URL
         let multipartFormData = MultipartFormData()
         multipartFormData.append(fileURL, withName: "empty_data")
 

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -109,7 +109,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
         if let error = error as? URLError {
             XCTAssertEqual(error.code, .serverCertificateUntrusted)
-        } else if let error = error as? NSError {
+        } else if let error = error as NSError? {
             XCTAssertEqual(error.domain, kCFErrorDomainCFNetwork as String)
             XCTAssertEqual(error.code, Int(CFNetworkErrors.cfErrorHTTPSProxyConnectionFailure.rawValue))
         } else {


### PR DESCRIPTION
The only new warnings from Xcode 8.3 were in the tests. This PR fixes them.