### PR TITLE
Implementing protocol EmptyResponse so that an empty response value can be returned when an empty http status code is encountered

### DIFF
--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -517,7 +517,7 @@ extension DownloadRequest {
 // MARK: - Empty
 /// A protocol for a type representing an empty response. Use `T.emptyValue` to get an instance.
 public protocol EmptyResponse {
-    static var emptyValue: EmptyResponse { get }
+    static func emptyResponseValue() -> Self
 }
 
 /// A type representing an empty response. Use `Empty.value` to get the instance.
@@ -526,7 +526,10 @@ public struct Empty: Decodable {
 }
 
 extension Empty: EmptyResponse {
-    public static var emptyValue: EmptyResponse { return value }
+    public static func emptyResponseValue() -> Empty {
+        return value
+    }
+    public static var emptyResponseValueVar: Empty { return value }
 }
 
 // MARK: - DataDecoder Protocol
@@ -583,11 +586,11 @@ public final class DecodableResponseSerializer<T: Decodable>: ResponseSerializer
                 throw AFError.responseSerializationFailed(reason: .inputDataNilOrZeroLength)
             }
 
-            guard let emptyResponseType = T.self as? EmptyResponse.Type, let emptyValue = emptyResponseType.emptyValue as? T else {
+            guard let emptyResponseType = T.self as? EmptyResponse.Type else {
                 throw AFError.responseSerializationFailed(reason: .invalidEmptyResponse(type: "\(T.self)"))
             }
 
-            return emptyValue
+            return emptyResponseType.emptyResponseValue() as! T
         }
 
         do {

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -515,10 +515,18 @@ extension DownloadRequest {
 }
 
 // MARK: - Empty
+/// A protocol for a type representing an empty response. Use `T.emptyValue` to get an instance.
+public protocol EmptyResponse {
+    static var emptyValue: EmptyResponse { get }
+}
 
 /// A type representing an empty response. Use `Empty.value` to get the instance.
 public struct Empty: Decodable {
     public static let value = Empty()
+}
+
+extension Empty: EmptyResponse {
+    public static var emptyValue: EmptyResponse { return value }
 }
 
 // MARK: - DataDecoder Protocol
@@ -575,7 +583,7 @@ public final class DecodableResponseSerializer<T: Decodable>: ResponseSerializer
                 throw AFError.responseSerializationFailed(reason: .inputDataNilOrZeroLength)
             }
 
-            guard let emptyValue = Empty.value as? T else {
+            guard let emptyResponseType = T.self as? EmptyResponse.Type, let emptyValue = emptyResponseType.emptyValue as? T else {
                 throw AFError.responseSerializationFailed(reason: .invalidEmptyResponse(type: "\(T.self)"))
             }
 

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -517,7 +517,7 @@ extension DownloadRequest {
 // MARK: - Empty
 /// A protocol for a type representing an empty response. Use `T.emptyValue` to get an instance.
 public protocol EmptyResponse {
-    static func emptyResponseValue() -> Self
+    static func emptyValue() -> Self
 }
 
 /// A type representing an empty response. Use `Empty.value` to get the instance.
@@ -526,10 +526,9 @@ public struct Empty: Decodable {
 }
 
 extension Empty: EmptyResponse {
-    public static func emptyResponseValue() -> Empty {
+    public static func emptyValue() -> Empty {
         return value
     }
-    public static var emptyResponseValueVar: Empty { return value }
 }
 
 // MARK: - DataDecoder Protocol
@@ -586,11 +585,11 @@ public final class DecodableResponseSerializer<T: Decodable>: ResponseSerializer
                 throw AFError.responseSerializationFailed(reason: .inputDataNilOrZeroLength)
             }
 
-            guard let emptyResponseType = T.self as? EmptyResponse.Type else {
+            guard let emptyResponseType = T.self as? EmptyResponse.Type, let emptyValue = emptyResponseType.emptyValue() as? T else {
                 throw AFError.responseSerializationFailed(reason: .invalidEmptyResponse(type: "\(T.self)"))
             }
 
-            return emptyResponseType.emptyResponseValue() as! T
+            return emptyValue
         }
 
         do {

--- a/Tests/AFError+AlamofireTests.swift
+++ b/Tests/AFError+AlamofireTests.swift
@@ -137,6 +137,11 @@ extension AFError {
         return false
     }
 
+    var isInvalidEmptyResponse: Bool {
+        if case let .responseSerializationFailed(reason) = self, reason.isInvalidEmptyResponse { return true }
+        return false
+    }
+
     // ResponseValidationFailureReason
 
     var isDataFileNil: Bool {
@@ -278,6 +283,11 @@ extension AFError.ResponseSerializationFailureReason {
 
     var isDecodingFailed: Bool {
         if case .decodingFailed = self { return true }
+        return false
+    }
+
+    var isInvalidEmptyResponse: Bool {
+        if case .invalidEmptyResponse = self { return true }
         return false
     }
 }

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -626,33 +626,6 @@ final class DecodableResponseSerializerTests: BaseTestCase {
             XCTFail("error should not be nil")
         }
     }
-
-    final class DecodableClassWithEmptyResponse: Decodable, EmptyResponse {
-        static func emptyValue() -> DecodableClassWithEmptyResponse {
-            return empty
-        }
-
-        static let empty = DecodableClassWithEmptyResponse(string: "");
-
-        init(string: String) { self.string = string }
-
-        let string: String
-    }
-
-    func testThatJSONDecodableResponseSerializerSucceedsWhenDataIsNilWithEmptyResponseStatusCodeAndDecodableClassHasEmptyResponse() {
-        // Given
-        let serializer = DecodableResponseSerializer<DecodableClassWithEmptyResponse>()
-        let response = HTTPURLResponse(statusCode: 204)
-
-        // When
-        let result = Result { try serializer.serialize(request: nil, response: response, data: nil, error: nil) }
-
-        // Then
-        XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertTrue(result.value! === DecodableClassWithEmptyResponse.empty)
-        XCTAssertNil(result.error)
-    }
 }
 
 // MARK: -

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -443,7 +443,7 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
 // used by testThatDecodableResponseSerializerSucceedsWhenDataIsNilWithEmptyResponseConformingTypeAndEmptyResponseStatusCode
 extension Bool: EmptyResponse {
-    public static var emptyValue: EmptyResponse {
+    public static func emptyResponseValue() -> Bool {
         return true
     }
 }
@@ -452,7 +452,9 @@ final class DecodableResponseSerializerTests: BaseTestCase {
     private let error = AFError.responseSerializationFailed(reason: .inputDataNilOrZeroLength)
 
     struct DecodableValue: Decodable, EmptyResponse {
-        static var emptyValue: EmptyResponse { return DecodableValue(string: "") }
+        static func emptyResponseValue() -> DecodableValue {
+            return DecodableValue(string: "")
+        }
 
         let string: String
     }
@@ -625,38 +627,12 @@ final class DecodableResponseSerializerTests: BaseTestCase {
         }
     }
 
-     struct DecodableValueWithEmptyResponseOfWrongType: Decodable, EmptyResponse {
-        static var emptyValue: EmptyResponse { return DecodableValue(string: ""); }
-
-        let string: String
-    }
-
-    func testThatDecodableResponseSerializerFailsWhenEmptyResponseIsWrongType() {
-        // Given
-        let serializer = DecodableResponseSerializer<DecodableValueWithEmptyResponseOfWrongType>()
-        let response = HTTPURLResponse(statusCode: 204)
-
-        // When
-        let result = Result { try serializer.serialize(request: nil, response: response, data: nil, error: nil) }
-
-        // Then
-        XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInvalidEmptyResponse)
-        } else {
-            XCTFail("error should not be nil")
-        }
-    }
-
-    class DecodableClassWithEmptyResponse: Decodable, EmptyResponse, Equatable {
-        static func == (lhs: DecodableClassWithEmptyResponse, rhs: DecodableClassWithEmptyResponse) -> Bool {
-            return lhs.string == rhs.string
+    final class DecodableClassWithEmptyResponse: Decodable, EmptyResponse {
+        static func emptyResponseValue() -> DecodableClassWithEmptyResponse {
+            return emptyValue
         }
 
-        static var emptyValue: EmptyResponse = { return DecodableClassWithEmptyResponse(string: ""); }()
+        static let emptyValue = DecodableClassWithEmptyResponse(string: "");
 
         init(string: String) { self.string = string }
 
@@ -674,8 +650,7 @@ final class DecodableResponseSerializerTests: BaseTestCase {
         // Then
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(result.value)
-        XCTAssertEqual(result.value, DecodableClassWithEmptyResponse.emptyValue as? DecodableClassWithEmptyResponse)
-        XCTAssertTrue(result.value! === DecodableClassWithEmptyResponse.emptyValue as! DecodableClassWithEmptyResponse)
+        XCTAssertTrue(result.value! === DecodableClassWithEmptyResponse.emptyValue)
         XCTAssertNil(result.error)
     }
 }

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -443,7 +443,7 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
 // used by testThatDecodableResponseSerializerSucceedsWhenDataIsNilWithEmptyResponseConformingTypeAndEmptyResponseStatusCode
 extension Bool: EmptyResponse {
-    public static func emptyResponseValue() -> Bool {
+    public static func emptyValue() -> Bool {
         return true
     }
 }
@@ -452,7 +452,7 @@ final class DecodableResponseSerializerTests: BaseTestCase {
     private let error = AFError.responseSerializationFailed(reason: .inputDataNilOrZeroLength)
 
     struct DecodableValue: Decodable, EmptyResponse {
-        static func emptyResponseValue() -> DecodableValue {
+        static func emptyValue() -> DecodableValue {
             return DecodableValue(string: "")
         }
 
@@ -628,11 +628,11 @@ final class DecodableResponseSerializerTests: BaseTestCase {
     }
 
     final class DecodableClassWithEmptyResponse: Decodable, EmptyResponse {
-        static func emptyResponseValue() -> DecodableClassWithEmptyResponse {
-            return emptyValue
+        static func emptyValue() -> DecodableClassWithEmptyResponse {
+            return empty
         }
 
-        static let emptyValue = DecodableClassWithEmptyResponse(string: "");
+        static let empty = DecodableClassWithEmptyResponse(string: "");
 
         init(string: String) { self.string = string }
 
@@ -650,7 +650,7 @@ final class DecodableResponseSerializerTests: BaseTestCase {
         // Then
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(result.value)
-        XCTAssertTrue(result.value! === DecodableClassWithEmptyResponse.emptyValue)
+        XCTAssertTrue(result.value! === DecodableClassWithEmptyResponse.empty)
         XCTAssertNil(result.error)
     }
 }


### PR DESCRIPTION
### Goals :soccer:
An empty result should not need to be derived from the `Empty` type.

### Implementation Details :construction:
It is inconvenient (and restrictive) to require that all empty response value derived form `Empty`. Using a protocol allows any response value type to declare its own empty value.

The `EmptyResponse` protocol essential does what the `Empty` struct did; and the `Empty` struct has been extended to implement `EmptyResponse`. No implementations of Empty should be adversely affected. 

This PR supersedes https://github.com/Alamofire/Alamofire/pull/2662, which was originally based the `alamofire5` branch and had a number of requested changes.

### Testing Details :mag:
Added tests to test for objects that implement `EmptyResponse` and objects that incorrectly implement `EmptyResponse.` `Bool` is extended in order to test a built-in type; `Int` is not extended and tested for failure.
