### PR TITLE
Add PathComponents parameter encoding

### DIFF
--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -442,7 +442,7 @@ public struct PropertyListEncoding: ParameterEncoding {
 ///
 ///     baseUri/value1/value2
 ///
-struct PathComponents: ParameterEncoding {
+public struct PathComponents: ParameterEncoding {
     
     // MARK: Properties
     
@@ -459,7 +459,7 @@ struct PathComponents: ParameterEncoding {
     /// - throws: An `Error` if the encoding process encounters an error.
     ///
     /// - returns: The encoded request.
-    func encode(_ urlRequest: URLRequestConvertible, with parameters: Parameters?) throws -> URLRequest {
+    public func encode(_ urlRequest: URLRequestConvertible, with parameters: Parameters?) throws -> URLRequest {
         var urlRequest = try urlRequest.asURLRequest()
         
         guard let parameters = parameters else { return urlRequest }

--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -431,6 +431,61 @@ public struct PropertyListEncoding: ParameterEncoding {
 
 // MARK: -
 
+/// Appends each parameter to the request URL as subcomponents. Parameters are inserted using the alphabetical orders
+/// of the keys.
+///
+/// Parameters should be provided with keys that define an order, such as:
+///
+///     ["1": value1, "2": value2]
+///
+/// The dictionary above is converted to:
+///
+///     baseUri/value1/value2
+///
+struct PathComponents: ParameterEncoding {
+    
+    // MARK: Properties
+    
+    /// Returns a default `PathComponents` instance.
+    public static var `default`: PathComponents { return PathComponents() }
+    
+    // MARK: Encoding
+    
+    /// Creates a URL request by encoding parameters and applying them onto an existing request.
+    ///
+    /// - parameter urlRequest: The request to have parameters applied.
+    /// - parameter parameters: The parameters to apply.
+    ///
+    /// - throws: An `Error` if the encoding process encounters an error.
+    ///
+    /// - returns: The encoded request.
+    func encode(_ urlRequest: URLRequestConvertible, with parameters: Parameters?) throws -> URLRequest {
+        var urlRequest = try urlRequest.asURLRequest()
+        
+        guard let parameters = parameters else { return urlRequest }
+        
+        guard let url = urlRequest.url else {
+            throw AFError.parameterEncodingFailed(reason: .missingURL)
+        }
+        
+        if let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false), !parameters.isEmpty {
+            var finalUrl = urlComponents.url!
+            
+            /// Since Swift dictionaries are not sorted, we keep the desired sorting
+            /// using the specified keys, which are useless in this kind of encoding.
+            let keys = parameters.keys.sorted(by: { $0 < $1 })
+            
+            keys.forEach { finalUrl.appendPathComponent("\(parameters[$0]!)") }
+            urlRequest.url = finalUrl
+        }
+        
+        return urlRequest
+    }
+    
+}
+
+// MARK: -
+
 extension NSNumber {
     fileprivate var isBool: Bool { return CFBooleanGetTypeID() == CFGetTypeID(self) }
 }

--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -824,3 +824,58 @@ class PropertyListParameterEncodingTestCase: ParameterEncodingTestCase {
         }
     }
 }
+
+// MARK: -
+
+class PathComponentsParameterEncodingTestCase: ParameterEncodingTestCase {
+    
+    // MARK: Properties
+    
+    let encoding = PathComponents.default
+    
+    // MARK: Tests
+    
+    func testPathComponentsParameterEncodeNilParameters() {
+        do {
+            // Given
+            let originalUrl = self.urlRequest.url
+            
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: nil)
+            
+            // Then
+            XCTAssertEqual(originalUrl, urlRequest.url)
+            XCTAssertNil(urlRequest.httpBody)
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
+    }
+    
+    func testPathComponentsParameterEncodeTwoParameters() {
+        do {
+            // Given
+            let value1 = "Something"
+            let value2 = "Else"
+            
+            let parameters: [String: Any] = [
+                "1": value1,
+                "2": value2
+            ]
+            
+            // When
+            let originalUrl = self.urlRequest.url
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            
+            // Then
+            XCTAssertNotEqual(originalUrl, urlRequest.url)
+            
+            if let components = urlRequest.url?.pathComponents {
+                XCTAssertEqual(components.last, value2)
+                XCTAssertEqual(components[components.count - 2], value1)
+            }
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
+    }
+    
+}


### PR DESCRIPTION
### Goals :soccer:
Recent REST services exposes GET APIs with parameters passed as subcomponents of the Request URL. 

This means that instead of encoding parameters as

`requestUri?key=value&key2=value2`

their requests are something like

`requestUri/value/value2`

### Implementation Details :construction:
I am using Alamofire to interact with an ASP.NET WebApi 2 service that accepts parameters as described above. I think that Alamofire should be able to treat these kind of requests as normal parameters, even if they actually modify the request URL.

To do this, I have added a new struct that implements the ParameterEncoding interface and encodes parameters as subcomponents of the request URL.

### Testing Details :mag:
I have two tests which verify that parameters are inserted in the requested order.