### PR TITLE
progressQueue and responseQueue

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -605,11 +605,11 @@ public class Request {
     /// Only the last closure provided is used.
     ///
     /// - Parameters:
-    ///   - queue:   The `DispatchQueue` to execute the closure on. Defaults to `.main`.
+    ///   - queue:   The `DispatchQueue` to execute the closure on. Defaults to `progressQueue`.
     ///   - closure: The code to be executed periodically as data is read from the server.
     /// - Returns:   The `Request`.
     @discardableResult
-    public func downloadProgress(queue: DispatchQueue = .main, closure: @escaping ProgressHandler) -> Self {
+    public func downloadProgress(queue: DispatchQueue = progressQueue, closure: @escaping ProgressHandler) -> Self {
         protectedMutableState.write { $0.downloadProgressHandler = (handler: closure, queue: queue) }
 
         return self
@@ -620,11 +620,11 @@ public class Request {
     /// Only the last closure provided is used.
     ///
     /// - Parameters:
-    ///   - queue:   The `DispatchQueue` to execute the closure on. Defaults to `.main`.
+    ///   - queue:   The `DispatchQueue` to execute the closure on. Defaults to `progressQueue`.
     ///   - closure: The closure to be executed periodically as data is sent to the server.
     /// - Returns:   The `Request`.
     @discardableResult
-    public func uploadProgress(queue: DispatchQueue = .main, closure: @escaping ProgressHandler) -> Self {
+    public func uploadProgress(queue: DispatchQueue = progressQueue, closure: @escaping ProgressHandler) -> Self {
         protectedMutableState.write { $0.uploadProgressHandler = (handler: closure, queue: queue) }
 
         return self
@@ -1154,3 +1154,7 @@ extension UploadRequest.Uploadable: UploadableConvertible {
 }
 
 public protocol UploadConvertible: UploadableConvertible & URLRequestConvertible { }
+
+/// Default queue for all functions with progress handler
+///
+public let progressQueue = DispatchQueue.main

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -104,11 +104,11 @@ extension DataRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `responseQueue`.
     ///   - completionHandler: The code to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
-    public func response(queue: DispatchQueue = .main, completionHandler: @escaping (DataResponse<Data?>) -> Void) -> Self {
+    public func response(queue: DispatchQueue = responseQueue, completionHandler: @escaping (DataResponse<Data?>) -> Void) -> Self {
         appendResponseSerializer {
             let result = AFResult(value: self.data, error: self.error)
             let response = DataResponse(request: self.request,
@@ -129,13 +129,13 @@ extension DataRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:              The queue on which the completion handler is dispatched. Defaults to `.main`.
+    ///   - queue:              The queue on which the completion handler is dispatched. Defaults to `responseQueue`.
     ///   - responseSerializer: The response serializer responsible for serializing the request, response, and data.
     ///   - completionHandler:  The code to be executed once the request has finished.
     /// - Returns:              The request.
     @discardableResult
     public func response<Serializer: DataResponseSerializerProtocol>(
-        queue: DispatchQueue = .main,
+        queue: DispatchQueue = responseQueue,
         responseSerializer: Serializer,
         completionHandler: @escaping (DataResponse<Serializer.SerializedObject>) -> Void)
         -> Self
@@ -201,12 +201,12 @@ extension DownloadRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `responseQueue`.
     ///   - completionHandler: The code to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
     public func response(
-        queue: DispatchQueue = .main,
+        queue: DispatchQueue = responseQueue,
         completionHandler: @escaping (DownloadResponse<URL?>) -> Void)
         -> Self
     {
@@ -231,14 +231,14 @@ extension DownloadRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:              The queue on which the completion handler is dispatched. Defaults to `.main`.
+    ///   - queue:              The queue on which the completion handler is dispatched. Defaults to `responseQueue`.
     ///   - responseSerializer: The response serializer responsible for serializing the request, response, and data
     ///                         contained in the destination url.
     ///   - completionHandler:  The code to be executed once the request has finished.
     /// - Returns:              The request.
     @discardableResult
     public func response<T: DownloadResponseSerializerProtocol>(
-        queue: DispatchQueue = .main,
+        queue: DispatchQueue = responseQueue,
         responseSerializer: T,
         completionHandler: @escaping (DownloadResponse<T.SerializedObject>) -> Void)
         -> Self
@@ -308,12 +308,12 @@ extension DataRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `responseQueue`.
     ///   - completionHandler: The code to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
     public func responseData(
-        queue: DispatchQueue = .main,
+        queue: DispatchQueue = responseQueue,
         completionHandler: @escaping (DataResponse<Data>) -> Void)
         -> Self
     {
@@ -363,12 +363,12 @@ extension DownloadRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `responseQueue`.
     ///   - completionHandler: The code to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
     public func responseData(
-        queue: DispatchQueue = .main,
+        queue: DispatchQueue = responseQueue,
         completionHandler: @escaping (DownloadResponse<Data>) -> Void)
         -> Self
     {
@@ -442,13 +442,13 @@ extension DataRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `responseQueue`.
     ///   - encoding:          The string encoding. Defaults to `nil`, in which case the encoding will be determined from
     ///                        the server response, falling back to the default HTTP character set, `ISO-8859-1`.
     ///   - completionHandler: A closure to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
-    public func responseString(queue: DispatchQueue = .main,
+    public func responseString(queue: DispatchQueue = responseQueue,
                                encoding: String.Encoding? = nil,
                                completionHandler: @escaping (DataResponse<String>) -> Void) -> Self {
         return response(queue: queue,
@@ -461,14 +461,14 @@ extension DownloadRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `responseQueue`.
     ///   - encoding:          The string encoding. Defaults to `nil`, in which case the encoding will be determined from
     ///                        the server response, falling back to the default HTTP character set, `ISO-8859-1`.
     ///   - completionHandler: A closure to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
     public func responseString(
-        queue: DispatchQueue = .main,
+        queue: DispatchQueue = responseQueue,
         encoding: String.Encoding? = nil,
         completionHandler: @escaping (DownloadResponse<String>) -> Void)
         -> Self
@@ -532,12 +532,12 @@ extension DataRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `responseQueue`.
     ///   - options:           The JSON serialization reading options. Defaults to `.allowFragments`.
     ///   - completionHandler: A closure to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
-    public func responseJSON(queue: DispatchQueue = .main,
+    public func responseJSON(queue: DispatchQueue = responseQueue,
                              options: JSONSerialization.ReadingOptions = .allowFragments,
                              completionHandler: @escaping (DataResponse<Any>) -> Void) -> Self {
         return response(queue: queue,
@@ -550,13 +550,13 @@ extension DownloadRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `responseQueue`.
     ///   - options:           The JSON serialization reading options. Defaults to `.allowFragments`.
     ///   - completionHandler: A closure to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
     public func responseJSON(
-        queue: DispatchQueue = .main,
+        queue: DispatchQueue = responseQueue,
         options: JSONSerialization.ReadingOptions = .allowFragments,
         completionHandler: @escaping (DownloadResponse<Any>) -> Void)
         -> Self
@@ -657,13 +657,13 @@ extension DataRequest {
     /// Adds a handler to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `.main`.
+    ///   - queue:             The queue on which the completion handler is dispatched. Defaults to `responseQueue`.
     ///   - decoder:           The `DataDecoder` to use to decode the response. Defaults to a `JSONDecoder` with default
     ///                        settings.
     ///   - completionHandler: A closure to be executed once the request has finished.
     /// - Returns:             The request.
     @discardableResult
-    public func responseDecodable<T: Decodable>(queue: DispatchQueue = .main,
+    public func responseDecodable<T: Decodable>(queue: DispatchQueue = responseQueue,
                                                 decoder: DataDecoder = JSONDecoder(),
                                                 completionHandler: @escaping (DataResponse<T>) -> Void) -> Self {
         return response(queue: queue,
@@ -671,3 +671,7 @@ extension DataRequest {
                         completionHandler: completionHandler)
     }
 }
+
+/// Default queue for all responses
+///
+public let responseQueue = DispatchQueue.main


### PR DESCRIPTION
### Goals :soccer:
Created constants for the default queues using in functions with progress handler and in responses. For instance it will useful [here](https://github.com/tristanhimmelman/AlamofireObjectMapper/blob/6.1.0/AlamofireObjectMapper/AlamofireObjectMapper.swift), we will be able to declare `public func responseObject<T: BaseMappable>(queue: DispatchQueue = .main, keyPath: String? = nil, mapToObject object: T? = nil, context: MapContext? = nil, completionHandler: @escaping (DataResponse<T>) -> Void) -> Self` as `public func responseObject<T: BaseMappable>(queue: DispatchQueue = Alamofire.responseQueue, keyPath: String? = nil, mapToObject object: T? = nil, context: MapContext? = nil, completionHandler: @escaping (DataResponse<T>) -> Void) -> Self`.

### Implementation Details :construction:
Added `public let progressQueue = DispatchQueue.main` and `public let responseQueue = DispatchQueue.main`, use them in the corresponding functions instead of `DispatchQueue.main`.

### Testing Details :mag:
No new tests added as this is a very light refactoring