### PR TITLE
Crash fix #2138

### DIFF
--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -83,7 +83,7 @@ open class SessionDelegate: NSObject {
     open var dataTaskDidBecomeDownloadTask: ((URLSession, URLSessionDataTask, URLSessionDownloadTask) -> Void)?
 
     /// Overrides default behavior for URLSessionDataDelegate method `urlSession(_:dataTask:didReceive:)`.
-    open var dataTaskDidReceiveData: ((URLSession, URLSessionDataTask, Data) -> Void)?
+    open var dataTaskDidReceiveData: ((URLSession, URLSessionDataTask, Data?) -> Void)?
 
     /// Overrides default behavior for URLSessionDataDelegate method `urlSession(_:dataTask:willCacheResponse:completionHandler:)`.
     open var dataTaskWillCacheResponse: ((URLSession, URLSessionDataTask, CachedURLResponse) -> CachedURLResponse?)?
@@ -550,10 +550,10 @@ extension SessionDelegate: URLSessionDataDelegate {
     /// - parameter session:  The session containing the data task that provided data.
     /// - parameter dataTask: The data task that provided data.
     /// - parameter data:     A data object containing the transferred data.
-    open func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+    open func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data?) {
         if let dataTaskDidReceiveData = dataTaskDidReceiveData {
             dataTaskDidReceiveData(session, dataTask, data)
-        } else if let delegate = self[dataTask]?.delegate as? DataTaskDelegate {
+        } else if let delegate = self[dataTask]?.delegate as? DataTaskDelegate, let data = data {
             delegate.urlSession(session, dataTask: dataTask, didReceive: data)
         }
     }

--- a/Tests/URLProtocolTests.swift
+++ b/Tests/URLProtocolTests.swift
@@ -96,7 +96,8 @@ extension ProxyURLProtocol: URLSessionDataDelegate {
 
     // MARK: NSURLSessionDelegate
 
-    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data?) {
+        guard let data = data else { return }
         client?.urlProtocol(self, didLoad: data)
     }
 


### PR DESCRIPTION
### Issue Link :link:
#2138 
 
### Goals :soccer:
The mail goal of this PR is to prevent unnecessary crashes which are caused within the bridging from the Objective-C code of `URLSession` to Swift. We currently get about 10 crashes/day from this.

### Implementation Details :construction:
As @gneil90 stated in #2138, this crash can be resolved by changing the delegate signature from `data: Data` to `data: Data?`.

### Testing Details :mag:
We are currently using this PR of Alamofire within our app in development and had no issues so far, we will also use this PR in production in future releases of our app.
