### PR TITLE
throw error while JSONEncoding without POST method

### DIFF
--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -172,6 +172,8 @@ public enum AFError: Error {
     case parameterEncoderFailed(reason: ParameterEncoderFailureReason)
     /// Multipart form encoding failed.
     case multipartEncodingFailed(reason: MultipartEncodingFailureReason)
+    /// `POST` method required with `httpBody`
+    case postMethodRequiredWithHttpBody
     /// `RequestAdapter` failed threw an error during adaptation.
     case requestAdaptationFailed(error: Error)
     /// Response validation failed.
@@ -444,6 +446,8 @@ extension AFError: LocalizedError {
             return reason.localizedDescription
         case .multipartEncodingFailed(let reason):
             return reason.localizedDescription
+        case .postMethodRequiredWithHttpBody:
+            return "`POST` method required with Http Body"
         case .requestAdaptationFailed(let error):
             return "Request adaption failed with error: \(error.localizedDescription)"
         case .responseValidationFailed(let reason):

--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -266,7 +266,7 @@ public struct JSONEncoding: ParameterEncoding {
         guard let parameters = parameters else { return urlRequest }
         // swift NSURLSession sends the 'Content-Length' header but not the message body for other methods; `httpBody` will hang up the remote session or make the packet confused in the server
         guard "POST" == ( urlRequest.httpMethod?.uppercased() ?? "") else {
-            throw AFError.ParameterEncoderFailureReason.missingRequiredComponent(.httpMethod(rawValue: "POST"))
+            throw AFError.parameterEncoderFailed(reason: .missingRequiredComponent(.httpMethod(rawValue: "POST")))
         }
 
         do {
@@ -299,7 +299,7 @@ public struct JSONEncoding: ParameterEncoding {
         guard let jsonObject = jsonObject else { return urlRequest }
         // swift NSURLSession sends the 'Content-Length' header but not the message body for other methods; `httpBody` will hang up the remote session or make the packet confused in the server
         guard "POST" == ( urlRequest.httpMethod?.uppercased() ?? "") else {
-            throw AFError.ParameterEncoderFailureReason.missingRequiredComponent(.httpMethod(rawValue: "POST"))
+            throw AFError.parameterEncoderFailed(reason: .missingRequiredComponent(.httpMethod(rawValue: "POST")))
         }
         
         do {

--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -264,10 +264,6 @@ public struct JSONEncoding: ParameterEncoding {
         var urlRequest = try urlRequest.asURLRequest()
 
         guard let parameters = parameters else { return urlRequest }
-        // swift NSURLSession sends the 'Content-Length' header but not the message body for other methods; `httpBody` will hang up the remote session or make the packet confused in the server
-        guard "POST" == ( urlRequest.httpMethod?.uppercased() ?? "") else {
-            throw AFError.parameterEncoderFailed(reason: .missingRequiredComponent(.httpMethod(rawValue: "POST")))
-        }
 
         do {
             let data = try JSONSerialization.data(withJSONObject: parameters, options: options)
@@ -294,14 +290,9 @@ public struct JSONEncoding: ParameterEncoding {
     /// - Throws:       Any `Error` produced during encoding.
     public func encode(_ urlRequest: URLRequestConvertible, withJSONObject jsonObject: Any? = nil) throws -> URLRequest {
         var urlRequest = try urlRequest.asURLRequest()
-        
-        
+
         guard let jsonObject = jsonObject else { return urlRequest }
-        // swift NSURLSession sends the 'Content-Length' header but not the message body for other methods; `httpBody` will hang up the remote session or make the packet confused in the server
-        guard "POST" == ( urlRequest.httpMethod?.uppercased() ?? "") else {
-            throw AFError.parameterEncoderFailed(reason: .missingRequiredComponent(.httpMethod(rawValue: "POST")))
-        }
-        
+
         do {
             let data = try JSONSerialization.data(withJSONObject: jsonObject, options: options)
 

--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -264,6 +264,10 @@ public struct JSONEncoding: ParameterEncoding {
         var urlRequest = try urlRequest.asURLRequest()
 
         guard let parameters = parameters else { return urlRequest }
+        // swift NSURLSession sends the 'Content-Length' header but not the message body for other methods; `httpBody` will hang up the remote session or make the packet confused in the server
+        guard "POST" == ( urlRequest.httpMethod?.uppercased() ?? "") else {
+            throw AFError.ParameterEncoderFailureReason.missingRequiredComponent(.httpMethod(rawValue: "POST"))
+        }
 
         do {
             let data = try JSONSerialization.data(withJSONObject: parameters, options: options)
@@ -290,9 +294,14 @@ public struct JSONEncoding: ParameterEncoding {
     /// - Throws:       Any `Error` produced during encoding.
     public func encode(_ urlRequest: URLRequestConvertible, withJSONObject jsonObject: Any? = nil) throws -> URLRequest {
         var urlRequest = try urlRequest.asURLRequest()
-
+        
+        
         guard let jsonObject = jsonObject else { return urlRequest }
-
+        // swift NSURLSession sends the 'Content-Length' header but not the message body for other methods; `httpBody` will hang up the remote session or make the packet confused in the server
+        guard "POST" == ( urlRequest.httpMethod?.uppercased() ?? "") else {
+            throw AFError.ParameterEncoderFailureReason.missingRequiredComponent(.httpMethod(rawValue: "POST"))
+        }
+        
         do {
             let data = try JSONSerialization.data(withJSONObject: jsonObject, options: options)
 


### PR DESCRIPTION
### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->
- https://github.com/Moya/Moya/issues/1533
- https://github.com/Moya/Moya/issues/1645
- https://stackoverflow.com/questions/52626403/alamofire-request-changes-method-name-on-its-own
- https://stackoverflow.com/questions/55172430/the-requested-resource-does-not-support-http-method-t-or-st-with-alamofire
- https://stackoverflow.com/questions/48654888/it-shows-405-server-error-at-first-time-to-get-result-from-api-server-and-it-wo?rq=1

### Implementation Details :construction:
The current behaviour, where `NSURLSession` sends the Content-Length header but not the message body, is hard to justify.

For example:

```
import Alamofire

let completionHandler: (DataResponse<String>) -> Void = { (resp) in
    switch resp.result {
    case .success(let txt):
        print("\(txt)")
    case .failure(let err):
        print("ERROR => \(err)")
    }
}

Alamofire.Session.default.request("http://httpbin.org/get",
    method: .get,
    parameters: [:],
    encoding: JSONEncoding.default).responseString(completionHandler: completionHandler)
```

The server will hang up and wait the client to send the request body, but `NSURLSession` will never send them.

```
	GET /get HTTP/1.1
	Host: httpbin.org
	Content-Type: application/json
	Connection: keep-alive
	Accept: */*
	User-Agent: demo3/1.0 (com.apple.dt.playground.stub.iOS_Simulator.demo3-0AAFA08A-42ED-4E2F-AF5A-AA0E3670BD87; build:1; iOS 12.4.0) Alamofire/5.0.0
	Accept-Language: en;q=1.0
	Content-Length: 2
	Accept-Encoding: br;q=1.0, gzip;q=0.9, deflate;q=0.8
```

The java servlet containers will read the next two bytes if exists, so the next http request will left
```
    T /some-url
    ST /some-url
```

The `T` means `GET`, and `ST` means 'POST`.

The developer should change parameters to `parameters: nil` or change encoding to `encoding: URLEncoding.default`.

So we should tell the developer : 
it's not suitable that using JSONEncoding in the GET request.
