### PR TITLE
Improve cURLRepresentation implementation readability

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -320,19 +320,19 @@ extension Request: CustomDebugStringConvertible {
 
         var headers: [AnyHashable: Any] = [:]
 
-        if let additionalHeaders = session.configuration.httpAdditionalHeaders {
-            for (field, value) in additionalHeaders where field != AnyHashable("Cookie") {
-                headers[field] = value
-            }
+        session.configuration.httpAdditionalHeaders?.filter { field, _ -> Bool in
+            field != AnyHashable("Cookie")
+        }.forEach { field, value in
+            headers[field] = value
         }
 
-        if let headerFields = request.allHTTPHeaderFields {
-            for (field, value) in headerFields where field != "Cookie" {
-                headers[field] = value
-            }
+        request.allHTTPHeaderFields?.filter { field, _ -> Bool in
+            field != "Cookie"
+        }.forEach { field, value in
+            headers[field] = value
         }
 
-        for (field, value) in headers {
+        headers.forEach { field, value in
             let escapedValue = String(describing: value).replacingOccurrences(of: "\"", with: "\\\"")
             components.append("-H \"\(field): \(escapedValue)\"")
         }

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -320,21 +320,16 @@ extension Request: CustomDebugStringConvertible {
 
         var headers: [AnyHashable: Any] = [:]
 
-        session.configuration.httpAdditionalHeaders?.filter { field, _ -> Bool in
-            field != AnyHashable("Cookie")
-        }.forEach { field, value in
-            headers[field] = value
-        }
+        session.configuration.httpAdditionalHeaders?.filter {  $0.0 != AnyHashable("Cookie") }
+                                                    .forEach { headers[$0.0] = $0.1 }
 
-        request.allHTTPHeaderFields?.filter { field, _ -> Bool in
-            field != "Cookie"
-        }.forEach { field, value in
-            headers[field] = value
-        }
+        request.allHTTPHeaderFields?.filter { $0.0 != "Cookie" }
+                                    .forEach { headers[$0.0] = $0.1 }
 
-        headers.forEach { field, value in
-            let escapedValue = String(describing: value).replacingOccurrences(of: "\"", with: "\\\"")
-            components.append("-H \"\(field): \(escapedValue)\"")
+        components += headers.map {
+            let escapedValue = String(describing: $0.value).replacingOccurrences(of: "\"", with: "\\\"")
+            
+            return "-H \"\($0.key): \(escapedValue)\""
         }
 
         if let httpBodyData = request.httpBody, let httpBody = String(data: httpBodyData, encoding: .utf8) {


### PR DESCRIPTION
### Goals :soccer:
This small `PR` will improve `cURLRepresentation` `func` implementation in `Request` core class.

### Implementation Details :construction:
Current implementation use multiple `if let` statements to check for variable `nil`-ness and if available perform some `for in` loops. We could achieve the same behavior using Swift native `Optional` features. In fact if we use `.forEach` instead of `for in` there's no need to check for variable `nil`-ness because the loop won't execute if the variable will be `nil`.

### Testing Details :mag:
Regular unit tests should be enough
