### PR TITLE
Make RetryPolicy a RequestInterceptor.

### DIFF
--- a/Source/RetryPolicy.swift
+++ b/Source/RetryPolicy.swift
@@ -26,7 +26,7 @@ import Foundation
 
 /// A retry policy that retries requests using an exponential backoff for allowed HTTP methods and HTTP status codes
 /// as well as certain types of networking errors.
-open class RetryPolicy: RequestRetrier {
+open class RetryPolicy: RequestInterceptor {
     /// The default retry limit for retry policies.
     public static let defaultRetryLimit: UInt = 2
 


### PR DESCRIPTION
### Goals :soccer:
This PR makes `RetryPolicy` conform to `RequestInterceptor` instead of just `RequestRetrier`, as `RequestInterceptor` is required by the new APIs and is unusable otherwise.
