### PR TITLE
Added response headers to the Validation failure case of `ResponseValidationFailureReason.unacceptableStatusCode`

### DIFF
--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -103,7 +103,7 @@ public enum AFError: Error {
         case dataFileReadFailed(at: URL)
         case missingContentType(acceptableContentTypes: [String])
         case unacceptableContentType(acceptableContentTypes: [String], responseContentType: String)
-        case unacceptableStatusCode(code: Int)
+        case unacceptableStatusCode(code: Int, headers: [AnyHashable : Any])
     }
 
     /// The underlying reason the response serialization error occurred.
@@ -247,6 +247,16 @@ extension AFError {
             return nil
         }
     }
+    
+    /// The response headers of a `.responseValidationFailed` error.
+    public var responseHeaders: [AnyHashable: Any]? {
+        switch self {
+        case .responseValidationFailed(let reason):
+            return reason.responseHeaders
+        default:
+            return nil
+        }
+    }
 
     /// The `String.Encoding` associated with a failed `.stringResponse()` call.
     public var failedStringEncoding: String.Encoding? {
@@ -316,8 +326,17 @@ extension AFError.ResponseValidationFailureReason {
 
     var responseCode: Int? {
         switch self {
-        case .unacceptableStatusCode(let code):
+        case .unacceptableStatusCode(let code,_):
             return code
+        default:
+            return nil
+        }
+    }
+    
+    var responseHeaders: [AnyHashable: Any]? {
+        switch self {
+        case .unacceptableStatusCode(_,let headers):
+            return headers
         default:
             return nil
         }

--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -93,7 +93,7 @@ extension Request {
         if acceptableStatusCodes.contains(response.statusCode) {
             return .success
         } else {
-            let reason: ErrorReason = .unacceptableStatusCode(code: response.statusCode)
+            let reason: ErrorReason = .unacceptableStatusCode(code: response.statusCode, headers: response.allHeaderFields)
             return .failure(AFError.responseValidationFailed(reason: reason))
         }
     }

--- a/Tests/ResultTests.swift
+++ b/Tests/ResultTests.swift
@@ -27,7 +27,7 @@ import Foundation
 import XCTest
 
 class ResultTestCase: BaseTestCase {
-    let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404))
+    let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404, headers: [:]))
 
     // MARK: - Is Success Tests
 


### PR DESCRIPTION
### Issue Link :link:

https://github.com/Alamofire/Alamofire/issues/2245

### Goals :soccer:

Adding the response headers to the `ResponseValidationFailureReason.unacceptableStatusCode` enum

### Implementation Details :construction:

The response headers help me to determine necessary information about the validation failure.

### Testing Details :mag:

A test has been created that the header is passed all the way through from `validate` in the test `testThatValidationForRequestWithUnacceptableStatusCodeResponseFailsWithResponseHeaders`
