### PR TITLE
Clarify OS versions affected by download resume bug

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -513,7 +513,7 @@ Alamofire.download("https://httpbin.org/image/png")
 
 If a `DownloadRequest` is cancelled or interrupted, the underlying URL session may generate resume data for the active `DownloadRequest`. If this happens, the resume data can be re-used to restart the `DownloadRequest` where it left off. The resume data can be accessed through the download response, then reused when trying to restart the request.
 
-> **IMPORTANT:** On the latest release of all the Apple platforms (iOS 10, macOS 10.12, tvOS 10, watchOS 3), `resumeData` is broken on background URL session configurations. There's an underlying bug in the `resumeData` generation logic where the data is written incorrectly and will always fail to resume the download. For more information about the bug and possible workarounds, please see this Stack Overflow [post](http://stackoverflow.com/a/39347461/1342462).
+> **IMPORTANT:** On some versions of the previous major release of all the Apple platforms (iOS 10–10.2, macOS 10.12–10.12.2, tvOS 10–10.1, watchOS 3–3.1.1), `resumeData` is broken on background URL session configurations. There's an underlying bug in the `resumeData` generation logic where the data is written incorrectly and will always fail to resume the download. For more information about the bug and possible workarounds, please see this Stack Overflow [post](http://stackoverflow.com/a/39347461/1342462).
 
 ```swift
 class ImageRequestor {


### PR DESCRIPTION
The bug referenced in `Usage.md` was fixed in iOS 10.2, etc. This PR updates the documentation which still erroneously refers to these as the "latest" release.