### PR TITLE
Swift dictionary convention

### DIFF
--- a/Example/Source/AppDelegate.swift
+++ b/Example/Source/AppDelegate.swift
@@ -33,7 +33,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
 
     func application(
         _ application: UIApplication,
-        didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]?)
+        didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?)
         -> Bool
     {
         let splitViewController = window!.rootViewController as! UISplitViewController


### PR DESCRIPTION
change invalid dictionary convention

remove spacing between `key` and and `:`