### PR TITLE
enable setter of the MultipartFormData's contentType

### DIFF
--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -92,7 +92,7 @@ open class MultipartFormData {
     // MARK: - Properties
 
     /// The `Content-Type` header value containing the boundary used to generate the `multipart/form-data`.
-    open var contentType: String { return "multipart/form-data; boundary=\(boundary)" }
+    open lazy var contentType: String = "multipart/form-data; boundary=\(self.boundary)"
 
     /// The content length of all body parts used to generate the `multipart/form-data` not including the boundaries.
     public var contentLength: UInt64 { return bodyParts.reduce(0) { $0 + $1.bodyContentLength } }


### PR DESCRIPTION
**Purpose**
The ```contentType``` of a ```MultipartFormData``` is ```multipart/form-data```
We could need to set it to another value (ex. ```multipart/related```), so i propose to set it writable

**Usage**
```
Alamofire.upload(multipartFormData: { mulitFormData -> Void in
        mulitFormData.contentType = "multipart/related; type=text/xml; boundary=\(mulitFormData.boundary)"
}, to: "https://example.com",
        method: .post,
        encodingCompletion: { encodingResult -> Void in
})
```
