### PR TITLE
Audit - HTTP Headers Refactor

### DIFF
--- a/Source/HTTPHeaders.swift
+++ b/Source/HTTPHeaders.swift
@@ -413,7 +413,7 @@ extension Collection where Element == String {
 
 extension URLRequest {
     /// Returns `allHTTPHeaderFields` as `HTTPHeaders`.
-    public var httpHeaders: HTTPHeaders {
+    public var headers: HTTPHeaders {
         get { return allHTTPHeaderFields.map(HTTPHeaders.init) ?? HTTPHeaders() }
         set { allHTTPHeaderFields = newValue.dictionary }
     }
@@ -421,14 +421,14 @@ extension URLRequest {
 
 extension HTTPURLResponse {
     /// Returns `allHeaderFields` as `HTTPHeaders`.
-    public var httpHeaders: HTTPHeaders {
+    public var headers: HTTPHeaders {
         return (allHeaderFields as? [String: String]).map(HTTPHeaders.init) ?? HTTPHeaders()
     }
 }
 
 extension URLSessionConfiguration {
     /// Returns `httpAdditionalHeaders` as `HTTPHeaders`.
-    public var httpHeaders: HTTPHeaders {
+    public var headers: HTTPHeaders {
         get { return (httpAdditionalHeaders as? [String: String]).map(HTTPHeaders.init) ?? HTTPHeaders() }
         set { httpAdditionalHeaders = newValue.dictionary }
     }

--- a/Source/ParameterEncoder.swift
+++ b/Source/ParameterEncoder.swift
@@ -80,8 +80,8 @@ open class JSONParameterEncoder: ParameterEncoder {
         do {
             let data = try encoder.encode(parameters)
             request.httpBody = data
-            if request.httpHeaders["Content-Type"] == nil {
-                request.httpHeaders.update(.contentType("application/json"))
+            if request.headers["Content-Type"] == nil {
+                request.headers.update(.contentType("application/json"))
             }
         } catch {
             throw AFError.parameterEncodingFailed(reason: .jsonEncodingFailed(error: error))
@@ -175,8 +175,8 @@ open class URLEncodedFormParameterEncoder: ParameterEncoder {
 
             request.url = newURL
         } else {
-            if request.httpHeaders["Content-Type"] == nil {
-                request.httpHeaders.update(.contentType("application/x-www-form-urlencoded; charset=utf-8"))
+            if request.headers["Content-Type"] == nil {
+                request.headers.update(.contentType("application/x-www-form-urlencoded; charset=utf-8"))
             }
 
             request.httpBody = try AFResult<Data> { try encoder.encode(parameters) }

--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -90,7 +90,7 @@ extension DataResponse: CustomStringConvertible, CustomDebugStringConvertible {
         let requestDescription = request.map { "\($0.httpMethod!) \($0)" } ?? "nil"
         let requestBody = request?.httpBody.map { String(decoding: $0, as: UTF8.self) } ?? "None"
         let responseDescription = response.map { (response) in
-            let sortedHeaders = response.httpHeaders.sorted()
+            let sortedHeaders = response.headers.sorted()
 
             return """
                    [Status Code]: \(response.statusCode)
@@ -278,7 +278,7 @@ extension DownloadResponse: CustomStringConvertible, CustomDebugStringConvertibl
         let requestDescription = request.map { "\($0.httpMethod!) \($0)" } ?? "nil"
         let requestBody = request?.httpBody.map { String(decoding: $0, as: UTF8.self) } ?? "None"
         let responseDescription = response.map { (response) in
-            let sortedHeaders = response.httpHeaders.sorted()
+            let sortedHeaders = response.headers.sorted()
 
             return """
                    [Status Code]: \(response.statusCode)

--- a/Source/URLSessionConfiguration+Alamofire.swift
+++ b/Source/URLSessionConfiguration+Alamofire.swift
@@ -28,7 +28,7 @@ extension URLSessionConfiguration: AlamofireExtended { }
 extension AlamofireExtension where ExtendedType: URLSessionConfiguration {
     public static var `default`: URLSessionConfiguration {
         let configuration = URLSessionConfiguration.default
-        configuration.httpHeaders = .default
+        configuration.headers = .default
 
         return configuration
     }

--- a/Tests/CacheTests.swift
+++ b/Tests/CacheTests.swift
@@ -94,7 +94,7 @@ class CacheTestCase: BaseTestCase {
         manager = {
             let configuration: URLSessionConfiguration = {
                 let configuration = URLSessionConfiguration.default
-                configuration.httpHeaders = HTTPHeaders.default
+                configuration.headers = HTTPHeaders.default
                 configuration.requestCachePolicy = .useProtocolCachePolicy
                 configuration.urlCache = urlCache
 

--- a/Tests/HTTPBin.swift
+++ b/Tests/HTTPBin.swift
@@ -42,7 +42,7 @@ extension URLRequest {
                                    headers: HTTPHeaders = .init()) -> URLRequest {
         var request = URLRequest(url: .makeHTTPBinURL(path: path))
         request.httpMethod = method.rawValue
-        request.httpHeaders = headers
+        request.headers = headers
 
         return request
     }
@@ -50,7 +50,7 @@ extension URLRequest {
     static func make(url: URL = URL(string: "https://httpbin.org/get")!, method: HTTPMethod = .get, headers: HTTPHeaders = .init()) -> URLRequest {
         var request = URLRequest(url:url)
         request.method = method
-        request.httpHeaders = headers
+        request.headers = headers
 
         return request
     }

--- a/Tests/ParameterEncoderTests.swift
+++ b/Tests/ParameterEncoderTests.swift
@@ -35,7 +35,7 @@ final class JSONParameterEncoderTests: BaseTestCase {
         let newRequest = try encoder.encode(HTTPBinParameters.default, into: request)
 
         // Then
-        XCTAssertEqual(newRequest.httpHeaders["Content-Type"], "application/json")
+        XCTAssertEqual(newRequest.headers["Content-Type"], "application/json")
         XCTAssertEqual(newRequest.httpBody?.asString, "{\"property\":\"property\"}")
     }
 
@@ -43,13 +43,13 @@ final class JSONParameterEncoderTests: BaseTestCase {
         // Given
         let encoder = JSONParameterEncoder()
         var request = URLRequest.makeHTTPBinRequest()
-        request.httpHeaders.update(.contentType("type"))
+        request.headers.update(.contentType("type"))
 
         // When
         let newRequest = try encoder.encode(HTTPBinParameters.default, into: request)
 
         // Then
-        XCTAssertEqual(newRequest.httpHeaders["Content-Type"], "type")
+        XCTAssertEqual(newRequest.headers["Content-Type"], "type")
         XCTAssertEqual(newRequest.httpBody?.asString, "{\"property\":\"property\"}")
     }
 
@@ -133,7 +133,7 @@ final class URLEncodedFormParameterEncoderTests: BaseTestCase {
         let newRequest = try encoder.encode(HTTPBinParameters.default, into: request)
 
         // Then
-        XCTAssertEqual(newRequest.httpHeaders["Content-Type"], "application/x-www-form-urlencoded; charset=utf-8")
+        XCTAssertEqual(newRequest.headers["Content-Type"], "application/x-www-form-urlencoded; charset=utf-8")
         XCTAssertEqual(newRequest.httpBody?.asString, "property=property")
     }
 
@@ -141,13 +141,13 @@ final class URLEncodedFormParameterEncoderTests: BaseTestCase {
         // Given
         let encoder = URLEncodedFormParameterEncoder()
         var request = URLRequest.makeHTTPBinRequest(method: .post)
-        request.httpHeaders.update(.contentType("type"))
+        request.headers.update(.contentType("type"))
 
         // When
         let newRequest = try encoder.encode(HTTPBinParameters.default, into: request)
 
         // Then
-        XCTAssertEqual(newRequest.httpHeaders["Content-Type"], "type")
+        XCTAssertEqual(newRequest.headers["Content-Type"], "type")
         XCTAssertEqual(newRequest.httpBody?.asString, "property=property")
     }
 

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -569,7 +569,7 @@ class RequestDebugDescriptionTestCase: BaseTestCase {
         headers["Accept-Language"] = "en-US"
 
         let configuration = URLSessionConfiguration.af.default
-        configuration.httpHeaders = headers
+        configuration.headers = headers
 
         let manager = Session(configuration: configuration)
 
@@ -581,7 +581,7 @@ class RequestDebugDescriptionTestCase: BaseTestCase {
         headers["Content-Type"] = "application/json"
 
         let configuration = URLSessionConfiguration.af.default
-        configuration.httpHeaders = headers
+        configuration.headers = headers
 
         let manager = Session(configuration: configuration)
 

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -76,10 +76,10 @@ class SessionTestCase: BaseTestCase {
 
                 var urlRequest = urlRequest
 
-                var finalHeaders = urlRequest.httpHeaders
+                var finalHeaders = urlRequest.headers
                 headers.forEach { finalHeaders.add($0) }
 
-                urlRequest.httpHeaders = finalHeaders
+                urlRequest.headers = finalHeaders
 
                 return urlRequest
             }
@@ -121,7 +121,7 @@ class SessionTestCase: BaseTestCase {
                 adaptedCount += 1
 
                 if shouldApplyAuthorizationHeader && adaptedCount > 1 {
-                    urlRequest.httpHeaders.update(.authorization(username: "user", password: "password"))
+                    urlRequest.headers.update(.authorization(username: "user", password: "password"))
                 }
 
                 return urlRequest
@@ -1537,7 +1537,7 @@ class SessionManagerConfigurationHeadersTestCase: BaseTestCase {
 
                 var headers = HTTPHeaders.default
                 headers["Authorization"] = "Bearer 123456"
-                configuration.httpHeaders = headers
+                configuration.headers = headers
 
                 return configuration
             }()

--- a/Tests/URLProtocolTests.swift
+++ b/Tests/URLProtocolTests.swift
@@ -37,7 +37,7 @@ class ProxyURLProtocol: URLProtocol {
     lazy var session: URLSession = {
         let configuration: URLSessionConfiguration = {
             let configuration = URLSessionConfiguration.ephemeral
-            configuration.httpHeaders = HTTPHeaders.default
+            configuration.headers = HTTPHeaders.default
 
             return configuration
         }()

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -399,7 +399,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
         let manager: Session = {
             let configuration: URLSessionConfiguration = {
                 let configuration = URLSessionConfiguration.ephemeral
-                configuration.httpHeaders = HTTPHeaders.default
+                configuration.headers = HTTPHeaders.default
 
                 return configuration
             }()


### PR DESCRIPTION
This PR refactors the `HTTPHeader` and `HTTPHeaders` types to `Header` and `Headers`.

### Goals :soccer:
The goal of this PR is to drop the unnecessary `HTTP` prefix as well as simplify the property extensions on system types. Properties with `http` in the name are the Apple variants, where ones without are the Alamofire variants.

### Implementation Details :construction:
Pretty straightforward, just refactored throughout the codebase.

### Testing Details :mag:
N/A
