### PR TITLE
Bugfix - Cancellation Loop

### DIFF
--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -1104,7 +1104,6 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -396,8 +396,19 @@ open class Request {
     /// Processes the next response serializer and calls all completions if response serialization is complete.
     func processNextResponseSerializer() {
         guard let responseSerializer = nextResponseSerializer() else {
-            // Execute all response serializer completions
-            protectedMutableState.directValue.responseSerializerCompletions.forEach { $0() }
+            // Execute all response serializer completions and clear them
+            protectedMutableState.write { mutableState in
+                let completions = mutableState.responseSerializerCompletions
+
+                // Clear out all response serializers and response serializer completions in mutable state since the
+                // request is complete. It's important to do this prior to calling the completion closures in case
+                // the completions call back into the request triggering a re-processing of the response serializers.
+                // An example of how this can happen is by calling cancel inside a response completion closure.
+                mutableState.responseSerializers.removeAll()
+                mutableState.responseSerializerCompletions.removeAll()
+
+                completions.forEach { $0() }
+            }
 
             // Cleanup the request
             cleanup()

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -397,8 +397,10 @@ open class Request {
     func processNextResponseSerializer() {
         guard let responseSerializer = nextResponseSerializer() else {
             // Execute all response serializer completions and clear them
+            var completions: [() -> Void] = []
+
             protectedMutableState.write { mutableState in
-                let completions = mutableState.responseSerializerCompletions
+                completions = mutableState.responseSerializerCompletions
 
                 // Clear out all response serializers and response serializer completions in mutable state since the
                 // request is complete. It's important to do this prior to calling the completion closures in case
@@ -406,9 +408,9 @@ open class Request {
                 // An example of how this can happen is by calling cancel inside a response completion closure.
                 mutableState.responseSerializers.removeAll()
                 mutableState.responseSerializerCompletions.removeAll()
-
-                completions.forEach { $0() }
             }
+
+            completions.forEach { $0() }
 
             // Cleanup the request
             cleanup()


### PR DESCRIPTION
This PR fixes an issue in the response serialization retry logic where calling `cancel` and a few other APIs would result in the response serializers running again.

### Goals :soccer:
Fix the issue where calling `request.cancel()` inside response serializer would result in the response serializer running again.

### Implementation Details :construction:
I should have realized this when I was building it, but it came up when moving our networking library onto AF5 and running the test suite over it. When we finish running all the response serializers and determine that we do not need to retry the request, we then execute all the response serializer completions sequentially. However, we don't exactly know what are in those completions. Therefore, we have to assume the worst and that they call back into the request to possibly do things like `request.cancel()`. I actually had a few unit tests doing this and found some dragons.

Solution is to clear out all the response serializers and completions from the mutable state prior to actually executing the completions. This is how the logic should have been implemented in the beginning.

### Testing Details :mag:
I added a test that fails without this change demonstrating the issue.
