### PR TITLE
Feature - Response Serializer Retry Support

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -351,17 +351,15 @@ open class Request {
 
     /// Called to trigger retry or finish this `Request`.
     func retryOrFinish(error: Error?) {
-        if let error = error, let delegate = delegate {
-            delegate.retryResult(for: self, dueTo: error) { retryResult in
-                switch retryResult {
-                case .doNotRetry, .doNotRetryWithError:
-                    self.finish(error: retryResult.error)
-                case .retry, .retryWithDelay:
-                    delegate.retryRequest(self, withDelay: retryResult.delay)
-                }
+        guard let error = error, let delegate = delegate else { finish(); return }
+
+        delegate.retryResult(for: self, dueTo: error) { retryResult in
+            switch retryResult {
+            case .doNotRetry, .doNotRetryWithError:
+                self.finish(error: retryResult.error)
+            case .retry, .retryWithDelay:
+                delegate.retryRequest(self, withDelay: retryResult.delay)
             }
-        } else {
-            finish()
         }
     }
 

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -84,8 +84,6 @@ open class Request {
         var cachedResponseHandler: CachedResponseHandler?
         /// Response serialization closures that handle parsing responses.
         var responseSerializers: [() -> Void] = []
-        /// Current response serialization closure index used to track iteration.
-        var responseSerializerIndex: Int = 0
         /// Response serialization completion closures executed once all response serialization is complete.
         var responseSerializerCompletions: [() -> Void] = []
         /// `URLCredential` used for authentication challenges.
@@ -386,9 +384,10 @@ open class Request {
         var responseSerializer: (() -> Void)?
 
         protectedMutableState.write { mutableState in
-            if mutableState.responseSerializerIndex < mutableState.responseSerializers.count {
-                responseSerializer = mutableState.responseSerializers[mutableState.responseSerializerIndex]
-                mutableState.responseSerializerIndex += 1
+            let responseSerializerIndex = mutableState.responseSerializerCompletions.count
+
+            if responseSerializerIndex < mutableState.responseSerializers.count {
+                responseSerializer = mutableState.responseSerializers[responseSerializerIndex]
             }
         }
 
@@ -419,10 +418,7 @@ open class Request {
         downloadProgress.totalUnitCount = 0
         downloadProgress.completedUnitCount = 0
 
-        protectedMutableState.write { mutableState in
-            mutableState.responseSerializerCompletions = []
-            mutableState.responseSerializerIndex = 0
-        }
+        protectedMutableState.write { $0.responseSerializerCompletions = [] }
     }
 
     /// Called when updating the upload progress.

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -289,13 +289,11 @@ open class Request {
         retryOrFinish(error: error)
     }
 
-    /// Called when a `URLSessionTask` is created on behalf of the `Request`. Calls `reset()`.
+    /// Called when a `URLSessionTask` is created on behalf of the `Request`.
     ///
     /// - Parameter task: The `URLSessionTask` created.
     func didCreateTask(_ task: URLSessionTask) {
         protectedMutableState.write { $0.tasks.append(task) }
-
-        reset()
 
         eventMonitor?.request(self, didCreateTask: task)
     }
@@ -342,9 +340,11 @@ open class Request {
         retryOrFinish(error: self.error)
     }
 
-    /// Called when the `RequestDelegate` is retrying this `Request`.
+    /// Called when the `RequestDelegate` is retrying this `Request`. Calls `reset()`.
     func requestIsRetrying() {
         protectedMutableState.write { $0.retryCount += 1 }
+
+        reset()
 
         eventMonitor?.requestIsRetrying(self)
     }

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -121,9 +121,9 @@ extension DataRequest {
 
             self.eventMonitor?.request(self, didParseResponse: response)
 
-            (queue ?? .main).async { completionHandler(response) }
-
-            return true
+            self.responseSerializerDidComplete {
+                (queue ?? .main).async { completionHandler(response) }
+            }
         }
 
         return self
@@ -165,7 +165,9 @@ extension DataRequest {
                 self.delegate?.retryRequest(self, dueTo: serializerError) { retryResult in
                     switch retryResult {
                     case .doNotRetry:
-                        (queue ?? .main).async { completionHandler(response) }
+                        self.responseSerializerDidComplete {
+                            (queue ?? .main).async { completionHandler(response) }
+                        }
 
                     case .doNotRetryWithError(let retryError):
                         let result = Result<Serializer.SerializedObject>.failure(retryError)
@@ -177,7 +179,9 @@ extension DataRequest {
                                                     serializationDuration: (end - start),
                                                     result: result)
 
-                        (queue ?? .main).async { completionHandler(response) }
+                        self.responseSerializerDidComplete {
+                            (queue ?? .main).async { completionHandler(response) }
+                        }
 
                     default:
                         // No-op: request is being retried
@@ -185,10 +189,10 @@ extension DataRequest {
                     }
                 }
             } else {
-                (queue ?? .main).async { completionHandler(response) }
+                self.responseSerializerDidComplete {
+                    (queue ?? .main).async { completionHandler(response) }
+                }
             }
-
-            return result.isSuccess
         }
 
         return self
@@ -219,9 +223,9 @@ extension DownloadRequest {
                                             serializationDuration: 0,
                                             result: result)
 
-            (queue ?? .main).async { completionHandler(response) }
-
-            return true
+            self.responseSerializerDidComplete {
+                (queue ?? .main).async { completionHandler(response) }
+            }
         }
 
         return self
@@ -263,7 +267,9 @@ extension DownloadRequest {
                 self.delegate?.retryRequest(self, dueTo: serializerError) { retryResult in
                     switch retryResult {
                     case .doNotRetry:
-                        (queue ?? .main).async { completionHandler(response) }
+                        self.responseSerializerDidComplete {
+                            (queue ?? .main).async { completionHandler(response) }
+                        }
 
                     case .doNotRetryWithError(let retryError):
                         let result = Result<T.SerializedObject>.failure(retryError)
@@ -276,7 +282,9 @@ extension DownloadRequest {
                                                         serializationDuration: (end - start),
                                                         result: result)
 
-                        (queue ?? .main).async { completionHandler(response) }
+                        self.responseSerializerDidComplete {
+                            (queue ?? .main).async { completionHandler(response) }
+                        }
 
                     default:
                         // No-op: request is being retried
@@ -284,10 +292,10 @@ extension DownloadRequest {
                     }
                 }
             } else {
-                (queue ?? .main).async { completionHandler(response) }
+                self.responseSerializerDidComplete {
+                    (queue ?? .main).async { completionHandler(response) }
+                }
             }
-
-            return result.isSuccess
         }
 
         return self

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -111,6 +111,7 @@ extension DataRequest {
     @discardableResult
     public func response(queue: DispatchQueue? = nil, completionHandler: @escaping (DataResponse<Data?>) -> Void) -> Self {
         appendResponseSerializer {
+            let queue = queue ?? .main
             let result = Result(value: self.data, error: self.error)
             let response = DataResponse(request: self.request,
                                         response: self.response,
@@ -121,9 +122,7 @@ extension DataRequest {
 
             self.eventMonitor?.request(self, didParseResponse: response)
 
-            self.responseSerializerDidComplete {
-                (queue ?? .main).async { completionHandler(response) }
-            }
+            self.responseSerializerDidComplete { queue.async { completionHandler(response) } }
         }
 
         return self
@@ -217,6 +216,7 @@ extension DownloadRequest {
         -> Self
     {
         appendResponseSerializer {
+            let queue = queue ?? .main
             let result = Result(value: self.fileURL , error: self.error)
             let response = DownloadResponse(request: self.request,
                                             response: self.response,
@@ -226,9 +226,7 @@ extension DownloadRequest {
                                             serializationDuration: 0,
                                             result: result)
 
-            self.responseSerializerDidComplete {
-                (queue ?? .main).async { completionHandler(response) }
-            }
+            self.responseSerializerDidComplete { queue.async { completionHandler(response) } }
         }
 
         return self

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -185,6 +185,7 @@ extension DataRequest {
 
                         default:
                             delegate.retryRequest(self, withDelay: retryResult.delay)
+                            didComplete = nil
                         }
                     }
 
@@ -290,6 +291,7 @@ extension DownloadRequest {
 
                         default:
                             delegate.retryRequest(self, withDelay: retryResult.delay)
+                            didComplete = nil
                         }
                     }
 

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -517,8 +517,8 @@ extension Session: RequestDelegate {
         return retrier(for: request) != nil
     }
 
-    public func retryRequest(_ request: Request, ifNecessaryWithError error: Error) {
-        guard let retrier = retrier(for: request) else { request.finish(); return }
+    public func retryRequest(_ request: Request, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
+        guard let retrier = retrier(for: request) else { completion(.doNotRetry); return }
 
         retrier.retry(request, for: self, dueTo: error) { result in
             guard !request.isCancelled else { return }
@@ -546,7 +546,7 @@ extension Session: RequestDelegate {
                         retryError = AFError.requestRetryFailed(retryError: retryResultError, originalError: error)
                     }
 
-                    request.finish(error: retryError)
+                    completion(.doNotRetryWithError(retryError))
                 }
             }
         }

--- a/Tests/RetryPolicyTests.swift
+++ b/Tests/RetryPolicyTests.swift
@@ -159,7 +159,7 @@ class RetryPolicyTestCase: BaseRetryPolicyTestCase {
 
             waitForExpectations(timeout: timeout, handler: nil)
 
-            request.requestIsRetrying()
+            request.prepareForRetry()
         }
 
         // Then
@@ -321,7 +321,7 @@ class RetryPolicyTestCase: BaseRetryPolicyTestCase {
 
             waitForExpectations(timeout: timeout, handler: nil)
 
-            request.requestIsRetrying()
+            request.prepareForRetry()
         }
 
         // Then

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -877,7 +877,7 @@ class SessionTestCase: BaseTestCase {
 
         // Then
         XCTAssertEqual(handler.adaptedCount, 2)
-        XCTAssertEqual(handler.retryCount, 2)
+        XCTAssertEqual(handler.retryCount, 3)
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, false)
         XCTAssertTrue(session.requestTaskMap.isEmpty)
@@ -905,9 +905,9 @@ class SessionTestCase: BaseTestCase {
 
         // Then
         XCTAssertEqual(sessionHandler.adaptedCount, 3)
-        XCTAssertEqual(sessionHandler.retryCount, 2)
+        XCTAssertEqual(sessionHandler.retryCount, 3)
         XCTAssertEqual(requestHandler.adaptedCount, 3)
-        XCTAssertEqual(requestHandler.retryCount, 3)
+        XCTAssertEqual(requestHandler.retryCount, 4)
         XCTAssertEqual(request.retryCount, 2)
         XCTAssertEqual(response?.result.isSuccess, false)
         XCTAssertTrue(session.requestTaskMap.isEmpty)
@@ -1053,7 +1053,7 @@ class SessionTestCase: BaseTestCase {
 
         // Then
         XCTAssertEqual(handler.adaptedCount, 1)
-        XCTAssertEqual(handler.retryCount, 2)
+        XCTAssertEqual(handler.retryCount, 3)
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, false)
         XCTAssertTrue(session.requestTaskMap.isEmpty)
@@ -1089,7 +1089,7 @@ class SessionTestCase: BaseTestCase {
 
         // Then
         XCTAssertEqual(handler.adaptedCount, 1)
-        XCTAssertEqual(handler.retryCount, 2)
+        XCTAssertEqual(handler.retryCount, 3)
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, false)
         XCTAssertTrue(session.requestTaskMap.isEmpty)

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -89,8 +89,10 @@ class SessionTestCase: BaseTestCase {
     }
 
     private class RequestHandler: RequestInterceptor {
+        var adaptCalledCount = 0
         var adaptedCount = 0
         var retryCount = 0
+        var retryCalledCount = 0
         var retryErrors: [Error] = []
 
         var shouldApplyAuthorizationHeader = false
@@ -101,15 +103,17 @@ class SessionTestCase: BaseTestCase {
         var retryDelay: TimeInterval?
 
         func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest>) -> Void) {
+            adaptCalledCount += 1
+
             let result: Result<URLRequest> = Result {
                 if throwsErrorOnFirstAdapt {
                     throwsErrorOnFirstAdapt = false
-                    throw AFError.invalidURL(url: "")
+                    throw AFError.invalidURL(url: "/adapt/error/1")
                 }
 
                 if throwsErrorOnSecondAdapt && adaptedCount == 1 {
                     throwsErrorOnSecondAdapt = false
-                    throw AFError.invalidURL(url: "")
+                    throw AFError.invalidURL(url: "/adapt/error/2")
                 }
 
                 var urlRequest = urlRequest
@@ -132,8 +136,10 @@ class SessionTestCase: BaseTestCase {
             dueTo error: Error,
             completion: @escaping (RetryResult) -> Void)
         {
+            retryCalledCount += 1
+
             if throwsErrorOnRetry {
-                let error = AFError.invalidURL(url: "")
+                let error = AFError.invalidURL(url: "/invalid/url/\(retryCalledCount)")
                 completion(.doNotRetryWithError(error))
                 return
             }
@@ -156,11 +162,15 @@ class SessionTestCase: BaseTestCase {
     }
 
     private class UploadHandler: RequestInterceptor {
+        var adaptCalledCount = 0
         var adaptedCount = 0
+        var retryCalledCount = 0
         var retryCount = 0
         var retryErrors: [Error] = []
 
         func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest>) -> Void) {
+            adaptCalledCount += 1
+
             let result: Result<URLRequest> = Result {
                 adaptedCount += 1
 
@@ -178,6 +188,8 @@ class SessionTestCase: BaseTestCase {
             dueTo error: Error,
             completion: @escaping (RetryResult) -> Void)
         {
+            retryCalledCount += 1
+
             retryCount += 1
             retryErrors.append(error)
 
@@ -876,7 +888,9 @@ class SessionTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
+        XCTAssertEqual(handler.adaptCalledCount, 2)
         XCTAssertEqual(handler.adaptedCount, 2)
+        XCTAssertEqual(handler.retryCalledCount, 3)
         XCTAssertEqual(handler.retryCount, 3)
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, false)
@@ -904,9 +918,13 @@ class SessionTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
+        XCTAssertEqual(sessionHandler.adaptCalledCount, 3)
         XCTAssertEqual(sessionHandler.adaptedCount, 3)
+        XCTAssertEqual(sessionHandler.retryCalledCount, 3)
         XCTAssertEqual(sessionHandler.retryCount, 3)
+        XCTAssertEqual(requestHandler.adaptCalledCount, 3)
         XCTAssertEqual(requestHandler.adaptedCount, 3)
+        XCTAssertEqual(requestHandler.retryCalledCount, 4)
         XCTAssertEqual(requestHandler.retryCount, 4)
         XCTAssertEqual(request.retryCount, 2)
         XCTAssertEqual(response?.result.isSuccess, false)
@@ -936,7 +954,9 @@ class SessionTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
+        XCTAssertEqual(handler.adaptCalledCount, 2)
         XCTAssertEqual(handler.adaptedCount, 2)
+        XCTAssertEqual(handler.retryCalledCount, 1)
         XCTAssertEqual(handler.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, true)
         XCTAssertTrue(session.requestTaskMap.isEmpty)
@@ -970,7 +990,9 @@ class SessionTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
+        XCTAssertEqual(handler.adaptCalledCount, 2)
         XCTAssertEqual(handler.adaptedCount, 2)
+        XCTAssertEqual(handler.retryCalledCount, 1)
         XCTAssertEqual(handler.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, true)
         XCTAssertTrue(session.requestTaskMap.isEmpty)
@@ -997,7 +1019,9 @@ class SessionTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
+        XCTAssertEqual(handler.adaptCalledCount, 2)
         XCTAssertEqual(handler.adaptedCount, 2)
+        XCTAssertEqual(handler.retryCalledCount, 1)
         XCTAssertEqual(handler.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, true)
         XCTAssertTrue(session.requestTaskMap.isEmpty)
@@ -1024,7 +1048,9 @@ class SessionTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
+        XCTAssertEqual(handler.adaptCalledCount, 2)
         XCTAssertEqual(handler.adaptedCount, 2)
+        XCTAssertEqual(handler.retryCalledCount, 1)
         XCTAssertEqual(handler.retryCount, 1)
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, true)
@@ -1052,7 +1078,9 @@ class SessionTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
+        XCTAssertEqual(handler.adaptCalledCount, 2)
         XCTAssertEqual(handler.adaptedCount, 1)
+        XCTAssertEqual(handler.retryCalledCount, 3)
         XCTAssertEqual(handler.retryCount, 3)
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, false)
@@ -1060,7 +1088,7 @@ class SessionTestCase: BaseTestCase {
 
         if let error = response?.result.error?.asAFError {
             XCTAssertTrue(error.isRequestAdaptationError)
-            XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "")
+            XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "/adapt/error/2")
         } else {
             XCTFail("error should not be nil")
         }
@@ -1088,7 +1116,9 @@ class SessionTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
+        XCTAssertEqual(handler.adaptCalledCount, 2)
         XCTAssertEqual(handler.adaptedCount, 1)
+        XCTAssertEqual(handler.retryCalledCount, 3)
         XCTAssertEqual(handler.retryCount, 3)
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, false)
@@ -1096,7 +1126,7 @@ class SessionTestCase: BaseTestCase {
 
         if let error = response?.result.error?.asAFError {
             XCTAssertTrue(error.isRequestAdaptationError)
-            XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "")
+            XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "/adapt/error/2")
         } else {
             XCTFail("error should not be nil")
         }
@@ -1123,7 +1153,9 @@ class SessionTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
+        XCTAssertEqual(handler.adaptCalledCount, 1)
         XCTAssertEqual(handler.adaptedCount, 1)
+        XCTAssertEqual(handler.retryCalledCount, 2)
         XCTAssertEqual(handler.retryCount, 0)
         XCTAssertEqual(request.retryCount, 0)
         XCTAssertEqual(response?.result.isSuccess, false)
@@ -1131,9 +1163,249 @@ class SessionTestCase: BaseTestCase {
 
         if let error = response?.result.error?.asAFError {
             XCTAssertTrue(error.isRequestRetryError)
-            XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "")
+            XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "/invalid/url/2")
         } else {
             XCTFail("error should not be nil")
+        }
+    }
+
+    // MARK: Tests - Response Serializer Retry
+
+    func testThatSessionCallsRequestRetrierWhenResponseSerializerThrowsError() {
+        // Given
+        let handler = RequestHandler()
+        handler.shouldRetry = false
+
+        let session = Session()
+
+        let expectation = self.expectation(description: "request should eventually fail")
+        var response: DataResponse<Any>?
+
+        // When
+        let request = session.request("https://httpbin.org/image/jpeg", interceptor: handler)
+            .validate()
+            .responseJSON { jsonResponse in
+                response = jsonResponse
+                expectation.fulfill()
+            }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertEqual(handler.adaptCalledCount, 1)
+        XCTAssertEqual(handler.adaptedCount, 1)
+        XCTAssertEqual(handler.retryCalledCount, 1)
+        XCTAssertEqual(handler.retryCount, 0)
+        XCTAssertEqual(request.retryCount, 0)
+        XCTAssertEqual(response?.result.isSuccess, false)
+        XCTAssertTrue(session.requestTaskMap.isEmpty)
+
+        if let error = response?.error?.asAFError {
+            XCTAssertTrue(error.isResponseSerializationError)
+            XCTAssertTrue(error.localizedDescription.starts(with: "JSON could not be serialized"))
+        } else {
+            XCTFail("error should not be nil")
+        }
+    }
+
+    func testThatSessionCallsRequestRetrierForAllResponseSerializersThatThrowError() throws {
+        // Given
+        let handler = RequestHandler()
+        handler.throwsErrorOnRetry = true
+
+        let session = Session()
+
+        let json1Expectation = self.expectation(description: "request should eventually fail")
+        var json1Response: DataResponse<Any>?
+
+        let json2Expectation = self.expectation(description: "request should eventually fail")
+        var json2Response: DataResponse<Any>?
+
+        // When
+        let request = session.request("https://httpbin.org/image/jpeg", interceptor: handler)
+            .validate()
+            .responseJSON { response in
+                json1Response = response
+                json1Expectation.fulfill()
+            }
+            .responseJSON { response in
+                json2Response = response
+                json2Expectation.fulfill()
+            }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertEqual(handler.adaptCalledCount, 1)
+        XCTAssertEqual(handler.adaptedCount, 1)
+        XCTAssertEqual(handler.retryCalledCount, 2)
+        XCTAssertEqual(handler.retryCount, 0)
+        XCTAssertEqual(request.retryCount, 0)
+        XCTAssertEqual(json1Response?.result.isSuccess, false)
+        XCTAssertEqual(json2Response?.result.isSuccess, false)
+        XCTAssertTrue(session.requestTaskMap.isEmpty)
+
+        let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error?.asAFError }
+        XCTAssertEqual(errors.count, 2)
+
+        for (index, error) in errors.enumerated() {
+            XCTAssertTrue(error.isRequestRetryError)
+            XCTAssertEqual(error.localizedDescription.starts(with: "Request retry failed with retry error"), true)
+
+            if case let .requestRetryFailed(retryError, originalError) = error {
+                XCTAssertEqual(try retryError.asAFError?.urlConvertible?.asURL().absoluteString, "/invalid/url/\(index + 1)")
+                XCTAssertTrue(originalError.localizedDescription.starts(with: "JSON could not be serialized"))
+            } else {
+                XCTFail("Error failure reason should be response serialization failure")
+            }
+        }
+    }
+
+    func testThatSessionRetriesRequestImmediatelyWhenResponseSerializerRequestsRetry() throws {
+        // Given
+        let handler = RequestHandler()
+        let session = Session()
+
+        let json1Expectation = self.expectation(description: "request should eventually fail")
+        var json1Response: DataResponse<Any>?
+
+        let json2Expectation = self.expectation(description: "request should eventually fail")
+        var json2Response: DataResponse<Any>?
+
+        // When
+        let request = session.request("https://httpbin.org/image/jpeg", interceptor: handler)
+            .validate()
+            .responseJSON { response in
+                json1Response = response
+                json1Expectation.fulfill()
+            }
+            .responseJSON { response in
+                json2Response = response
+                json2Expectation.fulfill()
+            }
+
+        waitForExpectations(timeout: 10, handler: nil)
+
+        // Then
+        XCTAssertEqual(handler.adaptCalledCount, 2)
+        XCTAssertEqual(handler.adaptedCount, 2)
+        XCTAssertEqual(handler.retryCalledCount, 3)
+        XCTAssertEqual(handler.retryCount, 3)
+        XCTAssertEqual(request.retryCount, 1)
+        XCTAssertEqual(json1Response?.result.isSuccess, false)
+        XCTAssertEqual(json2Response?.result.isSuccess, false)
+        XCTAssertTrue(session.requestTaskMap.isEmpty)
+
+        let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error?.asAFError }
+        XCTAssertEqual(errors.count, 2)
+
+        for error in errors {
+            XCTAssertTrue(error.isResponseSerializationError)
+            XCTAssertTrue(error.localizedDescription.starts(with: "JSON could not be serialized"))
+        }
+    }
+
+    func testThatSessionCallsResponseSerializerCompletionsWhenAdapterThrowsErrorDuringRetry() {
+        // Four retries should occur given this scenario:
+        // 1) Retrier is called from first response serializer failure (trips retry)
+        // 2) Retrier is called by Session for adapt error thrown
+        // 3) Retrier is called again from first response serializer failure
+        // 4) Retrier is called from second response serializer failure
+
+        // Given
+        let handler = RequestHandler()
+        handler.throwsErrorOnSecondAdapt = true
+
+        let session = Session()
+
+        let json1Expectation = self.expectation(description: "request should eventually fail")
+        var json1Response: DataResponse<Any>?
+
+        let json2Expectation = self.expectation(description: "request should eventually fail")
+        var json2Response: DataResponse<Any>?
+
+        // When
+        let request = session.request("https://httpbin.org/image/jpeg", interceptor: handler)
+            .validate()
+            .responseJSON { response in
+                json1Response = response
+                json1Expectation.fulfill()
+            }
+            .responseJSON { response in
+                json2Response = response
+                json2Expectation.fulfill()
+            }
+
+        waitForExpectations(timeout: 10, handler: nil)
+
+        // Then
+        XCTAssertEqual(handler.adaptCalledCount, 2)
+        XCTAssertEqual(handler.adaptedCount, 1)
+        XCTAssertEqual(handler.retryCalledCount, 4)
+        XCTAssertEqual(handler.retryCount, 4)
+        XCTAssertEqual(request.retryCount, 1)
+        XCTAssertEqual(json1Response?.result.isSuccess, false)
+        XCTAssertEqual(json2Response?.result.isSuccess, false)
+        XCTAssertTrue(session.requestTaskMap.isEmpty)
+
+        let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error?.asAFError }
+        XCTAssertEqual(errors.count, 2)
+
+        for error in errors {
+            XCTAssertTrue(error.isRequestAdaptationError)
+            XCTAssertEqual(error.localizedDescription, "Request adaption failed with error: URL is not valid: /adapt/error/2")
+        }
+    }
+
+    func testThatSessionCallsResponseSerializerCompletionsWhenAdapterThrowsErrorDuringRetryForDownloads() {
+        // Four retries should occur given this scenario:
+        // 1) Retrier is called from first response serializer failure (trips retry)
+        // 2) Retrier is called by Session for adapt error thrown
+        // 3) Retrier is called again from first response serializer failure
+        // 4) Retrier is called from second response serializer failure
+
+        // Given
+        let handler = RequestHandler()
+        handler.throwsErrorOnSecondAdapt = true
+
+        let session = Session()
+
+        let json1Expectation = self.expectation(description: "request should eventually fail")
+        var json1Response: DownloadResponse<Any>?
+
+        let json2Expectation = self.expectation(description: "request should eventually fail")
+        var json2Response: DownloadResponse<Any>?
+
+        // When
+        let request = session.download("https://httpbin.org/image/jpeg", interceptor: handler)
+            .validate()
+            .responseJSON { response in
+                json1Response = response
+                json1Expectation.fulfill()
+            }
+            .responseJSON { response in
+                json2Response = response
+                json2Expectation.fulfill()
+            }
+
+        waitForExpectations(timeout: 10, handler: nil)
+
+        // Then
+        XCTAssertEqual(handler.adaptCalledCount, 2)
+        XCTAssertEqual(handler.adaptedCount, 1)
+        XCTAssertEqual(handler.retryCalledCount, 4)
+        XCTAssertEqual(handler.retryCount, 4)
+        XCTAssertEqual(request.retryCount, 1)
+        XCTAssertEqual(json1Response?.result.isSuccess, false)
+        XCTAssertEqual(json2Response?.result.isSuccess, false)
+        XCTAssertTrue(session.requestTaskMap.isEmpty)
+
+        let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error?.asAFError }
+        XCTAssertEqual(errors.count, 2)
+
+        for error in errors {
+            XCTAssertTrue(error.isRequestAdaptationError)
+            XCTAssertEqual(error.localizedDescription, "Request adaption failed with error: URL is not valid: /adapt/error/2")
         }
     }
 


### PR DESCRIPTION
This PR demonstrates one potential way we can add retry support to response serializers. This approach is definitely a work in progress, so please keep that in mind. The test suite is passing and the approach is sound, it just requires us to make some decisions on how certain edge cases should behave.

### Issue Link :link:

The design flaw has several forms, but generally results in users having to parse JSON payloads in `Validation` closures to get the errors extracted to all the request to be retried. Issue #2214 is one example of many use cases. 

> Please link other related issues if you know of them. I'll try to find some more later.

### Goals :soccer:

To add retry support to response serializers without changing the public APIs. Response serializers should be able to retry requests with a `RequestRetrier` when serialization errors occur.

### Implementation Details :construction:

The implementation of this isn't too bad amazingly. 

#### Threading Model

The biggest change is around the threading model. Instead of tacking all the response serializers into an operation queue, we need to keep track of them as a collection of closures. I've created a simple `responseSerializers` array in the `MutableState` of a `Request` where we can append them. I also added `append`, `next`, and `remove` response serializer functions to safely access the response serializers in thread-safe ways. 

> I'm not at all tied to these APIs, just needed to put something together to demonstrate one way to do this.

#### Response Serializers

The response serializer closures are a bit different now than they were. First off, the closures are simply appended to the array of `responseSerializers` in the `Request`. They are no longer appended to the `internalQueue`. This allows us to iterate through them instead of resuming the queue.

The next change in them is that for both the `DataRequest` and `DownloadRequest` APIs where they take a `responseSerializer`, we call a `retryRequest(:dueTo:completion:)` API that will retry the `Request` if the `RequestRetrier` determines it should be retried. This is the exact same API that we use for retrying requests after validation.

If the retrier determines that the request should be retried, the request is restarted and all the response serializers stay in the array. If a response serializer completes successfully, its `completion` closure is called and it is removed from the array. This behavior presents some interesting questions in terms of multiple response serializers:

1. What if the next response serializer throws an error that trips retry?
  - Does it make sense to retry after the first response serializer has succeeded and been removed?
  - Should all response serializers be executed until an error trips retry or they all succeed?
2. If any response serializer trips retry, should they all be executed the next time around?
  - Currently, a successful response serializer is popped from the queue when it succeeds
3. If you can retry from a response serializer, does it make sense to allow multiple response serializers?
  - Supporting multiple greatly overcomplicates things
  - It's not difficult to make a custom response serializer that makes multiple passes if necessary

IMO, it is really weird if a response serializer succeeds and is completed, then a second one fails, the request is retried, and the first response serializer is unaware that that happened. However, I do understand that that might make sense in some cases. Personally, I would implement that as a single response serializer that might need to make multiple passes on the payload. This would allow me to call a single completion with a custom payload type, but that's just what I would do. I don't completely understand all the use cases for people using multiple response serializers for a single call, nor do I think it wise to add a precondition to only allow a single response serializer per request.

> If anyone has some really good examples of use cases where multiple response serializers make perfect sense, I'd love to hear them. The more info we have here the better the implementation we can land on for everyone.

### Testing Details :mag:

This PR is a work in progress, so I do not want to build out specific test cases until we've landed on the approach. Currently, the entire test suite is passing as is, so the functionality is sound. However, we do not currently have tests that exercise all the current edge cases.

---

## Updates

I've now been able to finalize this PR and have some answers to the questions posed above that are worth documenting in the PR.

1. What if the next response serializer throws an error that trips retry?

Completion closures are only called once all response serializers have completed. We never want to call the first response serializer's completion closure, then have the second response serializer trip a retry, and then the first response serializer is just out-of-luck.

2. If any response serializer trips retry, should they all be executed the next time around?

Yes, they will all be executed again. The response serializer completion closures will only be executed once all response serializers have completed.

3. If you can retry from a response serializer, does it make sense to allow multiple response serializers?

We are still going to allow it. It's difficult to foresee use cases where you would use more than one, but we've decided to continue to support it in AF5.