### PR TITLE
Casting to AnyObject makes life hard for Swift type checker.

### DIFF
--- a/Source/ServerTrustPolicy.swift
+++ b/Source/ServerTrustPolicy.swift
@@ -219,9 +219,9 @@ public enum ServerTrustPolicy {
             }
 
             if certificateChainEvaluationPassed {
-                outerLoop: for serverPublicKey in ServerTrustPolicy.publicKeys(for: serverTrust) as [AnyObject] {
-                    for pinnedPublicKey in pinnedPublicKeys as [AnyObject] {
-                        if serverPublicKey.isEqual(pinnedPublicKey) {
+                outerLoop: for serverPublicKey in ServerTrustPolicy.publicKeys(for: serverTrust) {
+                    for pinnedPublicKey in pinnedPublicKeys {
+                        if serverPublicKey == pinnedPublicKey {
                             serverTrustIsValid = true
                             break outerLoop
                         }


### PR DESCRIPTION
It takes about 500ms for the isEqual line, thus slowing down autocomplete and build times.

Using proper types types resolves this issue.

### Issue Link :link:
#2793

### Testing Details :mag:
Relevant test suite (ServerTrustPolicyPinPublicKeysTestCase) runs successfully.
