### PR TITLE
Update swiftLanguageVersions to swift-tools-version:4.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,5 +37,5 @@ let package = Package(
             name: "Alamofire",
             path: "Source")
     ],
-    swiftLanguageVersions: [3, 4]
+    swiftLanguageVersions: [.v3, .v4]
 )


### PR DESCRIPTION
This PR fixes incompatibilities with Swift 5 compiler due to an API change in the Package.swift manifest API.

`swiftLanguageVersions` changed from taking `[Int]` to `[SwiftVersion]` in PackageDescription API Version 4.2. For more information, see https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageDescriptionV4_2.md#swift-language-version.

I've tested this with Swift 4.2.1 (swiftlang-1000.11.42) and Swift 5 (swiftlang-1001.0.63.8), and it appears to work for both. It was difficult to verify because of build errors related to #2698, but I was able to work around that by passing an explicit macOS 10.12 target with the `-Xswiftc` flag:

```terminal
$ swift build -Xswiftc -target -Xswiftc x86_64-apple-macosx10.12
Compile Swift Module 'Alamofire' (30 sources)
```