### PR TITLE
Updated SPM installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The [Swift Package Manager](https://swift.org/package-manager/) is a tool for au
 
 Once you have your Swift package set up, adding Alamofire as a dependency is as easy as adding it to the `dependencies` value of your `Package.swift`.
 
-#### Swift 3
+#### Swift 4
 
 ```swift
 dependencies: [
@@ -137,7 +137,7 @@ dependencies: [
 ]
 ```
 
-#### Swift 4
+#### Swift 3
 
 ```swift
 dependencies: [


### PR DESCRIPTION
The Swift Package Manager instructions were swapped around with regards to the Swift 4 vs Swift 3 dependency syntax. (Swift 4 begins with the ".Package", not Swift 3).  Implemented the installation in server side swift with the correct Swift 4 syntax and it works.

### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
