### PR TITLE
Refactor - Condensing MultipartFormData Data APIs

### DIFF
--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -130,44 +130,6 @@ open class MultipartFormData {
     ///
     /// The body part data will be encoded using the following format:
     ///
-    /// - `Content-Disposition: form-data; name=#{name}` (HTTP Header)
-    /// - Encoded data
-    /// - Multipart form boundary
-    ///
-    /// - parameter data: The data to encode into the multipart form data.
-    /// - parameter name: The name to associate with the data in the `Content-Disposition` HTTP header.
-    public func append(_ data: Data, withName name: String) {
-        let headers = contentHeaders(withName: name)
-        let stream = InputStream(data: data)
-        let length = UInt64(data.count)
-
-        append(stream, withLength: length, headers: headers)
-    }
-
-    /// Creates a body part from the data and appends it to the multipart form data object.
-    ///
-    /// The body part data will be encoded using the following format:
-    ///
-    /// - `Content-Disposition: form-data; name=#{name}` (HTTP Header)
-    /// - `Content-Type: #{generated mimeType}` (HTTP Header)
-    /// - Encoded data
-    /// - Multipart form boundary
-    ///
-    /// - parameter data:     The data to encode into the multipart form data.
-    /// - parameter name:     The name to associate with the data in the `Content-Disposition` HTTP header.
-    /// - parameter mimeType: The MIME type to associate with the data content type in the `Content-Type` HTTP header.
-    public func append(_ data: Data, withName name: String, mimeType: String) {
-        let headers = contentHeaders(withName: name, mimeType: mimeType)
-        let stream = InputStream(data: data)
-        let length = UInt64(data.count)
-
-        append(stream, withLength: length, headers: headers)
-    }
-
-    /// Creates a body part from the data and appends it to the multipart form data object.
-    ///
-    /// The body part data will be encoded using the following format:
-    ///
     /// - `Content-Disposition: form-data; name=#{name}; filename=#{filename}` (HTTP Header)
     /// - `Content-Type: #{mimeType}` (HTTP Header)
     /// - Encoded file data
@@ -177,7 +139,7 @@ open class MultipartFormData {
     /// - parameter name:     The name to associate with the data in the `Content-Disposition` HTTP header.
     /// - parameter fileName: The filename to associate with the data in the `Content-Disposition` HTTP header.
     /// - parameter mimeType: The MIME type to associate with the data in the `Content-Type` HTTP header.
-    public func append(_ data: Data, withName name: String, fileName: String, mimeType: String) {
+    public func append(_ data: Data, withName name: String, fileName: String? = nil, mimeType: String? = nil) {
         let headers = contentHeaders(withName: name, fileName: fileName, mimeType: mimeType)
         let stream = InputStream(data: data)
         let length = UInt64(data.count)


### PR DESCRIPTION
This PR is a small modification from #2718 while maintaining attribution to @rivera-ernesto. It combines the data APIs in `MultipartFormData` into a single API.

### Issue Link :link:
This issue drops a couple of the changes in #2718 while maintaining attribution.

### Goals :soccer:
Squash the duplicate `MultipartFormData` APIs where applicable.

### Implementation Details :construction:
No functional changes, just using optionals and default arguments where applicable.

### Testing Details :mag:
Test suite is still passing.
