### PR TITLE
Add timeout argument for request function

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -126,6 +126,7 @@ extension URLRequest {
 /// - parameter parameters: The parameters. `nil` by default.
 /// - parameter encoding:   The parameter encoding. `URLEncoding.default` by default.
 /// - parameter headers:    The HTTP headers. `nil` by default.
+/// - parameter timeout:    The Request timeout. `nil` by default.
 ///
 /// - returns: The created `DataRequest`.
 @discardableResult
@@ -134,7 +135,8 @@ public func request(
     method: HTTPMethod = .get,
     parameters: Parameters? = nil,
     encoding: ParameterEncoding = URLEncoding.default,
-    headers: HTTPHeaders? = nil)
+    headers: HTTPHeaders? = nil,
+    timeout: TimeInterval? = nil)
     -> DataRequest
 {
     return SessionManager.default.request(
@@ -142,7 +144,8 @@ public func request(
         method: method,
         parameters: parameters,
         encoding: encoding,
-        headers: headers
+        headers: headers,
+        timeout: timeout
     )
 }
 
@@ -153,8 +156,8 @@ public func request(
 ///
 /// - returns: The created `DataRequest`.
 @discardableResult
-public func request(_ urlRequest: URLRequestConvertible) -> DataRequest {
-    return SessionManager.default.request(urlRequest)
+public func request(_ urlRequest: URLRequestConvertible, timeout: TimeInterval? = nil) -> DataRequest {
+    return SessionManager.default.request(urlRequest, timeout: timeout)
 }
 
 // MARK: - Download Request

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -220,6 +220,7 @@ open class SessionManager {
     /// - parameter parameters: The parameters. `nil` by default.
     /// - parameter encoding:   The parameter encoding. `URLEncoding.default` by default.
     /// - parameter headers:    The HTTP headers. `nil` by default.
+    /// - parameter timeout:    The Request timeout. `nil` by default.
     ///
     /// - returns: The created `DataRequest`.
     @discardableResult
@@ -228,7 +229,8 @@ open class SessionManager {
         method: HTTPMethod = .get,
         parameters: Parameters? = nil,
         encoding: ParameterEncoding = URLEncoding.default,
-        headers: HTTPHeaders? = nil)
+        headers: HTTPHeaders? = nil,
+        timeout: TimeInterval? = nil)
         -> DataRequest
     {
         var originalRequest: URLRequest?
@@ -236,7 +238,7 @@ open class SessionManager {
         do {
             originalRequest = try URLRequest(url: url, method: method, headers: headers)
             let encodedURLRequest = try encoding.encode(originalRequest!, with: parameters)
-            return request(encodedURLRequest)
+            return request(encodedURLRequest, timeout: timeout)
         } catch {
             return request(originalRequest, failedWith: error)
         }
@@ -247,12 +249,15 @@ open class SessionManager {
     /// If `startRequestsImmediately` is `true`, the request will have `resume()` called before being returned.
     ///
     /// - parameter urlRequest: The URL request.
+    /// - parameter timeout:    The Request timeout. `nil` by default.
     ///
     /// - returns: The created `DataRequest`.
-    open func request(_ urlRequest: URLRequestConvertible) -> DataRequest {
+    open func request(_ urlRequest: URLRequestConvertible, timeout: TimeInterval? = nil) -> DataRequest {
         var originalRequest: URLRequest?
 
         do {
+            self.session.configuration.timeoutIntervalForRequest = timeout ?? 60
+            
             originalRequest = try urlRequest.asURLRequest()
             let originalTask = DataRequest.Requestable(urlRequest: originalRequest!)
 

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -336,7 +336,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
     func testThatValidationForRequestWithAcceptableWildcardContentTypeResponseSucceedsWhenResponseIsNil() {
         // Given
         class MockManager: SessionManager {
-            override func request(_ urlRequest: URLRequestConvertible) -> DataRequest {
+            override func request(_ urlRequest: URLRequestConvertible, timeout: TimeInterval? = nil) -> DataRequest {
                 do {
                     let originalRequest = try urlRequest.asURLRequest()
                     let originalTask = DataRequest.Requestable(urlRequest: originalRequest)


### PR DESCRIPTION
I found out that many people use timeout like this:

```swift
let manager = Alamofire.SessionManager.default
manager.session.configuration.timeoutIntervalForRequest = 120
manager.request("yourUrl", method: .post, parameters: ["parameterKey": "value"])
```

Or rebuild configuration and set it to object’s session. 

I think it is not a good way to do it because if people work in teams these weird checks on exact "under-water" codes will make code very unreadable. Also not suit for Alamofire’s structure. 

I added this code because I thought it would be nice if Alamofire had this function as a basic feature. 