### PR TITLE
Use the hash(into:) API for hashing.

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -497,8 +497,8 @@ extension Request: Equatable {
 }
 
 extension Request: Hashable {
-    public var hashValue: Int {
-        return id.hashValue
+    public func hash(into hasher: inout Hasher) {
+        id.hash(into: &hasher)
     }
 }
 

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -498,7 +498,7 @@ extension Request: Equatable {
 
 extension Request: Hashable {
     public func hash(into hasher: inout Hasher) {
-        id.hash(into: &hasher)
+        hasher.combine(id)
     }
 }
 


### PR DESCRIPTION
### Goals :soccer:
This PR fixes a warning in Xcode by using the new `hash(into:)` API for `Hashable` on the `Request` type.

### Implementation Details :construction:
Instead of implementing `hashValue`, which has been deprecated, we use `hash(into:)` to hash into a `Hasher`. The value of `hashValue` will then come from the `Hasher`.

### Testing Details :mag:
This shouldn’t affect any tests, as none were dependent on `Request` having a deterministic `hashValue`.