### PR TITLE
Simplify and refactor

### DIFF
--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -204,54 +204,54 @@ extension Error {
 extension AFError {
     /// Returns whether the `AFError` is an explicitly cancelled error.
     public var isExplicitlyCancelledError: Bool {
-        if case .explicitlyCancelled = self { return true }
-        return false
+        guard case .explicitlyCancelled = self else { return false }
+        return true
     }
 
     /// Returns whether the AFError is an invalid URL error.
     public var isInvalidURLError: Bool {
-        if case .invalidURL = self { return true }
-        return false
+        guard case .invalidURL = self else { return false }
+        return true
     }
 
     /// Returns whether the AFError is a parameter encoding error. When `true`, the `underlyingError` property will
     /// contain the associated value.
     public var isParameterEncodingError: Bool {
-        if case .parameterEncodingFailed = self { return true }
-        return false
+        guard case .parameterEncodingFailed = self else { return false }
+        return true
     }
 
     /// Returns whether the instance is a parameter encoder error.
     public var isParameterEncoderError: Bool {
-        if case .parameterEncoderFailed = self { return true }
-        return false
+        guard case .parameterEncoderFailed = self else { return false }
+        return true
     }
 
     /// Returns whether the AFError is a multipart encoding error. When `true`, the `url` and `underlyingError` properties
     /// will contain the associated values.
     public var isMultipartEncodingError: Bool {
-        if case .multipartEncodingFailed = self { return true }
-        return false
+        guard case .multipartEncodingFailed = self else { return false }
+        return true
     }
 
     /// Returns whether the `AFError` is a response validation error. When `true`, the `acceptableContentTypes`,
     /// `responseContentType`, and `responseCode` properties will contain the associated values.
     public var isResponseValidationError: Bool {
-        if case .responseValidationFailed = self { return true }
-        return false
+        guard case .responseValidationFailed = self else { return false }
+        return true
     }
 
     /// Returns whether the `AFError` is a response serialization error. When `true`, the `failedStringEncoding` and
     /// `underlyingError` properties will contain the associated values.
     public var isResponseSerializationError: Bool {
-        if case .responseSerializationFailed = self { return true }
-        return false
+        guard case .responseSerializationFailed = self else { return false }
+        return true
     }
 
     /// Returns whether the `AFError` is a server trust evaluation error.
     public var isServerTrustEvaluationError: Bool {
-        if case .serverTrustEvaluationFailed = self { return true }
-        return false
+        guard case .serverTrustEvaluationFailed = self else { return false }
+        return true
     }
 }
 

--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -260,22 +260,14 @@ extension AFError {
 extension AFError {
     /// The `URLConvertible` associated with the error.
     public var urlConvertible: URLConvertible? {
-        switch self {
-        case .invalidURL(let url):
-            return url
-        default:
-            return nil
-        }
+        guard case .invalidURL(let url) = self else { return nil }
+        return url
     }
 
     /// The `URL` associated with the error.
     public var url: URL? {
-        switch self {
-        case .multipartEncodingFailed(let reason):
-            return reason.url
-        default:
-            return nil
-        }
+        guard case .multipartEncodingFailed(let reason) = self else { return nil }
+        return reason.url
     }
 
     /// The `Error` returned by a system framework associated with a `.parameterEncodingFailed`,
@@ -297,64 +289,40 @@ extension AFError {
 
     /// The acceptable `Content-Type`s of a `.responseValidationFailed` error.
     public var acceptableContentTypes: [String]? {
-        switch self {
-        case .responseValidationFailed(let reason):
-            return reason.acceptableContentTypes
-        default:
-            return nil
-        }
+        guard case .responseValidationFailed(let reason) = self else { return nil }
+        return reason.acceptableContentTypes
     }
 
     /// The response `Content-Type` of a `.responseValidationFailed` error.
     public var responseContentType: String? {
-        switch self {
-        case .responseValidationFailed(let reason):
-            return reason.responseContentType
-        default:
-            return nil
-        }
+        guard case  .responseValidationFailed(let reason) = self else { return nil }
+        return reason.responseContentType
     }
 
     /// The response code of a `.responseValidationFailed` error.
     public var responseCode: Int? {
-        switch self {
-        case .responseValidationFailed(let reason):
-            return reason.responseCode
-        default:
-            return nil
-        }
+        guard case .responseValidationFailed(let reason) = self else { return nil }
+        return reason.responseCode
     }
 
     /// The `String.Encoding` associated with a failed `.stringResponse()` call.
     public var failedStringEncoding: String.Encoding? {
-        switch self {
-        case .responseSerializationFailed(let reason):
-            return reason.failedStringEncoding
-        default:
-            return nil
-        }
+        guard case .responseSerializationFailed(let reason) = self else { return nil }
+        return reason.failedStringEncoding
     }
 }
 
 extension AFError.ParameterEncodingFailureReason {
     var underlyingError: Error? {
-        switch self {
-        case .jsonEncodingFailed(let error):
-            return error
-        default:
-            return nil
-        }
+        guard case .jsonEncodingFailed(let error) = self else { return nil }
+        return error
     }
 }
 
 extension AFError.ParameterEncoderFailureReason {
     var underlyingError: Error? {
-        switch self {
-        case .encoderFailed(let error):
-            return error
-        default:
-            return nil
-        }
+        guard case .encoderFailed(let error) = self else { return nil }
+        return error
     }
 }
 
@@ -394,41 +362,25 @@ extension AFError.ResponseValidationFailureReason {
     }
 
     var responseContentType: String? {
-        switch self {
-        case .unacceptableContentType(_, let responseType):
-            return responseType
-        default:
-            return nil
-        }
+        guard case .unacceptableContentType(_, let responseType) = self else { return nil }
+        return responseType
     }
 
     var responseCode: Int? {
-        switch self {
-        case .unacceptableStatusCode(let code):
-            return code
-        default:
-            return nil
-        }
+        guard case .unacceptableStatusCode(let code) = self else { return nil }
+        return code
     }
 }
 
 extension AFError.ResponseSerializationFailureReason {
     var failedStringEncoding: String.Encoding? {
-        switch self {
-        case .stringSerializationFailed(let encoding):
-            return encoding
-        default:
-            return nil
-        }
+        guard case .stringSerializationFailed(let encoding) = self else { return nil }
+        return encoding
     }
 
     var underlyingError: Error? {
-        switch self {
-        case .jsonSerializationFailed(let error):
-            return error
-        default:
-            return nil
-        }
+        guard case .jsonSerializationFailed(let error) = self else { return nil }
+        return error
     }
 }
 

--- a/Source/ParameterEncoder.swift
+++ b/Source/ParameterEncoder.swift
@@ -388,18 +388,14 @@ enum URLEncodedFormComponent {
 
     /// Converts self to an `[URLEncodedFormData]` or returns `nil` if not convertible.
     var array: [URLEncodedFormComponent]? {
-        switch self {
-        case let .array(array): return array
-        default: return nil
-        }
+        guard case let .array(array) = self else { return nil }
+        return array
     }
 
     /// Converts self to an `[String: URLEncodedFormData]` or returns `nil` if not convertible.
     var object: [String: URLEncodedFormComponent]? {
-        switch self {
-        case let .object(object): return object
-        default: return nil
-        }
+        guard case let .object(object) = self else { return nil }
+        return object
     }
 
     /// Sets self to the supplied value at a given path.

--- a/Source/ParameterEncoder.swift
+++ b/Source/ParameterEncoder.swift
@@ -216,7 +216,7 @@ public final class URLEncodedFormEncoder {
         func encode(_ value: Bool) -> String {
             switch self {
             case .numeric: return value ? "1" : "0"
-            case .literal: return value ? "true" : "false"
+            case .literal: return value.description
             }
         }
     }

--- a/Source/ParameterEncoder.swift
+++ b/Source/ParameterEncoder.swift
@@ -216,7 +216,7 @@ public final class URLEncodedFormEncoder {
         func encode(_ value: Bool) -> String {
             switch self {
             case .numeric: return value ? "1" : "0"
-            case .literal: return value.description
+            case .literal: return value ? "true" : "false"
             }
         }
     }

--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -108,11 +108,8 @@ public struct URLEncoding: ParameterEncoding {
 
     // MARK: Properties
 
-    /// Returns a default `URLEncoding` instance.
+    /// Returns a default `URLEncoding` instance with a `.methodDependent` destination.
     public static var `default`: URLEncoding { return URLEncoding() }
-
-    /// Returns a `URLEncoding` instance with a `.methodDependent` destination.
-    public static var methodDependent: URLEncoding { return URLEncoding() }
 
     /// Returns a `URLEncoding` instance with a `.queryString` destination.
     public static var queryString: URLEncoding { return URLEncoding(destination: .queryString) }

--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -101,7 +101,7 @@ public struct URLEncoding: ParameterEncoding {
             case .numeric:
                 return value ? "1" : "0"
             case .literal:
-                return value ? "true" : "false"
+                return value.description
             }
         }
     }

--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -69,6 +69,14 @@ public struct URLEncoding: ParameterEncoding {
     /// - httpBody:        Sets encoded query string result as the HTTP body of the URL request.
     public enum Destination {
         case methodDependent, queryString, httpBody
+
+        func encodesParametersInURL(for method: HTTPMethod) -> Bool {
+            switch self {
+            case .methodDependent: return [.get, .head, .delete].contains(method)
+            case .queryString: return true
+            case .httpBody: return false
+            }
+        }
     }
 
     /// Configures how `Array` parameters are encoded.
@@ -156,7 +164,7 @@ public struct URLEncoding: ParameterEncoding {
 
         guard let parameters = parameters else { return urlRequest }
 
-        if let method = HTTPMethod(rawValue: urlRequest.httpMethod ?? "GET"), encodesParametersInURL(with: method) {
+        if let method = HTTPMethod(rawValue: urlRequest.httpMethod ?? "GET"),  destination.encodesParametersInURL(for: method) {
             guard let url = urlRequest.url else {
                 throw AFError.parameterEncodingFailed(reason: .missingURL)
             }
@@ -226,24 +234,6 @@ public struct URLEncoding: ParameterEncoding {
             components += queryComponents(fromKey: key, value: value)
         }
         return components.map { "\($0)=\($1)" }.joined(separator: "&")
-    }
-
-    private func encodesParametersInURL(with method: HTTPMethod) -> Bool {
-        switch destination {
-        case .queryString:
-            return true
-        case .httpBody:
-            return false
-        default:
-            break
-        }
-
-        switch method {
-        case .get, .head, .delete:
-            return true
-        default:
-            return false
-        }
     }
 }
 

--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -164,7 +164,7 @@ public struct URLEncoding: ParameterEncoding {
 
         guard let parameters = parameters else { return urlRequest }
 
-        if let method = HTTPMethod(rawValue: urlRequest.httpMethod ?? "GET"),  destination.encodesParametersInURL(for: method) {
+        if let method = HTTPMethod(rawValue: urlRequest.httpMethod ?? HTTPMethod.get.rawValue), destination.encodesParametersInURL(for: method) {
             guard let url = urlRequest.url else {
                 throw AFError.parameterEncodingFailed(reason: .missingURL)
             }

--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -109,7 +109,7 @@ public struct URLEncoding: ParameterEncoding {
             case .numeric:
                 return value ? "1" : "0"
             case .literal:
-                return value.description
+                return value ? "true" : "false"
             }
         }
     }

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -109,7 +109,7 @@ extension DataRequest {
     ///   - completionHandler: The code to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
-    public func response(queue: DispatchQueue? = nil, completionHandler: @escaping (DataResponse<Data?>) -> Void) -> Self {
+    public func response(queue: DispatchQueue = .main, completionHandler: @escaping (DataResponse<Data?>) -> Void) -> Self {
         internalQueue.addOperation {
             self.serializationQueue.async {
                 let result = Result(value: self.data, error: self.error)
@@ -122,7 +122,7 @@ extension DataRequest {
 
                 self.eventMonitor?.request(self, didParseResponse: response)
 
-                (queue ?? .main).async { completionHandler(response) }
+                queue.async { completionHandler(response) }
             }
         }
 
@@ -139,7 +139,7 @@ extension DataRequest {
     /// - Returns:              The request.
     @discardableResult
     public func response<Serializer: DataResponseSerializerProtocol>(
-        queue: DispatchQueue? = nil,
+        queue: DispatchQueue = .main,
         responseSerializer: Serializer,
         completionHandler: @escaping (DataResponse<Serializer.SerializedObject>) -> Void)
         -> Self
@@ -162,7 +162,7 @@ extension DataRequest {
 
                 self.eventMonitor?.request(self, didParseResponse: response)
 
-                (queue ?? .main).async { completionHandler(response) }
+                queue.async { completionHandler(response) }
             }
         }
 
@@ -180,7 +180,7 @@ extension DownloadRequest {
     /// - Returns:             The request.
     @discardableResult
     public func response(
-        queue: DispatchQueue? = nil,
+        queue: DispatchQueue = .main,
         completionHandler: @escaping (DownloadResponse<URL?>) -> Void)
         -> Self
     {
@@ -195,7 +195,7 @@ extension DownloadRequest {
                                                 serializationDuration: 0,
                                                 result: result)
 
-                (queue ?? .main).async { completionHandler(response) }
+                queue.async { completionHandler(response) }
             }
         }
 
@@ -213,7 +213,7 @@ extension DownloadRequest {
     /// - Returns:              The request.
     @discardableResult
     public func response<T: DownloadResponseSerializerProtocol>(
-        queue: DispatchQueue? = nil,
+        queue: DispatchQueue = .main,
         responseSerializer: T,
         completionHandler: @escaping (DownloadResponse<T.SerializedObject>) -> Void)
         -> Self
@@ -235,7 +235,7 @@ extension DownloadRequest {
                                                 serializationDuration: (end - start),
                                                 result: result)
 
-                (queue ?? .main).async { completionHandler(response) }
+                queue.async { completionHandler(response) }
             }
         }
 
@@ -249,13 +249,12 @@ extension DataRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `nil`, which means
-    ///                        the handler is called on `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
     ///   - completionHandler: The code to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
     public func responseData(
-        queue: DispatchQueue? = nil,
+        queue: DispatchQueue = .main,
         completionHandler: @escaping (DataResponse<Data>) -> Void)
         -> Self
     {
@@ -305,13 +304,12 @@ extension DownloadRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `nil`, which means
-    ///                        the handler is called on `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
     ///   - completionHandler: The code to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
     public func responseData(
-        queue: DispatchQueue? = nil,
+        queue: DispatchQueue = .main,
         completionHandler: @escaping (DownloadResponse<Data>) -> Void)
         -> Self
     {
@@ -385,14 +383,13 @@ extension DataRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `nil`, which means
-    ///                        the handler is called on `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
     ///   - encoding:          The string encoding. Defaults to `nil`, in which case the encoding will be determined from
     ///                        the server response, falling back to the default HTTP character set, `ISO-8859-1`.
     ///   - completionHandler: A closure to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
-    public func responseString(queue: DispatchQueue? = nil,
+    public func responseString(queue: DispatchQueue = .main,
                                encoding: String.Encoding? = nil,
                                completionHandler: @escaping (DataResponse<String>) -> Void) -> Self {
         return response(queue: queue,
@@ -405,15 +402,14 @@ extension DownloadRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `nil`, which means
-    ///                        the handler is called on `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
     ///   - encoding:          The string encoding. Defaults to `nil`, in which case the encoding will be determined from
     ///                        the server response, falling back to the default HTTP character set, `ISO-8859-1`.
     ///   - completionHandler: A closure to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
     public func responseString(
-        queue: DispatchQueue? = nil,
+        queue: DispatchQueue = .main,
         encoding: String.Encoding? = nil,
         completionHandler: @escaping (DownloadResponse<String>) -> Void)
         -> Self
@@ -477,13 +473,12 @@ extension DataRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `nil`, which means
-    ///                        the handler is called on `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
     ///   - options:           The JSON serialization reading options. Defaults to `.allowFragments`.
     ///   - completionHandler: A closure to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
-    public func responseJSON(queue: DispatchQueue? = nil,
+    public func responseJSON(queue: DispatchQueue = .main,
                              options: JSONSerialization.ReadingOptions = .allowFragments,
                              completionHandler: @escaping (DataResponse<Any>) -> Void) -> Self {
         return response(queue: queue,
@@ -496,14 +491,13 @@ extension DownloadRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `nil`, which means
-    ///                        the handler is called on `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
     ///   - options:           The JSON serialization reading options. Defaults to `.allowFragments`.
     ///   - completionHandler: A closure to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
     public func responseJSON(
-        queue: DispatchQueue? = nil,
+        queue: DispatchQueue = .main,
         options: JSONSerialization.ReadingOptions = .allowFragments,
         completionHandler: @escaping (DownloadResponse<Any>) -> Void)
         -> Self
@@ -594,14 +588,13 @@ extension DataRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `nil`, which means
-    ///                        the handler is called on `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
     ///   - decoder:           The `DataDecoder` to use to decode the response. Defaults to a `JSONDecoder` with default
     ///                        settings.
     ///   - completionHandler: A closure to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
-    public func responseDecodable<T: Decodable>(queue: DispatchQueue? = nil,
+    public func responseDecodable<T: Decodable>(queue: DispatchQueue = .main,
                                                 decoder: DataDecoder = JSONDecoder(),
                                                 completionHandler: @escaping (DataResponse<T>) -> Void) -> Self {
         return response(queue: queue,

--- a/Source/Result.swift
+++ b/Source/Result.swift
@@ -50,37 +50,25 @@ public enum Result<Value> {
 
     /// Returns `true` if the result is a success, `false` otherwise.
     public var isSuccess: Bool {
-        switch self {
-        case .success:
-            return true
-        case .failure:
-            return false
-        }
+        guard case .success = self else { return false }
+        return true
     }
 
     /// Returns `true` if the result is a failure, `false` otherwise.
     public var isFailure: Bool {
-        return !isSuccess
+        return isSuccess
     }
 
     /// Returns the associated value if the result is a success, `nil` otherwise.
     public var value: Value? {
-        switch self {
-        case .success(let value):
-            return value
-        case .failure:
-            return nil
-        }
+        guard case .success(let value) = self else { return nil }
+        return value
     }
 
     /// Returns the associated error value if the result is a failure, `nil` otherwise.
     public var error: Error? {
-        switch self {
-        case .success:
-            return nil
-        case .failure(let error):
-            return error
-        }
+        guard case .failure(let error) = self else { return nil }
+        return error
     }
 }
 

--- a/Source/Result.swift
+++ b/Source/Result.swift
@@ -225,8 +225,12 @@ extension Result {
     /// - Returns: A `Result` instance containing the result of the transform. If this instance is a success, returns
     ///            the same instance.
     public func mapError<T: Error>(_ transform: (Error) -> T) -> Result {
-        guard case .failure(let error) = self else { return self }
-        return .failure(transform(error))
+        switch self {
+        case .failure(let error):
+            return .failure(transform(error))
+        case .success:
+            return self
+        }
     }
 
     /// Evaluates the specified closure when the `Result` is a failure, passing the unwrapped error as a parameter.

--- a/Source/Result.swift
+++ b/Source/Result.swift
@@ -56,7 +56,7 @@ public enum Result<Value> {
 
     /// Returns `true` if the result is a failure, `false` otherwise.
     public var isFailure: Bool {
-        return isSuccess
+        return !isSuccess
     }
 
     /// Returns the associated value if the result is a success, `nil` otherwise.

--- a/Source/Result.swift
+++ b/Source/Result.swift
@@ -50,8 +50,12 @@ public enum Result<Value> {
 
     /// Returns `true` if the result is a success, `false` otherwise.
     public var isSuccess: Bool {
-        guard case .success = self else { return false }
-        return true
+        switch self {
+        case .success:
+            return true
+        case .failure:
+            return false
+        }
     }
 
     /// Returns `true` if the result is a failure, `false` otherwise.
@@ -61,14 +65,22 @@ public enum Result<Value> {
 
     /// Returns the associated value if the result is a success, `nil` otherwise.
     public var value: Value? {
-        guard case .success(let value) = self else { return nil }
-        return value
+        switch self {
+        case .success(let value):
+            return value
+        case .failure:
+            return nil
+        }
     }
 
     /// Returns the associated error value if the result is a failure, `nil` otherwise.
     public var error: Error? {
-        guard case .failure(let error) = self else { return nil }
-        return error
+        switch self {
+        case .success:
+            return nil
+        case .failure(let error):
+            return error
+        }
     }
 }
 

--- a/Source/Result.swift
+++ b/Source/Result.swift
@@ -213,12 +213,8 @@ extension Result {
     /// - Returns: A `Result` instance containing the result of the transform. If this instance is a success, returns
     ///            the same instance.
     public func mapError<T: Error>(_ transform: (Error) -> T) -> Result {
-        switch self {
-        case .failure(let error):
-            return .failure(transform(error))
-        case .success:
-            return self
-        }
+        guard case .failure(let error) = self else { return self }
+        return .failure(transform(error))
     }
 
     /// Evaluates the specified closure when the `Result` is a failure, passing the unwrapped error as a parameter.


### PR DESCRIPTION
This is my first PR. First of all, I want to thank you for your time investment in `Alamofire`. Amazing lib 👏
### Goals :soccer:
Simplifying and refactoring some basic things.

### Implementation Details :construction:
- Most of which are simplification of `switch` statements. The `switch` cases which are simplified are 2 case statements and can we simplified by using `guard`.
- I set the default value of queue to` .main` rather than `nil`. I did this because under the hood, `.main` is used when the queue value is `nil`.
- I remove `methodDependent` property in `ParameterEncoding` since it is a duplication of `default`. (If there is a reason why `methodDependent` and `default` are included, I would be interested to know why 😄)
- I simplified the `encodesParametersInURL` in `ParameterEncoding` by making it part of `Destination`. (I occurred that in the same way `encodesParametersInURL` is implemented in `ParameterEncoder`)