### PR TITLE
[AF5 Refactor]: Lock Request.state access

### DIFF
--- a/Source/Protector.swift
+++ b/Source/Protector.swift
@@ -143,4 +143,11 @@ extension Protector where T == Request.MutableState {
             return true
         }
     }
+    
+    /// Perform a closure while locked with the provided `Request.State`.
+    ///
+    /// - Parameter perform: The closure to perform while locked.
+    func withState(perform: (Request.State) -> Void) {
+        lock.around { perform(value.state) }
+    }
 }

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -571,10 +571,8 @@ class DownloadResumeDataTestCase: BaseTestCase {
 
         var progressValues: [Double] = []
         var response2: DownloadResponse<Data>?
-        let destination = DownloadRequest.suggestedDownloadDestination(options: [.removePreviousFile, .createIntermediateDirectories])
-        // TODO: Added destination because temp file was being deleted very quickly.
-        AF.download(resumingWith: resumeData,
-                           to: destination)
+
+        AF.download(resumingWith: resumeData)
             .downloadProgress { progress in
                 progressValues.append(progress.fractionCompleted)
             }


### PR DESCRIPTION
### Goals :soccer:
This PR is an alternate take on #2809, ensure atomic and simultaneous updates to a `Request`'s `state` and `task` at the same time. This prevents async lifetime issues we've had in the past.

### Implementation Details :construction:
This PR adds API to `Protector` and `Request` to allow access to the `state` while locked. It also refactors `Request`'s `resume`, `suspend`, and `cancel` method to be locked and update the `state` and `task` at the same time. The `RequestDelegate` methods pertaining to these methods have been removed, as communication back to the `Session` is no longer needed.

### Testing Details :mag:
All tests currently pass, no additional tests were added, as there should be no change in behavior.
