### PR TITLE
Hotfix: Support for swift package manager 5 in Alamofire 4.8.x

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,5 +37,5 @@ let package = Package(
             name: "Alamofire",
             path: "Source")
     ],
-    swiftLanguageVersions: [3, 4]
+    swiftLanguageVersions: [.v3, .v4]
 )


### PR DESCRIPTION
Currently Alamofire 4.8.1 does not compile with `Apple Swift version 5.0 (swiftlang-1001.0.69.5 clang-1001.0.46.3)` on macOS 10.14.4.

Error: `cannot convert value of type 'Int' to expected element type 'SwiftVersion'`

This new `Package.swift` works with `Apple Swift Package Manager - Swift 4.2.0 (swiftpm-14460.2)` and `Apple Swift Package Manager - Swift 5.0.0 (swiftpm-14490.60.2)`.