### PR TITLE
Add description for SPM API version 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The [Swift Package Manager](https://swift.org/package-manager/) is a tool for au
 
 Once you have your Swift package set up, adding Alamofire as a dependency is as easy as adding it to the `dependencies` value of your `Package.swift`.
 
-#### PackageDescription API Version 3
+#### Swift 3
 
 ```swift
 dependencies: [
@@ -137,7 +137,7 @@ dependencies: [
 ]
 ```
 
-#### PackageDescription API Version 4
+#### Swift 4
 
 ```swift
 dependencies: [

--- a/README.md
+++ b/README.md
@@ -129,9 +129,19 @@ The [Swift Package Manager](https://swift.org/package-manager/) is a tool for au
 
 Once you have your Swift package set up, adding Alamofire as a dependency is as easy as adding it to the `dependencies` value of your `Package.swift`.
 
+#### PackageDescription API Version 3
+
 ```swift
 dependencies: [
     .Package(url: "https://github.com/Alamofire/Alamofire.git", majorVersion: 4)
+]
+```
+
+#### PackageDescription API Version 4
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/Alamofire/Alamofire.git", from: "4.0.0")
 ]
 ```
 


### PR DESCRIPTION
### Goals :soccer:
Enable to build project including Alamofire by using Swift Package Manager API Version 4

### Implementation Details :construction:
Recently, Swift Package Manager API Version is updated.
So, I added how to write `Package.swift` in APIv4 format.

https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageDescriptionV3.md
https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageDescriptionV4.md
