### PR TITLE
Issue #2052 - Change reachability computation

### DIFF
--- a/Source/NetworkReachabilityManager.swift
+++ b/Source/NetworkReachabilityManager.swift
@@ -184,19 +184,23 @@ public class NetworkReachabilityManager {
     func networkReachabilityStatusForFlags(_ flags: SCNetworkReachabilityFlags) -> NetworkReachabilityStatus {
         guard flags.contains(.reachable) else { return .notReachable }
 
-        var networkStatus: NetworkReachabilityStatus = .notReachable
-
-        if !flags.contains(.connectionRequired) { networkStatus = .reachable(.ethernetOrWiFi) }
-
-        if flags.contains(.connectionOnDemand) || flags.contains(.connectionOnTraffic) {
-            if !flags.contains(.interventionRequired) { networkStatus = .reachable(.ethernetOrWiFi) }
-        }
+        let isNetworkReachable = self.isNetworkReachable(with: flags)
+        guard isNetworkReachable else { return .notReachable }
+        
+        var networkStatus: NetworkReachabilityStatus = .reachable(.ethernetOrWiFi)
 
         #if os(iOS)
             if flags.contains(.isWWAN) { networkStatus = .reachable(.wwan) }
         #endif
 
         return networkStatus
+    }
+    
+    private func isNetworkReachable(with flags: SCNetworkReachabilityFlags) -> Bool {
+        let needsConnection = flags.contains(.connectionRequired)
+        let canConnectionAutomatically = flags.contains(.connectionOnDemand) || flags.contains(.connectionOnTraffic)
+        let canConnectWithoutUserInteraction = canConnectionAutomatically && !flags.contains(.interventionRequired)
+        return (!needsConnection || canConnectWithoutUserInteraction)
     }
 }
 

--- a/Source/NetworkReachabilityManager.swift
+++ b/Source/NetworkReachabilityManager.swift
@@ -182,10 +182,7 @@ public class NetworkReachabilityManager {
     // MARK: - Internal - Network Reachability Status
 
     func networkReachabilityStatusForFlags(_ flags: SCNetworkReachabilityFlags) -> NetworkReachabilityStatus {
-        guard flags.contains(.reachable) else { return .notReachable }
-
-        let isNetworkReachable = self.isNetworkReachable(with: flags)
-        guard isNetworkReachable else { return .notReachable }
+        guard flags.contains(.reachable), isNetworkReachable(with: flags) else { return .notReachable }
         
         var networkStatus: NetworkReachabilityStatus = .reachable(.ethernetOrWiFi)
 
@@ -198,8 +195,8 @@ public class NetworkReachabilityManager {
     
     private func isNetworkReachable(with flags: SCNetworkReachabilityFlags) -> Bool {
         let needsConnection = flags.contains(.connectionRequired)
-        let canConnectionAutomatically = flags.contains(.connectionOnDemand) || flags.contains(.connectionOnTraffic)
-        let canConnectWithoutUserInteraction = canConnectionAutomatically && !flags.contains(.interventionRequired)
+        let canConnectAutomatically = flags.contains(.connectionOnDemand) || flags.contains(.connectionOnTraffic)
+        let canConnectWithoutUserInteraction = canConnectAutomatically && !flags.contains(.interventionRequired)
         return (!needsConnection || canConnectWithoutUserInteraction)
     }
 }

--- a/Tests/NetworkReachabilityManagerTests.swift
+++ b/Tests/NetworkReachabilityManagerTests.swift
@@ -162,18 +162,30 @@ class NetworkReachabilityManagerTestCase: BaseTestCase {
         XCTAssertEqual(networkReachabilityStatus, .notReachable)
     }
 
-    func testThatManagerReturnsNotReachableStatusWhenInterventionIsRequired() {
+    func testThatManagerReturnsNotReachableStatusWhenConnectionIsRequired() {
         // Given
         let manager = NetworkReachabilityManager()
-        let flags: SCNetworkReachabilityFlags = [.reachable, .connectionRequired, .connectionOnDemand, .interventionRequired]
-
+        let flags: SCNetworkReachabilityFlags = [.reachable, .connectionRequired]
+        
         // When
         let networkReachabilityStatus = manager?.networkReachabilityStatusForFlags(flags)
-
+        
         // Then
         XCTAssertEqual(networkReachabilityStatus, .notReachable)
     }
-
+    
+    func testThatManagerReturnsNotReachableStatusWhenInterventionIsRequired() {
+        // Given
+        let manager = NetworkReachabilityManager()
+        let flags: SCNetworkReachabilityFlags = [.reachable, .connectionRequired, .interventionRequired]
+        
+        // When
+        let networkReachabilityStatus = manager?.networkReachabilityStatusForFlags(flags)
+        
+        // Then
+        XCTAssertEqual(networkReachabilityStatus, .notReachable)
+    }
+    
     func testThatManagerReturnsReachableOnWiFiStatusWhenConnectionIsNotRequired() {
         // Given
         let manager = NetworkReachabilityManager()
@@ -221,6 +233,18 @@ class NetworkReachabilityManagerTestCase: BaseTestCase {
 
         // Then
         XCTAssertEqual(networkReachabilityStatus, .reachable(.wwan))
+    }
+    
+    func testThatManagerReturnsNotReachableOnWWANStatusWhenIsWWANAndConnectionIsRequired() {
+        // Given
+        let manager = NetworkReachabilityManager()
+        let flags: SCNetworkReachabilityFlags = [.reachable, .isWWAN, .connectionRequired]
+        
+        // When
+        let networkReachabilityStatus = manager?.networkReachabilityStatusForFlags(flags)
+        
+        // Then
+        XCTAssertEqual(networkReachabilityStatus, .notReachable)
     }
 #endif
 }


### PR DESCRIPTION
It fixes the issue #2052. There is a bug with the reachability computation when the user has a sim but s/he didn't select the carrier yet. In this scenario we have both `.connectionRequired` and `.isWWAN`.