### PR TITLE
Feature - Terminal Response Serializers

### DIFF
--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -139,6 +139,8 @@ public enum AFError: Error {
         case decodingFailed(error: Error)
         /// Generic serialization failed for an empty response that wasn't type `Empty` but instead the associated type.
         case invalidEmptyResponse(type: String)
+        /// A response serializer was added to the request after the request was already finished.
+        case responseSerializerAddedAfterRequestFinished
     }
 
     /// Underlying reason a server trust evaluation error occured.
@@ -554,6 +556,8 @@ extension AFError.ResponseSerializationFailureReason {
             return "Empty response could not be serialized to type: \(type). Use Empty as the expected type for such responses."
         case .decodingFailed(let error):
             return "Response could not be decoded because of error:\n\(error.localizedDescription)"
+        case .responseSerializerAddedAfterRequestFinished:
+            return "Response serializer was added to the request after it had already finished."
         }
     }
 }

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -485,6 +485,9 @@ open class Session {
             case (_, .cancelled):
                 task.cancel()
                 rootQueue.async { request.didCancelTask(task) }
+            case (_, .finished):
+                // Do nothing
+                break
             }
         }
     }

--- a/Tests/AFError+AlamofireTests.swift
+++ b/Tests/AFError+AlamofireTests.swift
@@ -142,6 +142,11 @@ extension AFError {
         return false
     }
 
+    var isResponseSerializerAddedAfterRequestFinished: Bool {
+        if case let .responseSerializationFailed(reason) = self, reason.isResponseSerializerAddedAfterRequestFinished { return true }
+        return false
+    }
+
     // ResponseValidationFailureReason
 
     var isDataFileNil: Bool {
@@ -288,6 +293,11 @@ extension AFError.ResponseSerializationFailureReason {
 
     var isInvalidEmptyResponse: Bool {
         if case .invalidEmptyResponse = self { return true }
+        return false
+    }
+
+    var isResponseSerializerAddedAfterRequestFinished: Bool {
+        if case .responseSerializerAddedAfterRequestFinished = self { return true }
         return false
     }
 }

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -419,7 +419,7 @@ final class DownloadRequestEventsTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        XCTAssertEqual(request.state, .resumed)
+        XCTAssertEqual(request.state, .finished)
     }
 
     func testThatCancelledDownloadRequestTriggersAllAppropriateLifetimeEvents() {

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -1491,7 +1491,7 @@ class SessionTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        XCTAssertEqual(request.state, .resumed)
+        XCTAssertEqual(request.state, .finished)
         XCTAssertEqual(response?.result.isSuccess, true)
     }
 }

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -678,7 +678,7 @@ final class UploadRequestEventsTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        XCTAssertEqual(request.state, .resumed)
+        XCTAssertEqual(request.state, .finished)
     }
 
     func testThatCancelledUploadRequestTriggersAllAppropriateLifetimeEvents() {


### PR DESCRIPTION
This PR fixes an issue that should be an extreme edge case of misuse where developers are adding a response serializer to an already completed request. Previously, the completion would never be called. It's now called with a specific response serialization error.

### Goals :soccer:
Any response serializer added to a completed request should still have the completion called with a failure.

### Implementation Details :construction:
Thankfully, the implementation here is pretty straightforward. We are now tracking a `.finished` state on `Request`. When a response serializer is appended to a `Request`, we now check if the `Request` is `.finished`. If it is, we update the error on the `Request`, and kick off another round of response serialization processing. This will clear out the response serializer and the process can continue as many times as the client desires.

Overall, no one should ever hit this use case. We only found this due to a test creating a request, cancelling it, resuming it, then adding a response serializer to it.

```swift
let request = session.request(urlRequest)
    .cancel()
    .resume()
    .response { resp in
        response = resp
        expectation.fulfill()
    }
```

This is not a case that we intend to support because it is explicitly misusing the public API. However, we wanted to ensure that the response serializer completion was still called with a clear error that it was added after the `Request` has already completed.

#### Previous Behavior and Retry Logic

This use case is supported in AF 4.x with the way the internal Request queue handles response serializer additions. In AF5, we've rebuilt the threading system, and also the response serialization system to support retry as well. We cannot support both retry from response serializers as well as executing addition response serializers after the request completes due to really weird edge cases that would crop up with retry logic.

For example, let's say I am using retry, and append two response serializers correctly. I execute the request, it goes through a retry, and the two completions are called. Then a user adds a 3rd response serializer to the `Request`. If we just executed it like normal, it "could" trigger a retry, but how would we do that? We've already called the completions on the first two response serializers. It wouldn't make sense to execute them again. It also wouldn't make sense to retry a `Request` based on the third response serializer's retry result without the other two response serializers knowing about it. 

Because of these weird conditions, we've decided to have this simply result in an error. There are no conditions where you should be resuming your requests before adding response serializers through chaining when `startRequestsImmediately` is `false`. When it's `true`, You need to add your response serializers immediately after to ensure they are picked up before a cached response is pulled from the `URLCache`.

### Testing Details :mag:
Added a failing test that demonstrated the issue and the fix is now passing.
