### PR TITLE
[Alamofire 5]: AlamofireExtended extension point.

### DIFF
--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -124,6 +124,10 @@
 		31D83FCF20D5C29300D93E47 /* URLConvertible+URLRequestConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D83FCD20D5C29300D93E47 /* URLConvertible+URLRequestConvertible.swift */; };
 		31D83FD020D5C29300D93E47 /* URLConvertible+URLRequestConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D83FCD20D5C29300D93E47 /* URLConvertible+URLRequestConvertible.swift */; };
 		31D83FD120D5C29300D93E47 /* URLConvertible+URLRequestConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D83FCD20D5C29300D93E47 /* URLConvertible+URLRequestConvertible.swift */; };
+		31DADDFB224811ED0051390F /* AlamofireExtended.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DADDFA224811ED0051390F /* AlamofireExtended.swift */; };
+		31DADDFC224811ED0051390F /* AlamofireExtended.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DADDFA224811ED0051390F /* AlamofireExtended.swift */; };
+		31DADDFD224811ED0051390F /* AlamofireExtended.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DADDFA224811ED0051390F /* AlamofireExtended.swift */; };
+		31DADDFE224811ED0051390F /* AlamofireExtended.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DADDFA224811ED0051390F /* AlamofireExtended.swift */; };
 		31EBD9C120D1D89C00D1FF34 /* ValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AE910119D28DCC0078C7B2 /* ValidationTests.swift */; };
 		31EBD9C220D1D89C00D1FF34 /* ValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AE910119D28DCC0078C7B2 /* ValidationTests.swift */; };
 		31EBD9C320D1D89D00D1FF34 /* ValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AE910119D28DCC0078C7B2 /* ValidationTests.swift */; };
@@ -380,6 +384,7 @@
 		31B2CA9421AA24F5005B371A /* Package@swift-4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Package@swift-4.swift"; sourceTree = "<group>"; };
 		31B2CA9521AA25CD005B371A /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		31D83FCD20D5C29300D93E47 /* URLConvertible+URLRequestConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLConvertible+URLRequestConvertible.swift"; sourceTree = "<group>"; };
+		31DADDFA224811ED0051390F /* AlamofireExtended.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireExtended.swift; sourceTree = "<group>"; };
 		31ED52E61D73889D00199085 /* AFError+AlamofireTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AFError+AlamofireTests.swift"; sourceTree = "<group>"; };
 		31F5085C20B50DC400FE2A0C /* URLSessionConfiguration+Alamofire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSessionConfiguration+Alamofire.swift"; sourceTree = "<group>"; };
 		31F9683B20BB70290009606F /* NSLoggingEventMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLoggingEventMonitor.swift; sourceTree = "<group>"; };
@@ -708,8 +713,8 @@
 				319917A9209CDCB000103A19 /* HTTPHeaders.swift */,
 				31727417218BAEC90039FFCC /* HTTPMethod.swift */,
 				4CB928281C66BFBC00CE5F08 /* Notifications.swift */,
-				4CE2724E1AF88FB500F1D59A /* ParameterEncoding.swift */,
 				3172741C218BB1790039FFCC /* ParameterEncoder.swift */,
+				4CE2724E1AF88FB500F1D59A /* ParameterEncoding.swift */,
 				3191B5741F5F53A6003960A8 /* Protector.swift */,
 				31991790209CDA7F00103A19 /* Request.swift */,
 				319917A4209CDAC400103A19 /* RequestTaskMap.swift */,
@@ -725,6 +730,7 @@
 		4CDE2C491AF8A14E00BABAE5 /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				31DADDFA224811ED0051390F /* AlamofireExtended.swift */,
 				4C4466EA21F8F5D800AC9703 /* CachedResponseHandler.swift */,
 				3111CE8720A77843008315E2 /* EventMonitor.swift */,
 				4C23EB421B327C5B0090E0BC /* MultipartFormData.swift */,
@@ -1338,6 +1344,7 @@
 				3199179E209CDA7F00103A19 /* Session.swift in Sources */,
 				4CF627071BA7CBF60011A099 /* Alamofire.swift in Sources */,
 				3111CE8A20A77945008315E2 /* EventMonitor.swift in Sources */,
+				31DADDFD224811ED0051390F /* AlamofireExtended.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1409,6 +1416,7 @@
 				3199179D209CDA7F00103A19 /* Session.swift in Sources */,
 				4C0E5BF91B673D3400816CCC /* Result.swift in Sources */,
 				3111CE8920A77944008315E2 /* EventMonitor.swift in Sources */,
+				31DADDFC224811ED0051390F /* AlamofireExtended.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1446,6 +1454,7 @@
 				3199179F209CDA7F00103A19 /* Session.swift in Sources */,
 				E4202FD81B667AA100C997FB /* Validation.swift in Sources */,
 				3111CE8B20A77945008315E2 /* EventMonitor.swift in Sources */,
+				31DADDFE224811ED0051390F /* AlamofireExtended.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1483,6 +1492,7 @@
 				3199179C209CDA7F00103A19 /* Session.swift in Sources */,
 				4C0E5BF81B673D3400816CCC /* Result.swift in Sources */,
 				3111CE8820A77843008315E2 /* EventMonitor.swift in Sources */,
+				31DADDFB224811ED0051390F /* AlamofireExtended.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/AlamofireExtended.swift
+++ b/Source/AlamofireExtended.swift
@@ -1,7 +1,7 @@
 //
-//  URLSessionConfiguration+Alamofire.swift
+//  AlamofireExtended.swift
 //
-//  Copyright (c) 2014-2018 Alamofire Software Foundation (http://alamofire.org/)
+//  Copyright (c) 2019 Alamofire Software Foundation (http://alamofire.org/)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -22,14 +22,34 @@
 //  THE SOFTWARE.
 //
 
-import Foundation
+/// Type that acts as a generic extension point for all `AlamofireExtended` types.
+public struct AlamofireExtension<ExtendedType> {
+    /// Stores the type or metatype of any extended type.
+    let type: ExtendedType
 
-extension URLSessionConfiguration: AlamofireExtended { }
-extension AlamofireExtension where ExtendedType: URLSessionConfiguration {
-    public static var `default`: URLSessionConfiguration {
-        let configuration = URLSessionConfiguration.default
-        configuration.httpHeaders = .default
+    init(_ type: ExtendedType) {
+        self.type = type
+    }
+}
 
-        return configuration
+/// Protocol describing the `af` extension points for Alamofire extended types.
+public protocol AlamofireExtended {
+    associatedtype ExtendedType
+
+    /// Static Alamofire extension point.
+    static var af: AlamofireExtension<ExtendedType>.Type { get set }
+    /// Instance Alamofire extension point.
+    var af: AlamofireExtension<ExtendedType> { get set }
+}
+
+public extension AlamofireExtended {
+    static var af: AlamofireExtension<Self>.Type {
+        get { return AlamofireExtension<Self>.self }
+        set { }
+    }
+
+    var af: AlamofireExtension<Self> {
+        get { return AlamofireExtension(self) }
+        set { }
     }
 }

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -74,7 +74,7 @@ open class Session {
         delegate.stateProvider = self
     }
 
-    public convenience init(configuration: URLSessionConfiguration = .alamofireDefault,
+    public convenience init(configuration: URLSessionConfiguration = URLSessionConfiguration.af.default,
                             delegate: SessionDelegate = SessionDelegate(),
                             rootQueue: DispatchQueue = DispatchQueue(label: "org.alamofire.sessionManager.rootQueue"),
                             startRequestsImmediately: Bool = true,

--- a/Source/URLRequest+Alamofire.swift
+++ b/Source/URLRequest+Alamofire.swift
@@ -24,9 +24,9 @@
 
 import Foundation
 
-extension URLRequest {
+public extension URLRequest {
     var method: HTTPMethod? {
-        guard let httpMethod = self.httpMethod else { return nil }
+        guard let httpMethod = httpMethod else { return nil }
         return HTTPMethod(rawValue: httpMethod)
     }
 }

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -306,7 +306,7 @@ class RequestDebugDescriptionTestCase: BaseTestCase {
         var headers = HTTPHeaders.default
         headers["Accept-Language"] = "en-US"
 
-        let configuration = URLSessionConfiguration.alamofireDefault
+        let configuration = URLSessionConfiguration.af.default
         configuration.httpHeaders = headers
 
         let manager = Session(configuration: configuration)
@@ -318,7 +318,7 @@ class RequestDebugDescriptionTestCase: BaseTestCase {
         var headers = HTTPHeaders.default
         headers["Content-Type"] = "application/json"
 
-        let configuration = URLSessionConfiguration.alamofireDefault
+        let configuration = URLSessionConfiguration.af.default
         configuration.httpHeaders = headers
 
         let manager = Session(configuration: configuration)
@@ -327,14 +327,14 @@ class RequestDebugDescriptionTestCase: BaseTestCase {
     }()
 
     func managerWithCookie(_ cookie: HTTPCookie) -> Session {
-        let configuration = URLSessionConfiguration.alamofireDefault
+        let configuration = URLSessionConfiguration.af.default
         configuration.httpCookieStorage?.setCookie(cookie)
 
         return Session(configuration: configuration)
     }
 
     let managerDisallowingCookies: Session = {
-        let configuration = URLSessionConfiguration.alamofireDefault
+        let configuration = URLSessionConfiguration.af.default
         configuration.httpShouldSetCookies = false
 
         let manager = Session(configuration: configuration)

--- a/Tests/ServerTrustEvaluatorTests.swift
+++ b/Tests/ServerTrustEvaluatorTests.swift
@@ -1110,7 +1110,7 @@ class ServerTrustPolicyPinPublicKeysTestCase: ServerTrustPolicyTestCase {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafValidDNSName.trust
-        let keys = [TestCertificates.leafValidDNSName].publicKeys
+        let keys = [TestCertificates.leafValidDNSName].af.publicKeys
         let serverTrustPolicy = PublicKeysTrustEvaluator(keys: keys, validateHost: false)
 
         // When
@@ -1125,7 +1125,7 @@ class ServerTrustPolicyPinPublicKeysTestCase: ServerTrustPolicyTestCase {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafValidDNSName.trust
-        let keys = [TestCertificates.intermediateCA2].publicKeys
+        let keys = [TestCertificates.intermediateCA2].af.publicKeys
         let serverTrustPolicy = PublicKeysTrustEvaluator(keys: keys, validateHost: false)
 
         // When
@@ -1140,7 +1140,7 @@ class ServerTrustPolicyPinPublicKeysTestCase: ServerTrustPolicyTestCase {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafValidDNSName.trust
-        let keys = [TestCertificates.rootCA].publicKeys
+        let keys = [TestCertificates.rootCA].af.publicKeys
         let serverTrustPolicy = PublicKeysTrustEvaluator(keys: keys, validateHost: false)
 
         // When
@@ -1155,7 +1155,7 @@ class ServerTrustPolicyPinPublicKeysTestCase: ServerTrustPolicyTestCase {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafValidDNSName.trust
-        let keys = [TestCertificates.leafSignedByCA2].publicKeys
+        let keys = [TestCertificates.leafSignedByCA2].af.publicKeys
         let serverTrustPolicy = PublicKeysTrustEvaluator(keys: keys, validateHost: false)
 
         // When
@@ -1170,7 +1170,7 @@ class ServerTrustPolicyPinPublicKeysTestCase: ServerTrustPolicyTestCase {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafValidDNSName.trust
-        let keys = [TestCertificates.leafSignedByCA1, TestCertificates.intermediateCA1, TestCertificates.leafValidDNSName].publicKeys
+        let keys = [TestCertificates.leafSignedByCA1, TestCertificates.intermediateCA1, TestCertificates.leafValidDNSName].af.publicKeys
         let serverTrustPolicy = PublicKeysTrustEvaluator(keys: keys, validateHost: false)
 
         // When
@@ -1187,7 +1187,7 @@ class ServerTrustPolicyPinPublicKeysTestCase: ServerTrustPolicyTestCase {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafValidDNSName.trust
-        let keys = [TestCertificates.leafValidDNSName].publicKeys
+        let keys = [TestCertificates.leafValidDNSName].af.publicKeys
         let serverTrustPolicy = PublicKeysTrustEvaluator(keys: keys)
 
         // When
@@ -1202,7 +1202,7 @@ class ServerTrustPolicyPinPublicKeysTestCase: ServerTrustPolicyTestCase {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafValidDNSName.trust
-        let keys = [TestCertificates.intermediateCA2].publicKeys
+        let keys = [TestCertificates.intermediateCA2].af.publicKeys
         let serverTrustPolicy = PublicKeysTrustEvaluator(keys: keys)
 
         // When
@@ -1217,7 +1217,7 @@ class ServerTrustPolicyPinPublicKeysTestCase: ServerTrustPolicyTestCase {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafValidDNSName.trust
-        let keys = [TestCertificates.rootCA].publicKeys
+        let keys = [TestCertificates.rootCA].af.publicKeys
         let serverTrustPolicy = PublicKeysTrustEvaluator(keys: keys)
 
         // When
@@ -1232,7 +1232,7 @@ class ServerTrustPolicyPinPublicKeysTestCase: ServerTrustPolicyTestCase {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafValidDNSName.trust
-        let keys = [TestCertificates.leafSignedByCA2].publicKeys
+        let keys = [TestCertificates.leafSignedByCA2].af.publicKeys
         let serverTrustPolicy = PublicKeysTrustEvaluator(keys: keys)
 
         // When
@@ -1247,7 +1247,7 @@ class ServerTrustPolicyPinPublicKeysTestCase: ServerTrustPolicyTestCase {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafValidDNSName.trust
-        let keys = [TestCertificates.leafSignedByCA1, TestCertificates.intermediateCA1, TestCertificates.leafValidDNSName].publicKeys
+        let keys = [TestCertificates.leafSignedByCA1, TestCertificates.intermediateCA1, TestCertificates.leafValidDNSName].af.publicKeys
         let serverTrustPolicy = PublicKeysTrustEvaluator(keys: keys)
 
         // When
@@ -1264,7 +1264,7 @@ class ServerTrustPolicyPinPublicKeysTestCase: ServerTrustPolicyTestCase {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafValidDNSNameMissingIntermediate.trust
-        let keys = [TestCertificates.leafValidDNSName].publicKeys
+        let keys = [TestCertificates.leafValidDNSName].af.publicKeys
         let serverTrustPolicy = PublicKeysTrustEvaluator(keys: keys,
                                                          performDefaultValidation: false,
                                                          validateHost: false)
@@ -1281,7 +1281,7 @@ class ServerTrustPolicyPinPublicKeysTestCase: ServerTrustPolicyTestCase {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafValidDNSNameMissingIntermediate.trust
-        let keys = [TestCertificates.rootCA].publicKeys
+        let keys = [TestCertificates.rootCA].af.publicKeys
         let serverTrustPolicy = PublicKeysTrustEvaluator(keys: keys,
                                                          performDefaultValidation: false,
                                                          validateHost: false)
@@ -1298,7 +1298,7 @@ class ServerTrustPolicyPinPublicKeysTestCase: ServerTrustPolicyTestCase {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafValidDNSNameWithIncorrectIntermediate.trust
-        let keys = [TestCertificates.leafValidDNSName].publicKeys
+        let keys = [TestCertificates.leafValidDNSName].af.publicKeys
         let serverTrustPolicy = PublicKeysTrustEvaluator(keys: keys,
                                                          performDefaultValidation: false,
                                                          validateHost: false)
@@ -1315,7 +1315,7 @@ class ServerTrustPolicyPinPublicKeysTestCase: ServerTrustPolicyTestCase {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafExpired.trust
-        let keys = [TestCertificates.leafExpired].publicKeys
+        let keys = [TestCertificates.leafExpired].af.publicKeys
         let serverTrustPolicy = PublicKeysTrustEvaluator(keys: keys,
                                                          performDefaultValidation: false,
                                                          validateHost: false)
@@ -1332,7 +1332,7 @@ class ServerTrustPolicyPinPublicKeysTestCase: ServerTrustPolicyTestCase {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafExpired.trust
-        let keys = [TestCertificates.intermediateCA2].publicKeys
+        let keys = [TestCertificates.intermediateCA2].af.publicKeys
         let serverTrustPolicy = PublicKeysTrustEvaluator(keys: keys,
                                                          performDefaultValidation: false,
                                                          validateHost: false)
@@ -1349,7 +1349,7 @@ class ServerTrustPolicyPinPublicKeysTestCase: ServerTrustPolicyTestCase {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafExpired.trust
-        let keys = [TestCertificates.rootCA].publicKeys
+        let keys = [TestCertificates.rootCA].af.publicKeys
         let serverTrustPolicy = PublicKeysTrustEvaluator(keys: keys,
                                                          performDefaultValidation: false,
                                                          validateHost: false)
@@ -1461,7 +1461,7 @@ class ServerTrustPolicyCertificatesInBundleTestCase: ServerTrustPolicyTestCase {
         // keyDER.der: DER-encoded key, not a certificate, should fail
 
         // When
-        let certificates = Bundle(for: ServerTrustPolicyCertificatesInBundleTestCase.self).certificates
+        let certificates = Bundle(for: ServerTrustPolicyCertificatesInBundleTestCase.self).af.certificates
 
         // Then
         // Expectation: 19 well-formed certificates in the test bundle plus 4 invalid certificates.

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -423,7 +423,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
     func testThatExpiredCertificateRequestFailsWhenPinningLeafPublicKeyWithCertificateChainValidation() {
         // Given
-        let keys = [TestCertificates.leaf].publicKeys
+        let keys = [TestCertificates.leaf].af.publicKeys
         let evaluators = [
             expiredHost: PublicKeysTrustEvaluator(keys: keys)
         ]
@@ -457,7 +457,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
     func testThatExpiredCertificateRequestSucceedsWhenPinningLeafPublicKeyWithoutCertificateChainOrHostValidation() {
         // Given
-        let keys = [TestCertificates.leaf].publicKeys
+        let keys = [TestCertificates.leaf].af.publicKeys
         let evaluators = [
             expiredHost: PublicKeysTrustEvaluator(keys: keys, performDefaultValidation: false, validateHost: false)
         ]
@@ -485,7 +485,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
     func testThatExpiredCertificateRequestSucceedsWhenPinningIntermediateCAPublicKeyWithoutCertificateChainOrHostValidation() {
         // Given
-        let keys = [TestCertificates.intermediateCA2].publicKeys
+        let keys = [TestCertificates.intermediateCA2].af.publicKeys
         let evaluators = [
             expiredHost: PublicKeysTrustEvaluator(keys: keys, performDefaultValidation: false, validateHost: false)
         ]
@@ -513,7 +513,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
     func testThatExpiredCertificateRequestSucceedsWhenPinningRootCAPublicKeyWithoutCertificateChainValidation() {
         // Given
-        let keys = [TestCertificates.rootCA].publicKeys
+        let keys = [TestCertificates.rootCA].af.publicKeys
         let evaluators = [
             expiredHost: PublicKeysTrustEvaluator(keys: keys, performDefaultValidation: false, validateHost: false)
         ]


### PR DESCRIPTION
### Issue Link :link:
#2750

### Goals :soccer:
This PR adds the `AlamofireExtended` protocol and `AlamofireExtension` type to enable `.af` extension points on any conforming type. This allows us to put all of our extensions of types we don't own behind a single entry point.

### Implementation Details :construction:
Types conforming to `AlamofireExtended` receive the `.af` static and instance properties. Extending `AlamofireExtension where ExtendedType` is necessary to add functionality to those extension points on particular types. Our extensions of various Security types, as well as `URLSessionConfiguration`, have been updated to use this pattern. 

### Testing Details :mag:
Tests of the extended API have been updated, but no specific tests have been added, as the extension protocol and type have no functionality without extensions.