### PR TITLE
Alamofire 5: Customizable Empty Response Handling

### DIFF
--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -130,13 +130,13 @@ public enum AFError: Error {
     /// - jsonSerializationFailed:         JSON serialization failed with an underlying system error.
     /// - invalidEmptyResponse:            Generic serialization failed for an empty response that wasn't type `Empty`.
     public enum ResponseSerializationFailureReason {
-        case inputDataNil
         case inputDataNilOrZeroLength
         case inputFileNil
         case inputFileReadFailed(at: URL)
         case stringSerializationFailed(encoding: String.Encoding)
         case jsonSerializationFailed(error: Error)
         case invalidEmptyResponse(type: String)
+        case jsonDecodingFailed(error: Error)
     }
 
     /// Underlying reason a server trust evaluation error occured.
@@ -537,8 +537,6 @@ extension AFError.MultipartEncodingFailureReason {
 extension AFError.ResponseSerializationFailureReason {
     var localizedDescription: String {
         switch self {
-        case .inputDataNil:
-            return "Response could not be serialized, input data was nil."
         case .inputDataNilOrZeroLength:
             return "Response could not be serialized, input data was nil or zero length."
         case .inputFileNil:
@@ -551,6 +549,8 @@ extension AFError.ResponseSerializationFailureReason {
             return "JSON could not be serialized because of error:\n\(error.localizedDescription)"
         case .invalidEmptyResponse(let type):
             return "Empty response could not be serialized to type: \(type). Use Empty as the expected type for such responses."
+        case .jsonDecodingFailed(let error):
+            return "JSON could not be decoded because of error:\n\(error.localizedDescription)"
         }
     }
 }

--- a/Tests/AFError+AlamofireTests.swift
+++ b/Tests/AFError+AlamofireTests.swift
@@ -107,11 +107,6 @@ extension AFError {
 
     // ResponseSerializationFailureReason
 
-    var isInputDataNil: Bool {
-        if case let .responseSerializationFailed(reason) = self, reason.isInputDataNil { return true }
-        return false
-    }
-
     var isInputDataNilOrZeroLength: Bool {
         if case let .responseSerializationFailed(reason) = self, reason.isInputDataNilOrZeroLength { return true }
         return false
@@ -134,6 +129,11 @@ extension AFError {
 
     var isJSONSerializationFailed: Bool {
         if case let .responseSerializationFailed(reason) = self, reason.isJSONSerializationFailed { return true }
+        return false
+    }
+    
+    var isJSONDecodingFailed: Bool {
+        if case let .responseSerializationFailed(reason) = self, reason.isJSONDecodingFailed { return true }
         return false
     }
 
@@ -251,11 +251,6 @@ extension AFError.MultipartEncodingFailureReason {
 // MARK: -
 
 extension AFError.ResponseSerializationFailureReason {
-    var isInputDataNil: Bool {
-        if case .inputDataNil = self { return true }
-        return false
-    }
-
     var isInputDataNilOrZeroLength: Bool {
         if case .inputDataNilOrZeroLength = self { return true }
         return false
@@ -278,6 +273,11 @@ extension AFError.ResponseSerializationFailureReason {
 
     var isJSONSerializationFailed: Bool {
         if case .jsonSerializationFailed = self { return true }
+        return false
+    }
+    
+    var isJSONDecodingFailed: Bool {
+        if case .jsonDecodingFailed = self { return true }
         return false
     }
 }

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -30,7 +30,7 @@ class DataResponseSerializationTestCase: BaseTestCase {
 
     // MARK: Properties
 
-    private let error = AFError.responseSerializationFailed(reason: .inputDataNil)
+    private let error = AFError.responseSerializationFailed(reason: .inputDataNilOrZeroLength)
 
     // MARK: DataResponseSerializer
 
@@ -61,7 +61,7 @@ class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error)
 
         if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNil)
+            XCTAssertTrue(error.isInputDataNilOrZeroLength)
         } else {
             XCTFail("error should not be nil")
         }
@@ -80,7 +80,7 @@ class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error)
 
         if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNil)
+            XCTAssertTrue(error.isInputDataNilOrZeroLength)
         } else {
             XCTFail("error should not be nil")
         }
@@ -100,7 +100,7 @@ class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error, "result error should not be nil")
 
         if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNil)
+            XCTAssertTrue(error.isInputDataNilOrZeroLength)
         } else {
             XCTFail("error should not be nil")
         }
@@ -139,7 +139,7 @@ class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error)
 
         if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNil)
+            XCTAssertTrue(error.isInputDataNilOrZeroLength)
         } else {
             XCTFail("error should not be nil")
         }
@@ -254,7 +254,7 @@ class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error)
 
         if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNil)
+            XCTAssertTrue(error.isInputDataNilOrZeroLength)
         } else {
             XCTFail("error should not be nil")
         }
@@ -274,7 +274,7 @@ class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error)
 
         if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNil)
+            XCTAssertTrue(error.isInputDataNilOrZeroLength)
         } else {
             XCTFail("error should not be nil")
         }
@@ -386,7 +386,7 @@ class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error)
 
         if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNil)
+            XCTAssertTrue(error.isInputDataNilOrZeroLength)
         } else {
             XCTFail("error should not be nil")
         }
@@ -518,7 +518,7 @@ class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.error)
 
         if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNil)
+            XCTAssertTrue(error.isInputDataNilOrZeroLength)
         } else {
             XCTFail("error should not be nil")
         }
@@ -596,7 +596,7 @@ class DownloadResponseSerializationTestCase: BaseTestCase {
         XCTAssertNil(result.error)
     }
 
-    func testThatDataResponseSerializerSucceedsWhenFileDataIsNil() {
+    func testThatDataResponseSerializerFailsWhenFileDataIsEmpty() {
         // Given
         let serializer = DataResponseSerializer()
 
@@ -604,9 +604,15 @@ class DownloadResponseSerializationTestCase: BaseTestCase {
         let result = Result { try serializer.serializeDownload(request: nil, response: nil, fileURL: jsonEmptyDataFileURL, error: nil) }
 
         // Then
-        XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
+        XCTAssertTrue(result.isFailure)
+        XCTAssertNil(result.value)
+        XCTAssertNotNil(result.error)
+        
+        if let error = result.error?.asAFError {
+            XCTAssertTrue(error.isInputDataNilOrZeroLength)
+        } else {
+            XCTFail("error should not be nil")
+        }
     }
 
     func testThatDataResponseSerializerFailsWhenFileURLIsNil() {


### PR DESCRIPTION
### Issue Link :link:
#1713

### Goals :soccer:
This PR adds customization points to the various serializers to support custom response code and request method handling for empty responses, while providing default values.

### Implementation Details :construction:
This PR refactors some of the response parsing, while keeping all but one test passing exactly the same. It adds properties to all of the response serializers to let users customize them at initialization. It also adds support for request method parsing, to support empty responses for HEAD requests.

### Testing Details :mag:
Test cases cover this code pretty thoroughly. One test was inverted, as file and data response parsing are now the same by default.
