### PR TITLE
Feature - Redirect Handlers

### DIFF
--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -298,6 +298,9 @@
 		4CFB030D1D7D2FA20056F249 /* utf8_string.txt in Resources */ = {isa = PBXBuildFile; fileRef = 4CFB02F41D7D2FA20056F249 /* utf8_string.txt */; };
 		4CFB030E1D7D2FA20056F249 /* utf8_string.txt in Resources */ = {isa = PBXBuildFile; fileRef = 4CFB02F41D7D2FA20056F249 /* utf8_string.txt */; };
 		4CFB030F1D7D2FA20056F249 /* utf8_string.txt in Resources */ = {isa = PBXBuildFile; fileRef = 4CFB02F41D7D2FA20056F249 /* utf8_string.txt */; };
+		4CFD6B102201145500FFB5E3 /* RedirectHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFD6B0F2201145500FFB5E3 /* RedirectHandlerTests.swift */; };
+		4CFD6B112201145500FFB5E3 /* RedirectHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFD6B0F2201145500FFB5E3 /* RedirectHandlerTests.swift */; };
+		4CFD6B122201145500FFB5E3 /* RedirectHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFD6B0F2201145500FFB5E3 /* RedirectHandlerTests.swift */; };
 		4DD67C241A5C58FB00ED2280 /* Alamofire.h in Headers */ = {isa = PBXBuildFile; fileRef = F8111E3819A95C8B0040E7D1 /* Alamofire.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4DD67C251A5C590000ED2280 /* Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = F897FF4019AA800700AB5182 /* Alamofire.swift */; };
 		8035DB621BAB492500466CB3 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8111E3319A95C8B0040E7D1 /* Alamofire.framework */; };
@@ -428,6 +431,7 @@
 		4CFB02F21D7D2FA20056F249 /* empty_string.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = empty_string.txt; sourceTree = "<group>"; };
 		4CFB02F31D7D2FA20056F249 /* utf32_string.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = utf32_string.txt; sourceTree = "<group>"; };
 		4CFB02F41D7D2FA20056F249 /* utf8_string.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = utf8_string.txt; sourceTree = "<group>"; };
+		4CFD6B0F2201145500FFB5E3 /* RedirectHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedirectHandlerTests.swift; sourceTree = "<group>"; };
 		4DD67C0B1A5C55C900ED2280 /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B39E2F831C1A72F8002DA1A9 /* certDER.cer */ = {isa = PBXFileReference; lastKnownFileType = file; name = certDER.cer; path = selfSignedAndMalformedCerts/certDER.cer; sourceTree = "<group>"; };
 		B39E2F841C1A72F8002DA1A9 /* certDER.crt */ = {isa = PBXFileReference; lastKnownFileType = file; name = certDER.crt; path = selfSignedAndMalformedCerts/certDER.crt; sourceTree = "<group>"; };
@@ -535,6 +539,7 @@
 				3113D46A21878227001CCD21 /* HTTPHeadersTests.swift */,
 				4C3238E61B3604DB00FE04AE /* MultipartFormDataTests.swift */,
 				4C3D00571C66A8B900D1F709 /* NetworkReachabilityManagerTests.swift */,
+				4CFD6B0F2201145500FFB5E3 /* RedirectHandlerTests.swift */,
 				4C0B58381B747A4400C0B99C /* ResponseSerializationTests.swift */,
 				4C33A1421B52089C00873DFF /* ServerTrustEvaluatorTests.swift */,
 				F86AEFE51AE6A282007D9C76 /* TLSEvaluationTests.swift */,
@@ -1334,6 +1339,7 @@
 				317A6A7820B2208000A9FEC5 /* DownloadTests.swift in Sources */,
 				31F9683E20BB70290009606F /* NSLoggingEventMonitor.swift in Sources */,
 				3113D46D21878227001CCD21 /* HTTPHeadersTests.swift in Sources */,
+				4CFD6B122201145500FFB5E3 /* RedirectHandlerTests.swift in Sources */,
 				31501E8A2196962A005829F2 /* ParameterEncoderTests.swift in Sources */,
 				3107EA4120A1267D00445260 /* SessionDelegateTests.swift in Sources */,
 				31C2B0EC20B271060089BA7C /* CacheTests.swift in Sources */,
@@ -1470,6 +1476,7 @@
 				317A6A7620B2207F00A9FEC5 /* DownloadTests.swift in Sources */,
 				31F9683C20BB70290009606F /* NSLoggingEventMonitor.swift in Sources */,
 				3113D46B21878227001CCD21 /* HTTPHeadersTests.swift in Sources */,
+				4CFD6B102201145500FFB5E3 /* RedirectHandlerTests.swift in Sources */,
 				31501E882196962A005829F2 /* ParameterEncoderTests.swift in Sources */,
 				3107EA3F20A1267C00445260 /* SessionDelegateTests.swift in Sources */,
 				31C2B0EA20B271040089BA7C /* CacheTests.swift in Sources */,
@@ -1501,6 +1508,7 @@
 				317A6A7720B2208000A9FEC5 /* DownloadTests.swift in Sources */,
 				31F9683D20BB70290009606F /* NSLoggingEventMonitor.swift in Sources */,
 				3113D46C21878227001CCD21 /* HTTPHeadersTests.swift in Sources */,
+				4CFD6B112201145500FFB5E3 /* RedirectHandlerTests.swift in Sources */,
 				31501E892196962A005829F2 /* ParameterEncoderTests.swift in Sources */,
 				3107EA4020A1267C00445260 /* SessionDelegateTests.swift in Sources */,
 				31C2B0EB20B271050089BA7C /* CacheTests.swift in Sources */,

--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -164,6 +164,10 @@
 		4C43669C1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C43669A1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift */; };
 		4C43669D1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C43669A1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift */; };
 		4C43669E1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C43669A1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift */; };
+		4C4466E621F2866000AC9703 /* RedirectHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4466E521F2866000AC9703 /* RedirectHandler.swift */; };
+		4C4466E721F2866000AC9703 /* RedirectHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4466E521F2866000AC9703 /* RedirectHandler.swift */; };
+		4C4466E821F2866000AC9703 /* RedirectHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4466E521F2866000AC9703 /* RedirectHandler.swift */; };
+		4C4466E921F2866000AC9703 /* RedirectHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4466E521F2866000AC9703 /* RedirectHandler.swift */; };
 		4C743CF61C22772D00BCB23E /* certDER.cer in Resources */ = {isa = PBXBuildFile; fileRef = B39E2F831C1A72F8002DA1A9 /* certDER.cer */; };
 		4C743CF71C22772D00BCB23E /* certDER.crt in Resources */ = {isa = PBXBuildFile; fileRef = B39E2F841C1A72F8002DA1A9 /* certDER.crt */; };
 		4C743CF81C22772D00BCB23E /* certDER.der in Resources */ = {isa = PBXBuildFile; fileRef = B39E2F851C1A72F8002DA1A9 /* certDER.der */; };
@@ -378,6 +382,7 @@
 		4C3D00531C66A63000D1F709 /* NetworkReachabilityManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachabilityManager.swift; sourceTree = "<group>"; };
 		4C3D00571C66A8B900D1F709 /* NetworkReachabilityManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachabilityManagerTests.swift; sourceTree = "<group>"; };
 		4C43669A1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+Alamofire.swift"; sourceTree = "<group>"; };
+		4C4466E521F2866000AC9703 /* RedirectHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedirectHandler.swift; sourceTree = "<group>"; };
 		4C811F8C1B51856D00E0F59A /* ServerTrustEvaluation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerTrustEvaluation.swift; sourceTree = "<group>"; };
 		4C812C3A1B535F220017E0BF /* alamofire-root-ca.cer */ = {isa = PBXFileReference; lastKnownFileType = file; name = "alamofire-root-ca.cer"; path = "alamofire.org/alamofire-root-ca.cer"; sourceTree = "<group>"; };
 		4C812C3D1B535F2E0017E0BF /* alamofire-signing-ca1.cer */ = {isa = PBXFileReference; lastKnownFileType = file; name = "alamofire-signing-ca1.cer"; path = "alamofire.org/alamofire-signing-ca1.cer"; sourceTree = "<group>"; };
@@ -697,6 +702,7 @@
 				4C23EB421B327C5B0090E0BC /* MultipartFormData.swift */,
 				311B198F20B0D3B40036823B /* MultipartUpload.swift */,
 				4C3D00531C66A63000D1F709 /* NetworkReachabilityManager.swift */,
+				4C4466E521F2866000AC9703 /* RedirectHandler.swift */,
 				319917AE209CE34E00103A19 /* RequestAdapter.swift */,
 				319917B3209CE36E00103A19 /* RequestRetrier.swift */,
 				4CDE2C451AF89FF300BABAE5 /* ResponseSerialization.swift */,
@@ -1294,6 +1300,7 @@
 				4C43669D1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift in Sources */,
 				4C3D00561C66A63000D1F709 /* NetworkReachabilityManager.swift in Sources */,
 				311B199220B0E3480036823B /* MultipartUpload.swift in Sources */,
+				4C4466E821F2866000AC9703 /* RedirectHandler.swift in Sources */,
 				319917A2209CDA7F00103A19 /* SessionStateProvider.swift in Sources */,
 				4CF6270A1BA7CBF60011A099 /* ParameterEncoding.swift in Sources */,
 				31991796209CDA7F00103A19 /* Request.swift in Sources */,
@@ -1359,6 +1366,7 @@
 				4C43669C1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift in Sources */,
 				4C811F8E1B51856D00E0F59A /* ServerTrustEvaluation.swift in Sources */,
 				311B199120B0E3470036823B /* MultipartUpload.swift in Sources */,
+				4C4466E721F2866000AC9703 /* RedirectHandler.swift in Sources */,
 				319917A1209CDA7F00103A19 /* SessionStateProvider.swift in Sources */,
 				4C3D00551C66A63000D1F709 /* NetworkReachabilityManager.swift in Sources */,
 				31991795209CDA7F00103A19 /* Request.swift in Sources */,
@@ -1393,6 +1401,7 @@
 				4C43669E1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift in Sources */,
 				E4202FD41B667AA100C997FB /* Alamofire.swift in Sources */,
 				311B199320B0E3480036823B /* MultipartUpload.swift in Sources */,
+				4C4466E921F2866000AC9703 /* RedirectHandler.swift in Sources */,
 				319917A3209CDA7F00103A19 /* SessionStateProvider.swift in Sources */,
 				E4202FD51B667AA100C997FB /* MultipartFormData.swift in Sources */,
 				31991797209CDA7F00103A19 /* Request.swift in Sources */,
@@ -1427,6 +1436,7 @@
 				4C43669B1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift in Sources */,
 				4C3D00541C66A63000D1F709 /* NetworkReachabilityManager.swift in Sources */,
 				311B199020B0D3B40036823B /* MultipartUpload.swift in Sources */,
+				4C4466E621F2866000AC9703 /* RedirectHandler.swift in Sources */,
 				319917A0209CDA7F00103A19 /* SessionStateProvider.swift in Sources */,
 				4CDE2C431AF89F0900BABAE5 /* Validation.swift in Sources */,
 				31991794209CDA7F00103A19 /* Request.swift in Sources */,

--- a/Source/RedirectHandler.swift
+++ b/Source/RedirectHandler.swift
@@ -1,0 +1,46 @@
+//
+//  RedirectHandler.swift
+//
+//  Copyright (c) 2014-2018 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+/// A type that handles how an HTTP redirect response from a remote server should be redirected to the new request.
+public protocol RedirectHandler {
+    /// Determines how the HTTP redirect response should be redirected to the new request.
+    ///
+    /// The `completion` closure should be passed one of three possible options:
+    ///
+    ///   1. The new request specified by the redirect (this is the most common use case).
+    ///   2. A modified version of the new request (you may want to route it somewhere else).
+    ///   3. A `nil` value to deny the redirect request and return the body of the redirect response.
+    ///
+    /// - Parameters:
+    ///   - task:       The task whose request resulted in a redirect.
+    ///   - request:    The URL request object to the new location specified by the redirect response.
+    ///   - response:   The response containing the server's response to the original request.
+    ///   - completion: The closure to execute containing the new request, a modified request, or `nil`.
+    func task(_ task: URLSessionTask,
+              willBeRedirectedTo request: URLRequest,
+              for response: HTTPURLResponse,
+              completion: @escaping (URLRequest?) -> Void)
+}

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -80,6 +80,8 @@ open class Request {
         var uploadProgressHandler: (handler: ProgressHandler, queue: DispatchQueue)?
         /// `ProgressHandler` and `DispatchQueue` provided for download progress callbacks.
         var downloadProgressHandler: (handler: ProgressHandler, queue: DispatchQueue)?
+        /// `RetryHandler` provided for redirect responses.
+        var redirectHandler: RedirectHandler?
         /// `URLCredential` used for authentication challenges.
         var credential: URLCredential?
         /// All `URLRequest`s created by Alamofire on behalf of the `Request`.
@@ -130,6 +132,13 @@ open class Request {
     fileprivate var downloadProgressHandler: (handler: ProgressHandler, queue: DispatchQueue)? {
         get { return protectedMutableState.directValue.downloadProgressHandler }
         set { protectedMutableState.write { $0.downloadProgressHandler = newValue } }
+    }
+
+    // Redirects
+
+    public private(set) var redirectHandler: RedirectHandler? {
+        get { return protectedMutableState.directValue.redirectHandler }
+        set { protectedMutableState.write { $0.redirectHandler = newValue } }
     }
 
     // Credential
@@ -197,7 +206,6 @@ open class Request {
         get { return protectedMutableState.directValue.error }
         set { protectedMutableState.write { $0.error = newValue } }
     }
-
 
     /// Default initializer for the `Request` superclass.
     ///
@@ -484,6 +492,18 @@ open class Request {
     open func uploadProgress(queue: DispatchQueue = .main, closure: @escaping ProgressHandler) -> Self {
         protectedMutableState.write { $0.uploadProgressHandler = (handler: closure, queue: queue) }
 
+        return self
+    }
+
+    // MARK: - Redirects
+
+    /// Sets the redirect handler for the `Request` which will be used if a redirect response is encountered.
+    ///
+    /// - Parameter handler: The redirect handler.
+    /// - Returns: The `Request`.
+    @discardableResult
+    open func redirect(with handler: RedirectHandler) -> Self {
+        protectedMutableState.write { $0.redirectHandler = handler }
         return self
     }
 }

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -460,13 +460,6 @@ open class Request {
 
     /// Sets a closure to be called periodically during the lifecycle of the `Request` as data is read from the server.
     ///
-    /// - parameter queue:   The dispatch queue to execute the closure on.
-    /// - parameter closure: The code to be executed periodically as data is read from the server.
-    ///
-    /// - returns: The request.
-
-    /// Sets a closure to be called periodically during the lifecycle of the `Request` as data is read from the server.
-    ///
     /// Only the last closure provided is used.
     ///
     /// - Parameters:
@@ -499,11 +492,15 @@ open class Request {
 
     /// Sets the redirect handler for the `Request` which will be used if a redirect response is encountered.
     ///
-    /// - Parameter handler: The redirect handler.
-    /// - Returns: The `Request`.
+    /// - Parameter handler: The `RedirectHandler`.
+    /// - Returns:           The `Request`.
     @discardableResult
-    open func redirect(with handler: RedirectHandler) -> Self {
-        protectedMutableState.write { $0.redirectHandler = handler }
+    open func redirect(using handler: RedirectHandler) -> Self {
+        protectedMutableState.write { mutableState in
+            precondition(mutableState.redirectHandler == nil, "Redirect handler has already set")
+            mutableState.redirectHandler = handler
+        }
+
         return self
     }
 }

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -34,6 +34,7 @@ open class Session {
     public let adapter: RequestAdapter?
     public let retrier: RequestRetrier?
     public let serverTrustManager: ServerTrustManager?
+    public let redirectHandler: RedirectHandler?
 
     public let session: URLSession
     public let eventMonitor: CompositeEventMonitor
@@ -49,8 +50,9 @@ open class Session {
                 requestQueue: DispatchQueue? = nil,
                 serializationQueue: DispatchQueue? = nil,
                 adapter: RequestAdapter? = nil,
-                serverTrustManager: ServerTrustManager? = nil,
                 retrier: RequestRetrier? = nil,
+                serverTrustManager: ServerTrustManager? = nil,
+                redirectHandler: RedirectHandler? = nil,
                 eventMonitors: [EventMonitor] = []) {
         precondition(session.delegate === delegate,
                      "SessionManager(session:) initializer must be passed the delegate that has been assigned to the URLSession as the SessionDataProvider.")
@@ -66,6 +68,7 @@ open class Session {
         self.adapter = adapter
         self.retrier = retrier
         self.serverTrustManager = serverTrustManager
+        self.redirectHandler = redirectHandler
         eventMonitor = CompositeEventMonitor(monitors: defaultEventMonitors + eventMonitors)
         delegate.eventMonitor = eventMonitor
         delegate.stateProvider = self
@@ -78,8 +81,9 @@ open class Session {
                             requestQueue: DispatchQueue? = nil,
                             serializationQueue: DispatchQueue? = nil,
                             adapter: RequestAdapter? = nil,
-                            serverTrustManager: ServerTrustManager? = nil,
                             retrier: RequestRetrier? = nil,
+                            serverTrustManager: ServerTrustManager? = nil,
+                            redirectHandler: RedirectHandler? = nil,
                             eventMonitors: [EventMonitor] = []) {
         let delegateQueue = OperationQueue(maxConcurrentOperationCount: 1, underlyingQueue: rootQueue, name: "org.alamofire.sessionManager.sessionDelegateQueue")
         let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: delegateQueue)
@@ -90,8 +94,9 @@ open class Session {
                   requestQueue: requestQueue,
                   serializationQueue: serializationQueue,
                   adapter: adapter,
-                  serverTrustManager: serverTrustManager,
                   retrier: retrier,
+                  serverTrustManager: serverTrustManager,
+                  redirectHandler: redirectHandler,
                   eventMonitors: eventMonitors)
     }
 
@@ -525,7 +530,7 @@ extension Session: RequestDelegate {
     }
 }
 
-// MARK: - SessionDelegateDelegate
+// MARK: - SessionStateProvider
 
 extension Session: SessionStateProvider {
     public func request(for task: URLSessionTask) -> Request? {

--- a/Source/SessionStateProvider.swift
+++ b/Source/SessionStateProvider.swift
@@ -28,6 +28,7 @@ public protocol SessionStateProvider: AnyObject {
     func request(for task: URLSessionTask) -> Request?
     func didCompleteTask(_ task: URLSessionTask)
     var serverTrustManager: ServerTrustManager? { get }
+    var redirectHandler: RedirectHandler? { get }
     func credential(for task: URLSessionTask, protectionSpace: URLProtectionSpace) -> URLCredential?
 }
 
@@ -145,7 +146,11 @@ extension SessionDelegate: URLSessionTaskDelegate {
                          completionHandler: @escaping (URLRequest?) -> Void) {
         eventMonitor?.urlSession(session, task: task, willPerformHTTPRedirection: response, newRequest: request)
 
-        completionHandler(request)
+        if let redirectHandler = stateProvider?.request(for: task)?.redirectHandler ?? stateProvider?.redirectHandler {
+            redirectHandler.task(task, willBeRedirectedTo: request, for: response, completion: completionHandler)
+        } else {
+            completionHandler(request)
+        }
     }
 
     open func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {

--- a/Tests/RedirectHandlerTests.swift
+++ b/Tests/RedirectHandlerTests.swift
@@ -1,0 +1,224 @@
+//
+//  RedirectHandlerTests.swift
+//
+//  Copyright (c) 2019 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Alamofire
+import Foundation
+import XCTest
+
+final class RedirectHandlerTestCase: BaseTestCase {
+
+    // MARK: - Properties
+
+    private var redirectURLString: String { return "https://www.apple.com/" }
+    private var urlString: String { return "https://httpbin.org/redirect-to?url=\(redirectURLString)" }
+
+    // MARK: - Tests - Per Request
+
+    func testThatRequestRedirectHandlerCanFollowRedirects() {
+        // Given
+        let session = Session()
+
+        var response: DataResponse<Data?>?
+        let expectation = self.expectation(description: "Request should redirect to \(redirectURLString)")
+
+        // When
+        session.request(urlString).redirect(using: Redirector.follow).response { resp in
+            response = resp
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertNil(response?.error)
+
+        XCTAssertEqual(response?.response?.url?.absoluteString, redirectURLString)
+        XCTAssertEqual(response?.response?.statusCode, 200)
+    }
+
+    func testThatRequestRedirectHandlerCanNotFollowRedirects() {
+        // Given
+        let session = Session()
+
+        var response: DataResponse<Data?>?
+        let expectation = self.expectation(description: "Request should NOT redirect to \(redirectURLString)")
+
+        // When
+        session.request(urlString).redirect(using: Redirector.doNotFollow).response { resp in
+            response = resp
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNil(response?.data)
+        XCTAssertNil(response?.error)
+
+        XCTAssertEqual(response?.response?.url?.absoluteString, urlString)
+        XCTAssertEqual(response?.response?.statusCode, 302)
+    }
+
+    func testThatRequestRedirectHandlerCanModifyRedirects() {
+        // Given
+        let session = Session()
+        let redirectURLString = "https://www.nike.com"
+        let redirectURLRequest = URLRequest(url: URL(string: redirectURLString)!)
+
+        var response: DataResponse<Data?>?
+        let expectation = self.expectation(description: "Request should redirect to \(redirectURLString)")
+
+        // When
+        let redirector = Redirector(behavior: .modify { _, _, _ in redirectURLRequest })
+
+        session.request(urlString).redirect(using: redirector).response { resp in
+            response = resp
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertNil(response?.error)
+
+        XCTAssertEqual(response?.response?.url?.absoluteString, redirectURLString)
+        XCTAssertEqual(response?.response?.statusCode, 200)
+    }
+
+    // MARK: - Tests - Per Session
+
+    func testThatSessionRedirectHandlerCanFollowRedirects() {
+        // Given
+        let session = Session(redirectHandler: Redirector.follow)
+
+        var response: DataResponse<Data?>?
+        let expectation = self.expectation(description: "Request should redirect to \(redirectURLString)")
+
+        // When
+        session.request(urlString).response { resp in
+            response = resp
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertNil(response?.error)
+
+        XCTAssertEqual(response?.response?.url?.absoluteString, redirectURLString)
+        XCTAssertEqual(response?.response?.statusCode, 200)
+    }
+
+    func testThatSessionRedirectHandlerCanNotFollowRedirects() {
+        // Given
+        let session = Session(redirectHandler: Redirector.doNotFollow)
+
+        var response: DataResponse<Data?>?
+        let expectation = self.expectation(description: "Request should NOT redirect to \(redirectURLString)")
+
+        // When
+        session.request(urlString).response { resp in
+            response = resp
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNil(response?.data)
+        XCTAssertNil(response?.error)
+
+        XCTAssertEqual(response?.response?.url?.absoluteString, urlString)
+        XCTAssertEqual(response?.response?.statusCode, 302)
+    }
+
+    func testThatSessionRedirectHandlerCanModifyRedirects() {
+        // Given
+        let redirectURLString = "https://www.nike.com"
+        let redirectURLRequest = URLRequest(url: URL(string: redirectURLString)!)
+
+        let redirector = Redirector(behavior: .modify { _, _, _ in redirectURLRequest })
+        let session = Session(redirectHandler: redirector)
+
+        var response: DataResponse<Data?>?
+        let expectation = self.expectation(description: "Request should redirect to \(redirectURLString)")
+
+        // When
+        session.request(urlString).response { resp in
+            response = resp
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertNil(response?.error)
+
+        XCTAssertEqual(response?.response?.url?.absoluteString, redirectURLString)
+        XCTAssertEqual(response?.response?.statusCode, 200)
+    }
+
+    // MARK: - Tests - Per Request Prioritization
+
+    func testThatRequestRedirectHandlerIsPrioritizedOverSessionRedirectHandler() {
+        // Given
+        let session = Session(redirectHandler: Redirector.doNotFollow)
+
+        var response: DataResponse<Data?>?
+        let expectation = self.expectation(description: "Request should redirect to \(redirectURLString)")
+
+        // When
+        session.request(urlString).redirect(using: Redirector.follow).response { resp in
+            response = resp
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertNil(response?.error)
+
+        XCTAssertEqual(response?.response?.url?.absoluteString, redirectURLString)
+        XCTAssertEqual(response?.response?.statusCode, 200)
+    }
+}


### PR DESCRIPTION
This PR adds a `RedirectHandler` protocol which is leveraged as a `redirectHandler` property on both the `Request` and `Session` APIs. It allows clients full control over redirect behavior at the `Session` level, as well as at the `Request` level through a chainable `redirect` API.

> This is an alternative approach to #2563.

### Goals :soccer:

The goals of this PR are to:

- Add support to AF5 for customizing redirect behavior at the `Session` level to match AF4.x functionality
- Add support to AF5 for customizing redirect behavior per `Request` to make it easier to implement simple redirect logic for a single request

### Implementation Details :construction:

Currently, in AF 4.x, you can control redirect behavior only at the `SessionDelegate` level by either subclassing or setting the `taskWillPerformHTTPRedirectionWithCompletion` closure property. While this gives you the ability to control redirect behavior, it's pretty clunky. The changes in AF5 have cleaned this up a bunch, but do not currently expose the ability to control redirect behavior.

> You can currently subclass `SessionDelegate`, but the properties needed to customize the functionality are `internal` or `private`.

#### RedirectHandler Protocol

In this PR, I added a `RedirectHandler` protocol which contains a single API for determining what to do with a redirect response.

```swift
public protocol RedirectHandler {
    func task(_ task: URLSessionTask,
              willBeRedirectedTo request: URLRequest,
              for response: HTTPURLResponse,
              completion: @escaping (URLRequest?) -> Void)
}
```

This protocol is then added to a `Session` through the initializer and made available through a `redirectHandler` property. It can also be added to a `Request` through the new `redirect` chainable API. The nice thing about having the logic abstracted into a protocol is that it's much easier to share the functionality between a `Session` and `Request` instead of having custom ways of handling redirects between the two.

#### Redirect Control per Request

This is a really cool addition to Alamofire. Right now, you have no way to control redirect behavior per request. It's only configuring at the `SessionManager` level (or per session). Therefore, you need to use request introspection on the `URLSessionTask`'s originalRequest and hope that you can dig the info you need out to determine the redirect behavior.

For example, you may need to provide custom redirect behavior for a bunch of different endpoints. In order to implement this, your closure has to keep a custom map of the different endpoints and their matching redirect behaviors. They also might all redirect differently. Then you may also have different behaviors with different test subdomains, etc. It can quickly grow out of control.

Instead, in most cases, you'd rather implement the custom redirect logic at the time of creation of the request. That makes it MUCH easier to simply pair up the custom redirect logic with the actual request. Then you no longer need to maintain a map and perform all the introspection at the session level.

#### Redirect Closure on `Request`

I purposefully left out support in this PR for `redirect` support through a closure API. While it would be a nice addition, it creates an odd mismatch between `Request` and `Session`. We wouldn't want to support both the protocol and closure variants in the `Session`, but we probably would in the `Request`. Therefore, it seemed odd to add the closure variant only to the `Request`. If we did decide to add it, it would be something like this:

```swift
extension Request {
    public typealias RedirectClosure = (URLSessionTask, URLRequest, HTTPURLResponse, @escaping (URLRequest?) -> Void) -> Void

    @discardableResult
    open func redirect(closure: RedirectClosure) -> Self {
        protectedMutableState.write { $0.redirectClosure = closure }
        return self
    }
}
```

Then we'd have to add another fallback case in the `SessionDelegate` implementation to first grab the `redirectHandler`, then the `redirectClosure`, and then the `redirectHandler` on the `Session`. We could also only store the `redirectClosure` on the `Request` and grab the function pointer to the `RedirectHandler` API and set it as the `redirectClosure`. Then you'd have to grab the `redirectClosure` for a `Request` and `redirectHandler` for a `Session`, each of which are called differently in the `SessionDelegate`.

> Again, I chose to avoid this complexity for redirects by not providing a closure API for redirects. We could certainly add it though if everyone feels the convenience outweighs the implementation complexity.

### Testing Details :mag:

I have intentionally left tests out of this PR until we agree that this is the direction we'd like to take for this particular feature. Once the approach is locked, I'll add the appropriate tests.

**Update**

Tests have been added for per request and per session redirect handlers as well as prioritization of request over session.