### PR TITLE
Bugfix - Info.plist TestFlight Validation

### DIFF
--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.0.0-beta.4</string>
+	<string>5.0.0.beta.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
This PR replaces the `-` with `.` in the CFBundleShortVersionString value in the Info.plist to pass TestFlight validation.

### Issue Link :link:
#2797 

### Goals :soccer:
To ensure Alamofire can pass TestFlight validation when pulled in as a submodule.

### Implementation Details :construction:
This is much more complex than it seems. We typically use the following naming conventions for Git tags, Podspec versions, the Info.plist versions.

- MAJOR.MINOR.PATCH-{alpha|beta|rc}.{prerelease-version}

This is the most common SemVer friendly format to use for [pre-release versions](https://semver.org/#spec-item-9). It is required by Carthage and SPM. However, as pointed out in #2797, using a `-` in the CFBundleShortVersionString will result in a validation error when uploading to AppStore Connect. After some investigation, it appears that CocoaPods handles this situation by stripping the pre-release version altogether and just using `MAJOR.MINOR.PATCH`.

Because of all of this, we've decided to update the `CFBundleShortVersionString` to use a `.` instead of a `-`. This will fix the ASC validation issue, and also allow `5.0.0.beta.5` to show up in the user agent string instead of just `5.0.0` with submodules, Carthage, and SPM. Unfortunately, this will still show up as `5.0.0` when using CocoaPods, but we figured it was better to have inconsistency here to allow the pre-release version to show up in most places.

### Testing Details :mag:
N/A