### PR TITLE
Bugfix - Session Delegate Precondition

### DIFF
--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -54,8 +54,6 @@ open class Session {
                 redirectHandler: RedirectHandler? = nil,
                 cachedResponseHandler: CachedResponseHandler? = nil,
                 eventMonitors: [EventMonitor] = []) {
-        precondition(session.delegate === delegate,
-                     "SessionManager(session:) initializer must be passed the delegate that has been assigned to the URLSession as the SessionDataProvider.")
         precondition(session.delegateQueue.underlyingQueue === rootQueue,
                      "SessionManager(session:) intializer must be passed the DispatchQueue used as the delegateQueue's underlyingQueue as rootQueue.")
 


### PR DESCRIPTION
This PR removes the URL session delegate precondition check.

### Goals :soccer:
Users should be able to create `Session` instances alongside performance monitoring frameworks such as NewRelic that are swizzling our URLSessionDelegate APIs by proxying. 

### Implementation Details :construction:
While the session delegate precondition check is a good idea, enforcing the check causes Alamofire to be unusable with other frameworks that are swizzling out URL session delegate APIs. In cases where say Alamofire and NewRelic are being used within the same application, the precondition check will always fail.

![Screen Shot 2019-04-02 at 5 34 42 PM](https://user-images.githubusercontent.com/169110/55522211-d0a2d380-5638-11e9-9c98-7021324c7999.png)

> The above example demonstrates what you get when you `po` the `session.delegate` and `delegate` inside the `precondition` removed in this PR. The `session.delegate` is an `NRMAURLSessionTaskDelegate` (_courtesy of NewRelic proxy swizzling_) and the `delegate` is an `Alamofire.SessionDelegate`.

I'm open to other ideas here as well. We could add a flag to disable the precondition that's `false` by default, but I thought it might be overkill to expose this precondition controls through the public API.

### Testing Details :mag:
N/A.