### PR TITLE
Added resolved radars section to the README and moved 26761490 into it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1812,9 +1812,14 @@ There are some important things to remember when using network reachability to d
 The following radars have some effect on the current implementation of Alamofire.
 
 - [`rdar://21349340`](http://www.openradar.me/radar?id=5517037090635776) - Compiler throwing warning due to toll-free bridging issue in test case
-- [`rdar://26761490`](http://www.openradar.me/radar?id=5010235949318144) - Swift string interpolation causing memory leak with common usage
 - `rdar://26870455` - Background URL Session Configurations do not work in the simulator
 - `rdar://26849668` - Some URLProtocol APIs do not properly handle `URLRequest`
+
+## Resolved Radars
+
+The following radars have been resolved over time after being filed against the Alamofire project.
+
+- [`rdar://26761490`](http://www.openradar.me/radar?id=5010235949318144) - Swift string interpolation causing memory leak with common usage (Resolved on 9/1/17 in Xcode 9 beta 6).
 
 ## FAQ
 


### PR DESCRIPTION
### Goals :soccer:

Adds a `Resolved Radars` section to the README for keeping track of resolved radars that we've filed in the past. I moved `rdar://26761490` into it b/c I just resolved it after testing against Xcode 9 beta 6 after feedback from Apple.