### PR TITLE
Requests taking Encodable parameters

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -159,10 +159,10 @@ public func request(
 ///
 /// - returns: The created `DataRequest`.
 @discardableResult
-public func request(
+public func request<T: Encodable>(
     _ url: URLConvertible,
     method: HTTPMethod = .get,
-    parameters: Encodable? = nil,
+    parameters: T? = nil,
     encoding: ParameterEncoding = JSONEncoding.default,
     headers: HTTPHeaders? = nil)
     -> DataRequest

--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -146,6 +146,34 @@ public func request(
     )
 }
 
+/// Creates a `DataRequest` using the default `SessionManager` to retrieve the contents of the specified `url`,
+/// `method`, `parameters`, `encoding` and `headers`.
+///
+/// - parameter url:        The URL.
+/// - parameter method:     The HTTP method. `.get` by default.
+/// - parameter parameters: The parameters. `nil` by default.
+/// - parameter encoding:   The parameter encoding. `JSONEncoding.default` by default.
+/// - parameter headers:    The HTTP headers. `nil` by default.
+///
+/// - returns: The created `DataRequest`.
+@discardableResult
+public func request(
+    _ url: URLConvertible,
+    method: HTTPMethod = .get,
+    parameters: Encodable? = nil,
+    encoding: ParameterEncoding = JSONEncoding.default,
+    headers: HTTPHeaders? = nil)
+    -> DataRequest
+{
+    return SessionManager.default.request(
+        url,
+        method: method,
+        parameters: parameters,
+        encoding: encoding,
+        headers: headers
+    )
+}
+
 /// Creates a `DataRequest` using the default `SessionManager` to retrieve the contents of a URL based on the
 /// specified `urlRequest`.
 ///

--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -149,6 +149,8 @@ public func request(
 /// Creates a `DataRequest` using the default `SessionManager` to retrieve the contents of the specified `url`,
 /// `method`, `parameters`, `encoding` and `headers`.
 ///
+/// **NOTE** Does not support `URLEncoding`
+///
 /// - parameter url:        The URL.
 /// - parameter method:     The HTTP method. `.get` by default.
 /// - parameter parameters: The parameters. `nil` by default.

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -269,6 +269,36 @@ open class SessionManager {
         }
     }
 
+    /// Creates a `DataRequest` to retrieve the contents of the specified `url`, `method`, `parameters`, `encoding`
+    /// and `headers`.
+    ///
+    /// - parameter url:        The URL.
+    /// - parameter method:     The HTTP method. `.get` by default.
+    /// - parameter parameters: The parameters. `nil` by default.
+    /// - parameter encoding:   The parameter encoding. `URLEncoding.default` by default.
+    /// - parameter headers:    The HTTP headers. `nil` by default.
+    ///
+    /// - returns: The created `DataRequest`.
+    @discardableResult
+    open func request(
+        _ url: URLConvertible,
+        method: HTTPMethod = .get,
+        parameters: Encodable? = nil,
+        encoding: ParameterEncoding = JSONEncoding.default,
+        headers: HTTPHeaders? = nil)
+        -> DataRequest
+    {
+        var originalRequest: URLRequest?
+
+        do {
+            originalRequest = try URLRequest(url: url, method: method, headers: headers)
+            let encodedURLRequest = try encoding.encode(originalRequest!, with: parameters)
+            return request(encodedURLRequest)
+        } catch {
+            return request(originalRequest, failedWith: error)
+        }
+    }
+
     // MARK: Private - Request Implementation
 
     private func request(_ urlRequest: URLRequest?, failedWith error: Error) -> DataRequest {

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -282,10 +282,10 @@ open class SessionManager {
     ///
     /// - returns: The created `DataRequest`.
     @discardableResult
-    open func request(
+    open func request<T: Encodable>(
         _ url: URLConvertible,
         method: HTTPMethod = .get,
-        parameters: Encodable? = nil,
+        parameters: T? = nil,
         encoding: ParameterEncoding = JSONEncoding.default,
         headers: HTTPHeaders? = nil)
         -> DataRequest

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -272,6 +272,8 @@ open class SessionManager {
     /// Creates a `DataRequest` to retrieve the contents of the specified `url`, `method`, `parameters`, `encoding`
     /// and `headers`.
     ///
+    /// **NOTE** Does not support `URLEncoding`
+    ///
     /// - parameter url:        The URL.
     /// - parameter method:     The HTTP method. `.get` by default.
     /// - parameter parameters: The parameters. `nil` by default.


### PR DESCRIPTION
### Issue Link :link:
#2181

### Goals :soccer:
Allow users to pass in their `Encodable` types instead of having to manually convert them to dictionaries.

### Implementation Details :construction:
- `JSONEncoding` and `PropertyListEncoding` are currently using the old serializations methods. Those implementations have been deprecated in favour of new implementations using `JSONEncoder` and `PropertyListEncoder` respectively.
- New generic Alamofire request method that accepts an `Encodable` type.
- `typealias Parameters = [String: Any]` is now `typealias Parameters = [String: Encodable]`. This should be okay as all JSON and XML types, as well as URL query parameters are `Encodable`. When possible (likely Swift 4.1) this should be redefined as
```
protocol ParameterValue: Encodable {}
extension Int: ParameterValue {}
extension String: ParameterValue {}
extension Array: ParameterValue where Element: ParameterValue {}
// etc..

typealias Parameters = [String: ParameterValue]
```

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->