### PR TITLE
Fix #2658: default empty response values non-public

### DIFF
--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -54,8 +54,8 @@ extension ResponseSerializer {
     public static var defaultEmptyRequestMethods: Set<HTTPMethod> { return [.head] }
     public static var defaultEmptyResponseCodes: Set<Int> { return [204, 205] }
 
-    var emptyRequestMethods: Set<HTTPMethod> { return Self.defaultEmptyRequestMethods }
-    var emptyResponseCodes: Set<Int> { return Self.defaultEmptyResponseCodes }
+    public var emptyRequestMethods: Set<HTTPMethod> { return Self.defaultEmptyRequestMethods }
+    public var emptyResponseCodes: Set<Int> { return Self.defaultEmptyResponseCodes }
 
     public func requestAllowsEmptyResponseData(_ request: URLRequest?) -> Bool? {
         return request.flatMap { $0.httpMethod }

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -1066,6 +1066,31 @@ class DownloadResponseSerializationTestCase: BaseTestCase {
     }
 }
 
+final class CustomResponseSerializerTestCases: BaseTestCase {
+    func testThatCustomResponseSerializersCanBeWrittenWithoutCompilerIssues() {
+        // Given
+        final class UselessResponseSerializer: ResponseSerializer {
+            func serialize(request: URLRequest?, response: HTTPURLResponse?, data: Data?, error: Error?) throws -> Data? {
+                return data
+            }
+        }
+        let serializer = UselessResponseSerializer()
+        let expectation = self.expectation(description: "request should finish")
+        var data: Data?
+
+        // When
+        AF.request(URLRequest.makeHTTPBinRequest()).response(responseSerializer: serializer) { (response) in
+            data = response.data
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertNotNil(data)
+    }
+}
+
 extension HTTPURLResponse {
     convenience init(statusCode: Int, headers: HTTPHeaders? = nil) {
         let url = URL(string: "https://httpbin.org/get")!


### PR DESCRIPTION
### Issue Link :link:
#2658

### Goals :soccer:
This PR adds the public modifier to `ResponseSerializer`'s default `emptyResponseCodes` and `emptyResponseMethods`.

### Testing Details :mag:
Test added for creating a `ResponseSerializer` for public Alamofire.