### PR TITLE
Add missing @discardableResult

### DIFF
--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -249,6 +249,7 @@ open class SessionManager {
     /// - parameter urlRequest: The URL request.
     ///
     /// - returns: The created `DataRequest`.
+    @discardableResult
     open func request(_ urlRequest: URLRequestConvertible) -> DataRequest {
         var originalRequest: URLRequest?
 


### PR DESCRIPTION
### Goals :soccer:
- Align `request(_:)` with the other methods.

### Implementation Details :construction:
All the other request, download, upload and so on methods are annotated with `@discardableResult`. This changes makes sure that method can be used for fire-and-forget calls.