### PR TITLE
Feature - Appending Response Serializers

### DIFF
--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -111,8 +111,6 @@ public enum AFError: Error {
         case decodingFailed(error: Error)
         /// Generic serialization failed for an empty response that wasn't type `Empty` but instead the associated type.
         case invalidEmptyResponse(type: String)
-        /// A response serializer was added to the request after the request was already finished.
-        case responseSerializerAddedAfterRequestFinished
     }
 
     /// Underlying reason a server trust evaluation error occurred.
@@ -541,8 +539,6 @@ extension AFError.ResponseSerializationFailureReason {
             return "Empty response could not be serialized to type: \(type). Use Empty as the expected type for such responses."
         case .decodingFailed(let error):
             return "Response could not be decoded because of error:\n\(error.localizedDescription)"
-        case .responseSerializerAddedAfterRequestFinished:
-            return "Response serializer was added to the request after it had already finished."
         }
     }
 }

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -442,7 +442,7 @@ public class Request {
             mutableState.responseSerializers.append(closure)
 
             if mutableState.state == .finished {
-                mutableState.error = AFError.responseSerializationFailed(reason: .responseSerializerAddedAfterRequestFinished)
+                mutableState.state = .resumed
             }
 
             if mutableState.responseSerializerProcessingFinished {

--- a/Tests/AFError+AlamofireTests.swift
+++ b/Tests/AFError+AlamofireTests.swift
@@ -142,11 +142,6 @@ extension AFError {
         return false
     }
 
-    var isResponseSerializerAddedAfterRequestFinished: Bool {
-        if case let .responseSerializationFailed(reason) = self, reason.isResponseSerializerAddedAfterRequestFinished { return true }
-        return false
-    }
-
     // ResponseValidationFailureReason
 
     var isDataFileNil: Bool {
@@ -293,11 +288,6 @@ extension AFError.ResponseSerializationFailureReason {
 
     var isInvalidEmptyResponse: Bool {
         if case .invalidEmptyResponse = self { return true }
-        return false
-    }
-
-    var isResponseSerializerAddedAfterRequestFinished: Bool {
-        if case .responseSerializerAddedAfterRequestFinished = self { return true }
         return false
     }
 }


### PR DESCRIPTION
Appending a response serializer after the request has been completed now resumes the request and processes the new response serializer as if it was added prior to it finishing.

### Issue Link :link:
This PR solves an issue where it is currently possible to complete a request before appending a response serializer. There are two known cases where this behavior can manifest:

1. Failure in `URLRequestConvertible` creation
1. Cached URL response

### Goals :soccer:
Clients should be able to leverage cached URL responses as well as receive `URLRequestConvertible` errors directly whether the `Request` completes before the response serializer has been added or not. This is how Alamofire has behaved since the beginning.

### Implementation Details :construction:
When we added retry support for response serializers, we decided to not allow response serializers to be appended to a finished request due to complexity. We thought that it would be difficult to manage the request state and that you could end up with odd behaviors if a previous response serializer had already completed.

It turned out that that approach was a bit too heavy handed. Since Alamofire automatically starts creating the request when the `request` API is called, it's possible for the `Request` to be finished before a response serializer is added. Therefore, we need to alter the logic.

By allowing the `Request` to be resumed after it has finished when a new response serializer is added, we restore the previous behavior and also eliminate the race condition. The only downside of this approach is that the new response serializer could trigger a refresh and the previous response serializers will no longer be notified since they have been cleared. However, this is something that will rarely ever happen since 99.9% of clients will only ever use one response serializer. For those that do use more than one, they will almost certainly be adding them at the same time which will not hit this case.

The only way that you would hit a case where a previous response serializer would not be called in a retry scenario is if you would add an additional response serializer in a completion closure of a previous response serializer that triggered a retry. This is such a specific, advanced use case that I feel confident that the developer would understand exactly what they are trying to do.

### Tests
I modified the tests to verify that appending response serializers inside and outside response serializers closures behaves as expected.