### PR TITLE
Bugfix - Resumed Request State

### DIFF
--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -1435,6 +1435,65 @@ class SessionTestCase: BaseTestCase {
         // Then
         assertErrorIsAFError(error) { XCTAssertTrue($0.isSessionDeinitializedError) }
     }
+
+    // MARK: Tests - Request Cancellation
+
+    func testThatSessionOnlyCallsResponseSerializerCompletionWhenCancellingInsideCompletion() {
+        // Given
+        let handler = RequestHandler()
+        let session = Session()
+
+        let expectation = self.expectation(description: "request should complete")
+        var response: DataResponse<Any>?
+        var completionCallCount = 0
+
+        // When
+        let request = session.request("https://httpbin.org/get", interceptor: handler)
+        request.validate()
+
+        request.responseJSON { resp in
+            request.cancel()
+
+            response = resp
+            completionCallCount += 1
+
+            DispatchQueue.main.after(0.01) { expectation.fulfill() }
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertEqual(handler.adaptCalledCount, 1)
+        XCTAssertEqual(handler.adaptedCount, 1)
+        XCTAssertEqual(handler.retryCalledCount, 0)
+        XCTAssertEqual(handler.retryCount, 0)
+        XCTAssertEqual(request.retryCount, 0)
+        XCTAssertEqual(response?.result.isSuccess, true)
+        XCTAssertTrue(session.requestTaskMap.isEmpty)
+        XCTAssertEqual(completionCallCount, 1)
+    }
+
+    // MARK: Tests - Request State
+
+    func testThatSessionSetsRequestStateWhenStartRequestsImmediatelyIsTrue() {
+        // Given
+        let session = Session()
+
+        let expectation = self.expectation(description: "request should complete")
+        var response: DataResponse<Any>?
+
+        // When
+        let request = session.request("https://httpbin.org/get").responseJSON { resp in
+            response = resp
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertEqual(request.state, .resumed)
+        XCTAssertEqual(response?.result.isSuccess, true)
+    }
 }
 
 // MARK: -


### PR DESCRIPTION
This PR fixes an issue where the `Request.State` was never being set to `.resumed` when `startRequestsImmediately` is set to `true`.

### Goals :soccer:
When setting `startRequestsImmediately` to `true`, the request's state should reflect it's actual state.

### Implementation Details :construction:
There is a huge amount of complexity in this simple little method. I tried to actually document what's going on in the code because I thought it might be worthwhile to have. With the lack of thread-safety written in the state management in `Request` and the decoupling from the tasks themselves, we don't have any choice other than to run `resume` or `suspend` an extra time if the user is resuming the requests themselves. The `request.resume()` call is racing with the `Request` and `URLSessionTask` creation. Depending on which one wins, we can get into a scenario where `didResume` or `didSuspend` can be called twice even though only one `resume` or `suspend` call was actually made.

I don't really think this is an issue overall, it just required me to make some tests more robust once I realized these can be called more than once even if I only call them once. I don't think it's worth us trying to alter the entire threading model for this use case.

### Testing Details :mag:
I added a test to verify the state is now being set correctly when using `startRequestsImmediately`. I can't really write other reliable tests that will produce the race consistently. I do however have them in my networking test suite on top of AF and I can reproduce the race about 1 in 4 tries.
