### PR TITLE
Enable injection of FileManager

### DIFF
--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -99,6 +99,9 @@ open class MultipartFormData {
 
     /// The boundary used to separate the body parts in the encoded form data.
     public let boundary: String
+    
+    /// The file manager handling file related operations.
+    public let fileManager: FileManager
 
     private var bodyParts: [BodyPart]
     private var bodyPartError: AFError?
@@ -109,7 +112,7 @@ open class MultipartFormData {
     /// Creates a multipart form data object.
     ///
     /// - returns: The multipart form data object.
-    public init() {
+    public init(fileManager: FileManager = .default) {
         self.boundary = BoundaryGenerator.randomBoundary()
         self.bodyParts = []
 
@@ -120,6 +123,8 @@ open class MultipartFormData {
         ///
 
         self.streamBufferSize = 1024
+        
+        self.fileManager = fileManager
     }
 
     // MARK: - Body Parts

--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -262,7 +262,7 @@ open class MultipartFormData {
         var isDirectory: ObjCBool = false
         let path = fileURL.path
 
-        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) && !isDirectory.boolValue else {
+        guard self.fileManager.fileExists(atPath: path, isDirectory: &isDirectory) && !isDirectory.boolValue else {
             setBodyPartError(withReason: .bodyPartFileIsDirectory(at: fileURL))
             return
         }
@@ -274,7 +274,7 @@ open class MultipartFormData {
         let bodyContentLength: UInt64
 
         do {
-            guard let fileSize = try FileManager.default.attributesOfItem(atPath: path)[.size] as? NSNumber else {
+            guard let fileSize = try self.fileManager.attributesOfItem(atPath: path)[.size] as? NSNumber else {
                 setBodyPartError(withReason: .bodyPartFileSizeNotAvailable(at: fileURL))
                 return
             }
@@ -381,7 +381,7 @@ open class MultipartFormData {
             throw bodyPartError
         }
 
-        if FileManager.default.fileExists(atPath: fileURL.path) {
+        if self.fileManager.fileExists(atPath: fileURL.path) {
             throw AFError.multipartEncodingFailed(reason: .outputStreamFileAlreadyExists(at: fileURL))
         } else if !fileURL.isFileURL {
             throw AFError.multipartEncodingFailed(reason: .outputStreamURLInvalid(url: fileURL))

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -536,11 +536,12 @@ open class DownloadRequest: Request {
     /// - returns: A download file destination closure.
     open class func suggestedDownloadDestination(
         for directory: FileManager.SearchPathDirectory = .documentDirectory,
-        in domain: FileManager.SearchPathDomainMask = .userDomainMask)
+        in domain: FileManager.SearchPathDomainMask = .userDomainMask,
+        with fileManager: FileManager = .default)
         -> DownloadFileDestination
     {
         return { temporaryURL, response in
-            let directoryURLs = FileManager.default.urls(for: directory, in: domain)
+            let directoryURLs = fileManager.urls(for: directory, in: domain)
 
             if !directoryURLs.isEmpty {
                 return (directoryURLs[0].appendingPathComponent(response.suggestedFilename!), [])

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -103,6 +103,9 @@ open class Request {
 
     /// The session belonging to the underlying task.
     open let session: URLSession
+    
+    /// The file manager handling file related operations.
+    open let fileManager: FileManager
 
     /// The request sent or to be sent to the server.
     open var request: URLRequest? { return task?.originalRequest }
@@ -127,6 +130,7 @@ open class Request {
 
     init(session: URLSession, requestTask: RequestTask, error: Error? = nil, fileManager: FileManager) {
         self.session = session
+        self.fileManager = fileManager
 
         switch requestTask {
         case .data(let originalTask, let task):

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -125,7 +125,7 @@ open class Request {
 
     // MARK: Lifecycle
 
-    init(session: URLSession, requestTask: RequestTask, error: Error? = nil) {
+    init(session: URLSession, requestTask: RequestTask, error: Error? = nil, fileManager: FileManager) {
         self.session = session
 
         switch requestTask {
@@ -133,7 +133,7 @@ open class Request {
             taskDelegate = DataTaskDelegate(task: task)
             self.originalTask = originalTask
         case .download(let originalTask, let task):
-            taskDelegate = DownloadTaskDelegate(task: task)
+            taskDelegate = DownloadTaskDelegate(task: task, fileManager: fileManager)
             self.originalTask = originalTask
         case .upload(let originalTask, let task):
             taskDelegate = UploadTaskDelegate(task: task)

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -303,7 +303,7 @@ extension DownloadRequest {
     /// Creates a response serializer that returns the associated data as-is.
     ///
     /// - returns: A data response serializer.
-    public static func dataResponseSerializer(with fileManager: FileManager = .default) -> DownloadResponseSerializer<Data> {
+    public static func dataResponseSerializer() -> DownloadResponseSerializer<Data> {
         return DownloadResponseSerializer { _, response, fileURL, error in
             guard error == nil else { return .failure(error!) }
 
@@ -311,11 +311,10 @@ extension DownloadRequest {
                 return .failure(AFError.responseSerializationFailed(reason: .inputFileNil))
             }
 
-            if fileManager.isReadableFile(atPath: fileURL.path),
-               let data = fileManager.contents(atPath: fileURL.path) {
-                
+            do {
+                let data = try Data(contentsOf: fileURL)
                 return Request.serializeResponseData(response: response, data: data, error: error)
-            } else {
+            } catch {
                 return .failure(AFError.responseSerializationFailed(reason: .inputFileReadFailed(at: fileURL)))
             }
         }
@@ -334,7 +333,7 @@ extension DownloadRequest {
     {
         return response(
             queue: queue,
-            responseSerializer: DownloadRequest.dataResponseSerializer(with: self.fileManager),
+            responseSerializer: DownloadRequest.dataResponseSerializer(),
             completionHandler: completionHandler
         )
     }
@@ -431,8 +430,7 @@ extension DownloadRequest {
     ///
     /// - returns: A string response serializer.
     public static func stringResponseSerializer(
-        encoding: String.Encoding? = nil,
-        fileManager: FileManager = .default)
+        encoding: String.Encoding? = nil)
         -> DownloadResponseSerializer<String>
     {
         return DownloadResponseSerializer { _, response, fileURL, error in
@@ -442,12 +440,10 @@ extension DownloadRequest {
                 return .failure(AFError.responseSerializationFailed(reason: .inputFileNil))
             }
 
-            if
-                fileManager.isReadableFile(atPath: fileURL.path),
-                let data = fileManager.contents(atPath: fileURL.path)
-            {
+            do {
+                let data = try Data(contentsOf: fileURL)
                 return Request.serializeResponseString(encoding: encoding, response: response, data: data, error: error)
-            } else {
+            } catch {
                 return .failure(AFError.responseSerializationFailed(reason: .inputFileReadFailed(at: fileURL)))
             }
         }
@@ -557,8 +553,7 @@ extension DownloadRequest {
     ///
     /// - returns: A JSON object response serializer.
     public static func jsonResponseSerializer(
-        options: JSONSerialization.ReadingOptions = .allowFragments,
-        fileManager: FileManager = .default)
+        options: JSONSerialization.ReadingOptions = .allowFragments)
         -> DownloadResponseSerializer<Any>
     {
         return DownloadResponseSerializer { _, response, fileURL, error in
@@ -568,12 +563,10 @@ extension DownloadRequest {
                 return .failure(AFError.responseSerializationFailed(reason: .inputFileNil))
             }
             
-            if
-                fileManager.isReadableFile(atPath: fileURL.path),
-                let data = fileManager.contents(atPath: fileURL.path)
-            {
+            do {
+                let data = try Data(contentsOf: fileURL)
                 return Request.serializeResponseJSON(options: options, response: response, data: data, error: error)
-            } else {
+            } catch {
                 return .failure(AFError.responseSerializationFailed(reason: .inputFileReadFailed(at: fileURL)))
             }
         }
@@ -681,8 +674,7 @@ extension DownloadRequest {
     ///
     /// - returns: A property list object response serializer.
     public static func propertyListResponseSerializer(
-        options: PropertyListSerialization.ReadOptions = [],
-        fileManager: FileManager = .default)
+        options: PropertyListSerialization.ReadOptions = [])
         -> DownloadResponseSerializer<Any>
     {
         return DownloadResponseSerializer { _, response, fileURL, error in
@@ -692,12 +684,10 @@ extension DownloadRequest {
                 return .failure(AFError.responseSerializationFailed(reason: .inputFileNil))
             }
             
-            if
-                fileManager.isReadableFile(atPath: fileURL.path),
-                let data = fileManager.contents(atPath: fileURL.path)
-            {
+            do {
+                let data = try Data(contentsOf: fileURL)
                 return Request.serializeResponsePropertyList(options: options, response: response, data: data, error: error)
-            } else {
+            } catch {
                 return .failure(AFError.responseSerializationFailed(reason: .inputFileReadFailed(at: fileURL)))
             }
         }

--- a/Source/ServerTrustPolicy.swift
+++ b/Source/ServerTrustPolicy.swift
@@ -127,7 +127,7 @@ public enum ServerTrustPolicy {
     /// - parameter bundle: The bundle to search for all `.cer` files.
     ///
     /// - returns: All certificates within the given bundle.
-    public static func certificates(in bundle: Bundle = Bundle.main) -> [SecCertificate] {
+    public static func certificates(in bundle: Bundle = Bundle.main, with fileManager: FileManager) -> [SecCertificate] {
         var certificates: [SecCertificate] = []
 
         let paths = Set([".cer", ".CER", ".crt", ".CRT", ".der", ".DER"].map { fileExtension in
@@ -136,7 +136,7 @@ public enum ServerTrustPolicy {
 
         for path in paths {
             if
-                let certificateData = try? Data(contentsOf: URL(fileURLWithPath: path)) as CFData,
+                let certificateData = fileManager.contents(atPath: path) as CFData?,
                 let certificate = SecCertificateCreateWithData(nil, certificateData)
             {
                 certificates.append(certificate)
@@ -151,10 +151,10 @@ public enum ServerTrustPolicy {
     /// - parameter bundle: The bundle to search for all `*.cer` files.
     ///
     /// - returns: All public keys within the given bundle.
-    public static func publicKeys(in bundle: Bundle = Bundle.main) -> [SecKey] {
+    public static func publicKeys(in bundle: Bundle = Bundle.main, with fileManager: FileManager) -> [SecKey] {
         var publicKeys: [SecKey] = []
 
-        for certificate in certificates(in: bundle) {
+        for certificate in certificates(in: bundle, with: fileManager) {
             if let publicKey = publicKey(for: certificate) {
                 publicKeys.append(publicKey)
             }

--- a/Source/ServerTrustPolicy.swift
+++ b/Source/ServerTrustPolicy.swift
@@ -127,7 +127,7 @@ public enum ServerTrustPolicy {
     /// - parameter bundle: The bundle to search for all `.cer` files.
     ///
     /// - returns: All certificates within the given bundle.
-    public static func certificates(in bundle: Bundle = Bundle.main, with fileManager: FileManager) -> [SecCertificate] {
+    public static func certificates(in bundle: Bundle = Bundle.main, with fileManager: FileManager = .default) -> [SecCertificate] {
         var certificates: [SecCertificate] = []
 
         let paths = Set([".cer", ".CER", ".crt", ".CRT", ".der", ".DER"].map { fileExtension in

--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -162,6 +162,7 @@ open class SessionDelegate: NSObject {
 
     var retrier: RequestRetrier?
     weak var sessionManager: SessionManager?
+    var fileManager: FileManager
 
     private var requests: [Int: Request] = [:]
     private let lock = NSLock()
@@ -184,6 +185,7 @@ open class SessionDelegate: NSObject {
     ///
     /// - returns: The new `SessionDelegate` instance.
     public override init() {
+        self.fileManager = .default
         super.init()
     }
 
@@ -535,7 +537,7 @@ extension SessionDelegate: URLSessionDataDelegate {
         if let dataTaskDidBecomeDownloadTask = dataTaskDidBecomeDownloadTask {
             dataTaskDidBecomeDownloadTask(session, dataTask, downloadTask)
         } else {
-            self[downloadTask]?.delegate = DownloadTaskDelegate(task: downloadTask)
+            self[downloadTask]?.delegate = DownloadTaskDelegate(task: downloadTask, fileManager: fileManager)
         }
     }
 

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -665,7 +665,7 @@ open class SessionManager {
         encodingCompletion: ((MultipartFormDataEncodingResult) -> Void)?)
     {
         DispatchQueue.global(qos: .utility).async {
-            let formData = MultipartFormData()
+            let formData = MultipartFormData(fileManager: self.fileManager)
             multipartFormData(formData)
 
             var tempFileURL: URL?

--- a/Source/TaskDelegate.swift
+++ b/Source/TaskDelegate.swift
@@ -306,6 +306,8 @@ class DownloadTaskDelegate: TaskDelegate, URLSessionDownloadDelegate {
     // MARK: Properties
 
     var downloadTask: URLSessionDownloadTask { return task as! URLSessionDownloadTask }
+    
+    let fileManager: FileManager
 
     var progress: Progress
     var progressHandler: (closure: Request.ProgressHandler, queue: DispatchQueue)?
@@ -322,8 +324,9 @@ class DownloadTaskDelegate: TaskDelegate, URLSessionDownloadDelegate {
 
     // MARK: Lifecycle
 
-    override init(task: URLSessionTask?) {
+    init(task: URLSessionTask?, fileManager: FileManager) {
         progress = Progress(totalUnitCount: 0)
+        self.fileManager = fileManager
         super.init(task: task)
     }
 
@@ -359,16 +362,16 @@ class DownloadTaskDelegate: TaskDelegate, URLSessionDownloadDelegate {
         self.destinationURL = destinationURL
 
         do {
-            if options.contains(.removePreviousFile), FileManager.default.fileExists(atPath: destinationURL.path) {
-                try FileManager.default.removeItem(at: destinationURL)
+            if options.contains(.removePreviousFile), fileManager.fileExists(atPath: destinationURL.path) {
+                try fileManager.removeItem(at: destinationURL)
             }
 
             if options.contains(.createIntermediateDirectories) {
                 let directory = destinationURL.deletingLastPathComponent()
-                try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+                try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
             }
 
-            try FileManager.default.moveItem(at: location, to: destinationURL)
+            try fileManager.moveItem(at: location, to: destinationURL)
         } catch {
             self.error = error
         }

--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -292,11 +292,13 @@ extension DownloadRequest {
             guard let validFileURL = fileURL else {
                 return .failure(AFError.responseValidationFailed(reason: .dataFileNil))
             }
-
-            do {
-                let data = try Data(contentsOf: validFileURL)
+            
+            if
+                self.fileManager.isReadableFile(atPath: validFileURL.path),
+                let data = self.fileManager.contents(atPath: validFileURL.path)
+            {
                 return self.validate(contentType: acceptableContentTypes, response: response, data: data)
-            } catch {
+            } else {
                 return .failure(AFError.responseValidationFailed(reason: .dataFileReadFailed(at: validFileURL)))
             }
         }

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -342,7 +342,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
                     let originalTask = DataRequest.Requestable(urlRequest: originalRequest)
 
                     let task = try originalTask.task(session: session, adapter: adapter, queue: queue)
-                    let request = MockDataRequest(session: session, requestTask: .data(originalTask, task))
+                    let request = MockDataRequest(session: session, requestTask: .data(originalTask, task), fileManager: fileManager)
 
                     delegate[task] = request
 
@@ -350,7 +350,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
 
                     return request
                 } catch {
-                    let request = DataRequest(session: session, requestTask: .data(nil, nil), error: error)
+                    let request = DataRequest(session: session, requestTask: .data(nil, nil), error: error, fileManager: fileManager)
                     if startRequestsImmediately { request.resume() }
                     return request
                 }
@@ -366,7 +366,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
                     let originalTask = DownloadRequest.Downloadable.request(originalRequest)
 
                     let task = try originalTask.task(session: session, adapter: adapter, queue: queue)
-                    let request = MockDownloadRequest(session: session, requestTask: .download(originalTask, task))
+                    let request = MockDownloadRequest(session: session, requestTask: .download(originalTask, task), fileManager: fileManager)
 
                     request.downloadDelegate.destination = destination
 
@@ -376,7 +376,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
 
                     return request
                 } catch {
-                    let download = DownloadRequest(session: session, requestTask: .download(nil, nil), error: error)
+                    let download = DownloadRequest(session: session, requestTask: .download(nil, nil), error: error, fileManager: fileManager)
                     if startRequestsImmediately { download.resume() }
                     return download
                 }


### PR DESCRIPTION
### Goals :soccer:
Some enterprise MDM SDKs, like [BlackBerry Dynamics](https://us.blackberry.com/enterprise/blackberry-dynamics) have their own secure virtual file system, and the cache, and download of data needs to be stored using a custom subclass of FileManager, to interact with this database. In the current implementation of Alamofire, it relies on the `.default` singleton, being unable to inject, and so, replace this class.

### Implementation Details :construction:
Basically, all elements on Alamofire that uses a `FileManager` is receiving an instance on the initialiser, having a custom init with `.default` as the default parameter. Also, this reference is propagated to every sub component created.

### Testing Details :mag:
The hole project should behave equally, using `FileManager.default`, and interacting with the system the same way.