### PR TITLE
Mark RequestInterceptor closure callback arguments escaping

### DIFF
--- a/Source/RequestInterceptor.swift
+++ b/Source/RequestInterceptor.swift
@@ -101,8 +101,8 @@ extension RequestInterceptor {
     }
 }
 
-public typealias AdaptHandler = (URLRequest, Session, _ completion: (Result<URLRequest>) -> Void) -> Void
-public typealias RetryHandler = (Request, Session, Error, _ completion: (RetryResult) -> Void) -> Void
+public typealias AdaptHandler = (URLRequest, Session, _ completion: @escaping (Result<URLRequest>) -> Void) -> Void
+public typealias RetryHandler = (Request, Session, Error, _ completion: @escaping (RetryResult) -> Void) -> Void
 
 // MARK: -
 


### PR DESCRIPTION
### Goals :soccer:
`AdaptHandler` and `RetryHandler` are defined as closure equivalents of the `RequestAdapter` and `RequestRetrier` protocols but their completion arguments are not marked `@escaping` as the equivalents in the protocols are, the upshot being that implementations using the closure interfaces can not be made asynchronous.

### Implementation Details :construction:
Users of the concrete `Adapter`, `Retrier` and `Interceptor` classes will now be able to call their completion closures asynchronously, just as implementers of the equivalent protocols can.

### Testing Details :mag:
Added tests for using the concrete closure-based implementations asynchronously. 😃 