### PR TITLE
Allow changing boundary string in upload:multipartFormData callback

### DIFF
--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -98,7 +98,7 @@ open class MultipartFormData {
     public var contentLength: UInt64 { return bodyParts.reduce(0) { $0 + $1.bodyContentLength } }
 
     /// The boundary used to separate the body parts in the encoded form data.
-    public let boundary: String
+    public var boundary: String
 
     private let fileManager: FileManager
     private var bodyParts: [BodyPart]


### PR DESCRIPTION
### Goals :soccer:
Allow changing boundary string in upload:multipartFormData callback

### Implementation Details :construction:
Changes MultipartFormData::boundary definition from constant `let` to `var`

### Testing Details :mag:
No test added