### PR TITLE
Fix SCNetworkReachabilitySetCallback block-style

### DIFF
--- a/Source/NetworkReachabilityManager.swift
+++ b/Source/NetworkReachabilityManager.swift
@@ -1,7 +1,7 @@
 //
 //  NetworkReachabilityManager.swift
 //
-//  Copyright (c) 2014-2016 Alamofire Software Foundation (http://alamofire.org/)
+//  Copyright (c) 2014-2017 Alamofire Software Foundation (http://alamofire.org/)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -147,7 +147,7 @@ public class NetworkReachabilityManager {
 
         let callbackEnabled = SCNetworkReachabilitySetCallback(
             reachability,
-            { (_, flags, info) in
+            { _, flags, info in
                 let reachability = Unmanaged<NetworkReachabilityManager>.fromOpaque(info!).takeUnretainedValue()
                 reachability.notifyListener(flags)
             },


### PR DESCRIPTION

### Goals :soccer:
- Resolve an old block-style `{ (arg) in }` vs. { arg in }`

### Implementation Details :construction:
I was going through one of my projects and fixed all legacy-styles, so this one crossed my way 🙂.

### Testing Details :mag:
(No test required, just a syntactical change)
