### PR TITLE
Fix crash when casting to *Response<Any>

### DIFF
--- a/Source/EventMonitor.swift
+++ b/Source/EventMonitor.swift
@@ -583,9 +583,6 @@ open class ClosureEventMonitor: EventMonitor {
     /// Closure called on the `request(_:didParseResponse:)` event.
     open var requestDidParseResponse: ((DataRequest, DataResponse<Data?>) -> Void)?
 
-    /// Closure called on the `request(_:didParseResponse` event, casting the generic serialized object to `Any`.
-    open var requestDidParseAnyResponse: ((DataRequest, DataResponse<Any>) -> Void)?
-
     /// Closure called on the `request(_:didCreateUploadable:)` event.
     open var requestDidCreateUploadable: ((UploadRequest, UploadRequest.Uploadable) -> Void)?
 
@@ -606,9 +603,6 @@ open class ClosureEventMonitor: EventMonitor {
 
     /// Closure called on the `request(_:didParseResponse:)` event.
     open var requestDidParseDownloadResponse: ((DownloadRequest, DownloadResponse<URL?>) -> Void)?
-
-    /// Closure called on the `request(_:didParseResponse:)` event, casting the generic serialized object to `Any`.
-    open var requestDidParseAnyDownloadResponse: ((DownloadRequest, DownloadResponse<Any>) -> Void)?
 
     public let queue: DispatchQueue
 
@@ -748,11 +742,6 @@ open class ClosureEventMonitor: EventMonitor {
         requestDidParseResponse?(request, response)
     }
 
-    open func request<Value>(_ request: DataRequest, didParseResponse response: DataResponse<Value>) {
-        // TODO: Make all methods optional so this isn't required.
-        requestDidParseAnyResponse?(request, response as! DataResponse<Any>)
-    }
-
     open func request(_ request: UploadRequest, didCreateUploadable uploadable: UploadRequest.Uploadable) {
         requestDidCreateUploadable?(request, uploadable)
     }
@@ -789,7 +778,4 @@ open class ClosureEventMonitor: EventMonitor {
         requestDidParseDownloadResponse?(request, response)
     }
 
-    open func request<Value>(_ request: DownloadRequest, didParseResponse response: DownloadResponse<Value>) {
-        requestDidParseAnyDownloadResponse?(request, response as! DownloadResponse<Any>)
-    }
 }


### PR DESCRIPTION
### Goals :soccer:
This PR fixes a crash that occurs when using the `ClosureEventMonitor`'s `requestDidParseAnyResponse` closure, as casting from a generic `*Response<Value>` to `*Response<Any>` does not work.

### Implementation Details :construction:
This PR just removes the offending methods. Since there's no way to express generic closures we may not be able to support these events in `ClosureEventMonitor`.

### Testing Details :mag:
`EventMonitor` currently has no tests, but adding them is left for the future.
