### PR TITLE
Fix super minor language error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ dependencies: [
 
 ### Manually
 
-If you prefer not to use either of the aforementioned dependency managers, you can integrate Alamofire into your project manually.
+If you prefer not to use any of the aforementioned dependency managers, you can integrate Alamofire into your project manually.
 
 #### Embedded Framework
 


### PR DESCRIPTION
There are three previous examples, so the wording should be 'not use any' instead of 'not use either'.