### PR TITLE
requestRetrier should doesn't work immediately when the request had been canceled

### DIFF
--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -229,6 +229,14 @@
 		4DD67C241A5C58FB00ED2280 /* Alamofire.h in Headers */ = {isa = PBXBuildFile; fileRef = F8111E3819A95C8B0040E7D1 /* Alamofire.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4DD67C251A5C590000ED2280 /* Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = F897FF4019AA800700AB5182 /* Alamofire.swift */; };
 		8035DB621BAB492500466CB3 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8111E3319A95C8B0040E7D1 /* Alamofire.framework */; };
+		81428A871FAAF88300C04E08 /* NSError+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81428A861FAAF88300C04E08 /* NSError+Alamofire.swift */; };
+		81428A881FAAF88300C04E08 /* NSError+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81428A861FAAF88300C04E08 /* NSError+Alamofire.swift */; };
+		81428A891FAAF88300C04E08 /* NSError+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81428A861FAAF88300C04E08 /* NSError+Alamofire.swift */; };
+		81428A8A1FAAF88300C04E08 /* NSError+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81428A861FAAF88300C04E08 /* NSError+Alamofire.swift */; };
+		81428A8C1FAB1ACA00C04E08 /* SessionTaskStateOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81428A8B1FAB1ACA00C04E08 /* SessionTaskStateOperator.swift */; };
+		81428A8D1FAB1ACA00C04E08 /* SessionTaskStateOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81428A8B1FAB1ACA00C04E08 /* SessionTaskStateOperator.swift */; };
+		81428A8E1FAB1ACA00C04E08 /* SessionTaskStateOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81428A8B1FAB1ACA00C04E08 /* SessionTaskStateOperator.swift */; };
+		81428A8F1FAB1ACA00C04E08 /* SessionTaskStateOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81428A8B1FAB1ACA00C04E08 /* SessionTaskStateOperator.swift */; };
 		E4202FD01B667AA100C997FB /* ParameterEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE2724E1AF88FB500F1D59A /* ParameterEncoding.swift */; };
 		E4202FD11B667AA100C997FB /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDE2C391AF899EC00BABAE5 /* Request.swift */; };
 		E4202FD21B667AA100C997FB /* ResponseSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDE2C451AF89FF300BABAE5 /* ResponseSerialization.swift */; };
@@ -355,6 +363,8 @@
 		4CFCFE381D56E8D900A76388 /* TaskDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskDelegate.swift; sourceTree = "<group>"; };
 		4DD67C0B1A5C55C900ED2280 /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		72998D721BF26173006D3F69 /* Info-tvOS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
+		81428A861FAAF88300C04E08 /* NSError+Alamofire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSError+Alamofire.swift"; sourceTree = "<group>"; };
+		81428A8B1FAB1ACA00C04E08 /* SessionTaskStateOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTaskStateOperator.swift; sourceTree = "<group>"; };
 		B39E2F831C1A72F8002DA1A9 /* certDER.cer */ = {isa = PBXFileReference; lastKnownFileType = file; name = certDER.cer; path = selfSignedAndMalformedCerts/certDER.cer; sourceTree = "<group>"; };
 		B39E2F841C1A72F8002DA1A9 /* certDER.crt */ = {isa = PBXFileReference; lastKnownFileType = file; name = certDER.crt; path = selfSignedAndMalformedCerts/certDER.crt; sourceTree = "<group>"; };
 		B39E2F851C1A72F8002DA1A9 /* certDER.der */ = {isa = PBXFileReference; lastKnownFileType = file; name = certDER.der; path = selfSignedAndMalformedCerts/certDER.der; sourceTree = "<group>"; };
@@ -552,6 +562,7 @@
 			isa = PBXGroup;
 			children = (
 				4C43669A1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift */,
+				81428A861FAAF88300C04E08 /* NSError+Alamofire.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -608,6 +619,7 @@
 				4CFCFE2D1D56D31700A76388 /* SessionDelegate.swift */,
 				4CDE2C361AF8932A00BABAE5 /* SessionManager.swift */,
 				4CFCFE381D56E8D900A76388 /* TaskDelegate.swift */,
+				81428A8B1FAB1ACA00C04E08 /* SessionTaskStateOperator.swift */,
 			);
 			name = Core;
 			sourceTree = "<group>";
@@ -1187,6 +1199,7 @@
 				4CF6270C1BA7CBF60011A099 /* Result.swift in Sources */,
 				4CF627081BA7CBF60011A099 /* AFError.swift in Sources */,
 				4CF627131BA7CBF60011A099 /* Validation.swift in Sources */,
+				81428A8E1FAB1ACA00C04E08 /* SessionTaskStateOperator.swift in Sources */,
 				4CF6270E1BA7CBF60011A099 /* MultipartFormData.swift in Sources */,
 				4C80F9F81BB730EF001B46D2 /* Response.swift in Sources */,
 				4CB9282B1C66BFBC00CE5F08 /* Notifications.swift in Sources */,
@@ -1198,6 +1211,7 @@
 				4CFCFE3B1D56E8D900A76388 /* TaskDelegate.swift in Sources */,
 				4CF6270A1BA7CBF60011A099 /* ParameterEncoding.swift in Sources */,
 				4CF627101BA7CBF60011A099 /* ServerTrustPolicy.swift in Sources */,
+				81428A891FAAF88300C04E08 /* NSError+Alamofire.swift in Sources */,
 				4CF627071BA7CBF60011A099 /* Alamofire.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1238,6 +1252,7 @@
 				4CE272501AF88FB500F1D59A /* ParameterEncoding.swift in Sources */,
 				4CDE2C3B1AF899EC00BABAE5 /* Request.swift in Sources */,
 				4CDE2C471AF89FF300BABAE5 /* ResponseSerialization.swift in Sources */,
+				81428A8D1FAB1ACA00C04E08 /* SessionTaskStateOperator.swift in Sources */,
 				4C1DC8551B68908E00476DE3 /* AFError.swift in Sources */,
 				4CDE2C381AF8932A00BABAE5 /* SessionManager.swift in Sources */,
 				4C0B62521BB1001C009302D3 /* Response.swift in Sources */,
@@ -1249,6 +1264,7 @@
 				4CFCFE3A1D56E8D900A76388 /* TaskDelegate.swift in Sources */,
 				4C3D00551C66A63000D1F709 /* NetworkReachabilityManager.swift in Sources */,
 				4CDE2C441AF89F0900BABAE5 /* Validation.swift in Sources */,
+				81428A881FAAF88300C04E08 /* NSError+Alamofire.swift in Sources */,
 				4C0E5BF91B673D3400816CCC /* Result.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1262,6 +1278,7 @@
 				4CFCFE311D56D31700A76388 /* SessionDelegate.swift in Sources */,
 				E4202FD01B667AA100C997FB /* ParameterEncoding.swift in Sources */,
 				E4202FD11B667AA100C997FB /* Request.swift in Sources */,
+				81428A8F1FAB1ACA00C04E08 /* SessionTaskStateOperator.swift in Sources */,
 				4CEC605A1B745C9100E684F4 /* AFError.swift in Sources */,
 				E4202FD21B667AA100C997FB /* ResponseSerialization.swift in Sources */,
 				E4202FD31B667AA100C997FB /* SessionManager.swift in Sources */,
@@ -1273,6 +1290,7 @@
 				4CFCFE3C1D56E8D900A76388 /* TaskDelegate.swift in Sources */,
 				E4202FD51B667AA100C997FB /* MultipartFormData.swift in Sources */,
 				E4202FD61B667AA100C997FB /* ServerTrustPolicy.swift in Sources */,
+				81428A8A1FAAF88300C04E08 /* NSError+Alamofire.swift in Sources */,
 				E4202FD81B667AA100C997FB /* Validation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1286,6 +1304,7 @@
 				4CE2724F1AF88FB500F1D59A /* ParameterEncoding.swift in Sources */,
 				4CDE2C3A1AF899EC00BABAE5 /* Request.swift in Sources */,
 				4CDE2C461AF89FF300BABAE5 /* ResponseSerialization.swift in Sources */,
+				81428A8C1FAB1ACA00C04E08 /* SessionTaskStateOperator.swift in Sources */,
 				4C1DC8541B68908E00476DE3 /* AFError.swift in Sources */,
 				4CDE2C371AF8932A00BABAE5 /* SessionManager.swift in Sources */,
 				4C0B62511BB1001C009302D3 /* Response.swift in Sources */,
@@ -1297,6 +1316,7 @@
 				4CFCFE391D56E8D900A76388 /* TaskDelegate.swift in Sources */,
 				4CDE2C431AF89F0900BABAE5 /* Validation.swift in Sources */,
 				4CB928291C66BFBC00CE5F08 /* Notifications.swift in Sources */,
+				81428A871FAAF88300C04E08 /* NSError+Alamofire.swift in Sources */,
 				4C0E5BF81B673D3400816CCC /* Result.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1661,6 +1681,7 @@
 				PRODUCT_NAME = Alamofire;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -1678,6 +1699,7 @@
 				PRODUCT_NAME = Alamofire;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Source/NSError+Alamofire.swift
+++ b/Source/NSError+Alamofire.swift
@@ -1,5 +1,5 @@
 //
-//  DispatchQueue+Alamofire.swift
+//  NSError+Alamofire.swift
 //
 //  Copyright (c) 2014-2017 Alamofire Software Foundation (http://alamofire.org/)
 //
@@ -22,21 +22,21 @@
 //  THE SOFTWARE.
 //
 
-import Dispatch
-import Foundation
+import UIKit
 
-extension DispatchQueue {
-    static var userInteractive: DispatchQueue { return DispatchQueue.global(qos: .userInteractive) }
-    static var userInitiated: DispatchQueue { return DispatchQueue.global(qos: .userInitiated) }
-    static var utility: DispatchQueue { return DispatchQueue.global(qos: .utility) }
-    static var background: DispatchQueue { return DispatchQueue.global(qos: .background) }
+extension NSError {
 
-    func after(_ delay: TimeInterval, execute closure: @escaping () -> Void) {
-        asyncAfter(deadline: .now() + delay, execute: closure)
+    var isCancelled: Bool {
+        return NSURLErrorDomain == domain && NSURLErrorCancelled == code
     }
     
-    func after(_ delay: TimeInterval, execute workItem: DispatchWorkItem) {
-        asyncAfter(deadline: .now() + delay, execute: workItem)
+    class func makeCancelError(`for` url: URL) -> NSError {
+        let UserInfo: [String: Any] = [
+            NSURLErrorFailingURLErrorKey: url,
+            NSLocalizedDescriptionKey: "cancelled",
+            NSURLErrorFailingURLStringErrorKey: url.absoluteString
+        ]
+        return NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo:UserInfo)
     }
 
 }

--- a/Source/NSError+Alamofire.swift
+++ b/Source/NSError+Alamofire.swift
@@ -22,7 +22,7 @@
 //  THE SOFTWARE.
 //
 
-import UIKit
+import Foundation
 
 extension NSError {
 

--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -455,7 +455,7 @@ extension SessionDelegate: URLSessionTaskDelegate {
             completeTask(session, task, error)
             return
         }
-
+        
         // Run all validations on the request before checking if an error occurred
         request.validations.forEach { $0() }
 
@@ -468,22 +468,33 @@ extension SessionDelegate: URLSessionTaskDelegate {
 
         /// If an error occurred and the retrier is set, asynchronously ask the retrier if the request
         /// should be retried. Otherwise, complete the task by notifying the task delegate.
-        if let retrier = retrier, let error = error {
+        if let retrier = retrier, let error = error, !(error as NSError).isCancelled {
+
             retrier.should(sessionManager, retry: request, with: error) { [weak self] shouldRetry, timeDelay in
                 guard shouldRetry else { completeTask(session, task, error) ; return }
-
-                DispatchQueue.utility.after(timeDelay) { [weak self] in
+                var retrySucceeded = false
+                let workItem = DispatchWorkItem(qos: DispatchQueue.utility.qos) {
                     guard let strongSelf = self else { return }
-
-                    let retrySucceeded = strongSelf.sessionManager?.retry(request) ?? false
-
-                    if retrySucceeded, let task = request.task {
+                    
+                    retrySucceeded = strongSelf.sessionManager?.retry(request) ?? false
+                }
+                
+                workItem.notify(queue: DispatchQueue.utility) {
+                    guard let strongSelf = self else { return }
+                    
+                    if workItem.isCancelled {
+                        request.delegate.error = request.request?.url.flatMap({NSError.makeCancelError(for: $0.absoluteURL)})
+                        
+                        completeTask(session, task, request.delegate.error)
+                    } else if retrySucceeded, let task = request.task {
                         strongSelf[task] = request
-                        return
                     } else {
-                        completeTask(session, task, error)
+                        completeTask(session, task, request.delegate.error)
                     }
                 }
+                request.sessionTaskOperator = CancelRetriedRequestStateDecorator(retryWorkItem: workItem, contract: request.sessionTaskOperator)
+                
+                DispatchQueue.utility.after(timeDelay, execute: workItem)
             }
         } else {
             completeTask(session, task, error)

--- a/Source/SessionTaskStateOperator.swift
+++ b/Source/SessionTaskStateOperator.swift
@@ -1,0 +1,146 @@
+//
+//  SessionTaskStateOperator.swift
+//
+//  Copyright (c) 2014-2017 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+//MARK: SessionTaskStateContract
+
+protocol SessionTaskStateContract {
+    func resume()
+    func suspend()
+    func cancel()
+}
+
+//MARK: SessionTaskStateOperator
+
+class SessionTaskStateOperator: SessionTaskStateContract {
+    fileprivate var request: Request
+    fileprivate var task: URLSessionTask? { return request.delegate.task }
+
+    init(request: Request) {
+        self.request = request
+    }
+    
+    /// Resume the request.
+    func resume() {
+        guard let task = task else { request.delegate.queue.isSuspended = false ; return }
+        
+        if request.startTime == nil { request.startTime = CFAbsoluteTimeGetCurrent() }
+        
+        task.resume()
+        
+        NotificationCenter.default.post(
+            name: Notification.Name.Task.DidResume,
+            object: self,
+            userInfo: [Notification.Key.Task: task]
+        )
+    }
+    
+    /// Suspends the request.
+    func suspend() {
+        guard let task = task else { return }
+        
+        task.suspend()
+        
+        NotificationCenter.default.post(
+            name: Notification.Name.Task.DidSuspend,
+            object: self,
+            userInfo: [Notification.Key.Task: task]
+        )
+    }
+    
+    /// Cancels the request.
+    func cancel() {
+        guard let task = task else { return }
+        
+        task.cancel()
+        
+        NotificationCenter.default.post(
+            name: Notification.Name.Task.DidCancel,
+            object: self,
+            userInfo: [Notification.Key.Task: task]
+        )
+    }
+}
+
+//MARK: SessionTaskStateOperator
+
+class SessionDownloadTaskStateOperator: SessionTaskStateOperator {
+    
+    init(downloadRequest: DownloadRequest) {
+        super.init(request: downloadRequest)
+    }
+    
+    private var downloadRequest: DownloadRequest {
+        return request as! DownloadRequest
+    }
+
+    /// Cancels the download request.
+    override func cancel() {
+        downloadRequest.downloadDelegate.downloadTask.cancel { self.downloadRequest.downloadDelegate.resumeData = $0 }
+        
+        NotificationCenter.default.post(
+            name: Notification.Name.Task.DidCancel,
+            object: self,
+            userInfo: [Notification.Key.Task: task as Any]
+        )
+    }
+}
+
+//MARK: OperationQueueStateDecorator
+
+class OperationQueueStateDecorator: SessionTaskStateContract {
+    private let contract: SessionTaskStateContract
+    
+    init(contract: SessionTaskStateContract) {
+        self.contract = contract
+    }
+    
+    func resume() {
+        contract.resume()
+    }
+    
+    func cancel() {
+        contract.cancel()
+    }
+    
+    func suspend() {
+        contract.suspend()
+    }
+}
+
+//MARK: CancelRetriedRequestStateDecorator
+
+final class CancelRetriedRequestStateDecorator: OperationQueueStateDecorator {
+    private let retryWorkItem: DispatchWorkItem
+    
+    init(retryWorkItem: DispatchWorkItem, contract: SessionTaskStateContract) {
+        self.retryWorkItem = retryWorkItem
+        super.init(contract: contract)
+    }
+    
+    override func cancel() {
+       super.cancel()
+        retryWorkItem.cancel()
+    }
+    
+}

--- a/Source/SessionTaskStateOperator.swift
+++ b/Source/SessionTaskStateOperator.swift
@@ -139,8 +139,14 @@ final class CancelRetriedRequestStateDecorator: OperationQueueStateDecorator {
     }
     
     override func cancel() {
-       super.cancel()
+        super.cancel()
+        /// if workItem not perform, first cancel, then perform immediately, notify one time
+        
+        let isCancelled = retryWorkItem.isCancelled
         retryWorkItem.cancel()
+        if !isCancelled {
+            retryWorkItem.perform()
+        }
     }
     
 }

--- a/Tests/SessionManagerTests.swift
+++ b/Tests/SessionManagerTests.swift
@@ -53,14 +53,17 @@ class SessionManagerTestCase: BaseTestCase {
         var adaptedCount = 0
         var retryCount = 0
         var retryErrors: [Error] = []
+        var timeDelay = 0.0
+        var retryWork: ((_ request: Request, _ retryCount: Int)-> Void)? = nil
 
         var shouldApplyAuthorizationHeader = false
         var throwsErrorOnSecondAdapt = false
+        var throwsAdaptError = false
 
         func adapt(_ urlRequest: URLRequest) throws -> URLRequest {
             if throwsErrorOnSecondAdapt && adaptedCount == 1 {
                 throwsErrorOnSecondAdapt = false
-                throw AFError.invalidURL(url: "")
+                throw throwsAdaptError ? AdaptError(error: AFError.invalidURL(url: "")) : AFError.invalidURL(url: "")
             }
 
             var urlRequest = urlRequest
@@ -81,10 +84,12 @@ class SessionManagerTestCase: BaseTestCase {
             retryErrors.append(error)
 
             if retryCount < 2 {
-                completion(true, 0.0)
+                completion(true, timeDelay)
             } else {
-                completion(false, 0.0)
+                completion(false, timeDelay)
             }
+            
+            retryWork?(request, retryCount)
         }
     }
 
@@ -595,7 +600,6 @@ class SessionManagerTestCase: BaseTestCase {
                 response = jsonResponse
                 expectation.fulfill()
             }
-
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
@@ -769,6 +773,149 @@ class SessionManagerTestCase: BaseTestCase {
             XCTFail("error should not be nil")
         }
     }
+    
+    
+    func testThatDontRequestAfterCancelRequestWhenRequestIsRetried() {
+        // Given
+        let handler = RequestHandler()
+        handler.timeDelay = 5
+        handler.retryWork = { (request: Request, retryCount: Int)-> Void in
+            if retryCount == 1 {
+                DispatchQueue.main.after(2, execute: {
+                    request.cancel()
+                })
+            }
+        }
+        
+        let sessionManager = SessionManager()
+        sessionManager.adapter = handler
+        sessionManager.retrier = handler
+        
+        let expectation = self.expectation(description: "request should eventually fail")
+        var response: DataResponse<Any>?
+        
+        // When
+        let request = sessionManager.request("https://httpbin.org/basic-auth/user/password")
+            .validate()
+            .responseJSON { jsonResponse in
+                response = jsonResponse
+                expectation.fulfill()
+        }
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        // Then
+        XCTAssertEqual(handler.adaptedCount, 1)
+        XCTAssertEqual(handler.retryCount, 1)
+        XCTAssertEqual(request.retryCount, 0)
+        XCTAssertEqual(response?.result.isSuccess, false)
+        
+        if let error = response?.error as NSError? {
+            XCTAssertEqual(error.domain, NSURLErrorDomain)
+            XCTAssertEqual(error.code, NSURLErrorCancelled)
+        } else {
+            XCTFail("error should not be nil")
+        }
+
+    }
+    
+    func testThatAllowRetrierRequestAfterCancelRequestWhenRequestIsRetried() {
+        // Given
+        let handler = RequestHandler()
+        handler.timeDelay = 5
+        handler.retryWork = { (request: Request, retryCount: Int)-> Void in
+            if retryCount == 1 {
+                DispatchQueue.main.after(2, execute: {
+                    request.cancel()
+                })
+            }
+        }
+        handler.throwsAdaptError = true
+        
+        let sessionManager = SessionManager()
+        sessionManager.adapter = handler
+        sessionManager.retrier = handler
+        
+        let expectation = self.expectation(description: "request should eventually fail")
+        var response: DataResponse<Any>?
+        
+        // When
+        let request = sessionManager.request("https://httpbin.org/password")
+            .validate()
+            .responseJSON { jsonResponse in
+                response = jsonResponse
+                expectation.fulfill()
+        }
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        // Then
+        XCTAssertEqual(handler.retryCount, 1)
+        XCTAssertEqual(request.retryCount, 0)
+        XCTAssertEqual(response?.result.isSuccess, false)
+        
+        if let error = response?.error as NSError? {
+            XCTAssertEqual(error.domain, NSURLErrorDomain)
+            XCTAssertEqual(error.code, NSURLErrorCancelled)
+        } else {
+            XCTFail("error should not be nil")
+        }
+
+    }
+
+    
+    func testThatDontDownloadAfterCancelDownloadRequestWhenRequestIsRetried() {
+        // Given
+        
+        let urlString = "https://upload.wikimedia.org/wikipedia/commons/6/69/NASA-HS201427a-HubbleUltraDeepField2014-20140603.jpg"
+        let expectation = self.expectation(description: "Download should be cancelled ")
+        
+        var response: DefaultDownloadResponse?
+        let handler = RequestHandler()
+        handler.timeDelay = 5
+        handler.retryWork = { (request: Request, retryCount: Int)-> Void in
+            if retryCount == 1 {
+                DispatchQueue.main.after(2, execute: {
+                    request.cancel()
+                })
+            }
+        }
+        
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 0.1
+        configuration.timeoutIntervalForResource = 0.1
+        let sessionManager = SessionManager(configuration: configuration)
+        sessionManager.adapter = handler
+        sessionManager.retrier = handler
+
+        // When
+        let download = sessionManager.download(urlString)
+        download.response { resp in
+            response = resp
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        // Then
+        XCTAssertEqual(handler.adaptedCount, 1)
+        XCTAssertEqual(handler.retryCount, 1)
+        XCTAssertEqual(download.retryCount, 0)
+
+        XCTAssertNotNil(response?.request)
+        XCTAssertNil(response?.destinationURL)
+        XCTAssertNotNil(response?.error)
+        
+        XCTAssertNil(response?.resumeData)
+        XCTAssertNil(download.resumeData)
+        
+        if let error = response?.error as NSError? {
+            XCTAssertEqual(error.domain, NSURLErrorDomain)
+            XCTAssertEqual(error.code, NSURLErrorCancelled)
+        } else {
+            XCTFail("error should not be nil")
+        }
+
+    }
+
 }
 
 // MARK: -

--- a/Tests/SessionManagerTests.swift
+++ b/Tests/SessionManagerTests.swift
@@ -55,7 +55,7 @@ class SessionManagerTestCase: BaseTestCase {
         var retryErrors: [Error] = []
         var timeDelay = 0.0
         var retryWork: ((_ request: Request, _ retryCount: Int)-> Void)? = nil
-
+        var maxRetryCount = 2
         var shouldApplyAuthorizationHeader = false
         var throwsErrorOnSecondAdapt = false
         var throwsAdaptError = false
@@ -83,7 +83,7 @@ class SessionManagerTestCase: BaseTestCase {
             retryCount += 1
             retryErrors.append(error)
 
-            if retryCount < 2 {
+            if retryCount < maxRetryCount {
                 completion(true, timeDelay)
             } else {
                 completion(false, timeDelay)
@@ -779,6 +779,7 @@ class SessionManagerTestCase: BaseTestCase {
         // Given
         let handler = RequestHandler()
         handler.timeDelay = 5
+        handler.maxRetryCount = 5
         handler.retryWork = { (request: Request, retryCount: Int)-> Void in
             if retryCount == 1 {
                 DispatchQueue.main.after(2, execute: {
@@ -822,6 +823,8 @@ class SessionManagerTestCase: BaseTestCase {
         // Given
         let handler = RequestHandler()
         handler.timeDelay = 5
+        handler.throwsAdaptError = true
+        handler.maxRetryCount = 5
         handler.retryWork = { (request: Request, retryCount: Int)-> Void in
             if retryCount == 1 {
                 DispatchQueue.main.after(2, execute: {
@@ -829,7 +832,6 @@ class SessionManagerTestCase: BaseTestCase {
                 })
             }
         }
-        handler.throwsAdaptError = true
         
         let sessionManager = SessionManager()
         sessionManager.adapter = handler
@@ -871,6 +873,7 @@ class SessionManagerTestCase: BaseTestCase {
         var response: DefaultDownloadResponse?
         let handler = RequestHandler()
         handler.timeDelay = 5
+        handler.maxRetryCount = 5
         handler.retryWork = { (request: Request, retryCount: Int)-> Void in
             if retryCount == 1 {
                 DispatchQueue.main.after(2, execute: {


### PR DESCRIPTION
### Issue Link :link:
fix  [issue 2340](https://github.com/Alamofire/Alamofire/issues/2340)

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
cancel a request，requestRetrier doesn't work immediately.
### Implementation Details :construction:
1. class SessionTaskStateOperator use for decorate task state: `resume`、`suspend`、`cancel`.
the  classes, like `SessionTaskStateOperator`, `SessionDownloadTaskStateOperator`, `OperationQueueStateDecorator`, `CancelRetriedRequestStateDecorator`,  in SessionTaskStateOperator.swift.

2. when cancel request， should also cancel dispatch block. i use `DispatchWorkItem`,  cancel request easily.  also apply to `suspend`.

3. extension `NSError` and `DispatchQueue`. 
look at `Extensions` folder



### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
add three case: 
1. testThatDontRequestAfterCancelRequestWhenRequestIsRetried
2.testThatAllowRetrierRequestAfterCancelRequestWhenRequestIsRetried
3.testThatDontDownloadAfterCancelDownloadRequestWhenRequestIsRetried