### PR TITLE
Add an NSLock for the task delegate’s task.

### DIFF
--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -38,11 +38,22 @@ open class TaskDelegate: NSObject {
 
     /// The error generated throughout the lifecyle of the task.
     public var error: Error?
-
-    var task: URLSessionTask? {
+    
+    private var _task: URLSessionTask? {
         didSet { reset() }
     }
-
+    var task: URLSessionTask? {
+        set {
+            taskLock.lock(); defer { taskLock.unlock() }
+            _task = newValue
+        }
+        get {
+            taskLock.lock(); defer { taskLock.unlock() }
+            return _task
+        }
+    }
+    
+    private let taskLock = NSLock()
     var initialResponseTime: CFAbsoluteTime?
     var credential: URLCredential?
     var metrics: AnyObject? // URLSessionTaskMetrics
@@ -50,7 +61,7 @@ open class TaskDelegate: NSObject {
     // MARK: Lifecycle
 
     init(task: URLSessionTask?) {
-        self.task = task
+        _task = task
 
         self.queue = {
             let operationQueue = OperationQueue()

--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -39,9 +39,6 @@ open class TaskDelegate: NSObject {
     /// The error generated throughout the lifecyle of the task.
     public var error: Error?
 
-    private var _task: URLSessionTask? {
-        didSet { reset() }
-    }
     var task: URLSessionTask? {
         set {
             taskLock.lock(); defer { taskLock.unlock() }
@@ -52,11 +49,14 @@ open class TaskDelegate: NSObject {
             return _task
         }
     }
-
-    private let taskLock = NSLock()
     var initialResponseTime: CFAbsoluteTime?
     var credential: URLCredential?
     var metrics: AnyObject? // URLSessionTaskMetrics
+    
+    private var _task: URLSessionTask? {
+        didSet { reset() }
+    }
+    private let taskLock = NSLock()
 
     // MARK: Lifecycle
 

--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -38,7 +38,7 @@ open class TaskDelegate: NSObject {
 
     /// The error generated throughout the lifecyle of the task.
     public var error: Error?
-    
+
     private var _task: URLSessionTask? {
         didSet { reset() }
     }
@@ -52,7 +52,7 @@ open class TaskDelegate: NSObject {
             return _task
         }
     }
-    
+
     private let taskLock = NSLock()
     var initialResponseTime: CFAbsoluteTime?
     var credential: URLCredential?


### PR DESCRIPTION
### Issue Link :link:
Fixes #2189.

### Goals :soccer:
This PR makes the `TaskDelegate`'s `task` property thread safe by wrapping private storage with an `NSLock`.

### Implementation Details :construction:
Simple implementation that will be refined as we reevaluate the threading needs in AF5.

### Testing Details :mag:
No new tests, this PR lets the retry tests pass when running from Xcode 9 with the thread sanitizer active.