### PR TITLE
Escape quotes in headers when building cURLRepresentation

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -333,7 +333,8 @@ extension Request: CustomDebugStringConvertible {
         }
 
         for (field, value) in headers {
-            components.append("-H \"\(field): \(value)\"")
+            let escapedValue = String(describing: value).replacingOccurrences(of: "\"", with: "\\\"")
+            components.append("-H \"\(field): \(escapedValue)\"")
         }
 
         if let httpBodyData = request.httpBody, let httpBody = String(data: httpBodyData, encoding: .utf8) {

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -529,6 +529,18 @@ class RequestDebugDescriptionTestCase: BaseTestCase {
         XCTAssertEqual(components.last, "\"\(urlString)\"")
     }
 
+    func testGETRequestWithJSONHeaderDebugDescription() {
+        // Given
+        let urlString = "https://httpbin.org/get"
+
+        // When
+        let headers: [String: String] = [ "X-Custom-Header": "{\"key\": \"value\"}" ]
+        let request = manager.request(urlString, headers: headers)
+
+        // Then
+        XCTAssertNotNil(request.debugDescription.range(of: "-H \"X-Custom-Header: {\\\"key\\\": \\\"value\\\"}\""))
+    }
+
     func testGETRequestWithDuplicateHeadersDebugDescription() {
         // Given
         let urlString = "https://httpbin.org/get"


### PR DESCRIPTION
### Goals :soccer:
I'm working on an app that found it useful to pass some structured data in an HTTP header by serializing a dictionary to JSON. We also log the `curl` equivalent of our applications requests in debug builds so that we can easily reply a request of interest. 

We found that the logged `curl` commands failed to escape quotes in the header so our logged `curl` command would read as:

```
$ curl -x \
    -H "X-Custom-Header: {"key": "value"}" \
    "https://httpbin.org/get"
```
`curl` actually accepts and parses this, stripping the extra quotes from this header field:
```
> User-Agent: curl/7.54.0
> Accept: */*
> X-Custom-Header: {key: value}
```
Unfortunately this header string (`{key: value}`) is no longer parsable JSON.

Now `cURLRepresentation` will escape a single level of escaped quotes in headers resulting in:
```
$ curl -x \
    -H "X-Custom-Header: {\"key\": \"value\"}" \
    "https://httpbin.org/get"
```
```
> User-Agent: curl/7.54.0
> Accept: */*
> X-Custom-Header: {"key": "value"}
```

### Implementation Details :construction:
Hopefully not a breaking change for anyone since it changes only the debug description of the request.

This won't cover all possible escaped characters in header strings. It possible someone could want to output a command with multiple levels of nested quotes. However since https://github.com/Alamofire/Alamofire/blob/master/Source/Request.swift#L340 already only considers two levels of escaped quotes I think this is sufficient as an incremental improvement. A better solution might be to define a function to increase the number of escapes of all quotes in a string and use that to format all our quoted arguments.

### Testing Details :mag:
Added another unit test to `cURLRepresentation` to cover this case.