### PR TITLE
Add cancelAllRequests API

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -604,6 +604,7 @@ public class Request {
                 return
             }
 
+            // Resume to ensure metrics are gathered.
             task.resume()
             task.cancel()
             underlyingQueue.async { self.didCancelTask(task) }
@@ -1262,12 +1263,16 @@ public class DownloadRequest: Request {
             }
 
             if let completionHandler = completionHandler {
+                // Resume to ensure metrics are gathered.
+                task.resume()
                 task.cancel { (resumeData) in
                     self.protectedDownloadMutableState.write { $0.resumeData = resumeData }
                     self.underlyingQueue.async { self.didCancelTask(task) }
                     completionHandler(resumeData)
                 }
             } else {
+                // Resume to ensure metrics are gathered.
+                task.resume()
                 task.cancel()
                 self.underlyingQueue.async { self.didCancelTask(task) }
             }

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -777,6 +777,7 @@ public class Request {
 
     /// Final cleanup step executed when the instance finishes response serialization.
     open func cleanup() {
+        delegate?.cleanup(after: self)
         // No-op: override in subclass
     }
 }
@@ -892,6 +893,11 @@ extension Request {
 public protocol RequestDelegate: AnyObject {
     /// `URLSessionConfiguration` used to create the underlying `URLSessionTask`s.
     var sessionConfiguration: URLSessionConfiguration { get }
+
+    /// Notifies the delegate the `Request` has reached a point where it needs cleanup.
+    ///
+    /// - Parameter request: The `Request` to cleanup after.
+    func cleanup(after request: Request)
 
     /// Asynchronously ask the delegate whether a `Request` will be retried.
     ///

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -604,6 +604,7 @@ public class Request {
                 return
             }
 
+            task.resume()
             task.cancel()
             underlyingQueue.async { self.didCancelTask(task) }
         }
@@ -776,7 +777,7 @@ public class Request {
     // MARK: Cleanup
 
     /// Final cleanup step executed when the instance finishes response serialization.
-    open func cleanup() {
+    func cleanup() {
         delegate?.cleanup(after: self)
         // No-op: override in subclass
     }

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -202,11 +202,13 @@ open class Session {
     ///         `Request`s may not cancel immediately due internal work, and may not cancel at all if they are close to
     ///         completion when cancelled.
     ///
-    /// - Parameter completion: Closure to be called when all `Request`s have been cancelled.
-    public func cancelAllRequests(completion: (() -> Void)? = nil) {
+    /// - Parameters:
+    ///   - queue:      `DispatchQueue` on which the completion handler is run. `.main` by default.
+    ///   - completion: Closure to be called when all `Request`s have been cancelled.
+    public func cancelAllRequests(completingOnQueue queue: DispatchQueue = .main, completion: (() -> Void)? = nil) {
         rootQueue.async {
             self.activeRequests.forEach { $0.cancel() }
-            completion?()
+            queue.async { completion?() }
         }
     }
 
@@ -776,9 +778,9 @@ open class Session {
     /// - Parameter request: The `Request` to perform.
     func perform(_ request: Request) {
         switch request {
-        case let r as DataRequest: self.perform(r)
-        case let r as UploadRequest: self.perform(r)
-        case let r as DownloadRequest: self.perform(r)
+        case let r as DataRequest: perform(r)
+        case let r as UploadRequest: perform(r)
+        case let r as DownloadRequest: perform(r)
         default: fatalError("Attempted to perform unsupported Request subclass: \(type(of: request))")
         }
     }

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -893,6 +893,7 @@ open class Session {
                 task.suspend()
                 rootQueue.async { request.didSuspendTask(task) }
             case (_, .cancelled):
+                // Resume to ensure metrics are gathered.
                 task.resume()
                 task.cancel()
                 rootQueue.async { request.didCancelTask(task) }

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -64,6 +64,8 @@ open class Session {
 
     /// Internal map between `Request`s and any `URLSessionTasks` that may be in flight for them.
     var requestTaskMap = RequestTaskMap()
+    /// Set of currently active `Request`s.
+    var activeRequests: Set<Request> = []
 
     /// Creates a `Session` from a `URLSession` and other parameters.
     ///
@@ -190,6 +192,22 @@ open class Session {
     deinit {
         finishRequestsForDeinit()
         session.invalidateAndCancel()
+    }
+
+    // MARK: - Cancellation
+
+    /// Cancel all active `Request`s, optionally calling a completion handler when complete.
+    ///
+    /// - Note: This is an asynchronous operation and does not block the creation of future `Request`s. Cancelled
+    ///         `Request`s may not cancel immediately due internal work, and may not cancel at all if they are close to
+    ///         completion when cancelled.
+    ///
+    /// - Parameter completion: Closure to be called when all `Request`s have been cancelled.
+    public func cancelAllRequests(completion: (() -> Void)? = nil) {
+        rootQueue.async {
+            self.activeRequests.forEach { $0.cancel() }
+            completion?()
+        }
     }
 
     // MARK: - DataRequest
@@ -750,11 +768,17 @@ open class Session {
 
     // MARK: Perform
 
+
+    /// Perform `Request`.
+    ///
+    /// - Note: Called during retry.
+    ///
+    /// - Parameter request: The `Request` to perform.
     func perform(_ request: Request) {
         switch request {
-        case let r as DataRequest: perform(r)
-        case let r as UploadRequest: perform(r)
-        case let r as DownloadRequest: perform(r)
+        case let r as DataRequest: self.perform(r)
+        case let r as UploadRequest: self.perform(r)
+        case let r as DownloadRequest: self.perform(r)
         default: fatalError("Attempted to perform unsupported Request subclass: \(type(of: request))")
         }
     }
@@ -763,6 +787,8 @@ open class Session {
         requestQueue.async {
             guard !request.isCancelled else { return }
 
+            self.activeRequests.insert(request)
+
             self.performSetupOperations(for: request, convertible: request.convertible)
         }
     }
@@ -770,6 +796,8 @@ open class Session {
     func perform(_ request: UploadRequest) {
         requestQueue.async {
             guard !request.isCancelled else { return }
+
+            self.activeRequests.insert(request)
 
             do {
                 let uploadable = try request.upload.createUploadable()
@@ -785,6 +813,8 @@ open class Session {
     func perform(_ request: DownloadRequest) {
         requestQueue.async {
             guard !request.isCancelled else { return }
+
+            self.activeRequests.insert(request)
 
             switch request.downloadable {
             case let .request(convertible):
@@ -902,6 +932,10 @@ open class Session {
 extension Session: RequestDelegate {
     public var sessionConfiguration: URLSessionConfiguration {
         return session.configuration
+    }
+
+    public func cleanup(after request: Request) {
+        activeRequests.remove(request)
     }
 
     public func retryResult(for request: Request, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -893,6 +893,7 @@ open class Session {
                 task.suspend()
                 rootQueue.async { request.didSuspendTask(task) }
             case (_, .cancelled):
+                task.resume()
                 task.cancel()
                 rootQueue.async { request.didCancelTask(task) }
             case (_, .finished):

--- a/Tests/BaseTestCase.swift
+++ b/Tests/BaseTestCase.swift
@@ -66,4 +66,20 @@ class BaseTestCase: XCTestCase {
             evaluation(reason)
         }
     }
+
+    /// Runs assertions on a particular `DispatchQueue`.
+    ///
+    /// - Parameters:
+    ///   - queue: The `DispatchQueue` on which to run the assertions.
+    ///   - assertions: Closure containing assertions to run
+    func assert(on queue: DispatchQueue, assertions: @escaping () -> Void) {
+        let expect = expectation(description: "all assertsion are complete")
+
+        queue.async {
+            assertions()
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+    }
 }

--- a/Tests/BaseTestCase.swift
+++ b/Tests/BaseTestCase.swift
@@ -73,7 +73,7 @@ class BaseTestCase: XCTestCase {
     ///   - queue: The `DispatchQueue` on which to run the assertions.
     ///   - assertions: Closure containing assertions to run
     func assert(on queue: DispatchQueue, assertions: @escaping () -> Void) {
-        let expect = expectation(description: "all assertsion are complete")
+        let expect = expectation(description: "all assertions are complete")
 
         queue.async {
             assertions()

--- a/Tests/HTTPBin.swift
+++ b/Tests/HTTPBin.swift
@@ -39,10 +39,14 @@ extension URL {
 extension URLRequest {
     static func makeHTTPBinRequest(path: String = "get",
                                    method: HTTPMethod = .get,
-                                   headers: HTTPHeaders = .init()) -> URLRequest {
+                                   headers: HTTPHeaders = .init(),
+                                   timeout: TimeInterval = 60,
+                                   cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy) -> URLRequest {
         var request = URLRequest(url: .makeHTTPBinURL(path: path))
         request.httpMethod = method.rawValue
         request.headers = headers
+        request.timeoutInterval = timeout
+        request.cachePolicy = cachePolicy
 
         return request
     }

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -26,7 +26,7 @@
 import Foundation
 import XCTest
 
-class SessionTestCase: BaseTestCase {
+final class SessionTestCase: BaseTestCase {
 
     // MARK: Helper Types
 
@@ -895,7 +895,10 @@ class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCount, 3)
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, false)
-        XCTAssertTrue(session.requestTaskMap.isEmpty)
+        assert(on: session.rootQueue) {
+            XCTAssertTrue(session.requestTaskMap.isEmpty)
+            XCTAssertTrue(session.activeRequests.isEmpty)
+        }
     }
 
     func testThatSessionCallsRequestRetrierThenSessionRetrierWhenRequestEncountersError() {
@@ -929,7 +932,10 @@ class SessionTestCase: BaseTestCase {
         XCTAssertEqual(requestHandler.retryCount, 4)
         XCTAssertEqual(request.retryCount, 2)
         XCTAssertEqual(response?.result.isSuccess, false)
-        XCTAssertTrue(session.requestTaskMap.isEmpty)
+        assert(on: session.rootQueue) {
+            XCTAssertTrue(session.requestTaskMap.isEmpty)
+            XCTAssertTrue(session.activeRequests.isEmpty)
+        }
     }
 
     func testThatSessionCallsRequestRetrierWhenRequestInitiallyEncountersAdaptError() {
@@ -960,7 +966,10 @@ class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCalledCount, 1)
         XCTAssertEqual(handler.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, true)
-        XCTAssertTrue(session.requestTaskMap.isEmpty)
+        assert(on: session.rootQueue) {
+            XCTAssertTrue(session.requestTaskMap.isEmpty)
+            XCTAssertTrue(session.activeRequests.isEmpty)
+        }
     }
 
     func testThatSessionCallsRequestRetrierWhenDownloadInitiallyEncountersAdaptError() {
@@ -996,7 +1005,10 @@ class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCalledCount, 1)
         XCTAssertEqual(handler.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, true)
-        XCTAssertTrue(session.requestTaskMap.isEmpty)
+        assert(on: session.rootQueue) {
+            XCTAssertTrue(session.requestTaskMap.isEmpty)
+            XCTAssertTrue(session.activeRequests.isEmpty)
+        }
     }
 
     func testThatSessionCallsRequestRetrierWhenUploadInitiallyEncountersAdaptError() {
@@ -1025,7 +1037,10 @@ class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCalledCount, 1)
         XCTAssertEqual(handler.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, true)
-        XCTAssertTrue(session.requestTaskMap.isEmpty)
+        assert(on: session.rootQueue) {
+            XCTAssertTrue(session.requestTaskMap.isEmpty)
+            XCTAssertTrue(session.activeRequests.isEmpty)
+        }
     }
 
     func testThatSessionCallsAdapterWhenRequestIsRetried() {
@@ -1055,7 +1070,10 @@ class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCount, 1)
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, true)
-        XCTAssertTrue(session.requestTaskMap.isEmpty)
+        assert(on: session.rootQueue) {
+            XCTAssertTrue(session.requestTaskMap.isEmpty)
+            XCTAssertTrue(session.activeRequests.isEmpty)
+        }
     }
 
     func testThatSessionReturnsRequestAdaptationErrorWhenRequestIsRetried() {
@@ -1085,7 +1103,10 @@ class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCount, 3)
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, false)
-        XCTAssertTrue(session.requestTaskMap.isEmpty)
+        assert(on: session.rootQueue) {
+            XCTAssertTrue(session.requestTaskMap.isEmpty)
+            XCTAssertTrue(session.activeRequests.isEmpty)
+        }
 
         if let error = response?.result.error?.asAFError {
             XCTAssertTrue(error.isRequestAdaptationError)
@@ -1123,7 +1144,10 @@ class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCount, 3)
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, false)
-        XCTAssertTrue(session.requestTaskMap.isEmpty)
+        assert(on: session.rootQueue) {
+            XCTAssertTrue(session.requestTaskMap.isEmpty)
+            XCTAssertTrue(session.activeRequests.isEmpty)
+        }
 
         if let error = response?.result.error?.asAFError {
             XCTAssertTrue(error.isRequestAdaptationError)
@@ -1160,7 +1184,10 @@ class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCount, 0)
         XCTAssertEqual(request.retryCount, 0)
         XCTAssertEqual(response?.result.isSuccess, false)
-        XCTAssertTrue(session.requestTaskMap.isEmpty)
+        assert(on: session.rootQueue) {
+            XCTAssertTrue(session.requestTaskMap.isEmpty)
+            XCTAssertTrue(session.activeRequests.isEmpty)
+        }
 
         if let error = response?.result.error?.asAFError {
             XCTAssertTrue(error.isRequestRetryError)
@@ -1199,7 +1226,10 @@ class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCount, 0)
         XCTAssertEqual(request.retryCount, 0)
         XCTAssertEqual(response?.result.isSuccess, false)
-        XCTAssertTrue(session.requestTaskMap.isEmpty)
+        assert(on: session.rootQueue) {
+            XCTAssertTrue(session.requestTaskMap.isEmpty)
+            XCTAssertTrue(session.activeRequests.isEmpty)
+        }
 
         if let error = response?.error?.asAFError {
             XCTAssertTrue(error.isResponseSerializationError)
@@ -1244,7 +1274,10 @@ class SessionTestCase: BaseTestCase {
         XCTAssertEqual(request.retryCount, 0)
         XCTAssertEqual(json1Response?.result.isSuccess, false)
         XCTAssertEqual(json2Response?.result.isSuccess, false)
-        XCTAssertTrue(session.requestTaskMap.isEmpty)
+        assert(on: session.rootQueue) {
+            XCTAssertTrue(session.requestTaskMap.isEmpty)
+            XCTAssertTrue(session.activeRequests.isEmpty)
+        }
 
         let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error?.asAFError }
         XCTAssertEqual(errors.count, 2)
@@ -1295,7 +1328,10 @@ class SessionTestCase: BaseTestCase {
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(json1Response?.result.isSuccess, false)
         XCTAssertEqual(json2Response?.result.isSuccess, false)
-        XCTAssertTrue(session.requestTaskMap.isEmpty)
+        assert(on: session.rootQueue) {
+            XCTAssertTrue(session.requestTaskMap.isEmpty)
+            XCTAssertTrue(session.activeRequests.isEmpty)
+        }
 
         let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error?.asAFError }
         XCTAssertEqual(errors.count, 2)
@@ -1347,7 +1383,10 @@ class SessionTestCase: BaseTestCase {
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(json1Response?.result.isSuccess, false)
         XCTAssertEqual(json2Response?.result.isSuccess, false)
-        XCTAssertTrue(session.requestTaskMap.isEmpty)
+        assert(on: session.rootQueue) {
+            XCTAssertTrue(session.requestTaskMap.isEmpty)
+            XCTAssertTrue(session.activeRequests.isEmpty)
+        }
 
         let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error?.asAFError }
         XCTAssertEqual(errors.count, 2)
@@ -1399,7 +1438,10 @@ class SessionTestCase: BaseTestCase {
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(json1Response?.result.isSuccess, false)
         XCTAssertEqual(json2Response?.result.isSuccess, false)
-        XCTAssertTrue(session.requestTaskMap.isEmpty)
+        assert(on: session.rootQueue) {
+            XCTAssertTrue(session.requestTaskMap.isEmpty)
+            XCTAssertTrue(session.activeRequests.isEmpty)
+        }
 
         let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error?.asAFError }
         XCTAssertEqual(errors.count, 2)
@@ -1469,8 +1511,11 @@ class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCount, 0)
         XCTAssertEqual(request.retryCount, 0)
         XCTAssertEqual(response?.result.isSuccess, true)
-        XCTAssertTrue(session.requestTaskMap.isEmpty)
         XCTAssertEqual(completionCallCount, 1)
+        assert(on: session.rootQueue) {
+            XCTAssertTrue(session.requestTaskMap.isEmpty)
+            XCTAssertTrue(session.activeRequests.isEmpty)
+        }
     }
 
     // MARK: Tests - Request State
@@ -1498,7 +1543,71 @@ class SessionTestCase: BaseTestCase {
 
 // MARK: -
 
-class SessionManagerConfigurationHeadersTestCase: BaseTestCase {
+final class SessionCancellationTestCase: BaseTestCase {
+    func testThatAutomaticallyResumedRequestsCanBeMassCancelled() {
+        // Given
+        let session = Session()
+        let request = URLRequest.makeHTTPBinRequest(path: "delay/1")
+        var responses: [DataResponse<Data?>] = []
+        let completion = expectation(description: "all requests should finish")
+        completion.expectedFulfillmentCount = 25
+        let cancellation = expectation(description: "cancel all requests should be called")
+
+        // When
+        for _ in 1...25 {
+            session.request(request).response { (response) in
+                responses.append(response)
+                completion.fulfill()
+            }
+        }
+        session.cancelAllRequests {
+            cancellation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(responses.allSatisfy { $0.error?.asAFError?.isExplicitlyCancelledError == true })
+        assert(on: session.rootQueue) {
+            XCTAssertTrue(session.requestTaskMap.isEmpty)
+            XCTAssertTrue(session.activeRequests.isEmpty)
+        }
+    }
+
+    func testThatManuallyResumedRequestsCanBeMassCancelled() {
+        // Given
+        let session = Session(startRequestsImmediately: false)
+        let request = URLRequest.makeHTTPBinRequest(path: "delay/1")
+        var responses: [DataResponse<Data?>] = []
+        let completion = expectation(description: "all requests should finish")
+        completion.expectedFulfillmentCount = 25
+        let cancellation = expectation(description: "cancel all requests should be called")
+
+        // When
+        for _ in 1...25 {
+            session.request(request).response { (response) in
+                responses.append(response)
+                completion.fulfill()
+            }
+        }
+        session.cancelAllRequests {
+            cancellation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(responses.allSatisfy { $0.error?.asAFError?.isExplicitlyCancelledError == true })
+        assert(on: session.rootQueue) {
+            XCTAssertTrue(session.requestTaskMap.isEmpty)
+            XCTAssertTrue(session.activeRequests.isEmpty)
+        }
+    }
+}
+
+// MARK: -
+
+final class SessionConfigurationHeadersTestCase: BaseTestCase {
     enum ConfigurationType {
         case `default`, ephemeral, background
     }


### PR DESCRIPTION
### Issue Link :link:
While there's no specific request, this is a question that comes up every so often, so it makes sense to add an API for it.

### Goals :soccer:
This PR adds a `cancelAllRequests` method to `Session`, which cancels all currently in flight `Request`s. It's a more limited version of a similar API on `URLSession`, in that it does't block additional `Request`s from being made while cancellation is occurring.

### Implementation Details :construction:
This PR adds `var activeRequests: Set<Request>` to `Session`, and `Request`s are added when created and removed when they run `cleanup()` after running the response serializers.

This PR also adds a workaround for the apparent fact that `URLSessionTask`s which are never resumed will never return `URLSessionTaskMetrics`. Given this is an important event for Alamofire to see, we now always call `resume()` on tasks before calling `cancel()`. This appears to guarantee metrics will always be generated for the task. However, on the 2019 OSes, as of beta 5, this is not 100% reliable in Alamofire, resulting in about 1 failure per 25,000 cancellations, at least according to my tests. Previous OS versions are 100% reliable, so I've reported this as a bug (FB6789976).

### Testing Details :mag:
I've added tests for cancelling 100 auto resumed and non resumed `Request`s, as well as a retry scenario. Let me know if any other scenarios are needed.
