### PR TITLE
Set appropriate protection levels on NetworkReachabilityManager members

### DIFF
--- a/Source/NetworkReachabilityManager.swift
+++ b/Source/NetworkReachabilityManager.swift
@@ -33,7 +33,7 @@ import SystemConfiguration
 /// Reachability can be used to determine background information about why a network operation failed, or to retry
 /// network requests when a connection is established. It should not be used to prevent a user from initiating a network
 /// request, as it's possible that an initial request may be required to establish reachability.
-public class NetworkReachabilityManager {
+open class NetworkReachabilityManager {
     /// Defines the various states of network reachability.
     ///
     /// - unknown:      It is unknown whether the network is reachable.
@@ -61,27 +61,27 @@ public class NetworkReachabilityManager {
     // MARK: - Properties
 
     /// Whether the network is currently reachable.
-    public var isReachable: Bool { return isReachableOnWWAN || isReachableOnEthernetOrWiFi }
+    open var isReachable: Bool { return isReachableOnWWAN || isReachableOnEthernetOrWiFi }
 
     /// Whether the network is currently reachable over the WWAN interface.
-    public var isReachableOnWWAN: Bool { return networkReachabilityStatus == .reachable(.wwan) }
+    open var isReachableOnWWAN: Bool { return networkReachabilityStatus == .reachable(.wwan) }
 
     /// Whether the network is currently reachable over Ethernet or WiFi interface.
-    public var isReachableOnEthernetOrWiFi: Bool { return networkReachabilityStatus == .reachable(.ethernetOrWiFi) }
+    open var isReachableOnEthernetOrWiFi: Bool { return networkReachabilityStatus == .reachable(.ethernetOrWiFi) }
 
     /// The current network reachability status.
-    public var networkReachabilityStatus: NetworkReachabilityStatus {
+    open var networkReachabilityStatus: NetworkReachabilityStatus {
         guard let flags = self.flags else { return .unknown }
         return networkReachabilityStatusForFlags(flags)
     }
 
     /// The dispatch queue to execute the `listener` closure on.
-    public var listenerQueue: DispatchQueue = DispatchQueue.main
+    open var listenerQueue: DispatchQueue = DispatchQueue.main
 
     /// A closure executed when the network reachability status changes.
-    public var listener: Listener?
+    open var listener: Listener?
 
-    private var flags: SCNetworkReachabilityFlags? {
+    open var flags: SCNetworkReachabilityFlags? {
         var flags = SCNetworkReachabilityFlags()
 
         if SCNetworkReachabilityGetFlags(reachability, &flags) {
@@ -92,7 +92,7 @@ public class NetworkReachabilityManager {
     }
 
     private let reachability: SCNetworkReachability
-    private var previousFlags: SCNetworkReachabilityFlags
+    open var previousFlags: SCNetworkReachabilityFlags
 
     // MARK: - Initialization
 
@@ -141,7 +141,7 @@ public class NetworkReachabilityManager {
     ///
     /// - returns: `true` if listening was started successfully, `false` otherwise.
     @discardableResult
-    public func startListening() -> Bool {
+    open func startListening() -> Bool {
         var context = SCNetworkReachabilityContext(version: 0, info: nil, retain: nil, release: nil, copyDescription: nil)
         context.info = Unmanaged.passUnretained(self).toOpaque()
 
@@ -165,7 +165,7 @@ public class NetworkReachabilityManager {
     }
 
     /// Stops listening for changes in network reachability status.
-    public func stopListening() {
+    open func stopListening() {
         SCNetworkReachabilitySetCallback(reachability, nil, nil)
         SCNetworkReachabilitySetDispatchQueue(reachability, nil)
     }


### PR DESCRIPTION
### Goals :soccer:
I want to be able to mock `NetworkReachabilityManager` for unit testing in integrating projects. The current protection level of `public` does not allow inheritance forcing me to inconvenient testing methods with wrappers and the like. By changing the protection level to `open` the class and the appropriate members can be subclassed and overridden making mocking it is a breeze.

### Implementation Details :construction:
I've changed protection levels from `public` to `open` where applicable.

### Testing Details :mag:
I used a test project to reproduce the problem with inheritance and subsequent overriding. I made my changes and ran the test suite to make sure everything passes. I was thinking of creating a mock of `NetworkReachabilityManager` and adding it to the test target of the example app but I'm not sure it's a viable means of testing since compilation would be the assertion and the mock would be unused. Let me know if you think any kind of test is appropriate for this PR.
