### PR TITLE
🐷 Feature - Retry Policies

### DIFF
--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -158,6 +158,13 @@
 		4C256A1621F11EDA00AD5D87 /* ConnectionLostRetryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A1521F11EDA00AD5D87 /* ConnectionLostRetryPolicyTests.swift */; };
 		4C256A1721F11EDA00AD5D87 /* ConnectionLostRetryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A1521F11EDA00AD5D87 /* ConnectionLostRetryPolicyTests.swift */; };
 		4C256A1821F11EDA00AD5D87 /* ConnectionLostRetryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A1521F11EDA00AD5D87 /* ConnectionLostRetryPolicyTests.swift */; };
+		4C256A1A21F1449C00AD5D87 /* ExponentialBackoffRetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A1921F1449C00AD5D87 /* ExponentialBackoffRetryPolicy.swift */; };
+		4C256A1B21F1449C00AD5D87 /* ExponentialBackoffRetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A1921F1449C00AD5D87 /* ExponentialBackoffRetryPolicy.swift */; };
+		4C256A1C21F1449C00AD5D87 /* ExponentialBackoffRetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A1921F1449C00AD5D87 /* ExponentialBackoffRetryPolicy.swift */; };
+		4C256A1D21F1449C00AD5D87 /* ExponentialBackoffRetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A1921F1449C00AD5D87 /* ExponentialBackoffRetryPolicy.swift */; };
+		4C256A1F21F1454100AD5D87 /* ExponentialBackoffRetryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A1E21F1454100AD5D87 /* ExponentialBackoffRetryPolicyTests.swift */; };
+		4C256A2021F1454100AD5D87 /* ExponentialBackoffRetryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A1E21F1454100AD5D87 /* ExponentialBackoffRetryPolicyTests.swift */; };
+		4C256A2121F1454100AD5D87 /* ExponentialBackoffRetryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A1E21F1454100AD5D87 /* ExponentialBackoffRetryPolicyTests.swift */; };
 		4C256A531B096C770065714F /* BaseTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A501B096C2C0065714F /* BaseTestCase.swift */; };
 		4C256A541B096C770065714F /* BaseTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A501B096C2C0065714F /* BaseTestCase.swift */; };
 		4C33A1391B5207DB00873DFF /* rainbow.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 4C33A1231B5207DB00873DFF /* rainbow.jpg */; };
@@ -378,6 +385,8 @@
 		4C256A0A21EFE35300AD5D87 /* RetryPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryPolicy.swift; sourceTree = "<group>"; };
 		4C256A1021F11DA700AD5D87 /* ConnectionLostRetryPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionLostRetryPolicy.swift; sourceTree = "<group>"; };
 		4C256A1521F11EDA00AD5D87 /* ConnectionLostRetryPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionLostRetryPolicyTests.swift; sourceTree = "<group>"; };
+		4C256A1921F1449C00AD5D87 /* ExponentialBackoffRetryPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExponentialBackoffRetryPolicy.swift; sourceTree = "<group>"; };
+		4C256A1E21F1454100AD5D87 /* ExponentialBackoffRetryPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExponentialBackoffRetryPolicyTests.swift; sourceTree = "<group>"; };
 		4C256A501B096C2C0065714F /* BaseTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseTestCase.swift; sourceTree = "<group>"; };
 		4C3238E61B3604DB00FE04AE /* MultipartFormDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormDataTests.swift; sourceTree = "<group>"; };
 		4C33A1231B5207DB00873DFF /* rainbow.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = rainbow.jpg; sourceTree = "<group>"; };
@@ -537,6 +546,7 @@
 			children = (
 				4C341BB91B1A865A00C1B34D /* CacheTests.swift */,
 				4C256A1521F11EDA00AD5D87 /* ConnectionLostRetryPolicyTests.swift */,
+				4C256A1E21F1454100AD5D87 /* ExponentialBackoffRetryPolicyTests.swift */,
 				3113D46A21878227001CCD21 /* HTTPHeadersTests.swift */,
 				4C3238E61B3604DB00FE04AE /* MultipartFormDataTests.swift */,
 				4C3D00571C66A8B900D1F709 /* NetworkReachabilityManagerTests.swift */,
@@ -705,6 +715,7 @@
 			children = (
 				4C256A1021F11DA700AD5D87 /* ConnectionLostRetryPolicy.swift */,
 				3111CE8720A77843008315E2 /* EventMonitor.swift */,
+				4C256A1921F1449C00AD5D87 /* ExponentialBackoffRetryPolicy.swift */,
 				4C23EB421B327C5B0090E0BC /* MultipartFormData.swift */,
 				311B198F20B0D3B40036823B /* MultipartUpload.swift */,
 				4C3D00531C66A63000D1F709 /* NetworkReachabilityManager.swift */,
@@ -1309,6 +1320,7 @@
 				311B199220B0E3480036823B /* MultipartUpload.swift in Sources */,
 				319917A2209CDA7F00103A19 /* SessionStateProvider.swift in Sources */,
 				4CF6270A1BA7CBF60011A099 /* ParameterEncoding.swift in Sources */,
+				4C256A1C21F1449C00AD5D87 /* ExponentialBackoffRetryPolicy.swift in Sources */,
 				31991796209CDA7F00103A19 /* Request.swift in Sources */,
 				4CF627101BA7CBF60011A099 /* ServerTrustEvaluation.swift in Sources */,
 				3199179E209CDA7F00103A19 /* Session.swift in Sources */,
@@ -1322,6 +1334,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4CF627181BA7CC240011A099 /* RequestTests.swift in Sources */,
+				4C256A2121F1454100AD5D87 /* ExponentialBackoffRetryPolicyTests.swift in Sources */,
 				3111CE9720A7EC3A008315E2 /* ServerTrustEvaluatorTests.swift in Sources */,
 				3111CE9420A7EC32008315E2 /* ResponseSerializationTests.swift in Sources */,
 				3111CE8E20A7EBE7008315E2 /* MultipartFormDataTests.swift in Sources */,
@@ -1376,6 +1389,7 @@
 				311B199120B0E3470036823B /* MultipartUpload.swift in Sources */,
 				319917A1209CDA7F00103A19 /* SessionStateProvider.swift in Sources */,
 				4C3D00551C66A63000D1F709 /* NetworkReachabilityManager.swift in Sources */,
+				4C256A1B21F1449C00AD5D87 /* ExponentialBackoffRetryPolicy.swift in Sources */,
 				31991795209CDA7F00103A19 /* Request.swift in Sources */,
 				4CDE2C441AF89F0900BABAE5 /* Validation.swift in Sources */,
 				3199179D209CDA7F00103A19 /* Session.swift in Sources */,
@@ -1411,6 +1425,7 @@
 				311B199320B0E3480036823B /* MultipartUpload.swift in Sources */,
 				319917A3209CDA7F00103A19 /* SessionStateProvider.swift in Sources */,
 				E4202FD51B667AA100C997FB /* MultipartFormData.swift in Sources */,
+				4C256A1D21F1449C00AD5D87 /* ExponentialBackoffRetryPolicy.swift in Sources */,
 				31991797209CDA7F00103A19 /* Request.swift in Sources */,
 				E4202FD61B667AA100C997FB /* ServerTrustEvaluation.swift in Sources */,
 				3199179F209CDA7F00103A19 /* Session.swift in Sources */,
@@ -1446,6 +1461,7 @@
 				311B199020B0D3B40036823B /* MultipartUpload.swift in Sources */,
 				319917A0209CDA7F00103A19 /* SessionStateProvider.swift in Sources */,
 				4CDE2C431AF89F0900BABAE5 /* Validation.swift in Sources */,
+				4C256A1A21F1449C00AD5D87 /* ExponentialBackoffRetryPolicy.swift in Sources */,
 				31991794209CDA7F00103A19 /* Request.swift in Sources */,
 				4CB928291C66BFBC00CE5F08 /* Notifications.swift in Sources */,
 				3199179C209CDA7F00103A19 /* Session.swift in Sources */,
@@ -1459,6 +1475,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				31ED52E81D73891B00199085 /* AFError+AlamofireTests.swift in Sources */,
+				4C256A1F21F1454100AD5D87 /* ExponentialBackoffRetryPolicyTests.swift in Sources */,
 				3111CE9520A7EC39008315E2 /* ServerTrustEvaluatorTests.swift in Sources */,
 				3111CE9220A7EC30008315E2 /* ResponseSerializationTests.swift in Sources */,
 				3111CE8C20A7EBE6008315E2 /* MultipartFormDataTests.swift in Sources */,
@@ -1491,6 +1508,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				31ED52E91D73891C00199085 /* AFError+AlamofireTests.swift in Sources */,
+				4C256A2021F1454100AD5D87 /* ExponentialBackoffRetryPolicyTests.swift in Sources */,
 				3111CE9620A7EC3A008315E2 /* ServerTrustEvaluatorTests.swift in Sources */,
 				3111CE9320A7EC31008315E2 /* ResponseSerializationTests.swift in Sources */,
 				3111CE8D20A7EBE7008315E2 /* MultipartFormDataTests.swift in Sources */,

--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -147,6 +147,10 @@
 		4C256A0721EEB69000AD5D87 /* RequestInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A0521EEB69000AD5D87 /* RequestInterceptor.swift */; };
 		4C256A0821EEB69000AD5D87 /* RequestInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A0521EEB69000AD5D87 /* RequestInterceptor.swift */; };
 		4C256A0921EEB69000AD5D87 /* RequestInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A0521EEB69000AD5D87 /* RequestInterceptor.swift */; };
+		4C256A0B21EFE35300AD5D87 /* RetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A0A21EFE35300AD5D87 /* RetryPolicy.swift */; };
+		4C256A0C21EFE35300AD5D87 /* RetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A0A21EFE35300AD5D87 /* RetryPolicy.swift */; };
+		4C256A0D21EFE35300AD5D87 /* RetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A0A21EFE35300AD5D87 /* RetryPolicy.swift */; };
+		4C256A0E21EFE35300AD5D87 /* RetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A0A21EFE35300AD5D87 /* RetryPolicy.swift */; };
 		4C256A531B096C770065714F /* BaseTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A501B096C2C0065714F /* BaseTestCase.swift */; };
 		4C256A541B096C770065714F /* BaseTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A501B096C2C0065714F /* BaseTestCase.swift */; };
 		4C33A1391B5207DB00873DFF /* rainbow.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 4C33A1231B5207DB00873DFF /* rainbow.jpg */; };
@@ -364,6 +368,7 @@
 		4C1DC8531B68908E00476DE3 /* AFError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AFError.swift; sourceTree = "<group>"; };
 		4C23EB421B327C5B0090E0BC /* MultipartFormData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
 		4C256A0521EEB69000AD5D87 /* RequestInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestInterceptor.swift; sourceTree = "<group>"; };
+		4C256A0A21EFE35300AD5D87 /* RetryPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryPolicy.swift; sourceTree = "<group>"; };
 		4C256A501B096C2C0065714F /* BaseTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseTestCase.swift; sourceTree = "<group>"; };
 		4C3238E61B3604DB00FE04AE /* MultipartFormDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormDataTests.swift; sourceTree = "<group>"; };
 		4C33A1231B5207DB00873DFF /* rainbow.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = rainbow.jpg; sourceTree = "<group>"; };
@@ -694,6 +699,7 @@
 				4C3D00531C66A63000D1F709 /* NetworkReachabilityManager.swift */,
 				4C256A0521EEB69000AD5D87 /* RequestInterceptor.swift */,
 				4CDE2C451AF89FF300BABAE5 /* ResponseSerialization.swift */,
+				4C256A0A21EFE35300AD5D87 /* RetryPolicy.swift */,
 				4C811F8C1B51856D00E0F59A /* ServerTrustEvaluation.swift */,
 				4CDE2C421AF89F0900BABAE5 /* Validation.swift */,
 			);
@@ -1276,6 +1282,7 @@
 				31D83FD020D5C29300D93E47 /* URLConvertible+URLRequestConvertible.swift in Sources */,
 				319917A7209CDAC400103A19 /* RequestTaskMap.swift in Sources */,
 				4CF627131BA7CBF60011A099 /* Validation.swift in Sources */,
+				4C256A0D21EFE35300AD5D87 /* RetryPolicy.swift in Sources */,
 				31F5085F20B50DC400FE2A0C /* URLSessionConfiguration+Alamofire.swift in Sources */,
 				3172741F218BB1790039FFCC /* ParameterEncoder.swift in Sources */,
 				319917BB209CE53A00103A19 /* OperationQueue+Alamofire.swift in Sources */,
@@ -1340,6 +1347,7 @@
 				31D83FCF20D5C29300D93E47 /* URLConvertible+URLRequestConvertible.swift in Sources */,
 				319917A6209CDAC400103A19 /* RequestTaskMap.swift in Sources */,
 				4C1DC8551B68908E00476DE3 /* AFError.swift in Sources */,
+				4C256A0C21EFE35300AD5D87 /* RetryPolicy.swift in Sources */,
 				31F5085E20B50DC400FE2A0C /* URLSessionConfiguration+Alamofire.swift in Sources */,
 				3172741E218BB1790039FFCC /* ParameterEncoder.swift in Sources */,
 				319917BA209CE53A00103A19 /* OperationQueue+Alamofire.swift in Sources */,
@@ -1373,6 +1381,7 @@
 				31D83FD120D5C29300D93E47 /* URLConvertible+URLRequestConvertible.swift in Sources */,
 				319917A8209CDAC400103A19 /* RequestTaskMap.swift in Sources */,
 				4CEC605A1B745C9100E684F4 /* AFError.swift in Sources */,
+				4C256A0E21EFE35300AD5D87 /* RetryPolicy.swift in Sources */,
 				31F5086020B50DC400FE2A0C /* URLSessionConfiguration+Alamofire.swift in Sources */,
 				31727420218BB1790039FFCC /* ParameterEncoder.swift in Sources */,
 				319917BC209CE53A00103A19 /* OperationQueue+Alamofire.swift in Sources */,
@@ -1406,6 +1415,7 @@
 				31D83FCE20D5C29300D93E47 /* URLConvertible+URLRequestConvertible.swift in Sources */,
 				319917A5209CDAC400103A19 /* RequestTaskMap.swift in Sources */,
 				4C1DC8541B68908E00476DE3 /* AFError.swift in Sources */,
+				4C256A0B21EFE35300AD5D87 /* RetryPolicy.swift in Sources */,
 				31F5085D20B50DC400FE2A0C /* URLSessionConfiguration+Alamofire.swift in Sources */,
 				3172741D218BB1790039FFCC /* ParameterEncoder.swift in Sources */,
 				319917B9209CE53A00103A19 /* OperationQueue+Alamofire.swift in Sources */,

--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -151,6 +151,13 @@
 		4C256A0C21EFE35300AD5D87 /* RetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A0A21EFE35300AD5D87 /* RetryPolicy.swift */; };
 		4C256A0D21EFE35300AD5D87 /* RetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A0A21EFE35300AD5D87 /* RetryPolicy.swift */; };
 		4C256A0E21EFE35300AD5D87 /* RetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A0A21EFE35300AD5D87 /* RetryPolicy.swift */; };
+		4C256A1121F11DA700AD5D87 /* ConnectionLostRetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A1021F11DA700AD5D87 /* ConnectionLostRetryPolicy.swift */; };
+		4C256A1221F11DA700AD5D87 /* ConnectionLostRetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A1021F11DA700AD5D87 /* ConnectionLostRetryPolicy.swift */; };
+		4C256A1321F11DA700AD5D87 /* ConnectionLostRetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A1021F11DA700AD5D87 /* ConnectionLostRetryPolicy.swift */; };
+		4C256A1421F11DA700AD5D87 /* ConnectionLostRetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A1021F11DA700AD5D87 /* ConnectionLostRetryPolicy.swift */; };
+		4C256A1621F11EDA00AD5D87 /* ConnectionLostRetryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A1521F11EDA00AD5D87 /* ConnectionLostRetryPolicyTests.swift */; };
+		4C256A1721F11EDA00AD5D87 /* ConnectionLostRetryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A1521F11EDA00AD5D87 /* ConnectionLostRetryPolicyTests.swift */; };
+		4C256A1821F11EDA00AD5D87 /* ConnectionLostRetryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A1521F11EDA00AD5D87 /* ConnectionLostRetryPolicyTests.swift */; };
 		4C256A531B096C770065714F /* BaseTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A501B096C2C0065714F /* BaseTestCase.swift */; };
 		4C256A541B096C770065714F /* BaseTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C256A501B096C2C0065714F /* BaseTestCase.swift */; };
 		4C33A1391B5207DB00873DFF /* rainbow.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 4C33A1231B5207DB00873DFF /* rainbow.jpg */; };
@@ -369,6 +376,8 @@
 		4C23EB421B327C5B0090E0BC /* MultipartFormData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
 		4C256A0521EEB69000AD5D87 /* RequestInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestInterceptor.swift; sourceTree = "<group>"; };
 		4C256A0A21EFE35300AD5D87 /* RetryPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryPolicy.swift; sourceTree = "<group>"; };
+		4C256A1021F11DA700AD5D87 /* ConnectionLostRetryPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionLostRetryPolicy.swift; sourceTree = "<group>"; };
+		4C256A1521F11EDA00AD5D87 /* ConnectionLostRetryPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionLostRetryPolicyTests.swift; sourceTree = "<group>"; };
 		4C256A501B096C2C0065714F /* BaseTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseTestCase.swift; sourceTree = "<group>"; };
 		4C3238E61B3604DB00FE04AE /* MultipartFormDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormDataTests.swift; sourceTree = "<group>"; };
 		4C33A1231B5207DB00873DFF /* rainbow.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = rainbow.jpg; sourceTree = "<group>"; };
@@ -527,6 +536,7 @@
 			isa = PBXGroup;
 			children = (
 				4C341BB91B1A865A00C1B34D /* CacheTests.swift */,
+				4C256A1521F11EDA00AD5D87 /* ConnectionLostRetryPolicyTests.swift */,
 				3113D46A21878227001CCD21 /* HTTPHeadersTests.swift */,
 				4C3238E61B3604DB00FE04AE /* MultipartFormDataTests.swift */,
 				4C3D00571C66A8B900D1F709 /* NetworkReachabilityManagerTests.swift */,
@@ -693,6 +703,7 @@
 		4CDE2C491AF8A14E00BABAE5 /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				4C256A1021F11DA700AD5D87 /* ConnectionLostRetryPolicy.swift */,
 				3111CE8720A77843008315E2 /* EventMonitor.swift */,
 				4C23EB421B327C5B0090E0BC /* MultipartFormData.swift */,
 				311B198F20B0D3B40036823B /* MultipartUpload.swift */,
@@ -1293,6 +1304,7 @@
 				4CF6270F1BA7CBF60011A099 /* ResponseSerialization.swift in Sources */,
 				4C256A0821EEB69000AD5D87 /* RequestInterceptor.swift in Sources */,
 				4C43669D1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift in Sources */,
+				4C256A1321F11DA700AD5D87 /* ConnectionLostRetryPolicy.swift in Sources */,
 				4C3D00561C66A63000D1F709 /* NetworkReachabilityManager.swift in Sources */,
 				311B199220B0E3480036823B /* MultipartUpload.swift in Sources */,
 				319917A2209CDA7F00103A19 /* SessionStateProvider.swift in Sources */,
@@ -1322,6 +1334,7 @@
 				31727424218BB9A50039FFCC /* HTTPBin.swift in Sources */,
 				31EBD9C320D1D89D00D1FF34 /* ValidationTests.swift in Sources */,
 				3111CE8620A76370008315E2 /* SessionTests.swift in Sources */,
+				4C256A1821F11EDA00AD5D87 /* ConnectionLostRetryPolicyTests.swift in Sources */,
 				31C2B0F220B271380089BA7C /* TLSEvaluationTests.swift in Sources */,
 				3111CE9D20A7EC58008315E2 /* URLProtocolTests.swift in Sources */,
 				317A6A7820B2208000A9FEC5 /* DownloadTests.swift in Sources */,
@@ -1358,6 +1371,7 @@
 				4C23EB441B327C5B0090E0BC /* MultipartFormData.swift in Sources */,
 				4C256A0721EEB69000AD5D87 /* RequestInterceptor.swift in Sources */,
 				4C43669C1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift in Sources */,
+				4C256A1221F11DA700AD5D87 /* ConnectionLostRetryPolicy.swift in Sources */,
 				4C811F8E1B51856D00E0F59A /* ServerTrustEvaluation.swift in Sources */,
 				311B199120B0E3470036823B /* MultipartUpload.swift in Sources */,
 				319917A1209CDA7F00103A19 /* SessionStateProvider.swift in Sources */,
@@ -1392,6 +1406,7 @@
 				4CEC605B1B745C9100E684F4 /* Result.swift in Sources */,
 				4C256A0921EEB69000AD5D87 /* RequestInterceptor.swift in Sources */,
 				4C43669E1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift in Sources */,
+				4C256A1421F11DA700AD5D87 /* ConnectionLostRetryPolicy.swift in Sources */,
 				E4202FD41B667AA100C997FB /* Alamofire.swift in Sources */,
 				311B199320B0E3480036823B /* MultipartUpload.swift in Sources */,
 				319917A3209CDA7F00103A19 /* SessionStateProvider.swift in Sources */,
@@ -1426,6 +1441,7 @@
 				4C811F8D1B51856D00E0F59A /* ServerTrustEvaluation.swift in Sources */,
 				4C256A0621EEB69000AD5D87 /* RequestInterceptor.swift in Sources */,
 				4C43669B1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift in Sources */,
+				4C256A1121F11DA700AD5D87 /* ConnectionLostRetryPolicy.swift in Sources */,
 				4C3D00541C66A63000D1F709 /* NetworkReachabilityManager.swift in Sources */,
 				311B199020B0D3B40036823B /* MultipartUpload.swift in Sources */,
 				319917A0209CDA7F00103A19 /* SessionStateProvider.swift in Sources */,
@@ -1455,6 +1471,7 @@
 				31727422218BB9A50039FFCC /* HTTPBin.swift in Sources */,
 				31EBD9C120D1D89C00D1FF34 /* ValidationTests.swift in Sources */,
 				3111CE8420A7636E008315E2 /* SessionTests.swift in Sources */,
+				4C256A1621F11EDA00AD5D87 /* ConnectionLostRetryPolicyTests.swift in Sources */,
 				31C2B0F020B271370089BA7C /* TLSEvaluationTests.swift in Sources */,
 				3111CE9B20A7EC57008315E2 /* URLProtocolTests.swift in Sources */,
 				317A6A7620B2207F00A9FEC5 /* DownloadTests.swift in Sources */,
@@ -1486,6 +1503,7 @@
 				31727423218BB9A50039FFCC /* HTTPBin.swift in Sources */,
 				31EBD9C220D1D89C00D1FF34 /* ValidationTests.swift in Sources */,
 				3111CE8520A7636F008315E2 /* SessionTests.swift in Sources */,
+				4C256A1721F11EDA00AD5D87 /* ConnectionLostRetryPolicyTests.swift in Sources */,
 				31C2B0F120B271370089BA7C /* TLSEvaluationTests.swift in Sources */,
 				3111CE9C20A7EC58008315E2 /* URLProtocolTests.swift in Sources */,
 				317A6A7720B2208000A9FEC5 /* DownloadTests.swift in Sources */,

--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -32,12 +32,13 @@ public enum AF {
     /// using the `method`, `parameters`, `encoding`, and `headers` provided.
     ///
     /// - Parameters:
-    ///   - url:         The `URLConvertible` value.
-    ///   - method:      The `HTTPMethod`, `.get` by default.
-    ///   - parameters:  The `Parameters`, `nil` by default.
-    ///   - encoding:    The `ParameterEncoding`, `URLEncoding.default` by default.
-    ///   - headers:     The `HTTPHeaders`, `nil` by default.
-    ///   - interceptor: The `RequestInterceptor`, `nil` by default.
+    ///   - url:           The `URLConvertible` value.
+    ///   - method:        The `HTTPMethod`, `.get` by default.
+    ///   - parameters:    The `Parameters`, `nil` by default.
+    ///   - encoding:      The `ParameterEncoding`, `URLEncoding.default` by default.
+    ///   - headers:       The `HTTPHeaders`, `nil` by default.
+    ///   - interceptor:   The `RequestInterceptor`, `nil` by default.
+    ///   - retryPolicies: The `RetryPolicy` types, `[]` by default.
     ///
     /// - Returns: The created `DataRequest`.
     public static func request(_ url: URLConvertible,
@@ -45,25 +46,28 @@ public enum AF {
                                parameters: Parameters? = nil,
                                encoding: ParameterEncoding = URLEncoding.default,
                                headers: HTTPHeaders? = nil,
-                               interceptor: RequestInterceptor? = nil) -> DataRequest {
+                               interceptor: RequestInterceptor? = nil,
+                               retryPolicies: [RetryPolicy] = []) -> DataRequest {
         return Session.default.request(url,
                                        method: method,
                                        parameters: parameters,
                                        encoding: encoding,
                                        headers: headers,
-                                       interceptor: interceptor)
+                                       interceptor: interceptor,
+                                       retryPolicies: retryPolicies)
     }
 
     /// Creates a `DataRequest` using `SessionManager.default` to retrive the contents of the specified `url`
     /// using the `method`, `parameters`, `encoding`, and `headers` provided.
     ///
     /// - Parameters:
-    ///   - url:         The `URLConvertible` value.
-    ///   - method:      The `HTTPMethod`, `.get` by default.
-    ///   - parameters:  The `Encodable` parameters, `nil` by default.
-    ///   - encoding:    The `ParameterEncoding`, `URLEncodedFormParameterEncoder.default` by default.
-    ///   - headers:     The `HTTPHeaders`, `nil` by default.
-    ///   - interceptor: The `RequestInterceptor`, `nil` by default.
+    ///   - url:           The `URLConvertible` value.
+    ///   - method:        The `HTTPMethod`, `.get` by default.
+    ///   - parameters:    The `Encodable` parameters, `nil` by default.
+    ///   - encoding:      The `ParameterEncoding`, `URLEncodedFormParameterEncoder.default` by default.
+    ///   - headers:       The `HTTPHeaders`, `nil` by default.
+    ///   - interceptor:   The `RequestInterceptor`, `nil` by default.
+    ///   - retryPolicies: The `RetryPolicy` types, `[]` by default.
     ///
     /// - Returns: The created `DataRequest`.
     public static func request<Parameters: Encodable>(_ url: URLConvertible,
@@ -71,25 +75,29 @@ public enum AF {
                                                       parameters: Parameters? = nil,
                                                       encoder: ParameterEncoder = URLEncodedFormParameterEncoder.default,
                                                       headers: HTTPHeaders? = nil,
-                                                      interceptor: RequestInterceptor? = nil) -> DataRequest {
+                                                      interceptor: RequestInterceptor? = nil,
+                                                      retryPolicies: [RetryPolicy] = []) -> DataRequest {
         return Session.default.request(url,
                                        method: method,
                                        parameters: parameters,
                                        encoder: encoder,
                                        headers: headers,
-                                       interceptor: interceptor)
+                                       interceptor: interceptor,
+                                       retryPolicies: retryPolicies)
     }
 
     /// Creates a `DataRequest` using `SessionManager.default` to execute the specified `urlRequest`.
     ///
     /// - Parameters:
-    ///   - urlRequest:  The `URLRequestConvertible` value.
-    ///   - interceptor: The `RequestInterceptor`, `nil` by default.
+    ///   - urlRequest:    The `URLRequestConvertible` value.
+    ///   - interceptor:   The `RequestInterceptor`, `nil` by default.
+    ///   - retryPolicies: The `RetryPolicy` types, `[]` by default.
     ///
     /// - Returns: The created `DataRequest`.
     public static func request(_ urlRequest: URLRequestConvertible,
-                               interceptor: RequestInterceptor? = nil) -> DataRequest {
-        return Session.default.request(urlRequest, interceptor: interceptor)
+                               interceptor: RequestInterceptor? = nil,
+                               retryPolicies: [RetryPolicy] = []) -> DataRequest {
+        return Session.default.request(urlRequest, interceptor: interceptor, retryPolicies: retryPolicies)
     }
 
     // MARK: - Download Request
@@ -101,14 +109,15 @@ public enum AF {
     /// underlying `URLSession`.
     ///
     /// - Parameters:
-    ///   - url:         The `URLConvertible` value.
-    ///   - method:      The `HTTPMethod`, `.get` by default.
-    ///   - parameters:  The `Parameters`, `nil` by default.
-    ///   - encoding:    The `ParameterEncoding`, `URLEncoding.default` by default.
-    ///   - headers:     The `HTTPHeaders`, `nil` by default.
-    ///   - interceptor: The `RequestInterceptor`, `nil` by default.
-    ///   - destination: The `DownloadRequest.Destination` closure used the determine the destination of the downloaded
-    ///                  file. `nil` by default.
+    ///   - url:           The `URLConvertible` value.
+    ///   - method:        The `HTTPMethod`, `.get` by default.
+    ///   - parameters:    The `Parameters`, `nil` by default.
+    ///   - encoding:      The `ParameterEncoding`, `URLEncoding.default` by default.
+    ///   - headers:       The `HTTPHeaders`, `nil` by default.
+    ///   - interceptor:   The `RequestInterceptor`, `nil` by default.
+    ///   - retryPolicies: The `RetryPolicy` types, `[]` by default.
+    ///   - destination:   The `DownloadRequest.Destination` closure used the determine the destination of the
+    ///                    downloaded file. `nil` by default.
     ///
     /// - Returns: The created `DownloadRequest`.
     public static func download(_ url: URLConvertible,
@@ -117,6 +126,7 @@ public enum AF {
                                 encoding: ParameterEncoding = URLEncoding.default,
                                 headers: HTTPHeaders? = nil,
                                 interceptor: RequestInterceptor? = nil,
+                                retryPolicies: [RetryPolicy] = [],
                                 to destination: DownloadRequest.Destination? =  nil) -> DownloadRequest {
         return Session.default.download(url,
                                         method: method,
@@ -124,6 +134,7 @@ public enum AF {
                                         encoding: encoding,
                                         headers: headers,
                                         interceptor: interceptor,
+                                        retryPolicies: retryPolicies,
                                         to: destination)
     }
 
@@ -134,14 +145,15 @@ public enum AF {
     /// underlying `URLSession`.
     ///
     /// - Parameters:
-    ///   - url:         The `URLConvertible` value.
-    ///   - method:      The `HTTPMethod`, `.get` by default.
-    ///   - parameters:  The `Encodable` parameters, `nil` by default.
-    ///   - encoder:     The `ParameterEncoder`, `URLEncodedFormParameterEncoder.default` by default.
-    ///   - headers:     The `HTTPHeaders`, `nil` by default.
-    ///   - interceptor: The `RequestInterceptor`, `nil` by default.
-    ///   - destination: The `DownloadRequest.Destination` closure used the determine the destination of the downloaded
-    ///                  file. `nil` by default.
+    ///   - url:           The `URLConvertible` value.
+    ///   - method:        The `HTTPMethod`, `.get` by default.
+    ///   - parameters:    The `Encodable` parameters, `nil` by default.
+    ///   - encoder:       The `ParameterEncoder`, `URLEncodedFormParameterEncoder.default` by default.
+    ///   - headers:       The `HTTPHeaders`, `nil` by default.
+    ///   - interceptor:   The `RequestInterceptor`, `nil` by default.
+    ///   - retryPolicies: The `RetryPolicy` types, `[]` by default.
+    ///   - destination:   The `DownloadRequest.Destination` closure used the determine the destination of the
+    ///                    downloaded file. `nil` by default.
     ///
     /// - Returns: The created `DownloadRequest`.
     public static func download<Parameters: Encodable>(_ url: URLConvertible,
@@ -150,6 +162,7 @@ public enum AF {
                                                        encoder: ParameterEncoder = URLEncodedFormParameterEncoder.default,
                                                        headers: HTTPHeaders? = nil,
                                                        interceptor: RequestInterceptor? = nil,
+                                                       retryPolicies: [RetryPolicy] = [],
                                                        to destination: DownloadRequest.Destination? = nil) -> DownloadRequest {
         return Session.default.download(url,
                                         method: method,
@@ -157,6 +170,7 @@ public enum AF {
                                         encoder: encoder,
                                         headers: headers,
                                         interceptor: interceptor,
+                                        retryPolicies: retryPolicies,
                                         to: destination)
     }
 
@@ -166,16 +180,21 @@ public enum AF {
     /// the result to the provided `destination`.
     ///
     /// - Parameters:
-    ///   - urlRequest:  The `URLRequestConvertible` value.
-    ///   - interceptor: The `RequestInterceptor`, `nil` by default.
-    ///   - destination: The `DownloadRequest.Destination` closure used the determine the destination of the downloaded
-    ///                  file. `nil` by default.
+    ///   - urlRequest:    The `URLRequestConvertible` value.
+    ///   - interceptor:   The `RequestInterceptor`, `nil` by default.
+    ///   - retryPolicies: The `RetryPolicy` types, `[]` by default.
+    ///   - destination:   The `DownloadRequest.Destination` closure used the determine the destination of the
+    ///                    downloaded file. `nil` by default.
     ///
     /// - Returns: The created `DownloadRequest`.
     public static func download(_ urlRequest: URLRequestConvertible,
                                 interceptor: RequestInterceptor? = nil,
+                                retryPolicies: [RetryPolicy] = [],
                                 to destination: DownloadRequest.Destination? = nil) -> DownloadRequest {
-        return Session.default.download(urlRequest, interceptor: interceptor, to: destination)
+        return Session.default.download(urlRequest,
+                                        interceptor: interceptor,
+                                        retryPolicies: retryPolicies,
+                                        to: destination)
     }
 
     // MARK: Resume Data
@@ -192,18 +211,23 @@ public enum AF {
     /// information about the bug and possible workarounds, please refer to the [this Stack Overflow post](http://stackoverflow.com/a/39347461/1342462).
     ///
     /// - Parameters:
-    ///   - resumeData:  The resume `Data`. This is an opaque blob produced by `URLSessionDownloadTask` when a task is
-    ///                  cancelled. See [Apple's documentation](https://developer.apple.com/documentation/foundation/urlsessiondownloadtask/1411634-cancel)
-    ///                  for more information.
-    ///   - interceptor: The `RequestInterceptor`, `nil` by default.
-    ///   - destination: The `DownloadRequest.Destination` closure used to determine the destination of the downloaded
-    ///                  file. `nil` by default.
+    ///   - resumeData:    The resume `Data`. This is an opaque blob produced by `URLSessionDownloadTask` when a task is
+    ///                    cancelled. See [Apple's documentation](https://developer.apple.com/documentation/foundation/urlsessiondownloadtask/1411634-cancel)
+    ///                    for more information.
+    ///   - interceptor:   The `RequestInterceptor`, `nil` by default.
+    ///   - retryPolicies: The `RetryPolicy` types, `[]` by default.
+    ///   - destination:   The `DownloadRequest.Destination` closure used to determine the destination of the downloaded
+    ///                    file. `nil` by default.
     ///
     /// - Returns: The created `DownloadRequest`.
     public static func download(resumingWith resumeData: Data,
                                 interceptor: RequestInterceptor? = nil,
+                                retryPolicies: [RetryPolicy] = [],
                                 to destination: DownloadRequest.Destination? = nil) -> DownloadRequest {
-        return Session.default.download(resumingWith: resumeData, interceptor: interceptor, to: destination)
+        return Session.default.download(resumingWith: resumeData,
+                                        interceptor: interceptor,
+                                        retryPolicies: retryPolicies,
+                                        to: destination)
     }
 
     // MARK: - Upload Request
@@ -214,34 +238,43 @@ public enum AF {
     /// using the `url`, `method` and `headers` provided.
     ///
     /// - Parameters:
-    ///   - fileURL:     The `URL` of the file to upload.
-    ///   - url:         The `URLConvertible` value.
-    ///   - method:      The `HTTPMethod`, `.post` by default.
-    ///   - headers:     The `HTTPHeaders`, `nil` by default.
-    ///   - interceptor: The `RequestInterceptor`, `nil` by default.
+    ///   - fileURL:       The `URL` of the file to upload.
+    ///   - url:           The `URLConvertible` value.
+    ///   - method:        The `HTTPMethod`, `.post` by default.
+    ///   - headers:       The `HTTPHeaders`, `nil` by default.
+    ///   - interceptor:   The `RequestInterceptor`, `nil` by default.
+    ///   - retryPolicies: The `RetryPolicy` types, `[]` by default.
     ///
     /// - Returns: The created `UploadRequest`.
     public static func upload(_ fileURL: URL,
                               to url: URLConvertible,
                               method: HTTPMethod = .post,
                               headers: HTTPHeaders? = nil,
+                              retryPolicies: [RetryPolicy] = [],
                               interceptor: RequestInterceptor? = nil) -> UploadRequest {
-        return Session.default.upload(fileURL, to: url, method: method, headers: headers, interceptor: interceptor)
+        return Session.default.upload(fileURL,
+                                      to: url,
+                                      method: method,
+                                      headers: headers,
+                                      interceptor: interceptor,
+                                      retryPolicies: retryPolicies)
     }
 
     /// Creates an `UploadRequest` using the `SessionManager.default` to upload the contents of the `fileURL` specificed
     /// using the `urlRequest` provided.
     ///
     /// - Parameters:
-    ///   - fileURL:     The `URL` of the file to upload.
-    ///   - urlRequest:  The `URLRequestConvertible` value.
-    ///   - interceptor: The `RequestInterceptor`, `nil` by default.
+    ///   - fileURL:       The `URL` of the file to upload.
+    ///   - urlRequest:    The `URLRequestConvertible` value.
+    ///   - interceptor:   The `RequestInterceptor`, `nil` by default.
+    ///   - retryPolicies: The `RetryPolicy` types, `[]` by default.
     ///
     /// - Returns: The created `UploadRequest`.
     public static func upload(_ fileURL: URL,
                               with urlRequest: URLRequestConvertible,
+                              retryPolicies: [RetryPolicy] = [],
                               interceptor: RequestInterceptor? = nil) -> UploadRequest {
-        return Session.default.upload(fileURL, with: urlRequest, interceptor: interceptor)
+        return Session.default.upload(fileURL, with: urlRequest, interceptor: interceptor, retryPolicies: retryPolicies)
     }
 
     // MARK: Data
@@ -250,34 +283,43 @@ public enum AF {
     /// the `url`, `method` and `headers` provided.
     ///
     /// - Parameters:
-    ///   - data:        The `Data` to upload.
-    ///   - url:         The `URLConvertible` value.
-    ///   - method:      The `HTTPMethod`, `.post` by default.
-    ///   - headers:     The `HTTPHeaders`, `nil` by default.
-    ///   - interceptor: The `RequestInterceptor`, `nil` by default.
+    ///   - data:          The `Data` to upload.
+    ///   - url:           The `URLConvertible` value.
+    ///   - method:        The `HTTPMethod`, `.post` by default.
+    ///   - headers:       The `HTTPHeaders`, `nil` by default.
+    ///   - interceptor:   The `RequestInterceptor`, `nil` by default.
+    ///   - retryPolicies: The `RetryPolicy` types, `[]` by default.
     ///
     /// - Returns: The created `UploadRequest`.
     public static func upload(_ data: Data,
                               to url: URLConvertible,
                               method: HTTPMethod = .post,
                               headers: HTTPHeaders? = nil,
-                              interceptor: RequestInterceptor? = nil) -> UploadRequest {
-        return Session.default.upload(data, to: url, method: method, headers: headers, interceptor: interceptor)
+                              interceptor: RequestInterceptor? = nil,
+                              retryPolicies: [RetryPolicy] = []) -> UploadRequest {
+        return Session.default.upload(data,
+                                      to: url,
+                                      method: method,
+                                      headers: headers,
+                                      interceptor: interceptor,
+                                      retryPolicies: retryPolicies)
     }
 
     /// Creates an `UploadRequest` using `SessionManager.default` to upload the contents of the `data` specified using
     /// the `urlRequest` provided.
     ///
     /// - Parameters:
-    ///   - data:        The `Data` to upload.
-    ///   - urlRequest:  The `URLRequestConvertible` value.
-    ///   - interceptor: The `RequestInterceptor`, `nil` by default.
+    ///   - data:          The `Data` to upload.
+    ///   - urlRequest:    The `URLRequestConvertible` value.
+    ///   - interceptor:   The `RequestInterceptor`, `nil` by default.
+    ///   - retryPolicies: The `RetryPolicy` types, `[]` by default.
     ///
     /// - Returns: The created `UploadRequest`.
     public static func upload(_ data: Data,
                               with urlRequest: URLRequestConvertible,
-                              interceptor: RequestInterceptor? = nil) -> UploadRequest {
-        return Session.default.upload(data, with: urlRequest, interceptor: interceptor)
+                              interceptor: RequestInterceptor? = nil,
+                              retryPolicies: [RetryPolicy] = []) -> UploadRequest {
+        return Session.default.upload(data, with: urlRequest, interceptor: interceptor, retryPolicies: retryPolicies)
     }
 
     // MARK: InputStream
@@ -286,34 +328,43 @@ public enum AF {
     /// specified using the `url`, `method` and `headers` provided.
     ///
     /// - Parameters:
-    ///   - stream:      The `InputStream` to upload.
-    ///   - url:         The `URLConvertible` value.
-    ///   - method:      The `HTTPMethod`, `.post` by default.
-    ///   - headers:     The `HTTPHeaders`, `nil` by default.
-    ///   - interceptor: The `RequestInterceptor`, `nil` by default.
+    ///   - stream:        The `InputStream` to upload.
+    ///   - url:           The `URLConvertible` value.
+    ///   - method:        The `HTTPMethod`, `.post` by default.
+    ///   - headers:       The `HTTPHeaders`, `nil` by default.
+    ///   - interceptor:   The `RequestInterceptor`, `nil` by default.
+    ///   - retryPolicies: The `RetryPolicy` types, `[]` by default.
     ///
     /// - Returns: The created `UploadRequest`.
     public static func upload(_ stream: InputStream,
                               to url: URLConvertible,
                               method: HTTPMethod = .post,
                               headers: HTTPHeaders? = nil,
-                              interceptor: RequestInterceptor? = nil) -> UploadRequest {
-        return Session.default.upload(stream, to: url, method: method, headers: headers, interceptor: interceptor)
+                              interceptor: RequestInterceptor? = nil,
+                              retryPolicies: [RetryPolicy] = []) -> UploadRequest {
+        return Session.default.upload(stream,
+                                      to: url,
+                                      method: method,
+                                      headers: headers,
+                                      interceptor: interceptor,
+                                      retryPolicies: retryPolicies)
     }
 
     /// Creates an `UploadRequest` using `SessionManager.default` to upload the content provided by the `stream`
     /// specified using the `urlRequest` specified.
     ///
     /// - Parameters:
-    ///   - stream:      The `InputStream` to upload.
-    ///   - urlRequest:  The `URLRequestConvertible` value.
-    ///   - interceptor: The `RequestInterceptor`, `nil` by default.
+    ///   - stream:        The `InputStream` to upload.
+    ///   - urlRequest:    The `URLRequestConvertible` value.
+    ///   - interceptor:   The `RequestInterceptor`, `nil` by default.
+    ///   - retryPolicies: The `RetryPolicy` types, `[]` by default.
     ///
     /// - Returns: The created `UploadRequest`.
     public static func upload(_ stream: InputStream,
                               with urlRequest: URLRequestConvertible,
-                              interceptor: RequestInterceptor? = nil) -> UploadRequest {
-        return Session.default.upload(stream, with: urlRequest, interceptor: interceptor)
+                              interceptor: RequestInterceptor? = nil,
+                              retryPolicies: [RetryPolicy] = []) -> UploadRequest {
+        return Session.default.upload(stream, with: urlRequest, interceptor: interceptor, retryPolicies: retryPolicies)
     }
 
     // MARK: MultipartFormData
@@ -341,6 +392,7 @@ public enum AF {
     ///   - method:                  The `HTTPMethod`, `.post` by default.
     ///   - headers:                 The `HTTPHeaders`, `nil` by default.
     ///   - interceptor:             The `RequestInterceptor`, `nil` by default.
+    ///   - retryPolicies:           The `RetryPolicy` types, `[]` by default.
     ///
     /// - Returns: The created `UploadRequest`.
     public static func upload(multipartFormData: @escaping (MultipartFormData) -> Void,
@@ -348,13 +400,15 @@ public enum AF {
                               to url: URLConvertible,
                               method: HTTPMethod = .post,
                               headers: HTTPHeaders? = nil,
-                              interceptor: RequestInterceptor? = nil) -> UploadRequest {
+                              interceptor: RequestInterceptor? = nil,
+                              retryPolicies: [RetryPolicy] = []) -> UploadRequest {
         return Session.default.upload(multipartFormData: multipartFormData,
                                       usingThreshold: encodingMemoryThreshold,
                                       to: url,
                                       method: method,
                                       headers: headers,
-                                      interceptor: interceptor)
+                                      interceptor: interceptor,
+                                      retryPolicies: retryPolicies)
     }
 
     /// Encodes `multipartFormData` using `encodingMemoryThreshold` and uploads the result using `SessionManager.default`
@@ -378,16 +432,19 @@ public enum AF {
     ///   - encodingMemoryThreshold: The encoding memory threshold in bytes. `10_000_000` bytes by default.
     ///   - urlRequest:              The `URLRequestConvertible` value.
     ///   - interceptor:             The `RequestInterceptor`, `nil` by default.
+    ///   - retryPolicies:           The `RetryPolicy` types, `[]` by default.
     ///
     /// - Returns: The `UploadRequest` created.
     @discardableResult
     public static func upload(multipartFormData: @escaping (MultipartFormData) -> Void,
                               usingThreshold encodingMemoryThreshold: UInt64 = MultipartUpload.encodingMemoryThreshold,
                               with urlRequest: URLRequestConvertible,
-                              interceptor: RequestInterceptor? = nil) -> UploadRequest {
+                              interceptor: RequestInterceptor? = nil,
+                              retryPolicies: [RetryPolicy] = []) -> UploadRequest {
         return Session.default.upload(multipartFormData: multipartFormData,
                                       usingThreshold: encodingMemoryThreshold,
                                       with: urlRequest,
-                                      interceptor: interceptor)
+                                      interceptor: interceptor,
+                                      retryPolicies: retryPolicies)
     }
 }

--- a/Source/ConnectionLostRetryPolicy.swift
+++ b/Source/ConnectionLostRetryPolicy.swift
@@ -1,0 +1,106 @@
+//
+//  ConnectionLostRetryPolicy.swift
+//
+//  Copyright (c) 2014-2018 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+/// A retry policy that automatically retries idempotent requests for network connection lost errors. For more
+/// information about retrying network connection lost errors, please refer to Apple's
+/// [technical document](https://developer.apple.com/library/content/qa/qa1941/_index.html).
+public struct ConnectionLostRetryPolicy: RetryPolicy {
+
+    // MARK: - Properties
+
+    /// The total number of times the request is allowed to be retried.
+    public let retryLimit: UInt
+
+    /// The base of the exponential backoff policy (should always be greater than or equal to 2).
+    public let exponentialBackoffBase: UInt
+
+    /// The scale of the exponential backoff.
+    public let exponentialBackoffScale: Double
+
+    /// The idempotent http methods to retry.
+    /// See [RFC 2616 - Section 9.1.2](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html) for more information.
+    public let idempotentMethods: Set<HTTPMethod>
+
+    // MARK: - Initialization
+
+    /// Creates a `ConnectionLostRetryPolicy` instance from the specified parameters.
+    ///
+    /// - Parameters:
+    ///   - retryLimit:              The total number of times the request is allowed to be retried. `2` by default.
+    ///   - exponentialBackoffBase:  The base of the exponential backoff policy. `2` by default.
+    ///   - exponentialBackoffScale: The scale of the exponential backoff. `0.25` by default.
+    ///   - idempotentMethods:       The idempotent http methods to retry. `[.get, .head, .options, .trace]` by default.
+    public init(
+        retryLimit: UInt = 2,
+        exponentialBackoffBase: UInt = 2,
+        exponentialBackoffScale: Double = 0.25,
+        idempotentMethods: Set<HTTPMethod> = [.get, .head, .put, .delete, .options, .trace])
+    {
+        self.retryLimit = retryLimit
+        self.exponentialBackoffBase = exponentialBackoffBase
+        self.exponentialBackoffScale = exponentialBackoffScale
+        self.idempotentMethods = idempotentMethods
+    }
+
+    // MARK: - Retry
+
+    /// Returns whether the request should be retried with a time delay in seconds.
+    ///
+    /// - Parameters:
+    ///   - request: The request to potentially retry.
+    ///   - error:   The error encountered when executing the request.
+    ///
+    /// - Returns: `true` with a time delay if request should be retried, `false` and an ignored time delay otherwise.
+    public func shouldRetry(_ request: Request, with error: Error) -> (shouldRetry: Bool, timeDelay: TimeInterval) {
+        guard
+            request.retryCount < retryLimit,
+            isErrorConnectionLostError(error),
+            let urlRequest = request.request,
+            isRequestIdempotent(urlRequest)
+        else { return (false, 0) }
+
+        // Compute time delay for the exponential backoff (0.5s, 1.0s, 2.0s, 4.0s, ...)
+        let timeDelay = pow(Double(exponentialBackoffBase), Double(request.retryCount)) * exponentialBackoffScale
+
+        return (true, timeDelay)
+    }
+
+    // MARK: - Private - Helper Methods
+
+    private func isRequestIdempotent(_ urlRequest: URLRequest) -> Bool {
+        guard
+            let stringMethod = urlRequest.httpMethod,
+            let httpMethod = HTTPMethod(rawValue: stringMethod)
+        else { return false }
+
+        return idempotentMethods.contains(httpMethod)
+    }
+
+    private func isErrorConnectionLostError(_ error: Error) -> Bool {
+        guard let urlError = error as? URLError else { return false }
+        return urlError.code == .networkConnectionLost
+    }
+}

--- a/Source/ExponentialBackoffRetryPolicy.swift
+++ b/Source/ExponentialBackoffRetryPolicy.swift
@@ -1,0 +1,180 @@
+//
+//  ExponentialBackoffRetryPolicy.swift
+//
+//  Copyright (c) 2014-2018 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+/// A retry policy that retries requests using an exponential backoff for allowed HTTP methods and HTTP status codes
+/// as well as certain types of networking errors.
+public struct ExponentialBackoffRetryPolicy: RetryPolicy {
+
+    // MARK: - Properties
+
+    /// The total number of times the request is allowed to be retried.
+    public let retryLimit: UInt
+
+    /// The base of the exponential backoff policy (should always be greater than or equal to 2).
+    public let exponentialBackoffBase: UInt
+
+    /// The scale of the exponential backoff.
+    public let exponentialBackoffScale: Double
+
+    /// The HTTP methods that are allowed to be retried.
+    public let retryableHTTPMethods: Set<HTTPMethod>
+
+    /// The HTTP status codes that are automatically retried by the policy.
+    public let retryableStatusCodes: Set<Int>
+
+    // MARK: - Initialization
+
+    /// Creates an `ExponentialBackoffRetryPolicy` from the specified parameters.
+    ///
+    /// - Parameters:
+    ///   - retryLimit:              The total number of times the request is allowed to be retried. `2` by default.
+    ///   - exponentialBackoffBase:  The base of the exponential backoff policy. `2` by default.
+    ///   - exponentialBackoffScale: The scale of the exponential backoff. `0.5` by default.
+    ///   - retryableHTTPMethods:    The HTTP methods that are allowed to be retried.
+    ///                              `[.get, .head, .options, .trace]` by default.
+    ///   - retryableStatusCodes:    The HTTP status codes that are automatically retried by the policy.
+    ///                              `[408, 500, 502, 503, 504]` by default.
+    public init(
+        retryLimit: UInt = 2,
+        exponentialBackoffBase: UInt = 2,
+        exponentialBackoffScale: Double = 0.5,
+        retryableHTTPMethods: Set<HTTPMethod> = [.get, .head, .put, .delete, .options, .trace],
+        retryableStatusCodes: Set<Int> = [408, 500, 502, 503, 504])
+    {
+        self.retryLimit = retryLimit
+        self.exponentialBackoffBase = exponentialBackoffBase
+        self.exponentialBackoffScale = exponentialBackoffScale
+        self.retryableHTTPMethods = retryableHTTPMethods
+        self.retryableStatusCodes = retryableStatusCodes
+    }
+
+    // MARK: - Retry
+
+    /// Returns whether the request should be retried with a time delay in seconds.
+    ///
+    /// - Parameters:
+    ///   - request: The request to potentially retry.
+    ///   - error:   The error encountered when executing the request.
+    ///
+    /// - Returns: `true` with a time delay if request should be retried, `false` and an ignored time delay otherwise.
+    public func shouldRetry(
+        _ request: Alamofire.Request,
+        with error: Error)
+        -> (shouldRetry: Bool, timeDelay: TimeInterval)
+    {
+        // Make sure the retry limit has not been met
+        guard request.retryCount < retryLimit else { return (false, 0) }
+
+        // Only retry requests with retryable HTTP methods
+        if
+            let httpMethodString = request.request?.httpMethod,
+            let httpMethod = HTTPMethod(rawValue: httpMethodString),
+            !retryableHTTPMethods.contains(httpMethod)
+        {
+            return (false, 0)
+        }
+
+        // Inspect the HTTP status code and error to see if the request should be retried
+        guard isRetryable(request.response, with: error) else { return (false, 0) }
+
+        // Compute time delay for the exponential backoff (0.5s, 1.0s, 2.0s, 4.0s, ...)
+        let timeDelay = pow(Double(exponentialBackoffBase), Double(request.retryCount)) * exponentialBackoffScale
+
+        return (true, timeDelay)
+    }
+
+    // MARK: - Private - Retry Helpers
+
+    private func isRetryable(_ response: HTTPURLResponse?, with error: Error) -> Bool {
+        if let statusCode = response?.statusCode, retryableStatusCodes.contains(statusCode) {
+            // Check if the response status code is retriable
+            return true
+        } else if let urlError = error as? URLError {
+            return isRetryable(urlError)
+        }
+
+        return false
+    }
+
+    private func isRetryable(_ urlError: URLError) -> Bool {
+        switch urlError.code {
+        case
+            //.appTransportSecurityRequiresSecureConnection,
+            .backgroundSessionInUseByAnotherProcess,
+            //.backgroundSessionRequiresSharedContainer,
+            .backgroundSessionWasDisconnected,
+            .badServerResponse,
+            //.badURL,
+            .callIsActive,
+            //.cancelled,
+            //.cannotCloseFile,
+            .cannotConnectToHost,
+            //.cannotCreateFile,
+            //.cannotDecodeContentData,
+            //.cannotDecodeRawData,
+            .cannotFindHost,
+            .cannotLoadFromNetwork,
+            //.cannotMoveFile,
+            //.cannotOpenFile,
+            //.cannotParseResponse,
+            //.cannotRemoveFile,
+            //.cannotWriteToFile,
+            //.clientCertificateRejected,
+            //.clientCertificateRequired,
+            //.dataLengthExceedsMaximum,
+            .dataNotAllowed, // Refers to cellular data
+            .dnsLookupFailed,
+            .downloadDecodingFailedMidStream,
+            .downloadDecodingFailedToComplete,
+            //.fileDoesNotExist,
+            //.fileIsDirectory,
+            //.httpTooManyRedirects,
+            .internationalRoamingOff,
+            .networkConnectionLost,
+            //.noPermissionsToReadFile,
+            .notConnectedToInternet,
+            //.redirectToNonExistentLocation,
+            //.requestBodyStreamExhausted,
+            //.resourceUnavailable,
+            .secureConnectionFailed,
+            .serverCertificateHasBadDate,
+            //.serverCertificateHasUnknownRoot,
+            .serverCertificateNotYetValid,
+            //.serverCertificateUntrusted,
+            .timedOut:
+            //.unknown,
+            //.unsupportedURL,
+            //.userAuthenticationRequired,
+            //.userCancelledAuthentication,
+            //.zeroByteResource,
+
+            return true
+
+        default:
+            return false
+        }
+    }
+}

--- a/Source/RequestInterceptor.swift
+++ b/Source/RequestInterceptor.swift
@@ -48,11 +48,11 @@ public protocol RequestRetrier {
     /// to be retried. The one requirement is that the completion closure is called to ensure the request is properly
     /// cleaned up after.
     ///
-    /// - parameter manager:    The session manager the request was executed on.
+    /// - parameter session:    The session the request was executed on.
     /// - parameter request:    The request that failed due to the encountered error.
     /// - parameter error:      The error encountered when executing the request.
     /// - parameter completion: The completion closure to be executed when retry decision has been determined.
-    func should(_ manager: Session, retry request: Request, with error: Error, completion: @escaping RequestRetryCompletion)
+    func should(_ session: Session, retry request: Request, with error: Error, completion: @escaping RequestRetryCompletion)
 }
 
 // MARK: -

--- a/Source/RetryPolicy.swift
+++ b/Source/RetryPolicy.swift
@@ -1,0 +1,38 @@
+//
+//  RequestInterceptor.swift
+//
+//  Copyright (c) 2014-2018 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+/// Types adopting the `RetryPolicy` protocol are used to determine whether to retry requests that encounter
+/// an error during execution.
+public protocol RetryPolicy {
+    /// Returns whether the request should be retried with a time delay in seconds.
+    ///
+    /// - Parameters:
+    ///   - request: The request to potentially retry.
+    ///   - error:   The error encountered when executing the request.
+    ///
+    /// - Returns: `true` with a time delay if request should be retried, `false` and an ignored time delay otherwise.
+    func shouldRetry(_ request: Request, with error: Error) -> (shouldRetry: Bool, timeDelay: TimeInterval)
+}

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -454,6 +454,7 @@ open class Session {
                 adapter.adapt(initialRequest) { result in
                     do {
                         let adaptedRequest = try result.unwrap()
+
                         self.rootQueue.async {
                             request.didAdaptInitialRequest(initialRequest, to: adaptedRequest)
                             self.didCreateURLRequest(adaptedRequest, for: request)

--- a/Tests/ConnectionLostRetryPolicyTests.swift
+++ b/Tests/ConnectionLostRetryPolicyTests.swift
@@ -1,0 +1,220 @@
+//
+//  ConnectionLostRetryPolicyTests.swift
+//
+//  Copyright (c) 2014-2018 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+@testable import Alamofire
+import Foundation
+import XCTest
+
+class ConnectionLostRetryPolicyTestCase: BaseTestCase {
+
+    // MARK: - Helper Types
+
+    private class StubRequest: DataRequest {
+        let urlRequest: URLRequest
+        override var request: URLRequest? { return urlRequest }
+
+        init(_ url: URL, method: HTTPMethod, session: Session) {
+            let request = Session.RequestConvertible(
+                url: url,
+                method: method,
+                parameters: nil,
+                encoding: URLEncoding.default,
+                headers: nil
+            )
+
+            urlRequest = try! request.asURLRequest()
+
+            super.init(
+                convertible: request,
+                underlyingQueue: session.rootQueue,
+                serializationQueue: session.serializationQueue,
+                eventMonitor: session.eventMonitor,
+                interceptor: nil,
+                retryPolicies: [],
+                delegate: session
+            )
+        }
+    }
+
+    // MARK: - Properties
+
+    private let idempotentMethods: Set<HTTPMethod> = [.get, .head, .put, .delete, .options, .trace]
+    private let nonIdempotentMethods: Set<HTTPMethod> = [.post, .patch, .connect]
+    private var methods: Set<HTTPMethod> { return idempotentMethods.union(nonIdempotentMethods) }
+
+    private let session = Session(startRequestsImmediately: false)
+
+    private let url = URL(string: "https://api.example.com")!
+    private let connectionLostError = NSError(domain: URLError.errorDomain, code: URLError.networkConnectionLost.rawValue, userInfo: nil)
+    private let dnsLookupError = NSError(domain: URLError.errorDomain, code: URLError.dnsLookupFailed.rawValue, userInfo: nil)
+    private let badServerResponseError = NSError(domain: URLError.errorDomain, code: URLError.badServerResponse.rawValue, userInfo: nil)
+
+    // MARK: - Setup and Teardown
+
+    override func setUp() {
+        super.setUp()
+        // No-op
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        session.session.invalidateAndCancel()
+    }
+
+    // MARK: - Tests - Retry
+
+    func testThatRetryPolicyRetriesRequestsBelowRetryLimit() {
+        // Given
+        let retryPolicy = ConnectionLostRetryPolicy()
+        let request = self.request(method: .get)
+
+        var results: [Int: (shouldRetry: Bool, timeDelay: TimeInterval)] = [:]
+
+        // When
+        for index in 0...2 {
+            results[index] = retryPolicy.shouldRetry(request, with: connectionLostError)
+            request.requestIsRetrying()
+        }
+
+        // Then
+        XCTAssertEqual(results.count, 3)
+
+        if results.count == 3 {
+            XCTAssertEqual(results[0]?.shouldRetry, true)
+            XCTAssertEqual(results[0]?.timeDelay, 0.25)
+
+            XCTAssertEqual(results[1]?.shouldRetry, true)
+            XCTAssertEqual(results[1]?.timeDelay, 0.5)
+
+            XCTAssertEqual(results[2]?.shouldRetry, false)
+            XCTAssertEqual(results[2]?.timeDelay, 0.0)
+        }
+    }
+
+    func testThatRetryPolicyRetriesIdempotentRequestsWhenErrorIsConnectionLostError() {
+        // Given
+        let retryPolicy = ConnectionLostRetryPolicy()
+        var results: [HTTPMethod: (shouldRetry: Bool, timeDelay: TimeInterval)] = [:]
+
+        // When
+        for method in methods {
+            let request = self.request(method: method)
+            results[method] = retryPolicy.shouldRetry(request, with: connectionLostError)
+        }
+
+        // Then
+        XCTAssertEqual(results.count, methods.count)
+
+        for (method, result) in results {
+            XCTAssertEqual(result.shouldRetry, idempotentMethods.contains(method))
+            XCTAssertEqual(result.timeDelay, result.shouldRetry ? 0.25 : 0.0)
+        }
+    }
+
+    func testThatRetryPolicyDoesNotRetryRequestWithInvalidHTTPMethod() {
+        // Given
+        let retryPolicy = ConnectionLostRetryPolicy()
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "invalid"
+
+        let request = session.request(urlRequest)
+
+        // When
+        let (shouldRetry, timeDelay) = retryPolicy.shouldRetry(request, with: connectionLostError)
+
+        // Then
+        XCTAssertEqual(shouldRetry, false)
+        XCTAssertEqual(timeDelay, 0.0)
+    }
+
+    func testThatRetryPolicyDoesNotRetryWhenErrorIsNotConnectionLostError() {
+        // Given
+        let retryPolicy = ConnectionLostRetryPolicy()
+        let errors: [Error] = [dnsLookupError, badServerResponseError]
+
+        var results: [(shouldRetry: Bool, timeDelay: TimeInterval)] = []
+
+        // When
+        for error in errors {
+            let request = self.request(method: .get)
+            results.append(retryPolicy.shouldRetry(request, with: error))
+        }
+
+        // Then
+        XCTAssertEqual(results.count, errors.count)
+
+        for (shouldRetry, timeDelay) in results {
+            XCTAssertEqual(shouldRetry, false)
+            XCTAssertEqual(timeDelay, 0.0)
+        }
+    }
+
+    // MARK: - Tests - Exponential Backoff
+
+    func testThatRetryPolicyTimeDelayBacksOffExponentially() {
+        // Given
+        let retryPolicy = ConnectionLostRetryPolicy(
+            retryLimit: 4,
+            exponentialBackoffBase: 2,
+            exponentialBackoffScale: 0.25
+        )
+
+        let request = self.request(method: .get)
+
+        var results: [Int: (shouldRetry: Bool, timeDelay: TimeInterval)] = [:]
+
+        // When
+        for index in 0...4 {
+            results[index] = retryPolicy.shouldRetry(request, with: connectionLostError)
+            request.requestIsRetrying()
+        }
+
+        // Then
+        XCTAssertEqual(results.count, 5)
+
+        if results.count == 5 {
+            XCTAssertEqual(results[0]?.shouldRetry, true)
+            XCTAssertEqual(results[0]?.timeDelay, 0.25)
+
+            XCTAssertEqual(results[1]?.shouldRetry, true)
+            XCTAssertEqual(results[1]?.timeDelay, 0.5)
+
+            XCTAssertEqual(results[2]?.shouldRetry, true)
+            XCTAssertEqual(results[2]?.timeDelay, 1.0)
+
+            XCTAssertEqual(results[3]?.shouldRetry, true)
+            XCTAssertEqual(results[3]?.timeDelay, 2.0)
+
+            XCTAssertEqual(results[4]?.shouldRetry, false)
+            XCTAssertEqual(results[4]?.timeDelay, 0.0)
+        }
+    }
+
+    // MARK: - Private - Test Helpers
+
+    private func request(method: HTTPMethod) -> Request {
+        return StubRequest(url, method: method, session: session)
+    }
+}

--- a/Tests/ExponentialBackoffRetryPolicyTests.swift
+++ b/Tests/ExponentialBackoffRetryPolicyTests.swift
@@ -1,0 +1,320 @@
+//
+//  CacheTests.swift
+//
+//  Copyright (c) 2014-2018 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+@testable import Alamofire
+import Foundation
+import XCTest
+
+class ExponentialBackoffRetryPolicyTestCase: BaseTestCase {
+
+    // MARK: - Helper Types
+
+    private class StubRequest: DataRequest {
+        let urlRequest: URLRequest
+        override var request: URLRequest? { return urlRequest }
+
+        let mockedResponse: HTTPURLResponse?
+        override var response: HTTPURLResponse? { return mockedResponse }
+
+        init(_ url: URL, method: HTTPMethod, response: HTTPURLResponse?, session: Session) {
+            mockedResponse = response
+
+            let request = Session.RequestConvertible(
+                url: url,
+                method: method,
+                parameters: nil,
+                encoding: URLEncoding.default,
+                headers: nil
+            )
+
+            urlRequest = try! request.asURLRequest()
+
+            super.init(
+                convertible: request,
+                underlyingQueue: session.rootQueue,
+                serializationQueue: session.serializationQueue,
+                eventMonitor: session.eventMonitor,
+                interceptor: nil,
+                retryPolicies: [],
+                delegate: session
+            )
+        }
+    }
+
+    // MARK: - Properties
+
+    private let idempotentMethods: Set<HTTPMethod> = [.get, .head, .put, .delete, .options, .trace]
+    private let nonIdempotentMethods: Set<HTTPMethod> = [.post, .patch, .connect]
+    private var methods: Set<HTTPMethod> { return idempotentMethods.union(nonIdempotentMethods) }
+
+    private let session = Session(startRequestsImmediately: false)
+
+    private let url = URL(string: "https://api.nike.com")!
+    private let connectionLostError = NSError(domain: URLError.errorDomain, code: URLError.networkConnectionLost.rawValue, userInfo: nil)
+    private let resourceUnavailableError = NSError(domain: URLError.errorDomain, code: URLError.resourceUnavailable.rawValue, userInfo: nil)
+    private let unknownError = NSError(domain: URLError.errorDomain, code: URLError.unknown.rawValue, userInfo: nil)
+
+    private let retryableStatusCodes: Set<Int> = [408, 500, 502, 503, 504]
+
+    private let retryableErrorCodes: [URLError.Code] = [
+        .backgroundSessionInUseByAnotherProcess,
+        .backgroundSessionWasDisconnected,
+        .badServerResponse,
+        .callIsActive,
+        .cannotConnectToHost,
+        .cannotFindHost,
+        .cannotLoadFromNetwork,
+        .dataNotAllowed,
+        .dnsLookupFailed,
+        .downloadDecodingFailedMidStream,
+        .downloadDecodingFailedToComplete,
+        .internationalRoamingOff,
+        .networkConnectionLost,
+        .notConnectedToInternet,
+        .secureConnectionFailed,
+        .serverCertificateHasBadDate,
+        .serverCertificateNotYetValid,
+        .timedOut
+    ]
+
+    private let nonRetryableErrorCodes: [URLError.Code] = [
+        .appTransportSecurityRequiresSecureConnection,
+        .backgroundSessionRequiresSharedContainer,
+        .badURL,
+        .cancelled,
+        .cannotCloseFile,
+        .cannotCreateFile,
+        .cannotDecodeContentData,
+        .cannotDecodeRawData,
+        .cannotMoveFile,
+        .cannotOpenFile,
+        .cannotParseResponse,
+        .cannotRemoveFile,
+        .cannotWriteToFile,
+        .clientCertificateRejected,
+        .clientCertificateRequired,
+        .dataLengthExceedsMaximum,
+        .fileDoesNotExist,
+        .fileIsDirectory,
+        .httpTooManyRedirects,
+        .noPermissionsToReadFile,
+        .redirectToNonExistentLocation,
+        .requestBodyStreamExhausted,
+        .resourceUnavailable,
+        .serverCertificateHasUnknownRoot,
+        .serverCertificateUntrusted,
+        .unknown,
+        .unsupportedURL,
+        .userAuthenticationRequired,
+        .userCancelledAuthentication,
+        .zeroByteResource
+    ]
+
+    private var urlErrorCodes: [URLError.Code] {
+        return retryableErrorCodes + nonRetryableErrorCodes
+    }
+
+    // MARK: - Setup and Teardown
+
+    override func setUp() {
+        super.setUp()
+        // No-op
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        session.session.invalidateAndCancel()
+    }
+
+    // MARK: - Tests - Retry
+
+    func testThatRetryPolicyRetriesRequestsBelowRetryLimit() {
+        // Given
+        let retryPolicy = ExponentialBackoffRetryPolicy()
+        let request = self.request(method: .get)
+
+        var results: [Int: (shouldRetry: Bool, timeDelay: TimeInterval)] = [:]
+
+        // When
+        for index in 0...2 {
+            results[index] = retryPolicy.shouldRetry(request, with: connectionLostError)
+            request.requestIsRetrying()
+        }
+
+        // Then
+        XCTAssertEqual(results.count, 3)
+
+        if results.count == 3 {
+            XCTAssertEqual(results[0]?.shouldRetry, true)
+            XCTAssertEqual(results[0]?.timeDelay, 0.5)
+
+            XCTAssertEqual(results[1]?.shouldRetry, true)
+            XCTAssertEqual(results[1]?.timeDelay, 1.0)
+
+            XCTAssertEqual(results[2]?.shouldRetry, false)
+            XCTAssertEqual(results[2]?.timeDelay, 0.0)
+        }
+    }
+
+    func testThatRetryPolicyRetriesIdempotentRequests() {
+        // Given
+        let retryPolicy = ExponentialBackoffRetryPolicy()
+        var results: [HTTPMethod: (shouldRetry: Bool, timeDelay: TimeInterval)] = [:]
+
+        // When
+        for method in methods {
+            let request = self.request(method: method)
+            results[method] = retryPolicy.shouldRetry(request, with: connectionLostError)
+        }
+
+        // Then
+        XCTAssertEqual(results.count, methods.count)
+
+        for (method, result) in results {
+            XCTAssertEqual(result.shouldRetry, idempotentMethods.contains(method))
+            XCTAssertEqual(result.timeDelay, result.shouldRetry ? 0.5 : 0.0)
+        }
+    }
+
+    func testThatRetryPolicyRetriesRequestsWithRetryableStatusCodes() {
+        // Given
+        let retryPolicy = ExponentialBackoffRetryPolicy()
+        let statusCodes = Set(100...599)
+        var results: [Int: (shouldRetry: Bool, timeDelay: TimeInterval)] = [:]
+
+        // When
+        for statusCode in statusCodes {
+            let request = self.request(method: .get, statusCode: statusCode)
+            results[statusCode] = retryPolicy.shouldRetry(request, with: unknownError)
+        }
+
+        // Then
+        XCTAssertEqual(results.count, statusCodes.count)
+
+        for (statusCode, result) in results {
+            XCTAssertEqual(result.shouldRetry, retryableStatusCodes.contains(statusCode))
+            XCTAssertEqual(result.timeDelay, result.shouldRetry ? 0.5 : 0.0)
+        }
+    }
+
+    func testThatRetryPolicyRetriesRequestsWithRetryableErrors() {
+        // Given
+        let retryPolicy = ExponentialBackoffRetryPolicy()
+        var results: [URLError.Code: (shouldRetry: Bool, timeDelay: TimeInterval)] = [:]
+
+        // When
+        for code in urlErrorCodes {
+            let request = self.request(method: .get)
+            let error = urlError(with: code)
+
+            results[code] = retryPolicy.shouldRetry(request, with: error)
+        }
+
+        // Then
+        XCTAssertEqual(results.count, urlErrorCodes.count)
+
+        for (urlErrorCode, result) in results {
+            XCTAssertEqual(result.shouldRetry, retryableErrorCodes.contains(urlErrorCode))
+            XCTAssertEqual(result.timeDelay, result.shouldRetry ? 0.5 : 0.0)
+        }
+    }
+
+    func testThatRetryPolicyDoesNotRetryErrorsThatAreNotURLErrors() {
+        // Given
+        let retryPolicy = ExponentialBackoffRetryPolicy()
+        let request = self.request(method: .get)
+
+        let errors: [Error] = [
+            resourceUnavailableError,
+            unknownError
+        ]
+
+        var results: [(shouldRetry: Bool, timeDelay: TimeInterval)] = []
+
+        // When
+        for error in errors {
+            results.append(retryPolicy.shouldRetry(request, with: error))
+        }
+
+        // Then
+        XCTAssertEqual(results.count, errors.count)
+
+        for (shouldRetry, timeDelay) in results {
+            XCTAssertEqual(shouldRetry, false)
+            XCTAssertEqual(timeDelay, 0.0)
+        }
+    }
+
+    // MARK: - Tests - Exponential Backoff
+
+    func testThatRetryPolicyTimeDelayBacksOffExponentially() {
+        // Given
+        let retryPolicy = ExponentialBackoffRetryPolicy(retryLimit: 4)
+        let request = self.request(method: .get)
+
+        var results: [Int: (shouldRetry: Bool, timeDelay: TimeInterval)] = [:]
+
+        // When
+        for index in 0...4 {
+            results[index] = retryPolicy.shouldRetry(request, with: connectionLostError)
+            request.requestIsRetrying()
+        }
+
+        // Then
+        XCTAssertEqual(results.count, 5)
+
+        if results.count == 5 {
+            XCTAssertEqual(results[0]?.shouldRetry, true)
+            XCTAssertEqual(results[0]?.timeDelay, 0.5)
+
+            XCTAssertEqual(results[1]?.shouldRetry, true)
+            XCTAssertEqual(results[1]?.timeDelay, 1.0)
+
+            XCTAssertEqual(results[2]?.shouldRetry, true)
+            XCTAssertEqual(results[2]?.timeDelay, 2.0)
+
+            XCTAssertEqual(results[3]?.shouldRetry, true)
+            XCTAssertEqual(results[3]?.timeDelay, 4.0)
+
+            XCTAssertEqual(results[4]?.shouldRetry, false)
+            XCTAssertEqual(results[4]?.timeDelay, 0.0)
+        }
+    }
+
+    // MARK: - Private - Test Helpers
+
+    private func request(method: HTTPMethod = .get, statusCode: Int? = nil) -> Request {
+        var response: HTTPURLResponse?
+
+        if let statusCode = statusCode {
+            response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)
+        }
+
+        return StubRequest(url, method: method, response: response, session: session)
+    }
+
+    private func urlError(with code: URLError.Code) -> URLError {
+        return NSError(domain: URLError.errorDomain, code: code.rawValue, userInfo: nil) as! URLError
+    }
+}

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -89,7 +89,7 @@ class SessionTestCase: BaseTestCase {
             completion(result)
         }
 
-        func should(_ manager: Session, retry request: Request, with error: Error, completion: @escaping RequestRetryCompletion) {
+        func should(_ session: Session, retry request: Request, with error: Error, completion: @escaping RequestRetryCompletion) {
             guard shouldRetry else { completion(false, 0.0); return }
 
             retryCount += 1
@@ -120,7 +120,7 @@ class SessionTestCase: BaseTestCase {
             completion(result)
         }
 
-        func should(_ manager: Session, retry request: Request, with error: Error, completion: @escaping RequestRetryCompletion) {
+        func should(_ session: Session, retry request: Request, with error: Error, completion: @escaping RequestRetryCompletion) {
             retryCount += 1
             retryErrors.append(error)
 

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -336,12 +336,15 @@ class ContentTypeValidationTestCase: BaseTestCase {
     func testThatValidationForRequestWithAcceptableWildcardContentTypeResponseSucceedsWhenResponseIsNil() {
         // Given
         class MockManager: Session {
-            override func request(_ convertible: URLRequestConvertible, interceptor: RequestInterceptor? = nil) -> DataRequest {
+            override func request(_ convertible: URLRequestConvertible,
+                                  interceptor: RequestInterceptor? = nil,
+                                  retryPolicies: [RetryPolicy] = []) -> DataRequest {
                 let request = MockDataRequest(convertible: convertible,
                                               underlyingQueue: rootQueue,
                                               serializationQueue: serializationQueue,
                                               eventMonitor: eventMonitor,
                                               interceptor: interceptor,
+                                              retryPolicies: retryPolicies,
                                               delegate: self)
 
                 perform(request)
@@ -352,6 +355,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
             override func download(
                 _ convertible: URLRequestConvertible,
                 interceptor: RequestInterceptor? = nil,
+                retryPolicies: [RetryPolicy] = [],
                 to destination: DownloadRequest.Destination? = nil)
                 -> DownloadRequest
             {
@@ -360,6 +364,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
                                                   serializationQueue: serializationQueue,
                                                   eventMonitor: eventMonitor,
                                                   interceptor: interceptor,
+                                                  retryPolicies: retryPolicies,
                                                   delegate: self
                 )
 


### PR DESCRIPTION
**☠️💣💥☠️💣💥 DO NOT MERGE UNTIL REPOINTED AT MASTER!!! ☠️💣💥☠️💣💥**

### Goals :soccer:

This goal of this PR is to add the ability to apply retry policies to sessions as well as requests. These retry policies are completely separate from the `RequestRetrier` concept. They serve two different purposes.

The adapter/retrier (interceptor) APIs were designed to handle cases for authentication. Interceptors are supported at both the session and request level to enable different authentication systems to be used between requests made on the same session.

Retry policies serve a much different purpose. They are not designed to be tied to authentication in any way. They are also not asynchronous. Generally, when authentication fails, some form of a token needs to be refreshed, and then the requests can all be retried. Retry policy use cases are more meant for examining response status codes and errors to determine whether to retry the request or not. Two examples of good cases for retry policies are receiving a connection lost error or a receiving a 408 status code.

Neither of these cases are tied to the authentication system used for the request. Therefore, we want to separate the retrier from the retry policies. Additionally, you may want to apply a connection lost policy to all requests made on the session, but you may only want to apply an exponential backoff policy to certain requests. Because of this, retry policies are supported at both the session and request level.

### Implementation Details :construction:

#### Retry Policy

Retry policies are super simple at their core.

```swift
public protocol RetryPolicy {
    func shouldRetry(_ request: Request, with error: Error) -> (shouldRetry: Bool, timeDelay: TimeInterval)
}
```

A retry policy is handed a request and error, and MUST determine on the calling thread whether the request should be retried and whether to use a delay. This PR also ships a couple of useful retry policies that we've been using a Nike on an AF fork for some time.

##### Connection Lost Retry Policy

This is a simple retry policy that should most likely be applied to all requests. By default, requests made with idempotent HTTP methods will automatically be retried when receiving a `.connectionLost` error. For more information regarding connection lost errors, I'd recommend you refer to Apple's [technical document](https://developer.apple.com/library/content/qa/qa1941/_index.html).

> When using this retry policy, make sure to customize the idempotent requests for the services you are calling.
> At Nike, we are not able to safely include `.put` and `.delete` HTTP methods as idempotent.
> Some of our legacy services are not fully compliant.

##### Exponential Backoff Retry Policy

The second retry policy included in this PR is the `ExponentialBackoffRetryPolicy`. This retry policy will exponentially backoff retrying a request until it hits a retry limit. It allows you to customize the HTTP methods that can be retried and which status codes should automatically be retried. It also inspects the URL error codes that are returned and will retry the request if the error should be retried.

#### Retrying a Request

Retrying a request with a retry policy is simple. You first specify the retry policies you'd like to attach to either the `Session` or new `Request` being made. From there, the `Session` will execute the retry policies if an error occurred when making the `Request`. It will iterate first through the `Request` retry policies (in the order the were specified), and then it will iterate through all the `Session` retry policies. The request will be retried with the specified delay as soon as the first retry policy says that the request should, in fact, be retried.

If none of the retry policies return that the request should be retried, then the request is handed over to the retrier in one was specified. The retrier can then also decide whether to retry the request. Since the retrier is an asynchronous API, it may take some additional time to determine whether the request should be retried or not.

```swift
public class Session {
    public func retryRequest(_ request: Request, ifNecessaryWithError error: Error) {
        for retryPolicy in retryPolicies(for: request) {
            let (shouldRetry, timeDelay) = retryPolicy.shouldRetry(request, with: error)

            if shouldRetry {
                // execute retry
                return
            }
        }

        // if we don't have a retrier, finish the request

        retrier.should(self, retry: request, with: error) { shouldRetry, retryInterval in
            if shouldRetry {
                // execute retry
            }
        }
    }
}
```

> The example above has been simplified for demonstration purposes.

### Testing Details :mag:

This PR contains tests covering the retry functionality in the session as well as full coverage unit tests for the connection lost and exponential backoff retry policies.

### FAQ

**Q: Why not build retry policy support into the `RequestRetrier` protocol?**

The `RequestAdapter` and `RequestRetrier` (combined to be `RequestInterceptor`) protocols were designed to handle authentication systems for sets of requests. For example, we have an `OAuthInterceptor` in our internal Nike networking library.

Retry policies are a completely different concept that are not tied to authentication. For example, if I want to automatically retry all idempotent requests that encounter a connection lost error, I would have to add that to all my different interceptors that I was using for all requests. Fair enough, that would be possible, but let's consider another scenario.

Let's say I also want to enable exponential backoff on a handful of service calls that span multiple authentication systems. How would you add exponential backoff to certain services and not others if they were attached at the interceptor level? You'd have to inspect the relative path of the `URLRequest` and determine which retry policies should be applied to it. While this can work for a few services, it doesn't scale well when you start to consider hundreds of services.

Instead, you'd much rather specify the retry policies associated with that particular request when creating the request. This is the same thing you'd like to do with the authentication system as well. If you want to use one session for multiple authentication systems, you need to support per-request interceptors.

**Q: For a big networking library, how would I most effectively use interceptors in conjunction with retry policies?**

Ideally, you are only using a single `Session` instance to power all of your networking. You would then want to implement all your authentication systems as different `RequestInterceptor` implementations. Each request made would specify which interceptor should be used to handle authentication. 

You'd then want to define all the retry policies you would want to apply to all your requests (this PR already adds two different ones that you could leverage). Then you'd need to decide which retry policies should be applied to all requests, and which ones should be applied to certain requests. The retry policies that should be applied to all requests should be set on the `Session`. The ones that should be applied to certain requests should be applied to each individual `Request`.