### PR TITLE
Refactor - Upload MultipartFormData with Custom Boundary

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -337,6 +337,7 @@ public enum AF {
     /// - Parameters:
     ///   - multipartFormData:       The closure used to append body parts to the `MultipartFormData`.
     ///   - encodingMemoryThreshold: The encoding memory threshold in bytes. `10_000_000` bytes by default.
+    ///   - fileManager:             The `FileManager` instance to use to manage streaming and encoding.
     ///   - url:                     The `URLConvertible` value.
     ///   - method:                  The `HTTPMethod`, `.post` by default.
     ///   - headers:                 The `HTTPHeaders`, `nil` by default.
@@ -345,12 +346,14 @@ public enum AF {
     /// - Returns: The created `UploadRequest`.
     public static func upload(multipartFormData: @escaping (MultipartFormData) -> Void,
                               usingThreshold encodingMemoryThreshold: UInt64 = MultipartUpload.encodingMemoryThreshold,
+                              fileManager: FileManager = .default,
                               to url: URLConvertible,
                               method: HTTPMethod = .post,
                               headers: HTTPHeaders? = nil,
                               interceptor: RequestInterceptor? = nil) -> UploadRequest {
         return Session.default.upload(multipartFormData: multipartFormData,
                                       usingThreshold: encodingMemoryThreshold,
+                                      fileManager: fileManager,
                                       to: url,
                                       method: method,
                                       headers: headers,
@@ -381,7 +384,7 @@ public enum AF {
     ///
     /// - Returns: The `UploadRequest` created.
     @discardableResult
-    public static func upload(multipartFormData: @escaping (MultipartFormData) -> Void,
+    public static func upload(multipartFormData: MultipartFormData,
                               usingThreshold encodingMemoryThreshold: UInt64 = MultipartUpload.encodingMemoryThreshold,
                               with urlRequest: URLRequestConvertible,
                               interceptor: RequestInterceptor? = nil) -> UploadRequest {

--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -100,7 +100,8 @@ open class MultipartFormData {
     /// The boundary used to separate the body parts in the encoded form data.
     public let boundary: String
 
-    private let fileManager: FileManager
+    let fileManager: FileManager
+
     private var bodyParts: [BodyPart]
     private var bodyPartError: AFError?
     private let streamBufferSize: Int

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -326,22 +326,23 @@ open class Session {
                      interceptor: RequestInterceptor? = nil) -> UploadRequest {
         let convertible = ParameterlessRequestConvertible(url: url, method: method, headers: headers)
 
-        return upload(multipartFormData: multipartFormData,
+        let formData = MultipartFormData(fileManager: fileManager)
+        multipartFormData(formData)
+
+        return upload(multipartFormData: formData,
                       usingThreshold: encodingMemoryThreshold,
                       with: convertible,
                       interceptor: interceptor)
     }
 
-    open func upload(multipartFormData: @escaping (MultipartFormData) -> Void,
+    open func upload(multipartFormData: MultipartFormData,
                      usingThreshold encodingMemoryThreshold: UInt64 = MultipartUpload.encodingMemoryThreshold,
-                     fileManager: FileManager = .default,
                      with request: URLRequestConvertible,
                      interceptor: RequestInterceptor? = nil) -> UploadRequest {
         let multipartUpload = MultipartUpload(isInBackgroundSession: (session.configuration.identifier != nil),
                                               encodingMemoryThreshold: encodingMemoryThreshold,
                                               request: request,
-                                              fileManager: fileManager,
-                                              multipartBuilder: multipartFormData)
+                                              multipartFormData: multipartFormData)
 
         return upload(multipartUpload, interceptor: interceptor)
     }


### PR DESCRIPTION
This PR updates the upload APIs for `MultipartFormData` to support a builder closure for the more convenient API, and a `MultipartFormData` instance for the more complex one. This allows users to create custom boundaries if necessary. The builder closure does not expose the boundary as a parameter.

### Issue Link :link:
The original issue was raised in #2705.

### Goals :soccer:
We want to allow users that MUST change the boundary to still use the top-level APIs. We also want to avoid having to add new APIs to handle this use case if possible.

### Implementation Details :construction:
Pretty simple change overall, we just switched the complex API over from using a builder closure to taking an instance. This also allows us to remove the `fileManager` parameter from the API.

### Testing Details :mag:
Test suite is still passing as expected.
