### PR TITLE
Bugfix: DownloadRequest event duplication and missing events.

### DIFF
--- a/Source/RequestTaskMap.swift
+++ b/Source/RequestTaskMap.swift
@@ -115,7 +115,7 @@ struct RequestTaskMap {
             fatalError("RequestTaskMap consistency error: no events corresponding to task found.")
         }
 
-        switch events {
+        switch (events.completed, events.metricsGathered) {
         case (_, true): fatalError("RequestTaskMap consistency error: duplicate metricsGatheredForTask call.")
         case (false, false): taskEvents[task] = (completed: false, metricsGathered: true)
         case (true, false): self[task] = nil
@@ -127,7 +127,7 @@ struct RequestTaskMap {
             fatalError("RequestTaskMap consistency error: no events corresponding to task found.")
         }
 
-        switch events {
+        switch (events.completed, events.metricsGathered) {
         case (true, _): fatalError("RequestTaskMap consistency error: duplicate completionReceivedForTask call.")
         case (false, false): taskEvents[task] = (completed: true, metricsGathered: false)
         case (false, true): self[task] = nil

--- a/Source/RequestTaskMap.swift
+++ b/Source/RequestTaskMap.swift
@@ -28,14 +28,18 @@ import Foundation
 struct RequestTaskMap {
     private var tasksToRequests: [URLSessionTask: Request]
     private var requestsToTasks: [Request: URLSessionTask]
+    private var taskEvents: [URLSessionTask: (completed: Bool, metricsGathered: Bool)]
 
     var requests: [Request] {
         return Array(tasksToRequests.values)
     }
 
-    init(tasksToRequests: [URLSessionTask: Request] = [:], requestsToTasks: [Request: URLSessionTask] = [:]) {
+    init(tasksToRequests: [URLSessionTask: Request] = [:],
+         requestsToTasks: [Request: URLSessionTask] = [:],
+         taskEvents: [URLSessionTask: (completed: Bool, metricsGathered: Bool)] = [:]) {
         self.tasksToRequests = tasksToRequests
         self.requestsToTasks = requestsToTasks
+        self.taskEvents = taskEvents
     }
 
     subscript(_ request: Request) -> URLSessionTask? {
@@ -48,12 +52,14 @@ struct RequestTaskMap {
 
                 requestsToTasks.removeValue(forKey: request)
                 tasksToRequests.removeValue(forKey: task)
+                taskEvents.removeValue(forKey: task)
 
                 return
             }
 
             requestsToTasks[request] = newValue
             tasksToRequests[newValue] = request
+            taskEvents[newValue] = (completed: false, metricsGathered: false)
         }
     }
 
@@ -67,12 +73,14 @@ struct RequestTaskMap {
 
                 tasksToRequests.removeValue(forKey: task)
                 requestsToTasks.removeValue(forKey: request)
+                taskEvents.removeValue(forKey: task)
 
                 return
             }
 
             tasksToRequests[task] = newValue
             requestsToTasks[newValue] = task
+            taskEvents[task] = (completed: false, metricsGathered: false)
         }
     }
 
@@ -83,10 +91,46 @@ struct RequestTaskMap {
         return tasksToRequests.count
     }
 
+    var eventCount: Int {
+        precondition(taskEvents.count == count, "RequestTaskMap.eventCount invalid, count: \(count) != taskEvents.count: \(taskEvents.count)")
+
+        return taskEvents.count
+    }
+
     var isEmpty: Bool {
         precondition(tasksToRequests.isEmpty == requestsToTasks.isEmpty,
                      "RequestTaskMap.isEmpty invalid, requests.isEmpty: \(tasksToRequests.isEmpty) != tasks.isEmpty: \(requestsToTasks.isEmpty)")
 
         return tasksToRequests.isEmpty
+    }
+
+    var isEventsEmpty: Bool {
+        precondition(taskEvents.isEmpty == isEmpty, "RequestTaskMap.isEventsEmpty, isEmpty: \(isEmpty) != taskEvents.isEmpty: \(taskEvents.isEmpty)")
+
+        return taskEvents.isEmpty
+    }
+
+    mutating func metricsGatheredForTask(_ task: URLSessionTask) {
+        guard let events = taskEvents[task] else {
+            fatalError("RequestTaskMap consistency error: no events corresponding to task found.")
+        }
+
+        switch events {
+        case (_, true): fatalError("RequestTaskMap consistency error: duplicate metricsGatheredForTask call.")
+        case (false, false): taskEvents[task] = (completed: false, metricsGathered: true)
+        case (true, false): self[task] = nil
+        }
+    }
+
+    mutating func completionReceivedForTask(_ task: URLSessionTask) {
+        guard let events = taskEvents[task] else {
+            fatalError("RequestTaskMap consistency error: no events corresponding to task found.")
+        }
+
+        switch events {
+        case (true, _): fatalError("RequestTaskMap consistency error: duplicate completionReceivedForTask call.")
+        case (false, false): taskEvents[task] = (completed: true, metricsGathered: false)
+        case (false, true): self[task] = nil
+        }
     }
 }

--- a/Source/RequestTaskMap.swift
+++ b/Source/RequestTaskMap.swift
@@ -105,12 +105,12 @@ struct RequestTaskMap {
     }
 
     var isEventsEmpty: Bool {
-        precondition(taskEvents.isEmpty == isEmpty, "RequestTaskMap.isEventsEmpty, isEmpty: \(isEmpty) != taskEvents.isEmpty: \(taskEvents.isEmpty)")
+        precondition(taskEvents.isEmpty == isEmpty, "RequestTaskMap.isEventsEmpty invalid, isEmpty: \(isEmpty) != taskEvents.isEmpty: \(taskEvents.isEmpty)")
 
         return taskEvents.isEmpty
     }
 
-    mutating func metricsGatheredForTask(_ task: URLSessionTask) {
+    mutating func disassociateIfNecessaryAfterGatheringMetricsForTask(_ task: URLSessionTask) {
         guard let events = taskEvents[task] else {
             fatalError("RequestTaskMap consistency error: no events corresponding to task found.")
         }
@@ -122,7 +122,7 @@ struct RequestTaskMap {
         }
     }
 
-    mutating func completionReceivedForTask(_ task: URLSessionTask) {
+    mutating func disassociateIfNecessaryAfterCompletingTask(_ task: URLSessionTask) {
         guard let events = taskEvents[task] else {
             fatalError("RequestTaskMap consistency error: no events corresponding to task found.")
         }

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -220,6 +220,8 @@ extension DownloadRequest {
                                             serializationDuration: 0,
                                             result: result)
 
+            self.eventMonitor?.request(self, didParseResponse: response)
+
             self.responseSerializerDidComplete { queue.async { completionHandler(response) } }
         }
 
@@ -256,6 +258,8 @@ extension DownloadRequest {
                                             metrics: self.metrics,
                                             serializationDuration: (end - start),
                                             result: result)
+
+            self.eventMonitor?.request(self, didParseResponse: response)
 
             guard let serializerError = result.error, let delegate = self.delegate else {
                 self.responseSerializerDidComplete { queue.async { completionHandler(response) } }

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -556,7 +556,8 @@ extension Session: RequestDelegate {
         rootQueue.async {
             request.didCancel()
 
-            guard let task = self.requestTaskMap[request] else {
+            // Cancellation only has an effect on running or suspended tasks.
+            guard let task = self.requestTaskMap[request], [.running, .suspended].contains(task.state) else {
                 request.finish()
                 return
             }
@@ -570,7 +571,10 @@ extension Session: RequestDelegate {
         rootQueue.async {
             request.didCancel()
 
-            guard let downloadTask = self.requestTaskMap[request] as? URLSessionDownloadTask else {
+            // Cancellation only has an effect on running or suspended tasks.
+            guard
+                let downloadTask = self.requestTaskMap[request] as? URLSessionDownloadTask,
+                [.running, .suspended].contains(downloadTask.state) else {
                 request.finish()
                 return
             }
@@ -590,7 +594,8 @@ extension Session: RequestDelegate {
 
             request.didSuspend()
 
-            guard let task = self.requestTaskMap[request] else { return }
+            // Tasks can only be suspended if they're running.
+            guard let task = self.requestTaskMap[request], task.state == .running else { return }
 
             task.suspend()
             request.didSuspendTask(task)
@@ -603,7 +608,8 @@ extension Session: RequestDelegate {
 
             request.didResume()
 
-            guard let task = self.requestTaskMap[request] else { return }
+            // Tasks can only be resumed if they're suspended.
+            guard let task = self.requestTaskMap[request], task.state == .suspended else { return }
 
             task.resume()
             request.didResumeTask(task)
@@ -618,8 +624,12 @@ extension Session: SessionStateProvider {
         return requestTaskMap[task]
     }
 
+    public func didGatherMetricsForTask(_ task: URLSessionTask) {
+        requestTaskMap.metricsGatheredForTask(task)
+    }
+
     public func didCompleteTask(_ task: URLSessionTask) {
-        requestTaskMap[task] = nil
+        requestTaskMap.completionReceivedForTask(task)
     }
 
     public func credential(for task: URLSessionTask, in protectionSpace: URLProtectionSpace) -> URLCredential? {

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -625,11 +625,11 @@ extension Session: SessionStateProvider {
     }
 
     public func didGatherMetricsForTask(_ task: URLSessionTask) {
-        requestTaskMap.metricsGatheredForTask(task)
+        requestTaskMap.disassociateIfNecessaryAfterGatheringMetricsForTask(task)
     }
 
     public func didCompleteTask(_ task: URLSessionTask) {
-        requestTaskMap.completionReceivedForTask(task)
+        requestTaskMap.disassociateIfNecessaryAfterCompletingTask(task)
     }
 
     public func credential(for task: URLSessionTask, in protectionSpace: URLProtectionSpace) -> URLCredential? {

--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -30,6 +30,7 @@ protocol SessionStateProvider: AnyObject {
     var cachedResponseHandler: CachedResponseHandler? { get }
 
     func request(for task: URLSessionTask) -> Request?
+    func didGatherMetricsForTask(_ task: URLSessionTask)
     func didCompleteTask(_ task: URLSessionTask)
     func credential(for task: URLSessionTask, in protectionSpace: URLProtectionSpace) -> URLCredential?
     func cancelRequestsForSessionInvalidation(with error: Error?)
@@ -162,6 +163,8 @@ extension SessionDelegate: URLSessionTaskDelegate {
         eventMonitor?.urlSession(session, task: task, didFinishCollecting: metrics)
 
         stateProvider?.request(for: task)?.didGatherMetrics(metrics)
+
+        stateProvider?.didGatherMetricsForTask(task)
     }
 
     open func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -648,3 +648,75 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         }
     }
 }
+
+final class UploadRequestEventsTestCase: BaseTestCase {
+    func testThatUploadRequestTriggersAllAppropriateLifetimeEvents() {
+        // Given
+        let eventMonitor = ClosureEventMonitor()
+        let session = Session(eventMonitors: [eventMonitor])
+
+        let expect = expectation(description: "request should receive appropriate lifetime events")
+        expect.expectedFulfillmentCount = 11
+
+        eventMonitor.taskDidFinishCollectingMetrics = { (_, _, _) in expect.fulfill() }
+        eventMonitor.requestDidCreateURLRequest = { (_, _) in expect.fulfill() }
+        eventMonitor.requestDidCreateTask = { (_, _) in expect.fulfill() }
+        eventMonitor.requestDidGatherMetrics = { (_, _) in expect.fulfill() }
+        eventMonitor.requestDidCompleteTaskWithError = { (_, _, _) in expect.fulfill() }
+        eventMonitor.requestDidFinish = { (_) in expect.fulfill() }
+        eventMonitor.requestDidResume = { (_) in expect.fulfill() }
+        eventMonitor.requestDidResumeTask = { (_, _) in expect.fulfill() }
+        eventMonitor.requestDidCreateUploadable = { (_, _) in expect.fulfill() }
+        eventMonitor.requestDidParseResponse = { (_, _) in expect.fulfill() }
+
+        // When
+        let request = session.upload(Data("PAYLOAD".utf8),
+                                     with: URLRequest.makeHTTPBinRequest(path: "post", method: .post)).response { _ in
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertEqual(request.state, .resumed)
+    }
+
+    func testThatCancelledUploadRequestTriggersAllAppropriateLifetimeEvents() {
+        // Given
+        let eventMonitor = ClosureEventMonitor()
+        let session = Session(startRequestsImmediately: false, eventMonitors: [eventMonitor])
+
+        let expect = expectation(description: "request should receive appropriate lifetime events")
+        expect.expectedFulfillmentCount = 13
+
+        eventMonitor.taskDidFinishCollectingMetrics = { (_, _, _) in expect.fulfill() }
+        eventMonitor.requestDidCreateURLRequest = { (_, _) in expect.fulfill() }
+        eventMonitor.requestDidCreateTask = { (_, _) in expect.fulfill() }
+        eventMonitor.requestDidGatherMetrics = { (_, _) in expect.fulfill() }
+        eventMonitor.requestDidCompleteTaskWithError = { (_, _, _) in expect.fulfill() }
+        eventMonitor.requestDidFinish = { (_) in expect.fulfill() }
+        eventMonitor.requestDidResume = { (_) in expect.fulfill() }
+        eventMonitor.requestDidCreateUploadable = { (_, _) in expect.fulfill() }
+        eventMonitor.requestDidParseResponse = { (_, _) in expect.fulfill() }
+        eventMonitor.requestDidCancel = { (_) in expect.fulfill() }
+        eventMonitor.requestDidCancelTask = { (_, _) in expect.fulfill() }
+
+        // When
+        let request = session.upload(Data("PAYLOAD".utf8),
+                                     with: URLRequest.makeHTTPBinRequest(path: "post", method: .post)).response { _ in
+                                        expect.fulfill()
+        }
+
+        eventMonitor.requestDidResumeTask = { (_, _) in
+            request.cancel()
+            expect.fulfill()
+        }
+
+        request.resume()
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertEqual(request.state, .cancelled)
+    }
+}


### PR DESCRIPTION
### Issue Link :link:
This PR covers a variety of areas, but should also fix the `DownloadRequest` part of #2759.

### Goals :soccer:
This PR fixes a few issues:
- `DownloadRequest` overrides `cancel()` but didn't get the previous refactor. This PR applies the previous strategy to the overridden `cancel()` to fix duplicate event calls.
- `DownloadRequest` was missing event calls for response serialization. These have been added.
- Bizarrely, `DownloadRequest` gets metrics and task completion in a different order than `DataRequest`/`UploadRequest`, which meant that metrics were never actually being gathered, as the task / request map was broken as soon as the task completed but before metrics were gathered. Additional state and API has been added to `RequestTaskMap` to track both events and only break the association when both have been received.
- Duplicate task events could be received when tasks had already transitioned to a new state but the action's work was still enqueued. Logic has been added to ensure a task can be transitioned to a state before doing so. This should ensure that all task transitions happen only once.

### Testing Details :mag:
This PR adds tests for all request types to ensure all lifetime events are properly being called, no more, no less.
