### PR TITLE
🐷 Refactor - Switches and Queues

### DIFF
--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -294,22 +294,14 @@ extension AFError {
 extension AFError {
     /// The `URLConvertible` associated with the error.
     public var urlConvertible: URLConvertible? {
-        switch self {
-        case .invalidURL(let url):
-            return url
-        default:
-            return nil
-        }
+        guard case .invalidURL(let url) = self else { return nil }
+        return url
     }
 
     /// The `URL` associated with the error.
     public var url: URL? {
-        switch self {
-        case .multipartEncodingFailed(let reason):
-            return reason.url
-        default:
-            return nil
-        }
+        guard case .multipartEncodingFailed(let reason) = self else { return nil }
+        return reason.url
     }
 
     /// The underlying `Error` responsible for generating the failure associated with `.sessionInvalidated`,
@@ -338,64 +330,40 @@ extension AFError {
 
     /// The acceptable `Content-Type`s of a `.responseValidationFailed` error.
     public var acceptableContentTypes: [String]? {
-        switch self {
-        case .responseValidationFailed(let reason):
-            return reason.acceptableContentTypes
-        default:
-            return nil
-        }
+        guard case .responseValidationFailed(let reason) = self else { return nil }
+        return reason.acceptableContentTypes
     }
 
     /// The response `Content-Type` of a `.responseValidationFailed` error.
     public var responseContentType: String? {
-        switch self {
-        case .responseValidationFailed(let reason):
-            return reason.responseContentType
-        default:
-            return nil
-        }
+        guard case  .responseValidationFailed(let reason) = self else { return nil }
+        return reason.responseContentType
     }
 
     /// The response code of a `.responseValidationFailed` error.
     public var responseCode: Int? {
-        switch self {
-        case .responseValidationFailed(let reason):
-            return reason.responseCode
-        default:
-            return nil
-        }
+        guard case .responseValidationFailed(let reason) = self else { return nil }
+        return reason.responseCode
     }
 
     /// The `String.Encoding` associated with a failed `.stringResponse()` call.
     public var failedStringEncoding: String.Encoding? {
-        switch self {
-        case .responseSerializationFailed(let reason):
-            return reason.failedStringEncoding
-        default:
-            return nil
-        }
+        guard case .responseSerializationFailed(let reason) = self else { return nil }
+        return reason.failedStringEncoding
     }
 }
 
 extension AFError.ParameterEncodingFailureReason {
     var underlyingError: Error? {
-        switch self {
-        case .jsonEncodingFailed(let error):
-            return error
-        default:
-            return nil
-        }
+        guard case .jsonEncodingFailed(let error) = self else { return nil }
+        return error
     }
 }
 
 extension AFError.ParameterEncoderFailureReason {
     var underlyingError: Error? {
-        switch self {
-        case .encoderFailed(let error):
-            return error
-        default:
-            return nil
-        }
+        guard case .encoderFailed(let error) = self else { return nil }
+        return error
     }
 }
 
@@ -435,41 +403,25 @@ extension AFError.ResponseValidationFailureReason {
     }
 
     var responseContentType: String? {
-        switch self {
-        case .unacceptableContentType(_, let responseType):
-            return responseType
-        default:
-            return nil
-        }
+        guard case .unacceptableContentType(_, let responseType) = self else { return nil }
+        return responseType
     }
 
     var responseCode: Int? {
-        switch self {
-        case .unacceptableStatusCode(let code):
-            return code
-        default:
-            return nil
-        }
+        guard case .unacceptableStatusCode(let code) = self else { return nil }
+        return code
     }
 }
 
 extension AFError.ResponseSerializationFailureReason {
     var failedStringEncoding: String.Encoding? {
-        switch self {
-        case .stringSerializationFailed(let encoding):
-            return encoding
-        default:
-            return nil
-        }
+        guard case .stringSerializationFailed(let encoding) = self else { return nil }
+        return encoding
     }
 
     var underlyingError: Error? {
-        switch self {
-        case .jsonSerializationFailed(let error):
-            return error
-        default:
-            return nil
-        }
+        guard case .jsonSerializationFailed(let error) = self else { return nil }
+        return error
     }
 }
 

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -104,14 +104,12 @@ extension DataRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `nil`, which means
-    ///                        the handler is called on `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
     ///   - completionHandler: The code to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
-    public func response(queue: DispatchQueue? = nil, completionHandler: @escaping (DataResponse<Data?>) -> Void) -> Self {
+    public func response(queue: DispatchQueue = .main, completionHandler: @escaping (DataResponse<Data?>) -> Void) -> Self {
         appendResponseSerializer {
-            let queue = queue ?? .main
             let result = Result(value: self.data, error: self.error)
             let response = DataResponse(request: self.request,
                                         response: self.response,
@@ -131,14 +129,13 @@ extension DataRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:              The queue on which the completion handler is dispatched. Defaults to `nil`, which means
-    ///                         the handler is called on `.main`.
+    ///   - queue:              The queue on which the completion handler is dispatched. Defaults to `.main`.
     ///   - responseSerializer: The response serializer responsible for serializing the request, response, and data.
     ///   - completionHandler:  The code to be executed once the request has finished.
     /// - Returns:              The request.
     @discardableResult
     public func response<Serializer: DataResponseSerializerProtocol>(
-        queue: DispatchQueue? = nil,
+        queue: DispatchQueue = .main,
         responseSerializer: Serializer,
         completionHandler: @escaping (DataResponse<Serializer.SerializedObject>) -> Void)
         -> Self
@@ -151,7 +148,6 @@ extension DataRequest {
                                                                    error: self.error) }
             let end = CFAbsoluteTimeGetCurrent()
 
-            let queue: DispatchQueue = queue ?? .main
             let response = DataResponse(request: self.request,
                                         response: self.response,
                                         data: self.data,
@@ -205,18 +201,16 @@ extension DownloadRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `nil`, which means
-    ///                        the handler is called on `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
     ///   - completionHandler: The code to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
     public func response(
-        queue: DispatchQueue? = nil,
+        queue: DispatchQueue = .main,
         completionHandler: @escaping (DownloadResponse<URL?>) -> Void)
         -> Self
     {
         appendResponseSerializer {
-            let queue = queue ?? .main
             let result = Result(value: self.fileURL , error: self.error)
             let response = DownloadResponse(request: self.request,
                                             response: self.response,
@@ -235,15 +229,14 @@ extension DownloadRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:              The queue on which the completion handler is dispatched. Defaults to `nil`, which means
-    ///                         the handler is called on `.main`.
+    ///   - queue:              The queue on which the completion handler is dispatched. Defaults to `.main`.
     ///   - responseSerializer: The response serializer responsible for serializing the request, response, and data
     ///                         contained in the destination url.
     ///   - completionHandler:  The code to be executed once the request has finished.
     /// - Returns:              The request.
     @discardableResult
     public func response<T: DownloadResponseSerializerProtocol>(
-        queue: DispatchQueue? = nil,
+        queue: DispatchQueue = .main,
         responseSerializer: T,
         completionHandler: @escaping (DownloadResponse<T.SerializedObject>) -> Void)
         -> Self
@@ -256,7 +249,6 @@ extension DownloadRequest {
                                                                            error: self.error) }
             let end = CFAbsoluteTimeGetCurrent()
 
-            let queue: DispatchQueue = queue ?? .main
             let response = DownloadResponse(request: self.request,
                                             response: self.response,
                                             fileURL: self.fileURL,
@@ -312,13 +304,12 @@ extension DataRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `nil`, which means
-    ///                        the handler is called on `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
     ///   - completionHandler: The code to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
     public func responseData(
-        queue: DispatchQueue? = nil,
+        queue: DispatchQueue = .main,
         completionHandler: @escaping (DataResponse<Data>) -> Void)
         -> Self
     {
@@ -368,13 +359,12 @@ extension DownloadRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `nil`, which means
-    ///                        the handler is called on `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
     ///   - completionHandler: The code to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
     public func responseData(
-        queue: DispatchQueue? = nil,
+        queue: DispatchQueue = .main,
         completionHandler: @escaping (DownloadResponse<Data>) -> Void)
         -> Self
     {
@@ -448,14 +438,13 @@ extension DataRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `nil`, which means
-    ///                        the handler is called on `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
     ///   - encoding:          The string encoding. Defaults to `nil`, in which case the encoding will be determined from
     ///                        the server response, falling back to the default HTTP character set, `ISO-8859-1`.
     ///   - completionHandler: A closure to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
-    public func responseString(queue: DispatchQueue? = nil,
+    public func responseString(queue: DispatchQueue = .main,
                                encoding: String.Encoding? = nil,
                                completionHandler: @escaping (DataResponse<String>) -> Void) -> Self {
         return response(queue: queue,
@@ -468,15 +457,14 @@ extension DownloadRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `nil`, which means
-    ///                        the handler is called on `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
     ///   - encoding:          The string encoding. Defaults to `nil`, in which case the encoding will be determined from
     ///                        the server response, falling back to the default HTTP character set, `ISO-8859-1`.
     ///   - completionHandler: A closure to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
     public func responseString(
-        queue: DispatchQueue? = nil,
+        queue: DispatchQueue = .main,
         encoding: String.Encoding? = nil,
         completionHandler: @escaping (DownloadResponse<String>) -> Void)
         -> Self
@@ -540,13 +528,12 @@ extension DataRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `nil`, which means
-    ///                        the handler is called on `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
     ///   - options:           The JSON serialization reading options. Defaults to `.allowFragments`.
     ///   - completionHandler: A closure to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
-    public func responseJSON(queue: DispatchQueue? = nil,
+    public func responseJSON(queue: DispatchQueue = .main,
                              options: JSONSerialization.ReadingOptions = .allowFragments,
                              completionHandler: @escaping (DataResponse<Any>) -> Void) -> Self {
         return response(queue: queue,
@@ -559,14 +546,13 @@ extension DownloadRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `nil`, which means
-    ///                        the handler is called on `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
     ///   - options:           The JSON serialization reading options. Defaults to `.allowFragments`.
     ///   - completionHandler: A closure to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
     public func responseJSON(
-        queue: DispatchQueue? = nil,
+        queue: DispatchQueue = .main,
         options: JSONSerialization.ReadingOptions = .allowFragments,
         completionHandler: @escaping (DownloadResponse<Any>) -> Void)
         -> Self
@@ -667,14 +653,13 @@ extension DataRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `nil`, which means
-    ///                        the handler is called on `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
     ///   - decoder:           The `DataDecoder` to use to decode the response. Defaults to a `JSONDecoder` with default
     ///                        settings.
     ///   - completionHandler: A closure to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
-    public func responseDecodable<T: Decodable>(queue: DispatchQueue? = nil,
+    public func responseDecodable<T: Decodable>(queue: DispatchQueue = .main,
                                                 decoder: DataDecoder = JSONDecoder(),
                                                 completionHandler: @escaping (DataResponse<T>) -> Void) -> Self {
         return response(queue: queue,

--- a/Source/Result.swift
+++ b/Source/Result.swift
@@ -50,12 +50,8 @@ public enum Result<Value> {
 
     /// Returns `true` if the result is a success, `false` otherwise.
     public var isSuccess: Bool {
-        switch self {
-        case .success:
-            return true
-        case .failure:
-            return false
-        }
+        guard case .success = self else { return false }
+        return true
     }
 
     /// Returns `true` if the result is a failure, `false` otherwise.
@@ -65,22 +61,14 @@ public enum Result<Value> {
 
     /// Returns the associated value if the result is a success, `nil` otherwise.
     public var value: Value? {
-        switch self {
-        case .success(let value):
-            return value
-        case .failure:
-            return nil
-        }
+        guard case .success(let value) = self else { return nil }
+        return value
     }
 
     /// Returns the associated error value if the result is a failure, `nil` otherwise.
     public var error: Error? {
-        switch self {
-        case .success:
-            return nil
-        case .failure(let error):
-            return error
-        }
+        guard case .failure(let error) = self else { return nil }
+        return error
     }
 }
 
@@ -225,12 +213,8 @@ extension Result {
     /// - Returns: A `Result` instance containing the result of the transform. If this instance is a success, returns
     ///            the same instance.
     public func mapError<T: Error>(_ transform: (Error) -> T) -> Result {
-        switch self {
-        case .failure(let error):
-            return .failure(transform(error))
-        case .success:
-            return self
-        }
+        guard case .failure(let error) = self else { return self }
+        return .failure(transform(error))
     }
 
     /// Evaluates the specified closure when the `Result` is a failure, passing the unwrapped error as a parameter.


### PR DESCRIPTION
This PR is a simplification of #2691 where some of the changes have been culled out due to either being changes we do not agree with, or changes that were incorrect.

### Issue Link :link:
This is a subset of #2691 that maintains attribution to @jdisho.

### Goals :soccer:
To refactor the switches into guards where applicable and also move away from optional queues in the response serialization logic.

### Implementation Details :construction:
No real details here worth calling out other than this PR is piggy-backed on #2716 since that PR contains a lot of changes with regards to the DispatchQueue usage in response serialization.

### Testing Details :mag:
Test suite still looks good. These changes do not change any actual functionality.
