### PR TITLE
Improve query(_ parameters: ) func syntax

### DIFF
--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -233,7 +233,9 @@ public struct URLEncoding: ParameterEncoding {
             components += queryComponents(fromKey: key, value: parameters[key]!)
         })
 
-        return components.map { "\($0)=\($1)" }.joined(separator: "&")
+        return components.map({ (key, value) -> String in
+            return key + "=" + value
+        }).joined(separator: "&")
     }
 }
 

--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -229,10 +229,10 @@ public struct URLEncoding: ParameterEncoding {
     private func query(_ parameters: [String: Any]) -> String {
         var components: [(String, String)] = []
 
-        for key in parameters.keys.sorted(by: <) {
-            let value = parameters[key]!
-            components += queryComponents(fromKey: key, value: value)
-        }
+        parameters.keys.sorted(by: <).forEach({ key in
+            components += queryComponents(fromKey: key, value: parameters[key]!)
+        })
+
         return components.map { "\($0)=\($1)" }.joined(separator: "&")
     }
 }


### PR DESCRIPTION
### Goals :soccer:
This small `PR` will improve `ParameterEncoding`'s
```swift
query(_ parameters: [String: Any])
```
`func` by updating the code syntax

### Implementation Details :construction:
The code syntax has been improved in the following ways:

1. Removal of the empty `components` array initialization
2. Removal of the `<` `.sorted(by: )` `func` parameter, since `.sorted()` does the exact same thing
3. Replace of the `.append` logic by using a `.flatMap` + `.map` functional approach
