### PR TITLE
Add swift_version to spec

### DIFF
--- a/Alamofire.podspec
+++ b/Alamofire.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.authors = { 'Alamofire Software Foundation' => 'info@alamofire.org' }
   s.source = { :git => 'https://github.com/Alamofire/Alamofire.git', :tag => s.version }
 
+  s.swift_version = '3.2'
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '9.0'


### PR DESCRIPTION
### Goals :soccer:
* Specify the swift version that will be used for the pod regardless of the swift version the app target uses.

### Implementation Details :construction:
This feature was added on CocoaPods 1.4.0 (http://blog.cocoapods.org/CocoaPods-1.4.0/)