### PR TITLE
Update handling of os_unfair_lock to manage the buffer.

### DIFF
--- a/Source/Protector.swift
+++ b/Source/Protector.swift
@@ -28,14 +28,24 @@ import Foundation
 
 /// An `os_unfair_lock` wrapper.
 final class UnfairLock {
-    private var unfairLock = os_unfair_lock()
+    private let unfairLock: os_unfair_lock_t
+    
+    init() {
+        unfairLock = .allocate(capacity: 1)
+        unfairLock.initialize(to: os_unfair_lock())
+    }
+    
+    deinit {
+        unfairLock.deinitialize(count: 1)
+        unfairLock.deallocate()
+    }
 
     fileprivate func lock() {
-        os_unfair_lock_lock(&unfairLock)
+        os_unfair_lock_lock(unfairLock)
     }
 
     fileprivate func unlock() {
-        os_unfair_lock_unlock(&unfairLock)
+        os_unfair_lock_unlock(unfairLock)
     }
 
     /// Executes a closure returning a value while acquiring the lock.


### PR DESCRIPTION
### Goals :soccer:
In talking to Apple engineers at WWDC, I was told that passing a single lock instance by reference may lead to a crash rate of up to 1%, due to the compiler managing the lifetime of the instance in unexpected ways. This PR switches to keeping the memory buffer directly. We'll need to do the same thing if we add support for `pthread_mutex` back as well.

### Implementation Details :construction:
Rather than passing a single `os_unfair_lock` by reference to lock and unlock, manage the `os_unfair_lock_t` instance directly by manually allocating and initializing the memory, as well as cleaning up afterward.

### Testing Details :mag:
No tests were updated. I haven't seen this, so this is a preventative fix.