### PR TITLE
Makes rethrows all methods that can be marked as rethrows

### DIFF
--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -158,12 +158,12 @@ extension DataResponse {
     ///
     /// - returns: A `DataResponse` whose result wraps the value returned by the given closure. If this instance's
     ///            result is a failure, returns a response wrapping the same failure.
-    public func map<T>(_ transform: (Value) -> T) -> DataResponse<T> {
+    public func map<T>(_ transform: (Value) throws -> T) rethrows -> DataResponse<T> {
         var response = DataResponse<T>(
             request: request,
             response: self.response,
             data: data,
-            result: result.map(transform),
+            result: try result.map(transform),
             timeline: timeline
         )
 
@@ -209,12 +209,12 @@ extension DataResponse {
     ///
     /// - Parameter transform: A closure that takes the error of the instance.
     /// - Returns: A `DataResponse` instance containing the result of the transform.
-    public func mapError<E: Error>(_ transform: (Error) -> E) -> DataResponse {
+    public func mapError<E: Error>(_ transform: (Error) throws -> E) rethrows -> DataResponse {
         var response = DataResponse(
             request: request,
             response: self.response,
             data: data,
-            result: result.mapError(transform),
+            result: try result.mapError(transform),
             timeline: timeline
         )
 

--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -158,12 +158,12 @@ extension DataResponse {
     ///
     /// - returns: A `DataResponse` whose result wraps the value returned by the given closure. If this instance's
     ///            result is a failure, returns a response wrapping the same failure.
-    public func map<T>(_ transform: (Value) throws -> T) rethrows -> DataResponse<T> {
+    public func map<T>(_ transform: (Value) -> T) -> DataResponse<T> {
         var response = DataResponse<T>(
             request: request,
             response: self.response,
             data: data,
-            result: try result.map(transform),
+            result: result.map(transform),
             timeline: timeline
         )
 
@@ -209,12 +209,12 @@ extension DataResponse {
     ///
     /// - Parameter transform: A closure that takes the error of the instance.
     /// - Returns: A `DataResponse` instance containing the result of the transform.
-    public func mapError<E: Error>(_ transform: (Error) throws -> E) rethrows -> DataResponse {
+    public func mapError<E: Error>(_ transform: (Error) -> E) -> DataResponse {
         var response = DataResponse(
             request: request,
             response: self.response,
             data: data,
-            result: try result.mapError(transform),
+            result: result.mapError(transform),
             timeline: timeline
         )
 

--- a/Source/Result.swift
+++ b/Source/Result.swift
@@ -166,10 +166,10 @@ extension Result {
     ///
     /// - returns: A `Result` containing the result of the given closure. If this instance is a failure, returns the
     ///            same failure.
-    public func map<T>(_ transform: (Value) -> T) -> Result<T> {
+    public func map<T>(_ transform: (Value) throws -> T) rethrows -> Result<T> {
         switch self {
         case .success(let value):
-            return .success(transform(value))
+            return .success(try transform(value))
         case .failure(let error):
             return .failure(error)
         }
@@ -211,10 +211,10 @@ extension Result {
     /// - Parameter transform: A closure that takes the error of the instance.
     /// - Returns: A `Result` instance containing the result of the transform. If this instance is a success, returns
     ///            the same instance.
-    public func mapError<T: Error>(_ transform: (Error) -> T) -> Result {
+    public func mapError<T: Error>(_ transform: (Error) throws -> T) rethrows -> Result {
         switch self {
         case .failure(let error):
-            return .failure(transform(error))
+            return .failure(try transform(error))
         case .success:
             return self
         }
@@ -253,8 +253,8 @@ extension Result {
     /// - Parameter closure: A closure that takes the success value of this instance.
     /// - Returns: This `Result` instance, unmodified.
     @discardableResult
-    public func withValue(_ closure: (Value) -> Void) -> Result {
-        if case let .success(value) = self { closure(value) }
+    public func withValue(_ closure: (Value) throws -> Void) rethrows -> Result {
+        if case let .success(value) = self { try closure(value) }
 
         return self
     }
@@ -266,8 +266,8 @@ extension Result {
     /// - Parameter closure: A closure that takes the success value of this instance.
     /// - Returns: This `Result` instance, unmodified.
     @discardableResult
-    public func withError(_ closure: (Error) -> Void) -> Result {
-        if case let .failure(error) = self { closure(error) }
+    public func withError(_ closure: (Error) throws -> Void) rethrows -> Result {
+        if case let .failure(error) = self { try closure(error) }
 
         return self
     }
@@ -279,8 +279,8 @@ extension Result {
     /// - Parameter closure: A `Void` closure.
     /// - Returns: This `Result` instance, unmodified.
     @discardableResult
-    public func ifSuccess(_ closure: () -> Void) -> Result {
-        if isSuccess { closure() }
+    public func ifSuccess(_ closure: () throws -> Void) rethrows -> Result {
+        if isSuccess { try closure() }
 
         return self
     }
@@ -292,8 +292,8 @@ extension Result {
     /// - Parameter closure: A `Void` closure.
     /// - Returns: This `Result` instance, unmodified.
     @discardableResult
-    public func ifFailure(_ closure: () -> Void) -> Result {
-        if isFailure { closure() }
+    public func ifFailure(_ closure: () throws -> Void) rethrows -> Result {
+        if isFailure { try closure() }
 
         return self
     }

--- a/Source/Result.swift
+++ b/Source/Result.swift
@@ -166,10 +166,10 @@ extension Result {
     ///
     /// - returns: A `Result` containing the result of the given closure. If this instance is a failure, returns the
     ///            same failure.
-    public func map<T>(_ transform: (Value) throws -> T) rethrows -> Result<T> {
+    public func map<T>(_ transform: (Value) -> T) -> Result<T> {
         switch self {
         case .success(let value):
-            return .success(try transform(value))
+            return .success(transform(value))
         case .failure(let error):
             return .failure(error)
         }
@@ -211,10 +211,10 @@ extension Result {
     /// - Parameter transform: A closure that takes the error of the instance.
     /// - Returns: A `Result` instance containing the result of the transform. If this instance is a success, returns
     ///            the same instance.
-    public func mapError<T: Error>(_ transform: (Error) throws -> T) rethrows -> Result {
+    public func mapError<T: Error>(_ transform: (Error) -> T) -> Result {
         switch self {
         case .failure(let error):
-            return .failure(try transform(error))
+            return .failure(transform(error))
         case .success:
             return self
         }


### PR DESCRIPTION
### Goals :soccer:
Allows to use `try` in non-escaping closures.
For example, the following code, before the change:
```
let response: DataResponse<Data> = <...>
let result: Result<Any>
switch response.result {
case .failure(let error):
	result = .failure(error)
case .success(let value):
	result = .success(try JSONSerialization.jsonObject(with: value))
}
let newResponse = DataResponse(
	request: response.request,
	response: response.response,
	data: response.data,
	result: result,
	timeline: response.timeline
)
```
Would be able to be changed to:
```
let response: DataResponse<Data> = <...>
let newResponse = try response.map { try JSONSerialization.jsonObject(with: value) }
```

(this is a simplified example for demonstrating what the change brings - for this specific example, it might make more sense to use `flatMap`, or just use `responseJSON` if possible)

### Implementation Details :construction:
Just some syntax additions, adding `throws` to the closure and `rethrows` to the method that accepts the closure.

### Testing Details :mag:
None, as this is purely a change for programmer's. The tests still passes.
