### PR TITLE
Add optional encoding completion callback queue argument for multipart form upload

### DIFF
--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -611,6 +611,7 @@ open class SessionManager {
         to url: URLConvertible,
         method: HTTPMethod = .post,
         headers: HTTPHeaders? = nil,
+        queue: DispatchQueue? = nil,
         encodingCompletion: ((MultipartFormDataEncodingResult) -> Void)?)
     {
         do {
@@ -623,7 +624,7 @@ open class SessionManager {
                 encodingCompletion: encodingCompletion
             )
         } catch {
-            DispatchQueue.main.async { encodingCompletion?(.failure(error)) }
+            (queue ?? DispatchQueue.main).async { encodingCompletion?(.failure(error)) }
         }
     }
 
@@ -654,6 +655,7 @@ open class SessionManager {
         multipartFormData: @escaping (MultipartFormData) -> Void,
         usingThreshold encodingMemoryThreshold: UInt64 = SessionManager.multipartFormDataEncodingMemoryThreshold,
         with urlRequest: URLRequestConvertible,
+        queue: DispatchQueue? = nil,
         encodingCompletion: ((MultipartFormDataEncodingResult) -> Void)?)
     {
         DispatchQueue.global(qos: .utility).async {
@@ -677,7 +679,7 @@ open class SessionManager {
                         streamFileURL: nil
                     )
 
-                    DispatchQueue.main.async { encodingCompletion?(encodingResult) }
+                    (queue ?? DispatchQueue.main).async { encodingCompletion?(encodingResult) }
                 } else {
                     let fileManager = FileManager.default
                     let tempDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory())
@@ -713,7 +715,7 @@ open class SessionManager {
                         }
                     }
 
-                    DispatchQueue.main.async {
+                    (queue ?? DispatchQueue.main).async {
                         let encodingResult = MultipartFormDataEncodingResult.success(
                             request: upload,
                             streamingFromDisk: true,
@@ -733,7 +735,7 @@ open class SessionManager {
                     }
                 }
 
-                DispatchQueue.main.async { encodingCompletion?(.failure(error)) }
+                (queue ?? DispatchQueue.main).async { encodingCompletion?(.failure(error)) }
             }
         }
     }

--- a/Source/SessionManager.swift
+++ b/Source/SessionManager.swift
@@ -621,6 +621,7 @@ open class SessionManager {
                 multipartFormData: multipartFormData,
                 usingThreshold: encodingMemoryThreshold,
                 with: urlRequest,
+                queue: queue,
                 encodingCompletion: encodingCompletion
             )
         } catch {


### PR DESCRIPTION
### Goals :soccer:
This change adds an optional `queue` parameter to the `upload(multipartFormData:...)` functions.  If specified, that queue will be used for the encoding completion callback.  Otherwise the main queue will be used, as is the current functionality.

### Implementation Details :construction:
The `queue` argument has a default value of nil, and I've replaced existing calls to `DispatchQueue.main.async` with `(queue ?? DispatchQueue.main).async`, following the pattern seen in `DataRequest.response`.  Therefore merging this pull request will have no effect to existing usage of the `upload` function; it adds flexibility where users need it.

### Testing Details :mag:
I will admit I've tested this only minimally due to the simplicity of the change.  From what I've seen, calling `upload` with or without a `queue` specified results in the encoding callback coming from the expected queue (the specified queue or main queue, respectively).
