### PR TITLE
Remove unsafe URLCredential optional fields force unwrapping

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -293,11 +293,15 @@ extension Request: CustomDebugStringConvertible {
 
             if let credentials = credentialStorage.credentials(for: protectionSpace)?.values {
                 for credential in credentials {
-                    components.append("-u \(credential.user!):\(credential.password!)")
+                    let user = credential.user ?? ""
+                    let password = credential.password ?? ""
+                    components.append("-u \(user):\(password)")
                 }
             } else {
                 if let credential = delegate.credential {
-                    components.append("-u \(credential.user!):\(credential.password!)")
+                    let user = credential.user ?? ""
+                    let password = credential.password ?? ""
+                    components.append("-u \(user):\(password)")
                 }
             }
         }


### PR DESCRIPTION
Issue Link 🔗
No registered issue. 

Goals ⚽️
Alamofire crashes if log is enabled and request use client authentication through .pfx certificate. Log cant fetch user and password fields and crash by force unwrapping.

Implementation Details 🚧
Removed unsafe wrapping for user and password field.

Testing Details 🔍