### PR TITLE
Alamofire 5: Code Coverage for Framework Schemes

### DIFF
--- a/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire iOS.xcscheme
+++ b/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire iOS.xcscheme
@@ -41,7 +41,18 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableThreadSanitizer = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F8111E3219A95C8B0040E7D1"
+            BuildableName = "Alamofire.framework"
+            BlueprintName = "Alamofire iOS"
+            ReferencedContainer = "container:Alamofire.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire macOS.xcscheme
+++ b/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire macOS.xcscheme
@@ -42,7 +42,17 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4DD67C0A1A5C55C900ED2280"
+            BuildableName = "Alamofire.framework"
+            BlueprintName = "Alamofire macOS"
+            ReferencedContainer = "container:Alamofire.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire tvOS.xcscheme
+++ b/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire tvOS.xcscheme
@@ -41,7 +41,18 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableThreadSanitizer = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4CF626EE1BA7CB3E0011A099"
+            BuildableName = "Alamofire.framework"
+            BlueprintName = "Alamofire tvOS"
+            ReferencedContainer = "container:Alamofire.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
This PR enables code coverage for the iOS, macOS, and tvOS frameworks in their respective schemes. This will make it easier to diagnose gaps in test coverage for certain features such as the new `ParameterEncoder` logic.