### PR TITLE
Add configurable parameter handling to URLEncoding.

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -279,6 +279,38 @@ Alamofire.request("https://httpbin.org/post", method: .post, parameters: paramet
 // HTTP body: foo=bar&baz[]=a&baz[]=1&qux[x]=1&qux[y]=2&qux[z]=3
 ```
 
+##### Configuring the Encoding of `Bool` Parameters
+
+The `URLEncoding.BoolEncoding` enumeration provides the following methods for encoding `Bool` parameters:
+
+- `.numeric` - Encode `true` as `1` and `false` as `0`.
+- `.literal` - Encode `true` and `false` as string literals.
+
+By default, Alamofire uses the `.numeric` encoding.
+
+You can create your own `URLEncoding` and specify the desired `Bool` encoding in the initializer:
+
+```swift
+let encoding = URLEncoding(boolEncoding: .literal)
+```
+
+##### Configuring the Encoding of `Array` Parameters
+
+The `URLEncoding.ArrayEncoding` enumeration provides the following methods for encoding `Array` parameters:
+
+- `.brackets` - An empty set of square brackets is appended to the key for every value.
+- `.noBrackets` - No brackets are appended. The key is encoded as is.
+
+By default, Alamofire uses the `.brackets` encoding, where `foo=[1,2]` is encoded as `foo[]=1&foo[]=2`.
+
+Using the `.noBrackets` encoding will encode `foo=[1,2]` as `foo=1&foo=2`.
+
+You can create your own `URLEncoding` and specify the desired `Array` encoding in the initializer:
+
+```swift
+let encoding = URLEncoding(arrayEncoding: .noBrackets)
+```
+
 #### JSON Encoding
 
 The `JSONEncoding` type creates a JSON representation of the parameters object, which is set as the HTTP body of the request. The `Content-Type` HTTP header field of an encoded request is set to `application/json`.

--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -209,9 +209,8 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
 
     func testURLParameterEncodeStringKeyArrayValueParameterWithoutBrackets() {
         do {
-            let encoding = URLEncoding(arrayEncoding: .noBrackets)
-
             // Given
+            let encoding = URLEncoding(arrayEncoding: .noBrackets)
             let parameters = ["foo": ["a", 1, true]]
 
             // When
@@ -272,9 +271,8 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
 
     func testURLParameterEncodeStringKeyNestedDictionaryArrayValueParameterWithoutBrackets() {
         do {
-            let encoding = URLEncoding(arrayEncoding: .noBrackets)
-
             // Given
+            let encoding = URLEncoding(arrayEncoding: .noBrackets)
             let parameters = ["foo": ["bar": ["baz": ["a", 1, true]]]]
 
             // When
@@ -283,6 +281,38 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             // Then
             let expectedQuery = "foo%5Bbar%5D%5Bbaz%5D=a&foo%5Bbar%5D%5Bbaz%5D=1&foo%5Bbar%5D%5Bbaz%5D=1"
             XCTAssertEqual(urlRequest.url?.query, expectedQuery)
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
+    }
+
+    func testURLParameterLiteralBoolEncodingWorksAndDoesNotAffectNumbers() {
+        do {
+            // Given
+            let encoding = URLEncoding(boolEncoding: .literal)
+            let parameters: [String: Any] = [
+                // Must still encode to numbers
+                "a": 1,
+                "b": 0,
+                "c": 1.0,
+                "d": 0.0,
+                "e": NSNumber(value: 1),
+                "f": NSNumber(value: 0),
+                "g": NSNumber(value: 1.0),
+                "h": NSNumber(value: 0.0),
+
+                // Must encode to literals
+                "i": true,
+                "j": false,
+                "k": NSNumber(value: true),
+                "l": NSNumber(value: false)
+            ]
+
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+
+            // Then
+            XCTAssertEqual(urlRequest.url?.query, "a=1&b=0&c=1&d=0&e=1&f=0&g=1&h=0&i=true&j=false&k=true&l=false")
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }

--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -207,6 +207,23 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
         }
     }
 
+    func testURLParameterEncodeStringKeyArrayValueParameterWithoutBrackets() {
+        do {
+            let encoding = URLEncoding(arrayEncoding: .noBrackets)
+
+            // Given
+            let parameters = ["foo": ["a", 1, true]]
+
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+
+            // Then
+            XCTAssertEqual(urlRequest.url?.query, "foo=a&foo=1&foo=1")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
+    }
+
     func testURLParameterEncodeStringKeyDictionaryValueParameter() {
         do {
             // Given
@@ -247,6 +264,24 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
 
             // Then
             let expectedQuery = "foo%5Bbar%5D%5Bbaz%5D%5B%5D=a&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1&foo%5Bbar%5D%5Bbaz%5D%5B%5D=1"
+            XCTAssertEqual(urlRequest.url?.query, expectedQuery)
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
+    }
+
+    func testURLParameterEncodeStringKeyNestedDictionaryArrayValueParameterWithoutBrackets() {
+        do {
+            let encoding = URLEncoding(arrayEncoding: .noBrackets)
+
+            // Given
+            let parameters = ["foo": ["bar": ["baz": ["a", 1, true]]]]
+
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+
+            // Then
+            let expectedQuery = "foo%5Bbar%5D%5Bbaz%5D=a&foo%5Bbar%5D%5Bbaz%5D=1&foo%5Bbar%5D%5Bbaz%5D=1"
             XCTAssertEqual(urlRequest.url?.query, expectedQuery)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")


### PR DESCRIPTION
### Goals :soccer:

There is no real specification for how to URL encode collection parameters like arrays and
dictionaries.

For arrays, two conventions are in common use:

1. `foo=[1,2]` is encoded as `foo[]=1&foo[]=2`
2. `foo=[1,2]` is encoded as `foo=1&foo=2`

Alamofire follows the first convention, as does libraries such as jQuery and Rails.

The second convention is not currently supported by Alamofire, but is commonly required for communicating with Java-based web services.

This PR introduces optional support for the convention where square brackets are omitted 
from array keys.

### Implementation Details :construction:

- A new `ArrayEncoding` enumeration is added to `URLEncoding`. The cases are `.brackets` and `.noBrackets`.
- An `arrayEncoding` parameter is added to `URLEncoding.init` with a default value of `.brackets` to preserve the existing default behavior and maintain source compatibility.
- The `arrayEncoding` passed to `init` is used to control the array key serialization in `URLEncoding.queryComponents`.

### Testing Details :mag:

The two existing tests for URL encoding of arrays are:

- `testURLParameterEncodeStringKeyArrayValueParameter` (top level array)
- `testURLParameterEncodeStringKeyNestedDictionaryArrayValueParameter` (array nested inside a dictionary)

These have been duplicated and adapted to test an instance of `URLEncoding(arrayEncoding: .noBrackets)` instead of the default `URLEncoding`.

The two new tests are named like the existing tests, with an appended suffix:

- `testURLParameterEncodeStringKeyArrayValueParameterWithoutBrackets`
- `testURLParameterEncodeStringKeyNestedDictionaryArrayValueParameterWithoutBrackets`

All tests pass.

---

### Update

Amended the pull request with configurable boolean parameter encoding, as per @jshier 's comment.

- The bool value configuration follows the pattern of the array key configuration closely for consistency. 
- Source compatibility is maintained and the default bool encoding behavior is preserved.

Added the following test case: 

`testURLParameterLiteralBoolEncodingWorksAndDoesNotAffectNumbers`

The test verifies that 

- Boolean values can be encoded to literals as expected.
- Enabling literal bool encoding has no effect on the encoding of truthy or falsy numeric parameters like `NSNumber(value: 1)` etc. 