### PR TITLE
Fix memory rebinding in NetworkReachabilityManager

### DIFF
--- a/Source/NetworkReachabilityManager.swift
+++ b/Source/NetworkReachabilityManager.swift
@@ -114,7 +114,7 @@ open class NetworkReachabilityManager {
         address.sin_family = sa_family_t(AF_INET)
 
         guard let reachability = withUnsafePointer(to: &address, { pointer in
-            return pointer.withMemoryRebound(to: sockaddr.self, capacity: MemoryLayout<sockaddr>.size) {
+            return pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
                 return SCNetworkReachabilityCreateWithAddress(nil, $0)
             }
         }) else { return nil }

--- a/Source/NetworkReachabilityManager.swift
+++ b/Source/NetworkReachabilityManager.swift
@@ -113,10 +113,9 @@ open class NetworkReachabilityManager {
         address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
         address.sin_family = sa_family_t(AF_INET)
 
-        guard let reachability = withUnsafePointer(to: &address, { pointer in
-            return pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                return SCNetworkReachabilityCreateWithAddress(nil, $0)
-            }
+        guard let reachability = withUnsafePointer(to: &address, { pointer -> SCNetworkReachability? in
+            let reboundAddress = UnsafeRawPointer(pointer).bindMemory(to: sockaddr.self, capacity: 1)
+            return SCNetworkReachabilityCreateWithAddress(nil, reboundAddress)
         }) else { return nil }
 
         self.init(reachability: reachability)


### PR DESCRIPTION
### Goals :soccer:
 - Fix an incorrect usage of the `withMemoryRebound(to:capacity:)` method.
 - Replace `withMemoryRebound(to:capacity:)` with `bindMemory(to:capacity:)` which may be better fit.

### Implementation Details :construction:
The name  `capacity` for the second parameter of `withMemoryRebound(to:capacity:)` is misleading. It is in fact a count of instances. The documentation says it is _The number of instances of `Pointee` to bind to `type`_. And usages of it in the standard library confirm this : https://github.com/apple/swift/search?q=withMemoryRebound&unscoped_q=withMemoryRebound
Instead of `MemoryLayout<sockaddr>.size`, we should just pass `1`. This is what the first commit of this PR does.

Reading the documentation of `withMemoryRebound(to:capacity:)` further, it says :
> Note: Only use this method to rebind the pointer's memory to a type
> with the same size and stride as the currently bound `Pointee` type.
> To bind a region of memory to a type that is a different size, convert
> the pointer to a raw pointer and use the `bindMemory(to:capacity:)`
> method.

We're trying to rebind a `sockaddr_in` to a `sockaddr`. If my understanding of this old C API is correct, there is no guarantee that `sockaddr_in` and `sockaddr` are the same size. Only that, as its _parent_, `sockaddr` has a size less than or equal to `sockaddr_in` (although in practice we know they are the same size, and this is unlikely to ever change).
Still, following the documentation recommandation I've made another commit to use `bindMemory(to:capacity:)` instead of `withMemoryRebound(to:capacity:)` (second commit of this PR), but this may not be necessary.
