### PR TITLE
Fixed `substring` API warnings for Swift 3.2 and up

### DIFF
--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -223,9 +223,9 @@ public struct URLEncoding: ParameterEncoding {
                 let endIndex = string.index(index, offsetBy: batchSize, limitedBy: string.endIndex) ?? string.endIndex
                 let range = startIndex..<endIndex
 
-                let substring = string.substring(with: range)
+                let substring = string[range]
 
-                escaped += substring.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) ?? substring
+                escaped += substring.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) ?? String(substring)
 
                 index = endIndex
             }

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -308,7 +308,12 @@ extension Request: CustomDebugStringConvertible {
                 let cookies = cookieStorage.cookies(for: url), !cookies.isEmpty
             {
                 let string = cookies.reduce("") { $0 + "\($1.name)=\($1.value);" }
-                components.append("-b \"\(string.substring(to: string.characters.index(before: string.endIndex)))\"")
+
+                #if swift(>=3.2)
+                    components.append("-b \"\(string[..<string.index(before: string.endIndex)])\"")
+                #else
+                    components.append("-b \"\(string.substring(to: string.characters.index(before: string.endIndex)))\"")
+                #endif
             }
         }
 

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -308,11 +308,10 @@ extension Request: CustomDebugStringConvertible {
                 let cookies = cookieStorage.cookies(for: url), !cookies.isEmpty
             {
                 let string = cookies.reduce("") { $0 + "\($1.name)=\($1.value);" }
-
                 #if swift(>=3.2)
-                    components.append("-b \"\(string[..<string.index(before: string.endIndex)])\"")
+                components.append("-b \"\(string[..<string.index(before: string.endIndex)])\"")
                 #else
-                    components.append("-b \"\(string.substring(to: string.characters.index(before: string.endIndex)))\"")
+                components.append("-b \"\(string.substring(to: string.characters.index(before: string.endIndex)))\"")
                 #endif
             }
         }

--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -48,13 +48,11 @@ extension Request {
         init?(_ string: String) {
             let components: [String] = {
                 let stripped = string.trimmingCharacters(in: .whitespacesAndNewlines)
-
                 #if swift(>=3.2)
-                    let split = stripped[..<(stripped.range(of: ";")?.lowerBound ?? stripped.endIndex)]
+                let split = stripped[..<(stripped.range(of: ";")?.lowerBound ?? stripped.endIndex)]
                 #else
-                    let split = stripped.substring(to: stripped.range(of: ";")?.lowerBound ?? stripped.endIndex)
+                let split = stripped.substring(to: stripped.range(of: ";")?.lowerBound ?? stripped.endIndex)
                 #endif
-
                 return split.components(separatedBy: "/")
             }()
 

--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -48,7 +48,13 @@ extension Request {
         init?(_ string: String) {
             let components: [String] = {
                 let stripped = string.trimmingCharacters(in: .whitespacesAndNewlines)
-                let split = stripped.substring(to: stripped.range(of: ";")?.lowerBound ?? stripped.endIndex)
+
+                #if swift(>=3.2)
+                    let split = stripped[..<(stripped.range(of: ";")?.lowerBound ?? stripped.endIndex)]
+                #else
+                    let split = stripped.substring(to: stripped.range(of: ";")?.lowerBound ?? stripped.endIndex)
+                #endif
+
                 return split.components(separatedBy: "/")
             }()
 


### PR DESCRIPTION
As of the latest version of Xcode 9 beta, `substring` functions from `String` have been deprecated and show up as warnings when compiling using Swift 4 compiler. 

This pull request fixes those warnings by replacing calls to those functions with the new subscript slicing syntax.