### PR TITLE
Audit - Notification Names

### DIFF
--- a/Source/Notifications.swift
+++ b/Source/Notifications.swift
@@ -26,13 +26,13 @@ import Foundation
 
 public extension Request {
     /// Posted when a `Request` is resumed. The `Notification` contains the resumed `Request`.
-    static let didResume = Notification.Name(rawValue: "org.alamofire.notification.name.request.didResume")
+    static let didResumeNotification = Notification.Name(rawValue: "org.alamofire.notification.name.request.didResume")
     /// Posted when a `Request` is suspended. The `Notification` contains the suspended `Request`.
-    static let didSuspend = Notification.Name(rawValue: "org.alamofire.notification.name.request.didSuspend")
+    static let didSuspendNotification = Notification.Name(rawValue: "org.alamofire.notification.name.request.didSuspend")
     /// Posted when a `Request` is cancelled. The `Notification` contains the cancelled `Request`.
-    static let didCancel = Notification.Name(rawValue: "org.alamofire.notification.name.request.didCancel")
+    static let didCancelNotification = Notification.Name(rawValue: "org.alamofire.notification.name.request.didCancel")
     /// Posted when a `Request` is finished. The `Notification` contains the completed `Request`.
-    static let didFinish = Notification.Name(rawValue: "org.alamofire.notification.name.request.didFinish")
+    static let didFinishNotification = Notification.Name(rawValue: "org.alamofire.notification.name.request.didFinish")
 }
 
 // MARK: -
@@ -72,19 +72,19 @@ extension String {
 
 /// `EventMonitor` that provides Alamofire's notifications.
 public final class AlamofireNotifications: EventMonitor {
-    public func requestDidFinish(_ request: Request) {
-        NotificationCenter.default.postNotification(named: Request.didFinish, with: request)
-    }
-
     public func requestDidResume(_ request: Request) {
-        NotificationCenter.default.postNotification(named: Request.didResume, with: request)
+        NotificationCenter.default.postNotification(named: Request.didResumeNotification, with: request)
     }
 
     public func requestDidSuspend(_ request: Request) {
-        NotificationCenter.default.postNotification(named: Request.didSuspend, with: request)
+        NotificationCenter.default.postNotification(named: Request.didSuspendNotification, with: request)
     }
 
     public func requestDidCancel(_ request: Request) {
-        NotificationCenter.default.postNotification(named: Request.didCancel, with: request)
+        NotificationCenter.default.postNotification(named: Request.didCancelNotification, with: request)
+    }
+
+    public func requestDidFinish(_ request: Request) {
+        NotificationCenter.default.postNotification(named: Request.didFinishNotification, with: request)
     }
 }

--- a/Source/Notifications.swift
+++ b/Source/Notifications.swift
@@ -33,6 +33,15 @@ public extension Request {
     static let didCancelNotification = Notification.Name(rawValue: "org.alamofire.notification.name.request.didCancel")
     /// Posted when a `Request` is finished. The `Notification` contains the completed `Request`.
     static let didFinishNotification = Notification.Name(rawValue: "org.alamofire.notification.name.request.didFinish")
+
+    /// Posted when a `URLSessionTask` is resumed. The `Notification` contains the `Request` associated with the `URLSessionTask`.
+    static let didResumeTaskNotification = Notification.Name(rawValue: "org.alamofire.notification.name.request.didResumeTask")
+    /// Posted when a `URLSessionTask` is suspended. The `Notification` contains the `Request` associated with the `URLSessionTask`.
+    static let didSuspendTaskNotification = Notification.Name(rawValue: "org.alamofire.notification.name.request.didSuspendTask")
+    /// Posted when a `URLSessionTask` is cancelled. The `Notification` contains the `Request` associated with the `URLSessionTask`.
+    static let didCancelTaskNotification = Notification.Name(rawValue: "org.alamofire.notification.name.request.didCancelTask")
+    /// Posted when a `URLSessionTask` is completed. The `Notification` contains the `Request` associated with the `URLSessionTask`.
+    static let didCompleteTaskNotification = Notification.Name(rawValue: "org.alamofire.notification.name.request.didFinishTask")
 }
 
 // MARK: -
@@ -86,5 +95,21 @@ public final class AlamofireNotifications: EventMonitor {
 
     public func requestDidFinish(_ request: Request) {
         NotificationCenter.default.postNotification(named: Request.didFinishNotification, with: request)
+    }
+
+    public func request(_ request: Request, didResumeTask task: URLSessionTask) {
+        NotificationCenter.default.postNotification(named: Request.didResumeTaskNotification, with: request)
+    }
+
+    public func request(_ request: Request, didSuspendTask task: URLSessionTask) {
+        NotificationCenter.default.postNotification(named: Request.didSuspendTaskNotification, with: request)
+    }
+
+    public func request(_ request: Request, didCancelTask task: URLSessionTask) {
+        NotificationCenter.default.postNotification(named: Request.didCancelTaskNotification, with: request)
+    }
+
+    public func request(_ request: Request, didCompleteTask task: URLSessionTask, with error: Error?) {
+        NotificationCenter.default.postNotification(named: Request.didCompleteTaskNotification, with: request)
     }
 }

--- a/Source/Notifications.swift
+++ b/Source/Notifications.swift
@@ -41,7 +41,7 @@ public extension Request {
     /// Posted when a `URLSessionTask` is cancelled. The `Notification` contains the `Request` associated with the `URLSessionTask`.
     static let didCancelTaskNotification = Notification.Name(rawValue: "org.alamofire.notification.name.request.didCancelTask")
     /// Posted when a `URLSessionTask` is completed. The `Notification` contains the `Request` associated with the `URLSessionTask`.
-    static let didCompleteTaskNotification = Notification.Name(rawValue: "org.alamofire.notification.name.request.didFinishTask")
+    static let didCompleteTaskNotification = Notification.Name(rawValue: "org.alamofire.notification.name.request.didCompleteTask")
 }
 
 // MARK: -

--- a/Tests/SessionDelegateTests.swift
+++ b/Tests/SessionDelegateTests.swift
@@ -100,6 +100,8 @@ class SessionDelegateTestCase: BaseTestCase {
         // Given
         let session = Session(startRequestsImmediately: false)
         var resumedRequest: Request?
+        var resumedTaskRequest: Request?
+        var completedTaskRequest: Request?
         var completedRequest: Request?
         var requestResponse: DataResponse<Data?>?
         let expect = expectation(description: "request should complete")
@@ -115,6 +117,18 @@ class SessionDelegateTestCase: BaseTestCase {
             resumedRequest = notification.request
             return true
         }
+        expectation(forNotification: Request.didResumeTaskNotification, object: nil) { notification in
+            guard let receivedRequest = notification.request, receivedRequest == request else { return false }
+
+            resumedTaskRequest = notification.request
+            return true
+        }
+        expectation(forNotification: Request.didCompleteTaskNotification, object: nil) { notification in
+            guard let receivedRequest = notification.request, receivedRequest == request else { return false }
+
+            completedTaskRequest = notification.request
+            return true
+        }
         expectation(forNotification: Request.didFinishNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
@@ -127,7 +141,12 @@ class SessionDelegateTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
+        XCTAssertNotNil(resumedRequest)
+        XCTAssertNotNil(resumedTaskRequest)
+        XCTAssertNotNil(completedTaskRequest)
+        XCTAssertNotNil(completedRequest)
         XCTAssertEqual(resumedRequest, completedRequest)
+        XCTAssertEqual(resumedTaskRequest, completedTaskRequest)
         XCTAssertEqual(requestResponse?.response?.statusCode, 200)
     }
 
@@ -135,6 +154,8 @@ class SessionDelegateTestCase: BaseTestCase {
         // Given
         let session = Session(startRequestsImmediately: false)
         var resumedRequest: Request?
+        var resumedTaskRequest: Request?
+        var completedTaskRequest: Request?
         var completedRequest: Request?
         var requestResponse: DownloadResponse<URL?>?
         let expect = expectation(description: "request should complete")
@@ -150,6 +171,18 @@ class SessionDelegateTestCase: BaseTestCase {
             resumedRequest = notification.request
             return true
         }
+        expectation(forNotification: Request.didResumeTaskNotification, object: nil) { notification in
+            guard let receivedRequest = notification.request, receivedRequest == request else { return false }
+
+            resumedTaskRequest = notification.request
+            return true
+        }
+        expectation(forNotification: Request.didCompleteTaskNotification, object: nil) { notification in
+            guard let receivedRequest = notification.request, receivedRequest == request else { return false }
+
+            completedTaskRequest = notification.request
+            return true
+        }
         expectation(forNotification: Request.didFinishNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
@@ -162,7 +195,12 @@ class SessionDelegateTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
+        XCTAssertNotNil(resumedRequest)
+        XCTAssertNotNil(resumedTaskRequest)
+        XCTAssertNotNil(completedTaskRequest)
+        XCTAssertNotNil(completedRequest)
         XCTAssertEqual(resumedRequest, completedRequest)
+        XCTAssertEqual(resumedTaskRequest, completedTaskRequest)
         XCTAssertEqual(requestResponse?.response?.statusCode, 200)
     }
 }

--- a/Tests/SessionDelegateTests.swift
+++ b/Tests/SessionDelegateTests.swift
@@ -94,6 +94,8 @@ class SessionDelegateTestCase: BaseTestCase {
         XCTAssertEqual(response?.response?.statusCode, 200)
     }
 
+    // MARK: - Tests - Notification
+
     func testThatAppropriateNotificationsAreCalledWithRequestForDataRequest() {
         // Given
         let session = Session(startRequestsImmediately: false)
@@ -103,17 +105,17 @@ class SessionDelegateTestCase: BaseTestCase {
         let expect = expectation(description: "request should complete")
 
         // When
-        let request = session.request("https://httpbin.org/get").response { (response) in
+        let request = session.request("https://httpbin.org/get").response { response in
             requestResponse = response
             expect.fulfill()
         }
-        expectation(forNotification: Request.didResume, object: nil) { (notification) in
+        expectation(forNotification: Request.didResumeNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
             resumedRequest = notification.request
             return true
         }
-        expectation(forNotification: Request.didFinish, object: nil) { (notification) in
+        expectation(forNotification: Request.didFinishNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
             completedRequest = notification.request
@@ -142,13 +144,13 @@ class SessionDelegateTestCase: BaseTestCase {
             requestResponse = response
             expect.fulfill()
         }
-        expectation(forNotification: Request.didResume, object: nil) { (notification) in
+        expectation(forNotification: Request.didResumeNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
             resumedRequest = notification.request
             return true
         }
-        expectation(forNotification: Request.didFinish, object: nil) { (notification) in
+        expectation(forNotification: Request.didFinishNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
             completedRequest = notification.request


### PR DESCRIPTION
This PR adds a `Notification` suffix to the `Request` notification names to make the API more clear. It also adds notification support for task events.

### Goals :soccer:
To make the notification names more clear and add notification support for task events.

### Implementation Details :construction:
Refactored the property names and added new ones for the task events.

### Testing Details :mag:
Updated the tests to also check for task notifications.
