### PR TITLE
Implemented protocol EmptyResponse so that an empty response value ca…

### DIFF
--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -583,11 +583,11 @@ public final class DecodableResponseSerializer<T: Decodable>: ResponseSerializer
                 throw AFError.responseSerializationFailed(reason: .inputDataNilOrZeroLength)
             }
 
-            guard let emptyResponseType = T.self as? EmptyResponse.Type else {
+            guard let emptyResponseType = T.self as? EmptyResponse.Type, let emptyValue = emptyResponseType.emptyValue as? T else {
                 throw AFError.responseSerializationFailed(reason: .invalidEmptyResponse(type: "\(T.self)"))
             }
 
-            return emptyResponseType.emptyValue as! T
+            return emptyValue
         }
 
         do {

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -515,10 +515,18 @@ extension DownloadRequest {
 }
 
 // MARK: - Empty
+/// A protocol for a type representing an empty response. Use `T.emptyValue` to get an instance.
+public protocol EmptyResponse {
+    static var emptyValue: EmptyResponse { get }
+}
 
 /// A type representing an empty response. Use `Empty.value` to get the instance.
 public struct Empty: Decodable {
     public static let value = Empty()
+}
+
+extension Empty: EmptyResponse {
+    public static var emptyValue: EmptyResponse { return value }
 }
 
 // MARK: - DataDecoder Protocol
@@ -575,11 +583,11 @@ public final class DecodableResponseSerializer<T: Decodable>: ResponseSerializer
                 throw AFError.responseSerializationFailed(reason: .inputDataNilOrZeroLength)
             }
 
-            guard let emptyValue = Empty.value as? T else {
+            guard let emptyResponseType = T.self as? EmptyResponse.Type else {
                 throw AFError.responseSerializationFailed(reason: .invalidEmptyResponse(type: "\(T.self)"))
             }
 
-            return emptyValue
+            return emptyResponseType.emptyValue as! T
         }
 
         do {

--- a/Tests/AFError+AlamofireTests.swift
+++ b/Tests/AFError+AlamofireTests.swift
@@ -137,6 +137,11 @@ extension AFError {
         return false
     }
 
+    var isInvalidEmptyResponse: Bool {
+        if case let .responseSerializationFailed(reason) = self, reason.isInvalidEmptyResponse { return true }
+        return false
+    }
+
     // ResponseValidationFailureReason
 
     var isDataFileNil: Bool {
@@ -278,6 +283,11 @@ extension AFError.ResponseSerializationFailureReason {
 
     var isDecodingFailed: Bool {
         if case .decodingFailed = self { return true }
+        return false
+    }
+
+    var isInvalidEmptyResponse: Bool {
+        if case .invalidEmptyResponse = self { return true }
         return false
     }
 }


### PR DESCRIPTION
### Goals :soccer:
An empty result should not need to be derived from the `Empty` type.

### Implementation Details :construction:
It is inconvenient (and restrictive) to require that all empty response value derived form `Empty`. Using a protocol allows any response value type to declare its own empty value.

The `EmptyResponse` protocol essential does what the `Empty` struct did; and the `Empty` struct has been extended to implement `EmptyResponse`. No implementations of Empty should be adversely affected. If we're worried about var vs let on the static property, it seems like a static func in its place would probable solve it.

### Testing Details :mag:
Added tests to test for objects that implement `EmptyResponse` and objects that incorrectly implement `EmptyResponse.`
