### PR TITLE
[WIP] AF5 Feature - Redirects Per Request

### DIFF
--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -260,7 +260,11 @@ extension SessionDelegate: URLSessionTaskDelegate {
                          completionHandler: @escaping (URLRequest?) -> Void) {
         eventMonitor?.urlSession(session, task: task, willPerformHTTPRedirection: response, newRequest: request)
 
-        completionHandler(request)
+        if let afRequest = requestTaskMap[task] {
+            afRequest.performRedirection(for: response, newRequest: request, completionHandler: completionHandler)
+        } else {
+            completionHandler(request)
+        }
     }
 
     open func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {


### PR DESCRIPTION
This PR is a work in-progress, but currently adds the ability to AF5 to control redirect behavior per-request instead of only at the `SessionDelegate` level.

### Problem

The general issue with redirect handling is that you want to allow most endpoints to redirect, and deny several very specific ones. We recently ran into this issue and had to go to some extreme lengths to work around the lack of per-request redirect control in Alamofire. Commonly, the place where you are implementing the `SessionDelegate` or subclass of it will not know about all the URLs that are going to be piped through it, nor would you want it to. However, the `SessionDelegate` only has a single callback point for all requests hitting a redirect, so it would be awesome if Alamofire could automatically provide a way to control redirects per-request rather than having to do this through the `SessionDelegate`.

### Solution

Per-request redirect support! By adding a `Request.redirect` API that allows clients to specify redirect behavior for a specific request, it greatly simplifies the redirect logic. This gives clients full control over all redirects at the `Request` level, making it VERY easy to disable redirects for a single call without having to subclass the `SessionDelegate`.

### Callouts

@jshier I haven't added tests or anything for this behavior yet b/c I wanted to run the idea by you first to make sure this is going in the right direction. Feedback welcome!