### PR TITLE
Audit - MultipartUpload ACL

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -345,7 +345,7 @@ public enum AF {
     ///
     /// - Returns: The created `UploadRequest`.
     public static func upload(multipartFormData: @escaping (MultipartFormData) -> Void,
-                              usingThreshold encodingMemoryThreshold: UInt64 = MultipartUpload.encodingMemoryThreshold,
+                              usingThreshold encodingMemoryThreshold: UInt64 = MultipartFormData.encodingMemoryThreshold,
                               fileManager: FileManager = .default,
                               to url: URLConvertible,
                               method: HTTPMethod = .post,
@@ -385,7 +385,7 @@ public enum AF {
     /// - Returns: The `UploadRequest` created.
     @discardableResult
     public static func upload(multipartFormData: MultipartFormData,
-                              usingThreshold encodingMemoryThreshold: UInt64 = MultipartUpload.encodingMemoryThreshold,
+                              usingThreshold encodingMemoryThreshold: UInt64 = MultipartFormData.encodingMemoryThreshold,
                               with urlRequest: URLRequestConvertible,
                               interceptor: RequestInterceptor? = nil) -> UploadRequest {
         return Session.default.upload(multipartFormData: multipartFormData,

--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -91,6 +91,9 @@ open class MultipartFormData {
 
     // MARK: - Properties
 
+    /// Default memory threshold used when encoding `MultipartFormData`, in bytes.
+    public static let encodingMemoryThreshold: UInt64 = 10_000_000
+
     /// The `Content-Type` header value containing the boundary used to generate the `multipart/form-data`.
     open lazy var contentType: String = "multipart/form-data; boundary=\(self.boundary)"
 

--- a/Source/MultipartUpload.swift
+++ b/Source/MultipartUpload.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-class MultipartUpload {
+final class MultipartUpload {
     lazy var result = AFResult { try build() }
 
     let isInBackgroundSession: Bool

--- a/Source/MultipartUpload.swift
+++ b/Source/MultipartUpload.swift
@@ -24,10 +24,7 @@
 
 import Foundation
 
-open class MultipartUpload {
-    /// Default memory threshold used when encoding `MultipartFormData`, in bytes.
-    public static let encodingMemoryThreshold: UInt64 = 10_000_000
-
+class MultipartUpload {
     lazy var result = AFResult { try build() }
 
     let isInBackgroundSession: Bool
@@ -37,7 +34,7 @@ open class MultipartUpload {
     let fileManager: FileManager
 
     init(isInBackgroundSession: Bool,
-         encodingMemoryThreshold: UInt64 = MultipartUpload.encodingMemoryThreshold,
+         encodingMemoryThreshold: UInt64,
          request: URLRequestConvertible,
          multipartFormData: MultipartFormData) {
         self.isInBackgroundSession = isInBackgroundSession
@@ -79,11 +76,11 @@ open class MultipartUpload {
 }
 
 extension MultipartUpload: UploadConvertible {
-    public func asURLRequest() throws -> URLRequest {
+    func asURLRequest() throws -> URLRequest {
         return try result.get().request
     }
 
-    public func createUploadable() throws -> UploadRequest.Uploadable {
+    func createUploadable() throws -> UploadRequest.Uploadable {
         return try result.get().uploadable
     }
 }

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -316,7 +316,7 @@ open class Session {
     }
 
     open func upload(multipartFormData: @escaping (MultipartFormData) -> Void,
-                     usingThreshold encodingMemoryThreshold: UInt64 = MultipartUpload.encodingMemoryThreshold,
+                     usingThreshold encodingMemoryThreshold: UInt64 = MultipartFormData.encodingMemoryThreshold,
                      fileManager: FileManager = .default,
                      to url: URLConvertible,
                      method: HTTPMethod = .post,
@@ -334,7 +334,7 @@ open class Session {
     }
 
     open func upload(multipartFormData: MultipartFormData,
-                     usingThreshold encodingMemoryThreshold: UInt64 = MultipartUpload.encodingMemoryThreshold,
+                     usingThreshold encodingMemoryThreshold: UInt64 = MultipartFormData.encodingMemoryThreshold,
                      with request: URLRequestConvertible,
                      interceptor: RequestInterceptor? = nil) -> UploadRequest {
         let multipartUpload = MultipartUpload(isInBackgroundSession: (session.configuration.identifier != nil),


### PR DESCRIPTION
This PR changes the `MultipartUpload` ACL from `public` to `internal` and moves the `encodingMemoryThreshold` into `MultipartFormData`.

### Goals :soccer:
To make `MultipartUpload` an internal type since it is an internal upload implementation detail.

### Implementation Details :construction:
The `MultipartUpload` type should be an internal type that pulls `MultipartFormData` creation and encoding into a single location. This is pure AF implementation and isn't necessary to vend publicly. Therefore, this PR moves it to be an internal type.

The other required change is to then find a new home for `encodingMemoryThreshold`. It didn't make sense to me to make an entire type `public` just to expose a static property on it. It also conforms to multiple protocols so that conforms also then needed to be public. The two logic places to hang the API publicly are `UploadRequest` and `MultipartFormData`. I chose `MultipartFormData` for this PR, but I could easily see `UploadRequest` being a descent fit as well.

### Testing Details :mag:
N/A