### PR TITLE
Feature - Cached Responses

### DIFF
--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -305,6 +305,9 @@
 		4CFD6B102201145500FFB5E3 /* RedirectHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFD6B0F2201145500FFB5E3 /* RedirectHandlerTests.swift */; };
 		4CFD6B112201145500FFB5E3 /* RedirectHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFD6B0F2201145500FFB5E3 /* RedirectHandlerTests.swift */; };
 		4CFD6B122201145500FFB5E3 /* RedirectHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFD6B0F2201145500FFB5E3 /* RedirectHandlerTests.swift */; };
+		4CFD6B142201338E00FFB5E3 /* CachedResponseHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFD6B132201338E00FFB5E3 /* CachedResponseHandlerTests.swift */; };
+		4CFD6B152201338E00FFB5E3 /* CachedResponseHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFD6B132201338E00FFB5E3 /* CachedResponseHandlerTests.swift */; };
+		4CFD6B162201338E00FFB5E3 /* CachedResponseHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFD6B132201338E00FFB5E3 /* CachedResponseHandlerTests.swift */; };
 		4DD67C241A5C58FB00ED2280 /* Alamofire.h in Headers */ = {isa = PBXBuildFile; fileRef = F8111E3819A95C8B0040E7D1 /* Alamofire.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4DD67C251A5C590000ED2280 /* Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = F897FF4019AA800700AB5182 /* Alamofire.swift */; };
 		8035DB621BAB492500466CB3 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8111E3319A95C8B0040E7D1 /* Alamofire.framework */; };
@@ -437,6 +440,7 @@
 		4CFB02F31D7D2FA20056F249 /* utf32_string.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = utf32_string.txt; sourceTree = "<group>"; };
 		4CFB02F41D7D2FA20056F249 /* utf8_string.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = utf8_string.txt; sourceTree = "<group>"; };
 		4CFD6B0F2201145500FFB5E3 /* RedirectHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedirectHandlerTests.swift; sourceTree = "<group>"; };
+		4CFD6B132201338E00FFB5E3 /* CachedResponseHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedResponseHandlerTests.swift; sourceTree = "<group>"; };
 		4DD67C0B1A5C55C900ED2280 /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B39E2F831C1A72F8002DA1A9 /* certDER.cer */ = {isa = PBXFileReference; lastKnownFileType = file; name = certDER.cer; path = selfSignedAndMalformedCerts/certDER.cer; sourceTree = "<group>"; };
 		B39E2F841C1A72F8002DA1A9 /* certDER.crt */ = {isa = PBXFileReference; lastKnownFileType = file; name = certDER.crt; path = selfSignedAndMalformedCerts/certDER.crt; sourceTree = "<group>"; };
@@ -540,6 +544,7 @@
 		4C256A4F1B09656E0065714F /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				4CFD6B132201338E00FFB5E3 /* CachedResponseHandlerTests.swift */,
 				4C341BB91B1A865A00C1B34D /* CacheTests.swift */,
 				3113D46A21878227001CCD21 /* HTTPHeadersTests.swift */,
 				4C3238E61B3604DB00FE04AE /* MultipartFormDataTests.swift */,
@@ -1333,6 +1338,7 @@
 				3111CE9420A7EC32008315E2 /* ResponseSerializationTests.swift in Sources */,
 				3111CE8E20A7EBE7008315E2 /* MultipartFormDataTests.swift in Sources */,
 				311B199620B0ED990036823B /* UploadTests.swift in Sources */,
+				4CFD6B162201338E00FFB5E3 /* CachedResponseHandlerTests.swift in Sources */,
 				3107EA3720A11AE200445260 /* AuthenticationTests.swift in Sources */,
 				31ED52EA1D73891C00199085 /* AFError+AlamofireTests.swift in Sources */,
 				3107EA3A20A11F9700445260 /* ResponseTests.swift in Sources */,
@@ -1473,6 +1479,7 @@
 				3111CE9220A7EC30008315E2 /* ResponseSerializationTests.swift in Sources */,
 				3111CE8C20A7EBE6008315E2 /* MultipartFormDataTests.swift in Sources */,
 				311B199420B0ED980036823B /* UploadTests.swift in Sources */,
+				4CFD6B142201338E00FFB5E3 /* CachedResponseHandlerTests.swift in Sources */,
 				3107EA3520A11AE100445260 /* AuthenticationTests.swift in Sources */,
 				4CFB02901D7CF28F0056F249 /* FileManager+AlamofireTests.swift in Sources */,
 				3107EA3820A11F9600445260 /* ResponseTests.swift in Sources */,
@@ -1505,6 +1512,7 @@
 				3111CE9320A7EC31008315E2 /* ResponseSerializationTests.swift in Sources */,
 				3111CE8D20A7EBE7008315E2 /* MultipartFormDataTests.swift in Sources */,
 				311B199520B0ED980036823B /* UploadTests.swift in Sources */,
+				4CFD6B152201338E00FFB5E3 /* CachedResponseHandlerTests.swift in Sources */,
 				3107EA3620A11AE100445260 /* AuthenticationTests.swift in Sources */,
 				4CFB02911D7CF28F0056F249 /* FileManager+AlamofireTests.swift in Sources */,
 				3107EA3920A11F9600445260 /* ResponseTests.swift in Sources */,

--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -168,6 +168,10 @@
 		4C4466E721F2866000AC9703 /* RedirectHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4466E521F2866000AC9703 /* RedirectHandler.swift */; };
 		4C4466E821F2866000AC9703 /* RedirectHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4466E521F2866000AC9703 /* RedirectHandler.swift */; };
 		4C4466E921F2866000AC9703 /* RedirectHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4466E521F2866000AC9703 /* RedirectHandler.swift */; };
+		4C4466EB21F8F5D800AC9703 /* CachedResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4466EA21F8F5D800AC9703 /* CachedResponseHandler.swift */; };
+		4C4466EC21F8F5D800AC9703 /* CachedResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4466EA21F8F5D800AC9703 /* CachedResponseHandler.swift */; };
+		4C4466ED21F8F5D800AC9703 /* CachedResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4466EA21F8F5D800AC9703 /* CachedResponseHandler.swift */; };
+		4C4466EE21F8F5D800AC9703 /* CachedResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4466EA21F8F5D800AC9703 /* CachedResponseHandler.swift */; };
 		4C743CF61C22772D00BCB23E /* certDER.cer in Resources */ = {isa = PBXBuildFile; fileRef = B39E2F831C1A72F8002DA1A9 /* certDER.cer */; };
 		4C743CF71C22772D00BCB23E /* certDER.crt in Resources */ = {isa = PBXBuildFile; fileRef = B39E2F841C1A72F8002DA1A9 /* certDER.crt */; };
 		4C743CF81C22772D00BCB23E /* certDER.der in Resources */ = {isa = PBXBuildFile; fileRef = B39E2F851C1A72F8002DA1A9 /* certDER.der */; };
@@ -386,6 +390,7 @@
 		4C3D00571C66A8B900D1F709 /* NetworkReachabilityManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachabilityManagerTests.swift; sourceTree = "<group>"; };
 		4C43669A1D7BB93D00C38AAD /* DispatchQueue+Alamofire.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+Alamofire.swift"; sourceTree = "<group>"; };
 		4C4466E521F2866000AC9703 /* RedirectHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedirectHandler.swift; sourceTree = "<group>"; };
+		4C4466EA21F8F5D800AC9703 /* CachedResponseHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedResponseHandler.swift; sourceTree = "<group>"; };
 		4C811F8C1B51856D00E0F59A /* ServerTrustEvaluation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerTrustEvaluation.swift; sourceTree = "<group>"; };
 		4C812C3A1B535F220017E0BF /* alamofire-root-ca.cer */ = {isa = PBXFileReference; lastKnownFileType = file; name = "alamofire-root-ca.cer"; path = "alamofire.org/alamofire-root-ca.cer"; sourceTree = "<group>"; };
 		4C812C3D1B535F2E0017E0BF /* alamofire-signing-ca1.cer */ = {isa = PBXFileReference; lastKnownFileType = file; name = "alamofire-signing-ca1.cer"; path = "alamofire.org/alamofire-signing-ca1.cer"; sourceTree = "<group>"; };
@@ -703,6 +708,7 @@
 		4CDE2C491AF8A14E00BABAE5 /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				4C4466EA21F8F5D800AC9703 /* CachedResponseHandler.swift */,
 				3111CE8720A77843008315E2 /* EventMonitor.swift */,
 				4C23EB421B327C5B0090E0BC /* MultipartFormData.swift */,
 				311B198F20B0D3B40036823B /* MultipartUpload.swift */,
@@ -1306,6 +1312,7 @@
 				4C3D00561C66A63000D1F709 /* NetworkReachabilityManager.swift in Sources */,
 				311B199220B0E3480036823B /* MultipartUpload.swift in Sources */,
 				4C4466E821F2866000AC9703 /* RedirectHandler.swift in Sources */,
+				4C4466ED21F8F5D800AC9703 /* CachedResponseHandler.swift in Sources */,
 				319917A2209CDA7F00103A19 /* SessionStateProvider.swift in Sources */,
 				4CF6270A1BA7CBF60011A099 /* ParameterEncoding.swift in Sources */,
 				31991796209CDA7F00103A19 /* Request.swift in Sources */,
@@ -1373,6 +1380,7 @@
 				4C811F8E1B51856D00E0F59A /* ServerTrustEvaluation.swift in Sources */,
 				311B199120B0E3470036823B /* MultipartUpload.swift in Sources */,
 				4C4466E721F2866000AC9703 /* RedirectHandler.swift in Sources */,
+				4C4466EC21F8F5D800AC9703 /* CachedResponseHandler.swift in Sources */,
 				319917A1209CDA7F00103A19 /* SessionStateProvider.swift in Sources */,
 				4C3D00551C66A63000D1F709 /* NetworkReachabilityManager.swift in Sources */,
 				31991795209CDA7F00103A19 /* Request.swift in Sources */,
@@ -1408,6 +1416,7 @@
 				E4202FD41B667AA100C997FB /* Alamofire.swift in Sources */,
 				311B199320B0E3480036823B /* MultipartUpload.swift in Sources */,
 				4C4466E921F2866000AC9703 /* RedirectHandler.swift in Sources */,
+				4C4466EE21F8F5D800AC9703 /* CachedResponseHandler.swift in Sources */,
 				319917A3209CDA7F00103A19 /* SessionStateProvider.swift in Sources */,
 				E4202FD51B667AA100C997FB /* MultipartFormData.swift in Sources */,
 				31991797209CDA7F00103A19 /* Request.swift in Sources */,
@@ -1443,6 +1452,7 @@
 				4C3D00541C66A63000D1F709 /* NetworkReachabilityManager.swift in Sources */,
 				311B199020B0D3B40036823B /* MultipartUpload.swift in Sources */,
 				4C4466E621F2866000AC9703 /* RedirectHandler.swift in Sources */,
+				4C4466EB21F8F5D800AC9703 /* CachedResponseHandler.swift in Sources */,
 				319917A0209CDA7F00103A19 /* SessionStateProvider.swift in Sources */,
 				4CDE2C431AF89F0900BABAE5 /* Validation.swift in Sources */,
 				31991794209CDA7F00103A19 /* Request.swift in Sources */,

--- a/Source/CachedResponseHandler.swift
+++ b/Source/CachedResponseHandler.swift
@@ -1,0 +1,92 @@
+//
+//  CachedResponseHandler.swift
+//
+//  Copyright (c) 2019 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+/// A type that handles whether the data task should store the HTTP response in the cache.
+public protocol CachedResponseHandler {
+    /// Determines whether the HTTP response should be stored in the cache.
+    ///
+    /// The `completion` closure should be passed one of three possible options:
+    ///
+    ///   1. The cached response provided by the server (this is the most common use case).
+    ///   2. A modified version of the cached response (you may want to modify it in some way before caching).
+    ///   3. A `nil` value to prevent the cached response from being stored in the cache.
+    ///
+    /// - Parameters:
+    ///   - task: The data task whose request resulted in the cached response.
+    ///   - response: The cached response to potentially store in the cache.
+    ///   - completion: The closure to execute containing cached response, a modified response, or `nil`.
+    func dataTask(_ task: URLSessionDataTask,
+                  willCacheResponse response: CachedURLResponse,
+                  completion: @escaping (CachedURLResponse?) -> Void)
+}
+
+// MARK: -
+
+/// `ResponseCacher` is a convenience `CachedResponseHandler` making it easy to cache, not cache, or modify a cached
+/// response.
+public struct ResponseCacher {
+    /// Defines the behavior of the `ResponseCacher` type.
+    ///
+    /// - cache:      Stores the cached response in the cache.
+    /// - doNotCache: Prevents the cached response from being stored in the cache.
+    /// - modify:     Modifies the cached response before storing it in the cache.
+    public enum Behavior {
+        case cache
+        case doNotCache
+        case modify((URLSessionDataTask, CachedURLResponse) -> CachedURLResponse?)
+    }
+
+    /// Returns a `ResponseCacher` with a follow `Behavior`.
+    public static let cache = ResponseCacher(behavior: .cache)
+    /// Returns a `ResponseCacher` with a do not follow `Behavior`.
+    public static let doNotCache = ResponseCacher(behavior: .doNotCache)
+
+    /// The `Behavior` of the `ResponseCacher`.
+    public let behavior: Behavior
+
+    /// Creates a `ResponseCacher` instance from the `Behavior`.
+    ///
+    /// - Parameter behavior: The `Behavior`.
+    public init(behavior: Behavior) {
+        self.behavior = behavior
+    }
+}
+
+extension ResponseCacher: CachedResponseHandler {
+    public func dataTask(_ task: URLSessionDataTask,
+                         willCacheResponse response: CachedURLResponse,
+                         completion: @escaping (CachedURLResponse?) -> Void) {
+        switch behavior {
+        case .cache:
+            completion(response)
+        case .doNotCache:
+            completion(nil)
+        case .modify(let closure):
+            let response = closure(task, response)
+            completion(response)
+        }
+    }
+}

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -515,9 +515,17 @@ open class Request {
 
     // MARK: - Cached Responses
 
+    /// Sets the cached response handler for the `Request` which will be used when attempting to cache a response.
+    ///
+    /// - Parameter handler: The `CachedResponseHandler`.
+    /// - Returns:           The `Request`.
     @discardableResult
-    open func cacheResponse(with handler: CachedResponseHandler) -> Self {
-        protectedMutableState.write { $0.cachedResponseHandler = handler }
+    open func cacheResponse(using handler: CachedResponseHandler) -> Self {
+        protectedMutableState.write { mutableState in
+            precondition(mutableState.cachedResponseHandler == nil, "Cached response handler has already been set")
+            mutableState.cachedResponseHandler = handler
+        }
+
         return self
     }
 }

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -82,6 +82,8 @@ open class Request {
         var downloadProgressHandler: (handler: ProgressHandler, queue: DispatchQueue)?
         /// `RetryHandler` provided for redirect responses.
         var redirectHandler: RedirectHandler?
+        /// `CachedResponseHandler` provided to handle caching responses.
+        var cachedResponseHandler: CachedResponseHandler?
         /// `URLCredential` used for authentication challenges.
         var credential: URLCredential?
         /// All `URLRequest`s created by Alamofire on behalf of the `Request`.
@@ -139,6 +141,13 @@ open class Request {
     public private(set) var redirectHandler: RedirectHandler? {
         get { return protectedMutableState.directValue.redirectHandler }
         set { protectedMutableState.write { $0.redirectHandler = newValue } }
+    }
+
+    // Cached Responses
+
+    public private(set) var cachedResponseHandler: CachedResponseHandler? {
+        get { return protectedMutableState.directValue.cachedResponseHandler }
+        set { protectedMutableState.write { $0.cachedResponseHandler = newValue } }
     }
 
     // Credential
@@ -501,6 +510,14 @@ open class Request {
             mutableState.redirectHandler = handler
         }
 
+        return self
+    }
+
+    // MARK: - Cached Responses
+
+    @discardableResult
+    open func cacheResponse(with handler: CachedResponseHandler) -> Self {
+        protectedMutableState.write { $0.cachedResponseHandler = handler }
         return self
     }
 }

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -506,7 +506,7 @@ open class Request {
     @discardableResult
     open func redirect(using handler: RedirectHandler) -> Self {
         protectedMutableState.write { mutableState in
-            precondition(mutableState.redirectHandler == nil, "Redirect handler has already set")
+            precondition(mutableState.redirectHandler == nil, "Redirect handler has already been set")
             mutableState.redirectHandler = handler
         }
 

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -35,6 +35,7 @@ open class Session {
     public let retrier: RequestRetrier?
     public let serverTrustManager: ServerTrustManager?
     public let redirectHandler: RedirectHandler?
+    public let cachedResponseHandler: CachedResponseHandler?
 
     public let session: URLSession
     public let eventMonitor: CompositeEventMonitor
@@ -53,6 +54,7 @@ open class Session {
                 retrier: RequestRetrier? = nil,
                 serverTrustManager: ServerTrustManager? = nil,
                 redirectHandler: RedirectHandler? = nil,
+                cachedResponseHandler: CachedResponseHandler? = nil,
                 eventMonitors: [EventMonitor] = []) {
         precondition(session.delegate === delegate,
                      "SessionManager(session:) initializer must be passed the delegate that has been assigned to the URLSession as the SessionDataProvider.")
@@ -69,6 +71,7 @@ open class Session {
         self.retrier = retrier
         self.serverTrustManager = serverTrustManager
         self.redirectHandler = redirectHandler
+        self.cachedResponseHandler = cachedResponseHandler
         eventMonitor = CompositeEventMonitor(monitors: defaultEventMonitors + eventMonitors)
         delegate.eventMonitor = eventMonitor
         delegate.stateProvider = self
@@ -84,6 +87,7 @@ open class Session {
                             retrier: RequestRetrier? = nil,
                             serverTrustManager: ServerTrustManager? = nil,
                             redirectHandler: RedirectHandler? = nil,
+                            cachedResponseHandler: CachedResponseHandler? = nil,
                             eventMonitors: [EventMonitor] = []) {
         let delegateQueue = OperationQueue(maxConcurrentOperationCount: 1, underlyingQueue: rootQueue, name: "org.alamofire.sessionManager.sessionDelegateQueue")
         let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: delegateQueue)
@@ -97,6 +101,7 @@ open class Session {
                   retrier: retrier,
                   serverTrustManager: serverTrustManager,
                   redirectHandler: redirectHandler,
+                  cachedResponseHandler: cachedResponseHandler,
                   eventMonitors: eventMonitors)
     }
 

--- a/Source/SessionStateProvider.swift
+++ b/Source/SessionStateProvider.swift
@@ -29,6 +29,7 @@ public protocol SessionStateProvider: AnyObject {
     func didCompleteTask(_ task: URLSessionTask)
     var serverTrustManager: ServerTrustManager? { get }
     var redirectHandler: RedirectHandler? { get }
+    var cachedResponseHandler: CachedResponseHandler? { get }
     func credential(for task: URLSessionTask, protectionSpace: URLProtectionSpace) -> URLCredential?
 }
 
@@ -190,7 +191,11 @@ extension SessionDelegate: URLSessionDataDelegate {
                          completionHandler: @escaping (CachedURLResponse?) -> Void) {
         eventMonitor?.urlSession(session, dataTask: dataTask, willCacheResponse: proposedResponse)
 
-        completionHandler(proposedResponse)
+        if let handler = stateProvider?.request(for: dataTask)?.cachedResponseHandler ?? stateProvider?.cachedResponseHandler {
+            handler.dataTask(dataTask, willCacheResponse: proposedResponse, completion: completionHandler)
+        } else {
+            completionHandler(proposedResponse)
+        }
     }
 }
 

--- a/Tests/CachedResponseHandlerTests.swift
+++ b/Tests/CachedResponseHandlerTests.swift
@@ -1,0 +1,226 @@
+//
+//  CachedResponseHandlerTests.swift
+//
+//  Copyright (c) 2019 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Alamofire
+import Foundation
+import XCTest
+
+final class CachedResponseHandlerTestCase: BaseTestCase {
+
+    // MARK: Properties
+
+    private let urlString = "https://httpbin.org/get"
+
+    // MARK: Tests - Per Request
+
+    func testThatRequestCachedResponseHandlerCanCacheResponse() {
+        // Given
+        let session = self.session()
+
+        var response: DataResponse<Data?>?
+        let expectation = self.expectation(description: "Request should cache response")
+
+        // When
+        let request = session.request(urlString).cacheResponse(using: ResponseCacher.cache).response { resp in
+            response = resp
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertEqual(response?.result.isSuccess, true)
+        XCTAssertTrue(session.cachedResponseExists(for: request))
+    }
+
+    func testThatRequestCachedResponseHandlerCanNotCacheResponse() {
+        // Given
+        let session = self.session()
+
+        var response: DataResponse<Data?>?
+        let expectation = self.expectation(description: "Request should not cache response")
+
+        // When
+        let request = session.request(urlString).cacheResponse(using: ResponseCacher.doNotCache).response { resp in
+            response = resp
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertEqual(response?.result.isSuccess, true)
+        XCTAssertFalse(session.cachedResponseExists(for: request))
+    }
+
+    func testThatRequestCachedResponseHandlerCanModifyCacheResponse() {
+        // Given
+        let session = self.session()
+
+        var response: DataResponse<Data?>?
+        let expectation = self.expectation(description: "Request should cache response")
+
+        // When
+        let cacher = ResponseCacher(
+            behavior: .modify { _, response in
+                return CachedURLResponse(
+                    response: response.response,
+                    data: response.data,
+                    userInfo: ["key": "value"],
+                    storagePolicy: .allowed
+                )
+            }
+        )
+
+        let request = session.request(urlString).cacheResponse(using: cacher).response { resp in
+            response = resp
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertEqual(response?.result.isSuccess, true)
+        XCTAssertTrue(session.cachedResponseExists(for: request))
+        XCTAssertEqual(session.cachedResponse(for: request)?.userInfo?["key"] as? String, "value")
+    }
+
+    // MARK: Tests - Per Session
+
+    func testThatSessionCachedResponseHandlerCanCacheResponse() {
+        // Given
+        let session = self.session(using: ResponseCacher.cache)
+
+        var response: DataResponse<Data?>?
+        let expectation = self.expectation(description: "Request should cache response")
+
+        // When
+        let request = session.request(urlString).response { resp in
+            response = resp
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertEqual(response?.result.isSuccess, true)
+        XCTAssertTrue(session.cachedResponseExists(for: request))
+    }
+
+    func testThatSessionCachedResponseHandlerCanNotCacheResponse() {
+        // Given
+        let session = self.session(using: ResponseCacher.doNotCache)
+
+        var response: DataResponse<Data?>?
+        let expectation = self.expectation(description: "Request should not cache response")
+
+        // When
+        let request = session.request(urlString).cacheResponse(using: ResponseCacher.doNotCache).response { resp in
+            response = resp
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertEqual(response?.result.isSuccess, true)
+        XCTAssertFalse(session.cachedResponseExists(for: request))
+    }
+
+    func testThatSessionCachedResponseHandlerCanModifyCacheResponse() {
+        // Given
+        let cacher = ResponseCacher(
+            behavior: .modify { _, response in
+                return CachedURLResponse(
+                    response: response.response,
+                    data: response.data,
+                    userInfo: ["key": "value"],
+                    storagePolicy: .allowed
+                )
+            }
+        )
+
+        let session = self.session(using: cacher)
+
+        var response: DataResponse<Data?>?
+        let expectation = self.expectation(description: "Request should cache response")
+
+        // When
+        let request = session.request(urlString).cacheResponse(using: cacher).response { resp in
+            response = resp
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertEqual(response?.result.isSuccess, true)
+        XCTAssertTrue(session.cachedResponseExists(for: request))
+        XCTAssertEqual(session.cachedResponse(for: request)?.userInfo?["key"] as? String, "value")
+    }
+
+    // MARK: Tests - Per Request Prioritization
+
+    func testThatRequestCachedResponseHandlerIsPrioritizedOverSessionCachedResponseHandler() {
+        // Given
+        let session = self.session(using: ResponseCacher.cache)
+
+        var response: DataResponse<Data?>?
+        let expectation = self.expectation(description: "Request should cache response")
+
+        // When
+        let request = session.request(urlString).cacheResponse(using: ResponseCacher.doNotCache).response { resp in
+            response = resp
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertEqual(response?.result.isSuccess, true)
+        XCTAssertFalse(session.cachedResponseExists(for: request))
+    }
+
+    // MARK: Private - Test Helpers
+
+    private func session(using handler: CachedResponseHandler? = nil) -> Session {
+        let configuration = URLSessionConfiguration.alamofireDefault
+        configuration.urlCache = URLCache(memoryCapacity: 100_000_000, diskCapacity: 100_000_000, diskPath: UUID().uuidString)
+
+        return Session(configuration: configuration, cachedResponseHandler: handler)
+    }
+}
+
+// MARK: -
+
+extension Session {
+    fileprivate func cachedResponse(for request: Request) -> CachedURLResponse? {
+        guard let urlRequest = request.request else { return nil }
+        return session.configuration.urlCache?.cachedResponse(for: urlRequest)
+    }
+
+    fileprivate func cachedResponseExists(for request: Request) -> Bool {
+        return cachedResponse(for: request) != nil
+    }
+}


### PR DESCRIPTION
This PR adds a `CachedResponseHandler` protocol which is leveraged as a `cachedResponseHandler` property on both the `Request` and `Session` APIs. It allows clients full control over redirect behavior at the `Session` level, as well as at the `Request` level through a chainable `cachedResponse(with:)` API.

### Goals :soccer:

The goals of this PR are to:

- Add support to AF5 for customizing cached response behavior at the `Session` level to match AF4.x functionality
- Add support to AF5 for customizing cached response behavior per `Request` to make it easier to implement simple caching behaviors for a single request (most commonly to disable caching for a single request)

### Implementation Details :construction:

Currently, in AF 4.x, you can control response caching behavior only at the `SessionDelegate` level by either subclassing or setting the `dataTaskWillCacheResponse` closure property. While this gives you the ability to control response caching behavior, it's pretty clunky. The changes in AF5 have cleaned this up a bunch, but do not currently expose the ability to control response caching behavior.

> You can currently subclass `SessionDelegate`, but the properties needed to customize the functionality are `internal` or `private`.

#### `CachedResponseHandler` Protocol

In this PR, I added a `CachedResponseHandler` protocol which contains a single API for determining what to do with a redirect response.

```swift
public protocol CachedResponseHandler {
    func dataTask(_ task: URLSessionDataTask,
                  willCacheResponse response: CachedURLResponse,
                  completion: @escaping (CachedURLResponse?) -> Void)
}
```

This protocol is then added to a `Session` through the initializer and made available through a `cachedResponseHandler` property. It can also be added to a `Request` through the new `cacheResponse(with:)` chainable API. The nice thing about having the logic abstracted into a protocol is that it's much easier to share the functionality between a `Session` and `Request` instead of having custom ways of handling response caching between the two.

#### `ResponseCacher` Struct

In order to make it even easier to handle response caching, I added a `ResponseCacher` struct which conforms to `CachedResponseHandler` (if you have any better naming suggestions, I'm all ears). It makes it very easy to either cache or not cache the response, and also offers a closure behavior for fully customizing the cached response before saving it to the `URLCache`.

```swift
public struct ResponseCacher {
    public enum Behavior {
        case cache
        case doNotCache
        case modify((URLSessionDataTask, CachedURLResponse) -> CachedURLResponse?)
    }

    public let behavior: Behavior

    public init(behavior: Behavior) {
        self.behavior = behavior
    }
}
```

> This type is super simple and is merely provided for convenience. Clients can choose to use the `ResponseCacher` convenience type, or create their own type that conforms to `CachedResponseHandler`.

#### Response Caching Control per Request

This is a nice addition to Alamofire. Right now, you have no way to control response caching behavior per request. It's only configurable at the `SessionManager` level (or per session). Therefore, you need to use request introspection on the `URLSessionDataTask`'s originalRequest and hope that you can dig the info you need out to determine the response caching behavior.

> The reasoning is exactly the same as detailed in #2699 for redirects. Per request control can be very helpful in certain network architectures.

### Testing Details :mag:

I have intentionally left tests out of this PR until we agree that this is the direction we'd like to take for this particular feature. Once the approach is locked, I'll add the appropriate tests.

**Update**

Tests have been added for per request and per session cached response handlers as well as prioritization of request over session.