### PR TITLE
SPKI Support

### DIFF
--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -180,6 +180,8 @@ public enum AFError: Error {
         case certificatePinningFailed(host: String, trust: SecTrust, pinnedCertificates: [SecCertificate], serverCertificates: [SecCertificate])
         /// Public key pinning failed.
         case publicKeyPinningFailed(host: String, trust: SecTrust, pinnedKeys: [SecKey], serverKeys: [SecKey])
+        /// Subject PublicKey Info pinning failed
+        case subjectPublicKeyInfoPinningFailed(host: String, trust: SecTrust, pinnedKeys: [String], serverKeys:[SecKey])
     }
 
     case explicitlyCancelled
@@ -599,6 +601,8 @@ extension AFError.ServerTrustFailureReason {
             return "Certificate pinning failed for host \(host)."
         case let .publicKeyPinningFailed(host, _, _, _):
             return "Public key pinning failed for host \(host)."
+        case let .subjectPublicKeyInfoPinningFailed(host, _, _, _):
+            return "Subject Public key info pinning failed for host \(host)."
         }
     }
 }

--- a/Tests/ServerTrustEvaluatorTests.swift
+++ b/Tests/ServerTrustEvaluatorTests.swift
@@ -1363,6 +1363,63 @@ class ServerTrustPolicyPinPublicKeysTestCase: ServerTrustPolicyTestCase {
     }
 }
 
+class ServerTrustPolicyPinSubjectPublicKeysTestCase: ServerTrustPolicyTestCase {
+
+    func testThatPinningLeafKeyPassesEvaluationWithoutHostValidation() {
+        // Given
+        let host = "test.alamofire.org"
+        
+        // SPKI of Valid DNS Name        tW/0nr4+I+ugTkHNsTrtmYhavrOLTnKYpEe0x4U3zRE=
+        // openssl x509 -pubkey -inform der < valid-dns-name.cer | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary | base64
+        let serverTrust = TestTrusts.leafValidDNSName.trust
+        let keys = ["tW/0nr4+I+ugTkHNsTrtmYhavrOLTnKYpEe0x4U3zRE="]
+        let serverTrustPolicy = SubjectPublicKeysInfoTrustEvaluator(keys: keys, validateHost: false)
+        
+        // When
+        setRootCertificateAsLoneAnchorCertificateForTrust(serverTrust)
+        let result = Result { try serverTrustPolicy.evaluate(serverTrust, forHost: host) }
+
+        // Then
+        XCTAssertTrue(result.isSuccess, "server trust should pass evaluation")
+    }
+    
+    func testThatPinnedIntermediateCertificatePassesEvaluationWithoutHostValidation() {
+        // Given
+        let host = "test.alamofire.org"
+        
+        // SPKI of Alamofire Signing CA2 n0R/zZQ/dl0/URG5Ux/1CD43+F7SxDQeO+6Z+CZ/Cjk=
+        // openssl x509 -pubkey -inform der < alamofire-signing-ca2.cer | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary | base64
+        let serverTrust = TestTrusts.leafValidDNSName.trust
+        let keys = ["n0R/zZQ/dl0/URG5Ux/1CD43+F7SxDQeO+6Z+CZ/Cjk="]
+        let serverTrustPolicy = SubjectPublicKeysInfoTrustEvaluator(keys: keys, validateHost: false)
+
+        // When
+        setRootCertificateAsLoneAnchorCertificateForTrust(serverTrust)
+        let result = Result { try serverTrustPolicy.evaluate(serverTrust, forHost: host) }
+
+        // Then
+        XCTAssertTrue(result.isSuccess, "server trust should pass evaluation")
+    }
+    
+    func testThatPinnedRootCertificatePassesEvaluationWithoutHostValidation() {
+        // Given
+        let host = "test.alamofire.org"
+        // SPKI of Alamofire Root CA     pi+o8MdphyoodFJm96qqKXB5YLxd5Q8CWmSV/hU69VQ=
+        // openssl x509 -pubkey -inform der < alamofire-root-ca.cer | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary | base64
+        let serverTrust = TestTrusts.leafValidDNSName.trust
+        let keys = ["pi+o8MdphyoodFJm96qqKXB5YLxd5Q8CWmSV/hU69VQ="]
+        let serverTrustPolicy = SubjectPublicKeysInfoTrustEvaluator(keys: keys, validateHost: false)
+
+        // When
+        setRootCertificateAsLoneAnchorCertificateForTrust(serverTrust)
+        let result = Result { try serverTrustPolicy.evaluate(serverTrust, forHost: host) }
+
+        // Then
+        XCTAssertTrue(result.isSuccess, "server trust should pass evaluation")
+    }
+
+    
+}
 // MARK: -
 
 class ServerTrustPolicyDisableEvaluationTestCase: ServerTrustPolicyTestCase {


### PR DESCRIPTION
### Issue Link :link:
https://github.com/Alamofire/Alamofire/issues/2678

### Goals :soccer:
- Adds Subject Public Key Info Hash
- It is better to just include SPKI instead of including whole cert files for security and size wise.
- It is a standard. It can be used for [HPKP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning)

### Implementation Details :construction:
- CommonCrypto added for SHA-256 Hash
- Since it is complicated to parse ASN1 header, I used the same methods used by [TrustKit](https://github.com/datatheorem/TrustKit/blob/master/TrustKit/Pinning/TSKSPKIHashCache.m)
- I basically ported TrustKit algorithm to Swift for SHA-256 Hash
- New error code is added for SPKI failure

### Testing Details :mag:
- Three tests are added for verifying SPKI hash of leaf certificate.
