### PR TITLE
Add syntax for Alamofire 5.x

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -13,6 +13,8 @@ Alamofire.request("https://httpbin.org/get")
 Handling the `Response` of a `Request` made in Alamofire involves chaining a response handler onto the `Request`.
 
 ```swift
+// For Alamofire >=5.x, use `AF`
+// AF.request("https://httpbin.org/get").responseJSON { response in
 Alamofire.request("https://httpbin.org/get").responseJSON { response in
     print("Request: \(String(describing: response.request))")   // original url request
     print("Response: \(String(describing: response.response))") // http url response


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
* Update syntax in Usage.md#making-a-request for Alamofire 5.x

### Testing Details :mag:
* The compiler no longer outputs the error `Module 'Alamofire' has no member named 'request'` and calls can be successfully made.