### PR TITLE
Add option to not create resume data on cancel for DownloadRequest

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -497,8 +497,19 @@ open class DownloadRequest: Request {
     // MARK: State
 
     /// Cancels the request.
-    open override func cancel() {
-        downloadDelegate.downloadTask.cancel { self.downloadDelegate.resumeData = $0 }
+    override open func cancel() {
+        cancel(createResumeData: true)
+    }
+    
+    /// Cancels the request.
+    ///
+    /// - parameter createResumeData: Determines whether resume data is created via the underlying download task or not.
+    open func cancel(createResumeData: Bool) {
+        if createResumeData {
+            downloadDelegate.downloadTask.cancel { self.downloadDelegate.resumeData = $0 }
+        } else {
+            downloadDelegate.downloadTask.cancel()
+        }
 
         NotificationCenter.default.post(
             name: Notification.Name.Task.DidCancel,


### PR DESCRIPTION
### Issue Link :link:
https://github.com/Alamofire/Alamofire/issues/2841

### Goals :soccer:
Add option to not create resume data on cancel for DownloadRequest. I've noticed that in Alamofire 5 this has now become the default behaviour of the cancel for DownloadRequest. It would be great to at least add this possibility to Alamofire 4.

### Implementation Details :construction:
An assumption is made that there is no problem to just leave the resumeData-property of the downloadDelegate as-is.

### Testing Details :mag:
I've added a test that verifies that this function is not adding any resume data.
