### PR TITLE
Brotli Accept-Encoding Support

### DIFF
--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -55,7 +55,19 @@ open class SessionManager {
     /// Creates default values for the "Accept-Encoding", "Accept-Language" and "User-Agent" headers.
     open static let defaultHTTPHeaders: HTTPHeaders = {
         // Accept-Encoding HTTP Header; see https://tools.ietf.org/html/rfc7230#section-4.2.3
-        let acceptEncoding: String = "br;q=1.0, gzip;q=0.9, compress;q=0.8"
+        let acceptEncoding: String = {
+            let encodings: [String]
+            if #available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *) {
+                encodings = ["br", "gzip", "deflate"]
+            } else {
+                encodings = ["gzip", "deflate"]
+            }
+            
+            return encodings.enumerated().map { (index, encoding) in
+                let quality = 1.0 - (Double(index) * 0.1)
+                return "\(encoding);q=\(quality)"
+                }.joined(separator: ", ")
+        }()
 
         // Accept-Language HTTP Header; see https://tools.ietf.org/html/rfc7231#section-5.3.5
         let acceptLanguage = Locale.preferredLanguages.prefix(6).enumerated().map { index, languageCode in

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -55,7 +55,7 @@ open class SessionManager {
     /// Creates default values for the "Accept-Encoding", "Accept-Language" and "User-Agent" headers.
     open static let defaultHTTPHeaders: HTTPHeaders = {
         // Accept-Encoding HTTP Header; see https://tools.ietf.org/html/rfc7230#section-4.2.3
-        let acceptEncoding: String = "gzip;q=1.0, compress;q=0.5"
+        let acceptEncoding: String = "br;q=1.0, gzip;q=0.9, compress;q=0.8"
 
         // Accept-Language HTTP Header; see https://tools.ietf.org/html/rfc7231#section-5.3.5
         let acceptLanguage = Locale.preferredLanguages.prefix(6).enumerated().map { index, languageCode in

--- a/Tests/SessionManagerTests.swift
+++ b/Tests/SessionManagerTests.swift
@@ -254,6 +254,49 @@ class SessionManagerTestCase: BaseTestCase {
         let expectedUserAgent = "Unknown/Unknown (Unknown; build:Unknown; \(osNameVersion)) \(alamofireVersion)"
         XCTAssertEqual(userAgent, expectedUserAgent)
     }
+    
+    // MARK: Tests - Supported Accept-Encodings
+    
+    func testDefaultAcceptEncodingSupportsAppropriateEncodingsOnAppropriateSystems() {
+        // Given
+        let brotliURL = URL(string: "https://httpbin.org/brotli")!
+        let gzipURL = URL(string: "https://httpbin.org/gzip")!
+        let deflateURL = URL(string: "https://httpbin.org/deflate")!
+        let brotliExpectation = expectation(description: "brotli request should complete")
+        let gzipExpectation = expectation(description: "gzip request should complete")
+        let deflateExpectation = expectation(description: "deflate request should complete")
+        var brotliResponse: DataResponse<Any>?
+        var gzipResponse: DataResponse<Any>?
+        var deflateResponse: DataResponse<Any>?
+        
+        // When
+        Alamofire.request(brotliURL).responseJSON { (response) in
+            brotliResponse = response
+            brotliExpectation.fulfill()
+        }
+        
+        Alamofire.request(gzipURL).responseJSON { (response) in
+            gzipResponse = response
+            gzipExpectation.fulfill()
+        }
+        
+        Alamofire.request(deflateURL).responseJSON { (response) in
+            deflateResponse = response
+            deflateExpectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
+        
+        // Then
+        if #available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *) {
+            XCTAssertTrue(brotliResponse?.result.isSuccess == true)
+        } else {
+            XCTAssertFalse(brotliResponse?.result.isSuccess == true)
+        }
+        
+        XCTAssertTrue(gzipResponse?.result.isSuccess == true)
+        XCTAssertTrue(deflateResponse?.result.isSuccess == true)
+    }
 
     // MARK: Tests - Start Requests Immediately
 


### PR DESCRIPTION
### Issue Link :link:
#2230

### Goals :soccer:
This PR adds the Brotli encoding to the default `Accept-Encoding` header.

### Implementation Details :construction:
The `Accept-Encoding` header was made dynamic based on the available system. Unfortunately it can't be made entirely dynamic, as there's no way to query for supported encodings, but these changes match the header generated by `URLSession` if it isn't already there. It also removes `compress` support since it's not normally advertised and there wasn't a way to test it.

### Testing Details :mag:
Adds a `SessionManager` test against `httpbin.org` endpoints for supported encoding types to ensure we detect regressions.
