### PR TITLE
Overriding RetryPolicy Logic

### DIFF
--- a/Source/RetryPolicy.swift
+++ b/Source/RetryPolicy.swift
@@ -26,7 +26,7 @@ import Foundation
 
 /// A retry policy that retries requests using an exponential backoff for allowed HTTP methods and HTTP status codes
 /// as well as certain types of networking errors.
-open class RetryPolicy {
+open class RetryPolicy: RequestRetrier {
     /// The default retry limit for retry policies.
     public static let defaultRetryLimit: UInt = 2
 
@@ -309,11 +309,7 @@ open class RetryPolicy {
         self.retryableHTTPStatusCodes = retryableHTTPStatusCodes
         self.retryableURLErrorCodes = retryableURLErrorCodes
     }
-}
 
-// MARK: -
-
-extension RetryPolicy: RequestRetrier {
     open func retry(
         _ request: Request,
         for session: Session,


### PR DESCRIPTION
This is a simple PR that moves the `retry` implementation for the `RequestRetrier` conformance on `RetryPolicy` into the actual class and out of the extension. The reason for this is to allow subclasses to override the method. If the method is implemented in an extension, it cannot be overridden even though it is `open`. This PR fixes the issue.

### Goals :soccer:

To allow `RetryPolicy` subclasses to override the `retry` API if necessary.

### Testing Details :mag:

No tests are necessary for this change.
