### PR TITLE
Bugfix - Dropping Pre-Release Version from CFBundleShortVersionString

### DIFF
--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.0.0.beta.5</string>
+	<string>5.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
This PR drops the pre-release version from the `CFBundleShortVersionString` in the `Info.plist`.

### Issue Link :link:
#2797 and #2799 

### Goals :soccer:
To allow users to be able to submit Alamofire betas to the AppStore using submodules and Carthage.

### Implementation Details :construction:
N/A

### Testing Details :mag:
N/A
