### PR TITLE
Fix an issue where empty Encodable Parameters resulted in a non-nil query string.

### DIFF
--- a/Source/ParameterEncoder.swift
+++ b/Source/ParameterEncoder.swift
@@ -167,7 +167,7 @@ open class URLEncodedFormParameterEncoder: ParameterEncoder {
             let query: String = try AFResult<String> { try encoder.encode(parameters) }
                                 .mapError { AFError.parameterEncoderFailed(reason: .encoderFailed(error: $0)) }.get()
             let newQueryString = [components.percentEncodedQuery, query].compactMap { $0 }.joinedWithAmpersands()
-            components.percentEncodedQuery = newQueryString
+            components.percentEncodedQuery = newQueryString.isEmpty ? nil : newQueryString
 
             guard let newURL = components.url else {
                 throw AFError.parameterEncoderFailed(reason: .missingRequiredComponent(.url))

--- a/Tests/ParameterEncoderTests.swift
+++ b/Tests/ParameterEncoderTests.swift
@@ -177,6 +177,19 @@ final class URLEncodedFormParameterEncoderTests: BaseTestCase {
         let components = URLComponents(url: newRequest.url!, resolvingAgainstBaseURL: false)
         XCTAssertEqual(components?.percentEncodedQuery, "property=property")
     }
+
+    func testThatQueryIsNilWhenEncodableResultsInAnEmptyString() throws {
+        // Given
+        let encoder = URLEncodedFormParameterEncoder(destination: .queryString)
+        let request = URLRequest.makeHTTPBinRequest()
+
+        // When
+        let newRequest = try encoder.encode([String: String](), into: request)
+
+        // Then
+        let components = URLComponents(url: newRequest.url!, resolvingAgainstBaseURL: false)
+        XCTAssertNil(components?.percentEncodedQuery)
+    }
 }
 
 final class URLEncodedFormEncoderTests: BaseTestCase {


### PR DESCRIPTION
### Goals :soccer:
This fixes an issue where a `Parameters` instance passed to `URLEncodedFormParameterEncoder` that produced an empty query string would result in that empty string being set to the `percentEncodedQuery` instead of `nil`. This would result in a URL of `https://httpbin.org/get?` instead of `https://httpbin.org/get` and differs from the behavior of the existing `URLEncoding`.


### Implementation Details :construction:
This adds a check for an empty string when setting the `percentEncodedQuery` and sets `nil` instead in that case.

### Testing Details :mag:
A new test was added to cover this case using an empty dictionary as the parameter type. This test mirrors one that exists for `URLEncoding` for this situation.
