### PR TITLE
extend userInfo-dict of .DidComplete-Notification to contain responseData of DataTasks

### DIFF
--- a/Source/Notifications.swift
+++ b/Source/Notifications.swift
@@ -48,5 +48,8 @@ extension Notification {
     public struct Key {
         /// User info dictionary key representing the `URLSessionTask` associated with the notification.
         public static let Task = "org.alamofire.notification.key.task"
+
+        /// User info dictionary key representing the responseData associated with the notification.
+        public static let ResponseData = "org.alamofire.notification.key.responseData"
     }
 }

--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -442,10 +442,16 @@ extension SessionDelegate: URLSessionTaskDelegate {
 
             strongSelf[task]?.delegate.urlSession(session, task: task, didCompleteWithError: error)
 
+            var userInfo: [String: Any] = [Notification.Key.Task: task]
+
+            if let data = (strongSelf[task]?.delegate as? DataTaskDelegate)?.data {
+                userInfo[Notification.Key.ResponseData] = data
+            }
+
             NotificationCenter.default.post(
                 name: Notification.Name.Task.DidComplete,
                 object: strongSelf,
-                userInfo: [Notification.Key.Task: task]
+                userInfo: userInfo
             )
 
             strongSelf[task] = nil

--- a/Tests/SessionDelegateTests.swift
+++ b/Tests/SessionDelegateTests.swift
@@ -529,9 +529,11 @@ class SessionDelegateTestCase: BaseTestCase {
         let expectation = self.expectation(forNotification: Notification.Name.Task.DidComplete.rawValue, object: nil) { notif -> Bool in
 
             // check that we are handling notif for a dataTask
-            guard notif.userInfo?[Notification.Key.Task] is URLSessionDataTask else {
+            guard let task = notif.userInfo?[Notification.Key.Task] as? URLSessionDataTask else {
                 return false
             }
+
+            response = task.response as? HTTPURLResponse
 
             // check that responseData are set in userInfo-dict and it's not empty
             if let responseData = notif.userInfo?[Notification.Key.ResponseData] as? Data {
@@ -542,9 +544,7 @@ class SessionDelegateTestCase: BaseTestCase {
         }
 
         // When
-        manager.request("https://httpbin.org/get").responseJSON { closureResponse in
-            response = closureResponse.response
-        }
+        manager.request("https://httpbin.org/get").responseJSON { resp in }
 
         wait(for: [expectation], timeout: timeout)
 
@@ -561,9 +561,11 @@ class SessionDelegateTestCase: BaseTestCase {
         let expectation = self.expectation(forNotification: Notification.Name.Task.DidComplete.rawValue, object: nil) { notif -> Bool in
 
             // check that we are handling notif for a downloadTask
-            guard notif.userInfo?[Notification.Key.Task] is URLSessionDownloadTask else {
+            guard let task = notif.userInfo?[Notification.Key.Task] as? URLSessionDownloadTask else {
                 return false
             }
+
+            response = task.response as? HTTPURLResponse
 
             // check that responseData are NOT set in userInfo-dict
             notificationCalledWithNilResponseData = notif.userInfo?[Notification.Key.ResponseData] == nil
@@ -571,9 +573,7 @@ class SessionDelegateTestCase: BaseTestCase {
         }
 
         // When
-        manager.download("https://httpbin.org/get").response { resp in
-            response = resp.response
-        }
+        manager.download("https://httpbin.org/get").response {resp in }
 
         wait(for: [expectation], timeout: timeout)
 

--- a/Tests/SessionDelegateTests.swift
+++ b/Tests/SessionDelegateTests.swift
@@ -520,4 +520,65 @@ class SessionDelegateTestCase: BaseTestCase {
         XCTAssertTrue(overrideClosureCalled)
         XCTAssertEqual(response?.statusCode, 200)
     }
+
+    func testThatDidCompleteNotificationIsCalledWithResponseDataForDataTasks() {
+        // Given
+        var notificationCalledWithResponseData = false
+        var response: HTTPURLResponse?
+
+        let expectation = self.expectation(forNotification: Notification.Name.Task.DidComplete.rawValue, object: nil) { notif -> Bool in
+
+            // check that we are handling notif for a dataTask
+            guard notif.userInfo?[Notification.Key.Task] is URLSessionDataTask else {
+                return false
+            }
+
+            // check that responseData are set in userInfo-dict and it's not empty
+            if let responseData = notif.userInfo?[Notification.Key.ResponseData] as? Data {
+                notificationCalledWithResponseData = responseData.count > 0
+            }
+
+            return notificationCalledWithResponseData
+        }
+
+        // When
+        manager.request("https://httpbin.org/get").responseJSON { closureResponse in
+            response = closureResponse.response
+        }
+
+        wait(for: [expectation], timeout: timeout)
+
+        // Then
+        XCTAssertTrue(notificationCalledWithResponseData)
+        XCTAssertEqual(response?.statusCode, 200)
+    }
+
+    func testThatDidCompleteNotificationIsntCalledForDownloadTasks() {
+        // Given
+        var notificationCalledWithNilResponseData = false
+        var response: HTTPURLResponse?
+
+        let expectation = self.expectation(forNotification: Notification.Name.Task.DidComplete.rawValue, object: nil) { notif -> Bool in
+
+            // check that we are handling notif for a downloadTask
+            guard notif.userInfo?[Notification.Key.Task] is URLSessionDownloadTask else {
+                return false
+            }
+
+            // check that responseData are NOT set in userInfo-dict
+            notificationCalledWithNilResponseData = notif.userInfo?[Notification.Key.ResponseData] == nil
+            return notificationCalledWithNilResponseData
+        }
+
+        // When
+        manager.download("https://httpbin.org/get").response { resp in
+            response = resp.response
+        }
+
+        wait(for: [expectation], timeout: timeout)
+
+        // Then
+        XCTAssertTrue(notificationCalledWithNilResponseData)
+        XCTAssertEqual(response?.statusCode, 200)
+    }
 }


### PR DESCRIPTION
### Goals :soccer:
Alamofire currently doesn't allow generic logging of DataTask-Responses via Notifications. This would be especially useful if you use a wrapper around Alamofire like SwaggerClient and can't access or configure the logging directly.

The .DidComplete-Notification already provides access to the URLSessionDataTask via the userInfo-dictionary, but there's no way to get the raw responseData associated with such a DataTask.

AFNetworking implements a similar notification mechanism, but instead also provides access to the responseData via userInfo-dictionary.

### Implementation Details :construction:
I've simply extended `open func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?)` to check if the task's delegate is a DataTaskDelegate and if so, put it's data into the userInfo-dictionary of the .DidComplete-notification.

### Testing Details :mag:
I've extended SessionDelegateTestCase with 2 proper test-methods.