### PR TITLE
Add re-designed Package.swift manifest for swift 4

### DIFF
--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,41 @@
+// swift-tools-version:4.0
+
+//
+//  Package.swift
+//
+//  Copyright (c) 2014-2018 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import PackageDescription
+
+let package = Package(
+    name: "Alamofire",
+    products: [
+        .library(
+            name: "Alamofire",
+            targets: ["Alamofire"])
+    ],
+    targets: [
+        .target(
+            name: "Alamofire",
+            path: "Source")
+    ]
+)


### PR DESCRIPTION
### Goals :soccer:
```
warning: PackageDescription API v3 is deprecated and will be removed in the future; used by package(s): Alamofire
```
This message has appeared when a user uses Alamofire via PackageManager with Swift 4.
Because of [Package Manager Manifest API(https://swift.org/blog/swift-package-manager-manifest-api-redesign/) has been redesigned].

### Implementation Details :construction:
Added the Package@swift-4.swift that will affect for above swift version 4.
