### PR TITLE
fixed: cookies not shown in cURLRepresentation

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -319,6 +319,7 @@ extension Request: CustomDebugStringConvertible {
         }
 
         var headers: [AnyHashable: Any] = [:]
+        var cookies: String?
 
         if let additionalHeaders = session.configuration.httpAdditionalHeaders {
             for (field, value) in additionalHeaders where field != AnyHashable("Cookie") {
@@ -327,13 +328,21 @@ extension Request: CustomDebugStringConvertible {
         }
 
         if let headerFields = request.allHTTPHeaderFields {
-            for (field, value) in headerFields where field != "Cookie" {
-                headers[field] = value
+            for (field, value) in headerFields {
+                if field != "Cookie" {
+                    headers[field] = value
+                } else {
+                    cookies = value
+                }
             }
         }
 
         for (field, value) in headers {
             components.append("-H \"\(field): \(value)\"")
+        }
+
+        if let c = cookies, !session.configuration.httpShouldSetCookies {
+            components.append("-b \"\(c)\"")
         }
 
         if let httpBodyData = request.httpBody, let httpBody = String(data: httpBodyData, encoding: .utf8) {


### PR DESCRIPTION
When disabled cookies in session configuration and set cookies as a header, show cookies in curl query.

### Issue Link :https://github.com/Alamofire/Alamofire/issues/2435:


### Goals :soccer:
fixed: cookies not shown in cURLRepresentation
