### PR TITLE
Added Radar for URLSessionTaskMetrics Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ The following radars have some effect on the current implementation of Alamofire
 - [`rdar://21349340`](http://www.openradar.me/radar?id=5517037090635776) - Compiler throwing warning due to toll-free bridging issue in test case
 - `rdar://26870455` - Background URL Session Configurations do not work in the simulator
 - `rdar://26849668` - Some URLProtocol APIs do not properly handle `URLRequest`
+- [`rdar://36082113`](http://openradar.appspot.com/radar?id=4942308441063424) - `URLSessionTaskMetrics` failing to link on watchOS 3.0+
 
 ## Resolved Radars
 


### PR DESCRIPTION
Added radar to the README for the URLSessionTaskMetrics issue on watchOS.

### Goals :soccer:
To draw attention to the radars we've filed that affect the project.

### Implementation Details :construction:
Just filed another radar. The details are in the other project which can be found [here](https://github.com/Alamofire/Rdar-URLSessionTaskMetrics).