### PR TITLE
Podspec explicitly specify documentation url

### DIFF
--- a/Alamofire.podspec
+++ b/Alamofire.podspec
@@ -7,6 +7,7 @@ Pod::Spec.new do |s|
   s.social_media_url = 'http://twitter.com/AlamofireSF'
   s.authors = { 'Alamofire Software Foundation' => 'info@alamofire.org' }
   s.source = { :git => 'https://github.com/Alamofire/Alamofire.git', :tag => s.version }
+  s.documentation_ur = 'https://alamofire.github.io/Alamofire/'
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'


### PR DESCRIPTION
Cocoadocs does not work anymore. To avoid a 404 when a user clicks the documentation link on cocoapods, you need to specify a url.