### PR TITLE
Create version specific manifest for Swift 4.2 and update Package.swift to swift-tools-version:5.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,5 +37,5 @@ let package = Package(
             name: "Alamofire",
             path: "Source")
     ],
-    swiftLanguageVersions: [3, 4]
+    swiftLanguageVersions: [.v3, .v4]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,10 @@ import PackageDescription
 let package = Package(
     name: "Alamofire",
     platforms: [
-        .macOS(.v10_12)
+        .macOS(.v10_12),
+        .iOS(.v10),
+        .tvOS(.v10),
+        .watchOS(.v3)
     ],
     products: [
         .library(

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:4.2
 //
 //  Package.swift
 //
@@ -27,9 +27,6 @@ import PackageDescription
 
 let package = Package(
     name: "Alamofire",
-    platforms: [
-        .macOS(.v10_12)
-    ],
     products: [
         .library(
             name: "Alamofire",
@@ -40,5 +37,5 @@ let package = Package(
             name: "Alamofire",
             path: "Source")
     ],
-    swiftLanguageVersions: [.v4]
+    swiftLanguageVersions: [.v3, .v4]
 )


### PR DESCRIPTION
Following up on #2736, this PR updates Package.swift to swift-tools-version:5.0 and takes advantage of the new [`platforms` API](https://github.com/apple/swift-package-manager/pull/1869) to specify a requirement for macOS >= 10.12, which fixes #2698.

This PR also provides a version-specific manifest (`Package@swift-4.2.swift`) that provides backwards-compatibility with Xcode 10.1.

I believe that this provides a solution that allows you to address #2698 without waiting for Xcode 10.2 to GM. However, I certainly understand if you'd prefer to hold off for a final release.