### PR TITLE
Fix typo SessionManager.swift -> Session.swift

### DIFF
--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -1,5 +1,5 @@
 //
-//  SessionManager.swift
+//  Session.swift
 //
 //  Copyright (c) 2014-2018 Alamofire Software Foundation (http://alamofire.org/)
 //


### PR DESCRIPTION
Hey guys, this is a fix for a small typo I've noticed while browsing the `Session` file.

Also, thanks so much for working on this awesome library throughout the years :)