### PR TITLE
Add failure constraint to *Response

### DIFF
--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -25,7 +25,7 @@
 import Foundation
 
 /// Used to store all data associated with a serialized response of a data or upload request.
-public struct DataResponse<Success> {
+public struct DataResponse<Success, Failure: Error> {
     /// The URL request sent to the server.
     public let request: URLRequest?
 
@@ -42,13 +42,13 @@ public struct DataResponse<Success> {
     public let serializationDuration: TimeInterval
 
     /// The result of response serialization.
-    public let result: Result<Success, Error>
+    public let result: Result<Success, Failure>
 
     /// Returns the associated value of the result if it is a success, `nil` otherwise.
     public var value: Success? { return result.success }
 
     /// Returns the associated error value if the result if it is a failure, `nil` otherwise.
-    public var error: Error? { return result.failure }
+    public var error: Failure? { return result.failure }
 
     /// Creates a `DataResponse` instance with the specified parameters derviced from the response serialization.
     ///
@@ -64,7 +64,7 @@ public struct DataResponse<Success> {
                 data: Data?,
                 metrics: URLSessionTaskMetrics?,
                 serializationDuration: TimeInterval,
-                result: Result<Success, Error>) {
+                result: Result<Success, Failure>) {
         self.request = request
         self.response = response
         self.data = data
@@ -129,8 +129,8 @@ extension DataResponse {
     ///
     /// - returns: A `DataResponse` whose result wraps the value returned by the given closure. If this instance's
     ///            result is a failure, returns a response wrapping the same failure.
-    public func map<NewSuccess>(_ transform: (Success) -> NewSuccess) -> DataResponse<NewSuccess> {
-        return DataResponse<NewSuccess>(
+    public func map<NewSuccess>(_ transform: (Success) -> NewSuccess) -> DataResponse<NewSuccess, Failure> {
+        return DataResponse<NewSuccess, Failure>(
             request: request,
             response: self.response,
             data: data,
@@ -154,8 +154,8 @@ extension DataResponse {
     ///
     /// - returns: A success or failure `DataResponse` depending on the result of the given closure. If this instance's
     ///            result is a failure, returns the same failure.
-    public func tryMap<NewSuccess>(_ transform: (Success) throws -> NewSuccess) -> DataResponse<NewSuccess> {
-        return DataResponse<NewSuccess>(
+    public func tryMap<NewSuccess>(_ transform: (Success) throws -> NewSuccess) -> DataResponse<NewSuccess, Error> {
+        return DataResponse<NewSuccess, Error>(
             request: request,
             response: self.response,
             data: data,
@@ -175,8 +175,8 @@ extension DataResponse {
     /// - Parameter transform: A closure that takes the error of the instance.
     ///
     /// - Returns: A `DataResponse` instance containing the result of the transform.
-    public func mapError<NewFailure: Error>(_ transform: (Error) -> NewFailure) -> DataResponse<Success> {
-        return DataResponse<Success>(
+    public func mapError<NewFailure: Error>(_ transform: (Error) -> NewFailure) -> DataResponse<Success, NewFailure> {
+        return DataResponse<Success, NewFailure>(
             request: request,
             response: self.response,
             data: data,
@@ -198,8 +198,8 @@ extension DataResponse {
     /// - Parameter transform: A throwing closure that takes the error of the instance.
     ///
     /// - Returns: A `DataResponse` instance containing the result of the transform.
-    public func tryMapError<NewFailure: Error>(_ transform: (Error) throws -> NewFailure) -> DataResponse<Success> {
-        return DataResponse<Success>(
+    public func tryMapError<NewFailure: Error>(_ transform: (Failure) throws -> NewFailure) -> DataResponse<Success, Error> {
+        return DataResponse<Success, Error>(
             request: request,
             response: self.response,
             data: data,
@@ -213,7 +213,7 @@ extension DataResponse {
 // MARK: -
 
 /// Used to store all data associated with a serialized response of a download request.
-public struct DownloadResponse<Success> {
+public struct DownloadResponse<Success, Failure: Error> {
     /// The URL request sent to the server.
     public let request: URLRequest?
 
@@ -233,13 +233,13 @@ public struct DownloadResponse<Success> {
     public let serializationDuration: TimeInterval
 
     /// The result of response serialization.
-    public let result: Result<Success, Error>
+    public let result: Result<Success, Failure>
 
     /// Returns the associated value of the result if it is a success, `nil` otherwise.
     public var value: Success? { return result.success }
 
     /// Returns the associated error value if the result if it is a failure, `nil` otherwise.
-    public var error: Error? { return result.failure }
+    public var error: Failure? { return result.failure }
 
     /// Creates a `DownloadResponse` instance with the specified parameters derived from response serialization.
     ///
@@ -259,7 +259,7 @@ public struct DownloadResponse<Success> {
         resumeData: Data?,
         metrics: URLSessionTaskMetrics?,
         serializationDuration: TimeInterval,
-        result: Result<Success, Error>)
+        result: Result<Success, Failure>)
     {
         self.request = request
         self.response = response
@@ -326,8 +326,8 @@ extension DownloadResponse {
     ///
     /// - returns: A `DownloadResponse` whose result wraps the value returned by the given closure. If this instance's
     ///            result is a failure, returns a response wrapping the same failure.
-    public func map<NewSuccess>(_ transform: (Success) -> NewSuccess) -> DownloadResponse<NewSuccess> {
-        return DownloadResponse<NewSuccess>(
+    public func map<NewSuccess>(_ transform: (Success) -> NewSuccess) -> DownloadResponse<NewSuccess, Failure> {
+        return DownloadResponse<NewSuccess, Failure>(
             request: request,
             response: response,
             fileURL: fileURL,
@@ -352,8 +352,8 @@ extension DownloadResponse {
     ///
     /// - returns: A success or failure `DownloadResponse` depending on the result of the given closure. If this
     /// instance's result is a failure, returns the same failure.
-    public func tryMap<NewSuccess>(_ transform: (Success) throws -> NewSuccess) -> DownloadResponse<NewSuccess> {
-        return DownloadResponse<NewSuccess>(
+    public func tryMap<NewSuccess>(_ transform: (Success) throws -> NewSuccess) -> DownloadResponse<NewSuccess, Error> {
+        return DownloadResponse<NewSuccess, Error>(
             request: request,
             response: response,
             fileURL: fileURL,
@@ -374,8 +374,8 @@ extension DownloadResponse {
     /// - Parameter transform: A closure that takes the error of the instance.
     ///
     /// - Returns: A `DownloadResponse` instance containing the result of the transform.
-    public func mapError<NewFailure: Error>(_ transform: (Error) -> NewFailure) -> DownloadResponse {
-        return DownloadResponse<Success>(
+    public func mapError<NewFailure: Error>(_ transform: (Failure) -> NewFailure) -> DownloadResponse<Success, NewFailure> {
+        return DownloadResponse<Success, NewFailure>(
             request: request,
             response: response,
             fileURL: fileURL,
@@ -398,8 +398,8 @@ extension DownloadResponse {
     /// - Parameter transform: A throwing closure that takes the error of the instance.
     ///
     /// - Returns: A `DownloadResponse` instance containing the result of the transform.
-    public func tryMapError<NewFailure: Error>(_ transform: (Error) throws -> NewFailure) -> DownloadResponse {
-        return DownloadResponse<Success>(
+    public func tryMapError<NewFailure: Error>(_ transform: (Failure) throws -> NewFailure) -> DownloadResponse<Success, Error> {
+        return DownloadResponse<Success, Error>(
             request: request,
             response: response,
             fileURL: fileURL,

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -176,7 +176,7 @@ extension DataRequest {
     ///
     /// - Returns:             The request.
     @discardableResult
-    public func response(queue: DispatchQueue = .main, completionHandler: @escaping (DataResponse<Data?>) -> Void) -> Self {
+    public func response(queue: DispatchQueue = .main, completionHandler: @escaping (DataResponse<Data?, Error>) -> Void) -> Self {
         appendResponseSerializer {
             // Start work that should be on the serialization queue.
             let result = Result<Data?, Error>(value: self.data, error: self.error)
@@ -211,7 +211,7 @@ extension DataRequest {
     public func response<Serializer: DataResponseSerializerProtocol>(
         queue: DispatchQueue = .main,
         responseSerializer: Serializer,
-        completionHandler: @escaping (DataResponse<Serializer.SerializedObject>) -> Void)
+        completionHandler: @escaping (DataResponse<Serializer.SerializedObject, Error>) -> Void)
         -> Self
     {
         appendResponseSerializer {
@@ -291,7 +291,7 @@ extension DownloadRequest {
     @discardableResult
     public func response(
         queue: DispatchQueue = .main,
-        completionHandler: @escaping (DownloadResponse<URL?>) -> Void)
+        completionHandler: @escaping (DownloadResponse<URL?, Error>) -> Void)
         -> Self
     {
         appendResponseSerializer {
@@ -330,7 +330,7 @@ extension DownloadRequest {
     public func response<T: DownloadResponseSerializerProtocol>(
         queue: DispatchQueue = .main,
         responseSerializer: T,
-        completionHandler: @escaping (DownloadResponse<T.SerializedObject>) -> Void)
+        completionHandler: @escaping (DownloadResponse<T.SerializedObject, Error>) -> Void)
         -> Self
     {
         appendResponseSerializer {
@@ -413,7 +413,7 @@ extension DataRequest {
     @discardableResult
     public func responseData(
         queue: DispatchQueue = .main,
-        completionHandler: @escaping (DataResponse<Data>) -> Void)
+        completionHandler: @escaping (DataResponse<Data, Error>) -> Void)
         -> Self
     {
         return response(queue: queue,
@@ -472,7 +472,7 @@ extension DownloadRequest {
     @discardableResult
     public func responseData(
         queue: DispatchQueue = .main,
-        completionHandler: @escaping (DownloadResponse<Data>) -> Void)
+        completionHandler: @escaping (DownloadResponse<Data, Error>) -> Void)
         -> Self
     {
         return response(
@@ -557,7 +557,7 @@ extension DataRequest {
     @discardableResult
     public func responseString(queue: DispatchQueue = .main,
                                encoding: String.Encoding? = nil,
-                               completionHandler: @escaping (DataResponse<String>) -> Void) -> Self {
+                               completionHandler: @escaping (DataResponse<String, Error>) -> Void) -> Self {
         return response(queue: queue,
                         responseSerializer: StringResponseSerializer(encoding: encoding),
                         completionHandler: completionHandler)
@@ -578,7 +578,7 @@ extension DownloadRequest {
     public func responseString(
         queue: DispatchQueue = .main,
         encoding: String.Encoding? = nil,
-        completionHandler: @escaping (DownloadResponse<String>) -> Void)
+        completionHandler: @escaping (DownloadResponse<String, Error>) -> Void)
         -> Self
     {
         return response(
@@ -651,7 +651,7 @@ extension DataRequest {
     @discardableResult
     public func responseJSON(queue: DispatchQueue = .main,
                              options: JSONSerialization.ReadingOptions = .allowFragments,
-                             completionHandler: @escaping (DataResponse<Any>) -> Void) -> Self {
+                             completionHandler: @escaping (DataResponse<Any, Error>) -> Void) -> Self {
         return response(queue: queue,
                         responseSerializer: JSONResponseSerializer(options: options),
                         completionHandler: completionHandler)
@@ -671,7 +671,7 @@ extension DownloadRequest {
     public func responseJSON(
         queue: DispatchQueue = .main,
         options: JSONSerialization.ReadingOptions = .allowFragments,
-        completionHandler: @escaping (DownloadResponse<Any>) -> Void)
+        completionHandler: @escaping (DownloadResponse<Any, Error>) -> Void)
         -> Self
     {
         return response(queue: queue,
@@ -789,7 +789,7 @@ extension DataRequest {
     public func responseDecodable<T: Decodable>(of type: T.Type = T.self,
                                                 queue: DispatchQueue = .main,
                                                 decoder: DataDecoder = JSONDecoder(),
-                                                completionHandler: @escaping (DataResponse<T>) -> Void) -> Self {
+                                                completionHandler: @escaping (DataResponse<T, Error>) -> Void) -> Self {
         return response(queue: queue,
                         responseSerializer: DecodableResponseSerializer(decoder: decoder),
                         completionHandler: completionHandler)

--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -65,7 +65,7 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
         // Given
         let expectation = self.expectation(description: "\(urlString) 401")
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         manager.request(urlString)
@@ -89,7 +89,7 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
         // Given
         let expectation = self.expectation(description: "\(urlString) 200")
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         manager.request(urlString)
@@ -115,7 +115,7 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
         let expectation = self.expectation(description: "\(urlString) 200")
         let headers: HTTPHeaders = [.authorization(username: user, password: password)]
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         manager.request(urlString, headers: headers)
@@ -149,7 +149,7 @@ class HTTPDigestAuthenticationTestCase: AuthenticationTestCase {
         // Given
         let expectation = self.expectation(description: "\(urlString) 401")
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         manager.request(urlString)
@@ -173,7 +173,7 @@ class HTTPDigestAuthenticationTestCase: AuthenticationTestCase {
         // Given
         let expectation = self.expectation(description: "\(urlString) 200")
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         manager.request(urlString)

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -83,7 +83,7 @@ class DownloadResponseTestCase: BaseTestCase {
         let destination: DownloadRequest.Destination = { _, _ in (fileURL, []) }
 
         let expectation = self.expectation(description: "Download request should download data to file: \(urlString)")
-        var response: DownloadResponse<URL?>?
+        var response: DownloadResponse<URL?, Error>?
 
         // When
         AF.download(urlString, to: destination)
@@ -120,7 +120,7 @@ class DownloadResponseTestCase: BaseTestCase {
         let destination: DownloadRequest.Destination = { _, _ in (fileURL, []) }
 
         let expectation = self.expectation(description: "Cancelled download request should not download data to file")
-        var response: DownloadResponse<URL?>?
+        var response: DownloadResponse<URL?, Error>?
 
         // When
         AF.download(urlString, to: destination)
@@ -146,7 +146,7 @@ class DownloadResponseTestCase: BaseTestCase {
         let expectation = self.expectation(description: "Bytes download progress should be reported: \(urlString)")
 
         var progressValues: [Double] = []
-        var response: DownloadResponse<URL?>?
+        var response: DownloadResponse<URL?, Error>?
 
         // When
         AF.download(urlString)
@@ -189,7 +189,7 @@ class DownloadResponseTestCase: BaseTestCase {
         let destination: DownloadRequest.Destination = { _, _ in (fileURL, []) }
 
         let expectation = self.expectation(description: "Download request should download data to file")
-        var response: DownloadResponse<URL?>?
+        var response: DownloadResponse<URL?, Error>?
 
         // When
         AF.download(urlString, parameters: parameters, to: destination)
@@ -227,7 +227,7 @@ class DownloadResponseTestCase: BaseTestCase {
         let destination: DownloadRequest.Destination = { _, _ in (fileURL, []) }
 
         let expectation = self.expectation(description: "Download request should download data to file: \(fileURL)")
-        var response: DownloadResponse<URL?>?
+        var response: DownloadResponse<URL?, Error>?
 
         // When
         AF.download(urlString, headers: headers, to: destination)
@@ -262,7 +262,7 @@ class DownloadResponseTestCase: BaseTestCase {
         let fileURL = testDirectoryURL.appendingPathComponent("some/random/folder/test_output.json")
 
         let expectation = self.expectation(description: "Download request should download data but fail to move file")
-        var response: DownloadResponse<URL?>?
+        var response: DownloadResponse<URL?, Error>?
 
         // When
         AF.download("https://httpbin.org/get", to: { _, _ in (fileURL, [])})
@@ -292,7 +292,7 @@ class DownloadResponseTestCase: BaseTestCase {
         let fileURL = testDirectoryURL.appendingPathComponent("some/random/folder/test_output.json")
 
         let expectation = self.expectation(description: "Download request should download data to file: \(fileURL)")
-        var response: DownloadResponse<URL?>?
+        var response: DownloadResponse<URL?, Error>?
 
         // When
         AF.download("https://httpbin.org/get", to: { _, _ in (fileURL, [.createIntermediateDirectories])})
@@ -321,7 +321,7 @@ class DownloadResponseTestCase: BaseTestCase {
             try "random_data".write(to: fileURL, atomically: true, encoding: .utf8)
 
             let expectation = self.expectation(description: "Download should complete but fail to move file")
-            var response: DownloadResponse<URL?>?
+            var response: DownloadResponse<URL?, Error>?
 
             // When
             AF.download("https://httpbin.org/get", to: { _, _ in (fileURL, [])})
@@ -359,7 +359,7 @@ class DownloadResponseTestCase: BaseTestCase {
         let fileURL = directoryURL.appendingPathComponent("test_output.json")
 
         let expectation = self.expectation(description: "Download should complete and move file to URL: \(fileURL)")
-        var response: DownloadResponse<URL?>?
+        var response: DownloadResponse<URL?, Error>?
 
         // When
         AF.download("https://httpbin.org/get", to: { _, _ in (fileURL, [.removePreviousFile, .createIntermediateDirectories])})
@@ -496,7 +496,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         let expectation = self.expectation(description: "Download should be cancelled")
         var cancelled = false
 
-        var response: DownloadResponse<URL?>?
+        var response: DownloadResponse<URL?, Error>?
 
         // When
         let download = AF.download(urlString)
@@ -530,7 +530,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         let expectation = self.expectation(description: "Download should be cancelled")
         var cancelled = false
 
-        var response: DownloadResponse<URL?>?
+        var response: DownloadResponse<URL?, Error>?
 
         // When
         let download = AF.download(urlString)
@@ -566,7 +566,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         let expectation = self.expectation(description: "Download should be cancelled")
         var cancelled = false
 
-        var response: DownloadResponse<Any>?
+        var response: DownloadResponse<Any, Error>?
 
         // When
         let download = AF.download(urlString)
@@ -603,7 +603,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         let expectation1 = self.expectation(description: "Download should be cancelled")
         var cancelled = false
 
-        var response1: DownloadResponse<Data>?
+        var response1: DownloadResponse<Data, Error>?
 
         // When
         let download = AF.download(urlString)
@@ -630,7 +630,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         let expectation2 = self.expectation(description: "Download should complete")
 
         var progressValues: [Double] = []
-        var response2: DownloadResponse<Data>?
+        var response2: DownloadResponse<Data, Error>?
 
         AF.download(resumingWith: resumeData)
             .downloadProgress { progress in
@@ -663,7 +663,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         let expectation = self.expectation(description: "Download should be cancelled")
         var cancelled = false
         var receivedResumeData: Data?
-        var response: DownloadResponse<URL?>?
+        var response: DownloadResponse<URL?, Error>?
 
         // When
         let download = AF.download(urlString)
@@ -705,7 +705,7 @@ class DownloadResponseMapTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DownloadResponse<String>?
+        var response: DownloadResponse<String, Error>?
 
         // When
         AF.download(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -734,7 +734,7 @@ class DownloadResponseMapTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail with 404")
 
-        var response: DownloadResponse<String>?
+        var response: DownloadResponse<String, Error>?
 
         // When
         AF.download(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -763,7 +763,7 @@ class DownloadResponseFlatMapTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DownloadResponse<String>?
+        var response: DownloadResponse<String, Error>?
 
         // When
         AF.download(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -794,7 +794,7 @@ class DownloadResponseFlatMapTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DownloadResponse<String>?
+        var response: DownloadResponse<String, Error>?
 
         // When
         AF.download(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -826,7 +826,7 @@ class DownloadResponseFlatMapTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail with 404")
 
-        var response: DownloadResponse<String>?
+        var response: DownloadResponse<String, Error>?
 
         // When
         AF.download(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -853,7 +853,7 @@ class DownloadResponseMapErrorTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should not succeed")
 
-        var response: DownloadResponse<Any>?
+        var response: DownloadResponse<Any, Error>?
 
         // When
         AF.download(urlString).responseJSON { resp in
@@ -884,7 +884,7 @@ class DownloadResponseMapErrorTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DownloadResponse<Data>?
+        var response: DownloadResponse<Data, Error>?
 
         // When
         AF.download(urlString).responseData { resp in
@@ -912,7 +912,7 @@ class DownloadResponseFlatMapErrorTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DownloadResponse<Data>?
+        var response: DownloadResponse<Data, Error>?
 
         // When
         AF.download(urlString).responseData { resp in
@@ -937,7 +937,7 @@ class DownloadResponseFlatMapErrorTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail")
 
-        var response: DownloadResponse<Data>?
+        var response: DownloadResponse<Data, Error>?
 
         // When
         AF.download(urlString).responseData { resp in
@@ -969,7 +969,7 @@ class DownloadResponseFlatMapErrorTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail")
 
-        var response: DownloadResponse<Data>?
+        var response: DownloadResponse<Data, Error>?
 
         // When
         AF.download(urlString).responseData { resp in

--- a/Tests/NSLoggingEventMonitor.swift
+++ b/Tests/NSLoggingEventMonitor.swift
@@ -164,19 +164,19 @@ public final class NSLoggingEventMonitor: EventMonitor {
         NSLog("Request: \(request) didCancelTask: \(task)")
     }
 
-    public func request(_ request: DataRequest, didParseResponse response: DataResponse<Data?>) {
+    public func request(_ request: DataRequest, didParseResponse response: DataResponse<Data?, Error>) {
         NSLog("Request: \(request), didParseResponse: \(response)")
     }
 
-    public func request<Value>(_ request: DataRequest, didParseResponse response: DataResponse<Value>) {
+    public func request<Value>(_ request: DataRequest, didParseResponse response: DataResponse<Value, Error>) {
         NSLog("Request: \(request), didParseResponse: \(response)")
     }
 
-    public func request(_ request: DownloadRequest, didParseResponse response: DownloadResponse<Data?>) {
+    public func request(_ request: DownloadRequest, didParseResponse response: DownloadResponse<Data?, Error>) {
         NSLog("Request: \(request), didParseResponse: \(response)")
     }
 
-    public func request<Value>(_ request: DownloadRequest, didParseResponse response: DownloadResponse<Value>) {
+    public func request<Value>(_ request: DownloadRequest, didParseResponse response: DownloadResponse<Value, Error>) {
         NSLog("Request: \(request), didParseResponse: \(response)")
     }
 

--- a/Tests/RedirectHandlerTests.swift
+++ b/Tests/RedirectHandlerTests.swift
@@ -39,7 +39,7 @@ final class RedirectHandlerTestCase: BaseTestCase {
         // Given
         let session = Session()
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
         let expectation = self.expectation(description: "Request should redirect to \(redirectURLString)")
 
         // When
@@ -64,7 +64,7 @@ final class RedirectHandlerTestCase: BaseTestCase {
         // Given
         let session = Session()
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
         let expectation = self.expectation(description: "Request should NOT redirect to \(redirectURLString)")
 
         // When
@@ -91,7 +91,7 @@ final class RedirectHandlerTestCase: BaseTestCase {
         let redirectURLString = "https://www.nike.com"
         let redirectURLRequest = URLRequest(url: URL(string: redirectURLString)!)
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
         let expectation = self.expectation(description: "Request should redirect to \(redirectURLString)")
 
         // When
@@ -120,7 +120,7 @@ final class RedirectHandlerTestCase: BaseTestCase {
         // Given
         let session = Session(redirectHandler: Redirector.follow)
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
         let expectation = self.expectation(description: "Request should redirect to \(redirectURLString)")
 
         // When
@@ -145,7 +145,7 @@ final class RedirectHandlerTestCase: BaseTestCase {
         // Given
         let session = Session(redirectHandler: Redirector.doNotFollow)
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
         let expectation = self.expectation(description: "Request should NOT redirect to \(redirectURLString)")
 
         // When
@@ -174,7 +174,7 @@ final class RedirectHandlerTestCase: BaseTestCase {
         let redirector = Redirector(behavior: .modify { _, _, _ in redirectURLRequest })
         let session = Session(redirectHandler: redirector)
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
         let expectation = self.expectation(description: "Request should redirect to \(redirectURLString)")
 
         // When
@@ -201,7 +201,7 @@ final class RedirectHandlerTestCase: BaseTestCase {
         // Given
         let session = Session(redirectHandler: Redirector.doNotFollow)
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
         let expectation = self.expectation(description: "Request should redirect to \(redirectURLString)")
 
         // When

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -31,7 +31,7 @@ final class RequestResponseTestCase: BaseTestCase {
         // Given
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "GET request should succeed: \(urlString)")
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"])
@@ -57,7 +57,7 @@ final class RequestResponseTestCase: BaseTestCase {
         let expectation = self.expectation(description: "Bytes download progress should be reported: \(urlString)")
 
         var progressValues: [Double] = []
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         AF.request(urlString)
@@ -103,7 +103,7 @@ final class RequestResponseTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
 
         // When
         AF.request(urlString, method: .post, parameters: parameters)
@@ -155,7 +155,7 @@ final class RequestResponseTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
 
         // When
         AF.request(urlString, method: .post, parameters: parameters)
@@ -188,7 +188,7 @@ final class RequestResponseTestCase: BaseTestCase {
         let queue = DispatchQueue(label: "org.alamofire.testSerializationQueue")
         let manager = Session(serializationQueue: queue)
         let expectation = self.expectation(description: "request should complete")
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
 
         // When
         manager.request("https://httpbin.org/get").responseJSON { (resp) in
@@ -208,7 +208,7 @@ final class RequestResponseTestCase: BaseTestCase {
         let serializationQueue = DispatchQueue(label: "org.alamofire.testSerializationQueue")
         let manager = Session(requestQueue: requestQueue, serializationQueue: serializationQueue)
         let expectation = self.expectation(description: "request should complete")
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
 
         // When
         manager.request("https://httpbin.org/get").responseJSON { (resp) in
@@ -228,11 +228,11 @@ final class RequestResponseTestCase: BaseTestCase {
         // Given
         let parameters = HTTPBinParameters(property: "one")
         let expect = expectation(description: "request should complete")
-        var receivedResponse: DataResponse<HTTPBinResponse>?
+        var receivedResponse: DataResponse<HTTPBinResponse, Error>?
 
         // When
         AF.request("https://httpbin.org/post", method: .post, parameters: parameters, encoder: JSONParameterEncoder.default)
-          .responseDecodable { (response: DataResponse<HTTPBinResponse>) in
+          .responseDecodable { (response: DataResponse<HTTPBinResponse, Error>) in
               receivedResponse = response
               expect.fulfill()
           }
@@ -247,11 +247,11 @@ final class RequestResponseTestCase: BaseTestCase {
         // Given
         let parameters = HTTPBinParameters(property: "one")
         let expect = expectation(description: "request should complete")
-        var receivedResponse: DataResponse<HTTPBinResponse>?
+        var receivedResponse: DataResponse<HTTPBinResponse, Error>?
 
         // When
         AF.request("https://httpbin.org/get", method: .get, parameters: parameters)
-          .responseDecodable { (response: DataResponse<HTTPBinResponse>) in
+          .responseDecodable { (response: DataResponse<HTTPBinResponse, Error>) in
               receivedResponse = response
               expect.fulfill()
           }
@@ -266,11 +266,11 @@ final class RequestResponseTestCase: BaseTestCase {
         // Given
         let parameters = HTTPBinParameters(property: "one")
         let expect = expectation(description: "request should complete")
-        var receivedResponse: DataResponse<HTTPBinResponse>?
+        var receivedResponse: DataResponse<HTTPBinResponse, Error>?
 
         // When
         AF.request("https://httpbin.org/post", method: .post, parameters: parameters)
-            .responseDecodable { (response: DataResponse<HTTPBinResponse>) in
+            .responseDecodable { (response: DataResponse<HTTPBinResponse, Error>) in
                 receivedResponse = response
                 expect.fulfill()
         }
@@ -644,8 +644,8 @@ final class RequestResponseTestCase: BaseTestCase {
         // Given
         let session = Session()
 
-        var response1: DataResponse<Any>?
-        var response2: DataResponse<Any>?
+        var response1: DataResponse<Any, Error>?
+        var response2: DataResponse<Any, Error>?
 
         let expect = expectation(description: "both response serializer completions should be called")
         expect.expectedFulfillmentCount = 2
@@ -676,9 +676,9 @@ final class RequestResponseTestCase: BaseTestCase {
         // Given
         let session = Session()
 
-        var response1: DataResponse<Any>?
-        var response2: DataResponse<Any>?
-        var response3: DataResponse<Any>?
+        var response1: DataResponse<Any, Error>?
+        var response2: DataResponse<Any, Error>?
+        var response3: DataResponse<Any, Error>?
 
         let expect = expectation(description: "both response serializer completions should be called")
         expect.expectedFulfillmentCount = 3
@@ -714,9 +714,9 @@ final class RequestResponseTestCase: BaseTestCase {
         let session = Session()
         let request = session.request(URLRequest.makeHTTPBinRequest())
 
-        var response1: DataResponse<Any>?
-        var response2: DataResponse<Any>?
-        var response3: DataResponse<Any>?
+        var response1: DataResponse<Any, Error>?
+        var response2: DataResponse<Any, Error>?
+        var response3: DataResponse<Any, Error>?
 
         // When
         let expect1 = expectation(description: "response serializer 1 completion should be called")

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -531,7 +531,7 @@ class ResponseMapErrorTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should not succeed")
 
-        var response: DataResponse<Any, TestError>!
+        var response: DataResponse<Any, TestError>?
 
         // When
         AF.request(urlString).responseJSON { resp in
@@ -559,7 +559,7 @@ class ResponseMapErrorTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Data, TestError>!
+        var response: DataResponse<Data, TestError>?
 
         // When
         AF.request(urlString).responseData { resp in
@@ -586,7 +586,7 @@ class ResponseTryMapErrorTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Data, Error>!
+        var response: DataResponse<Data, Error>?
 
         // When
         AF.request(urlString).responseData { resp in
@@ -609,7 +609,7 @@ class ResponseTryMapErrorTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail")
 
-        var response: DataResponse<Data, Error>!
+        var response: DataResponse<Data, Error>?
 
         // When
         AF.request(urlString).responseData { resp in
@@ -631,7 +631,7 @@ class ResponseTryMapErrorTestCase: BaseTestCase {
             XCTFail("tryMapError should catch the transformation error")
         }
 
-        XCTAssertNotNil(response.metrics)
+        XCTAssertNotNil(response?.metrics)
     }
 
     func testThatTryMapErrorTransformsError() {
@@ -639,7 +639,7 @@ class ResponseTryMapErrorTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail")
 
-        var response: DataResponse<Data, Error>!
+        var response: DataResponse<Data, Error>?
 
         // When
         AF.request(urlString).responseData { resp in

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -32,7 +32,7 @@ class ResponseTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).response { resp in
@@ -55,7 +55,7 @@ class ResponseTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail with 404")
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).response { resp in
@@ -82,7 +82,7 @@ class ResponseDataTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Data>?
+        var response: DataResponse<Data, Error>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
@@ -106,7 +106,7 @@ class ResponseDataTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail with 404")
 
-        var response: DataResponse<Data>?
+        var response: DataResponse<Data, Error>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
@@ -133,7 +133,7 @@ class ResponseStringTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<String>?
+        var response: DataResponse<String, Error>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseString { resp in
@@ -157,7 +157,7 @@ class ResponseStringTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail with 404")
 
-        var response: DataResponse<String>?
+        var response: DataResponse<String, Error>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseString { resp in
@@ -184,7 +184,7 @@ class ResponseJSONTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -208,7 +208,7 @@ class ResponseJSONTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail")
 
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -231,7 +231,7 @@ class ResponseJSONTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -264,7 +264,7 @@ class ResponseJSONTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/post"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
 
         // When
         AF.request(urlString, method: .post, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -299,10 +299,10 @@ class ResponseJSONDecodableTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<HTTPBinResponse>?
+        var response: DataResponse<HTTPBinResponse, Error>?
 
         // When
-        AF.request(urlString, parameters: [:]).responseDecodable { (resp: DataResponse<HTTPBinResponse>) in
+        AF.request(urlString, parameters: [:]).responseDecodable { (resp: DataResponse<HTTPBinResponse, Error>) in
             response = resp
             expectation.fulfill()
         }
@@ -323,7 +323,7 @@ class ResponseJSONDecodableTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<HTTPBinResponse>?
+        var response: DataResponse<HTTPBinResponse, Error>?
 
         // When
         AF.request(urlString, parameters: [:]).responseDecodable(of: HTTPBinResponse.self) {
@@ -347,10 +347,10 @@ class ResponseJSONDecodableTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail")
 
-        var response: DataResponse<HTTPBinResponse>?
+        var response: DataResponse<HTTPBinResponse, Error>?
 
         // When
-        AF.request(urlString, parameters: [:]).responseDecodable { (resp: DataResponse<HTTPBinResponse>) in
+        AF.request(urlString, parameters: [:]).responseDecodable { (resp: DataResponse<HTTPBinResponse, Error>) in
             response = resp
             expectation.fulfill()
         }
@@ -374,7 +374,7 @@ class ResponseMapTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<String>?
+        var response: DataResponse<String, Error>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -402,7 +402,7 @@ class ResponseMapTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail with 404")
 
-        var response: DataResponse<String>?
+        var response: DataResponse<String, Error>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
@@ -423,18 +423,18 @@ class ResponseMapTestCase: BaseTestCase {
 
 // MARK: -
 
-class ResponseFlatMapTestCase: BaseTestCase {
-    func testThatFlatMapTransformsSuccessValue() {
+class ResponseTryMapTestCase: BaseTestCase {
+    func testThatTryMapTransformsSuccessValue() {
         // Given
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<String>?
+        var response: DataResponse<String, Error>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
             response = resp.tryMap { json in
-                // json["args"]["foo"] is "bar": use this invariant to test the flatMap function
+                // json["args"]["foo"] is "bar": use this invariant to test the tryMap function
                 return ((json as? [String: Any])?["args"] as? [String: Any])?["foo"] as? String ?? "invalid"
             }
 
@@ -452,14 +452,14 @@ class ResponseFlatMapTestCase: BaseTestCase {
         XCTAssertNotNil(response?.metrics)
     }
 
-    func testThatFlatMapCatchesTransformationError() {
+    func testThatTryMapCatchesTransformationError() {
         // Given
         struct TransformError: Error {}
 
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<String>?
+        var response: DataResponse<String, Error>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
@@ -481,18 +481,18 @@ class ResponseFlatMapTestCase: BaseTestCase {
         if let error = response?.result.error {
             XCTAssertTrue(error is TransformError)
         } else {
-            XCTFail("flatMap should catch the transformation error")
+            XCTFail("tryMap should catch the transformation error")
         }
 
         XCTAssertNotNil(response?.metrics)
     }
 
-    func testThatFlatMapPreservesFailureError() {
+    func testThatTryMapPreservesFailureError() {
         // Given
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail with 404")
 
-        var response: DataResponse<String>?
+        var response: DataResponse<String, Error>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
@@ -531,7 +531,7 @@ class ResponseMapErrorTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should not succeed")
 
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, TestError>!
 
         // When
         AF.request(urlString).responseJSON { resp in
@@ -549,7 +549,7 @@ class ResponseMapErrorTestCase: BaseTestCase {
         XCTAssertNil(response?.response)
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
-        guard let error = response?.error as? TestError, case .error = error else { XCTFail(); return }
+        guard let error = response?.error, case .error = error else { XCTFail(); return }
 
         XCTAssertNotNil(response?.metrics)
     }
@@ -559,7 +559,7 @@ class ResponseMapErrorTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Data>?
+        var response: DataResponse<Data, TestError>!
 
         // When
         AF.request(urlString).responseData { resp in
@@ -580,13 +580,13 @@ class ResponseMapErrorTestCase: BaseTestCase {
 
 // MARK: -
 
-class ResponseFlatMapErrorTestCase: BaseTestCase {
-    func testThatFlatMapErrorPreservesSuccessValue() {
+class ResponseTryMapErrorTestCase: BaseTestCase {
+    func testThatTryMapErrorPreservesSuccessValue() {
         // Given
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Data>?
+        var response: DataResponse<Data, Error>!
 
         // When
         AF.request(urlString).responseData { resp in
@@ -604,12 +604,12 @@ class ResponseFlatMapErrorTestCase: BaseTestCase {
         XCTAssertNotNil(response?.metrics)
     }
 
-    func testThatFlatMapErrorCatchesTransformationError() {
+    func testThatTryMapErrorCatchesTransformationError() {
         // Given
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail")
 
-        var response: DataResponse<Data>?
+        var response: DataResponse<Data, Error>!
 
         // When
         AF.request(urlString).responseData { resp in
@@ -628,18 +628,18 @@ class ResponseFlatMapErrorTestCase: BaseTestCase {
         if let error = response?.result.error {
             XCTAssertTrue(error is TransformationError)
         } else {
-            XCTFail("flatMapError should catch the transformation error")
+            XCTFail("tryMapError should catch the transformation error")
         }
 
-        XCTAssertNotNil(response?.metrics)
+        XCTAssertNotNil(response.metrics)
     }
 
-    func testThatFlatMapErrorTransformsError() {
+    func testThatTryMapErrorTransformsError() {
         // Given
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail")
 
-        var response: DataResponse<Data>?
+        var response: DataResponse<Data, Error>!
 
         // When
         AF.request(urlString).responseData { resp in

--- a/Tests/SessionDelegateTests.swift
+++ b/Tests/SessionDelegateTests.swift
@@ -45,7 +45,7 @@ class SessionDelegateTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "Request should redirect to \(redirectURLString)")
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         manager.request(urlString)
@@ -73,7 +73,7 @@ class SessionDelegateTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "Request should redirect to \(redirectURLString)")
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         manager.request(urlString)
@@ -103,7 +103,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var resumedTaskRequest: Request?
         var completedTaskRequest: Request?
         var completedRequest: Request?
-        var requestResponse: DataResponse<Data?>?
+        var requestResponse: DataResponse<Data?, Error>?
         let expect = expectation(description: "request should complete")
 
         // When
@@ -157,7 +157,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var resumedTaskRequest: Request?
         var completedTaskRequest: Request?
         var completedRequest: Request?
-        var requestResponse: DownloadResponse<URL?>?
+        var requestResponse: DownloadResponse<URL?, Error>?
         let expect = expectation(description: "request should complete")
 
         // When

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -321,9 +321,9 @@ final class SessionTestCase: BaseTestCase {
         let brotliExpectation = expectation(description: "brotli request should complete")
         let gzipExpectation = expectation(description: "gzip request should complete")
         let deflateExpectation = expectation(description: "deflate request should complete")
-        var brotliResponse: DataResponse<Any>?
-        var gzipResponse: DataResponse<Any>?
-        var deflateResponse: DataResponse<Any>?
+        var brotliResponse: DataResponse<Any, Error>?
+        var gzipResponse: DataResponse<Any, Error>?
+        var deflateResponse: DataResponse<Any, Error>?
 
         // When
         AF.request(brotliURL).responseJSON { response in
@@ -391,7 +391,7 @@ final class SessionTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "\(url)")
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         let request = session.request(urlRequest)
@@ -423,7 +423,7 @@ final class SessionTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "\(url)")
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         let request = session.request(urlRequest)
@@ -457,7 +457,7 @@ final class SessionTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "\(url)")
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         let request = session.request(urlRequest)
@@ -530,7 +530,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
         let expectation = self.expectation(description: "Request should fail with error")
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         session.request("https://httpbin.org/get/äëïöü").response { resp in
@@ -559,7 +559,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
         let expectation = self.expectation(description: "Download should fail with error")
 
-        var response: DownloadResponse<URL?>?
+        var response: DownloadResponse<URL?, Error>?
 
         // When
         session.download("https://httpbin.org/get/äëïöü").response { resp in
@@ -589,7 +589,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
         let expectation = self.expectation(description: "Upload should fail with error")
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         session.upload(Data(), to: "https://httpbin.org/get/äëïöü").response { resp in
@@ -618,7 +618,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
         let expectation = self.expectation(description: "Upload should fail with error")
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         session.upload(URL(fileURLWithPath: "/invalid"), to: "https://httpbin.org/get/äëïöü").response { resp in
@@ -647,7 +647,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
         let expectation = self.expectation(description: "Upload should fail with error")
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         session.upload(InputStream(data: Data()), to: "https://httpbin.org/get/äëïöü").response { resp in
@@ -876,7 +876,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
 
         // When
         let request = session.request("https://httpbin.org/basic-auth/user/password", interceptor: handler)
@@ -909,7 +909,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session(interceptor: sessionHandler)
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
 
         // When
         let request = session.request("https://httpbin.org/basic-auth/user/password", interceptor: requestHandler)
@@ -948,7 +948,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
 
         // When
         session.request("https://httpbin.org/basic-auth/user/password", interceptor: handler)
@@ -982,7 +982,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DownloadResponse<Any>?
+        var response: DownloadResponse<Any, Error>?
 
         let destination: DownloadRequest.Destination = { _, _ in
             let fileURL = self.testDirectoryURL.appendingPathComponent("test-output.json")
@@ -1017,7 +1017,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session(interceptor: handler)
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
 
         let uploadData = Data("upload data".utf8)
 
@@ -1051,7 +1051,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session(interceptor: handler)
 
         let expectation = self.expectation(description: "request should eventually succeed")
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
 
         // When
         let request = session.request("https://httpbin.org/basic-auth/user/password")
@@ -1084,7 +1084,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session(interceptor: handler)
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
 
         // When
         let request = session.request("https://httpbin.org/basic-auth/user/password")
@@ -1125,7 +1125,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session(interceptor: handler)
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
 
         // When
         let request = session.request("https://httpbin.org/basic-auth/user/password")
@@ -1165,7 +1165,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session(interceptor: handler)
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
 
         // When
         let request = session.request("https://httpbin.org/basic-auth/user/password")
@@ -1207,7 +1207,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
 
         // When
         let request = session.request("https://httpbin.org/image/jpeg", interceptor: handler)
@@ -1247,10 +1247,10 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let json1Expectation = self.expectation(description: "request should eventually fail")
-        var json1Response: DataResponse<Any>?
+        var json1Response: DataResponse<Any, Error>?
 
         let json2Expectation = self.expectation(description: "request should eventually fail")
-        var json2Response: DataResponse<Any>?
+        var json2Response: DataResponse<Any, Error>?
 
         // When
         let request = session.request("https://httpbin.org/image/jpeg", interceptor: handler)
@@ -1301,10 +1301,10 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let json1Expectation = self.expectation(description: "request should eventually fail")
-        var json1Response: DataResponse<Any>?
+        var json1Response: DataResponse<Any, Error>?
 
         let json2Expectation = self.expectation(description: "request should eventually fail")
-        var json2Response: DataResponse<Any>?
+        var json2Response: DataResponse<Any, Error>?
 
         // When
         let request = session.request("https://httpbin.org/image/jpeg", interceptor: handler)
@@ -1356,10 +1356,10 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let json1Expectation = self.expectation(description: "request should eventually fail")
-        var json1Response: DataResponse<Any>?
+        var json1Response: DataResponse<Any, Error>?
 
         let json2Expectation = self.expectation(description: "request should eventually fail")
-        var json2Response: DataResponse<Any>?
+        var json2Response: DataResponse<Any, Error>?
 
         // When
         let request = session.request("https://httpbin.org/image/jpeg", interceptor: handler)
@@ -1411,10 +1411,10 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let json1Expectation = self.expectation(description: "request should eventually fail")
-        var json1Response: DownloadResponse<Any>?
+        var json1Response: DownloadResponse<Any, Error>?
 
         let json2Expectation = self.expectation(description: "request should eventually fail")
-        var json2Response: DownloadResponse<Any>?
+        var json2Response: DownloadResponse<Any, Error>?
 
         // When
         let request = session.download("https://httpbin.org/image/jpeg", interceptor: handler)
@@ -1486,7 +1486,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let expectation = self.expectation(description: "request should complete")
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
         var completionCallCount = 0
 
         // When
@@ -1525,7 +1525,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let expectation = self.expectation(description: "request should complete")
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
 
         // When
         let request = session.request("https://httpbin.org/get").responseJSON { resp in
@@ -1548,7 +1548,7 @@ final class SessionCancellationTestCase: BaseTestCase {
         // Given
         let count = 100
         let session = Session()
-        var responses: [DataResponse<Data?>] = []
+        var responses: [DataResponse<Data?, Error>] = []
         let completion = expectation(description: "all requests should finish")
         completion.expectedFulfillmentCount = count
         let cancellation = expectation(description: "cancel all requests should be called")
@@ -1580,7 +1580,7 @@ final class SessionCancellationTestCase: BaseTestCase {
         let count = 100
         let session = Session(startRequestsImmediately: false)
         let request = URLRequest.makeHTTPBinRequest(path: "delay/1")
-        var responses: [DataResponse<Data?>] = []
+        var responses: [DataResponse<Data?, Error>] = []
         let completion = expectation(description: "all requests should finish")
         completion.expectedFulfillmentCount = count
         let cancellation = expectation(description: "cancel all requests should be called")
@@ -1633,7 +1633,7 @@ final class SessionCancellationTestCase: BaseTestCase {
             }
         }
 
-        var received: DataResponse<Data?>?
+        var received: DataResponse<Data?, Error>?
 
         // When
         session.request(request).validate().response { (response) in
@@ -1657,7 +1657,7 @@ final class SessionCancellationTestCase: BaseTestCase {
         var request = URLRequest.makeHTTPBinRequest()
         request.httpBody = Data("invalid".utf8)
         let expect = expectation(description: "request should complete")
-        var response: DataResponse<HTTPBinResponse>?
+        var response: DataResponse<HTTPBinResponse, Error>?
 
         // When
         session.request(request).responseDecodable(of: HTTPBinResponse.self) { resp in
@@ -1687,7 +1687,7 @@ final class SessionCancellationTestCase: BaseTestCase {
         let session = Session(interceptor: InvalidAdapter())
         let request = URLRequest.makeHTTPBinRequest()
         let expect = expectation(description: "request should complete")
-        var response: DataResponse<HTTPBinResponse>?
+        var response: DataResponse<HTTPBinResponse, Error>?
 
         // When
         session.request(request).responseDecodable(of: HTTPBinResponse.self) { resp in
@@ -1754,7 +1754,7 @@ final class SessionConfigurationHeadersTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "request should complete successfully")
 
-        var response: DataResponse<Any>?
+        var response: DataResponse<Any, Error>?
 
         // When
         session.request("https://httpbin.org/headers")

--- a/Tests/URLProtocolTests.swift
+++ b/Tests/URLProtocolTests.swift
@@ -145,7 +145,7 @@ class URLProtocolTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "GET request should succeed")
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         manager.request(urlRequest)

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -180,7 +180,7 @@ class UploadDataTestCase: BaseTestCase {
         let data = Data("Lorem ipsum dolor sit amet".utf8)
 
         let expectation = self.expectation(description: "Upload request should succeed: \(urlString)")
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         AF.upload(data, to: urlString)
@@ -208,7 +208,7 @@ class UploadDataTestCase: BaseTestCase {
         var uploadProgressValues: [Double] = []
         var downloadProgressValues: [Double] = []
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         AF.upload(data, to: urlString)
@@ -273,7 +273,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         let expectation = self.expectation(description: "multipart form data upload should succeed")
 
         var formData: MultipartFormData?
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         AF.upload(
@@ -315,7 +315,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         formData.append(uploadData, withName: "upload_data")
 
         let expectation = self.expectation(description: "multipart form data upload should succeed")
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         AF.upload(multipartFormData: formData, with: urlRequest).response { resp in
@@ -346,7 +346,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         let japaneseData = Data("日本語".utf8)
 
         let expectation = self.expectation(description: "multipart form data upload should succeed")
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         AF.upload(
@@ -384,7 +384,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         let japaneseData = Data("日本語".utf8)
 
         let expectation = self.expectation(description: "multipart form data upload should succeed")
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         let request = AF.upload(
@@ -417,7 +417,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         let expectation = self.expectation(description: "multipart form data upload should succeed")
 
         var formData: MultipartFormData?
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         let request = AF.upload(
@@ -457,7 +457,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         let japaneseData = Data("日本語".utf8)
 
         let expectation = self.expectation(description: "multipart form data upload should succeed")
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         let request = AF.upload(
@@ -489,7 +489,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         let uploadData = Data("upload_data".utf8)
 
         let expectation = self.expectation(description: "multipart form data upload should succeed")
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
         var formData: MultipartFormData?
 
         // When
@@ -592,7 +592,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         var uploadProgressValues: [Double] = []
         var downloadProgressValues: [Double] = []
 
-        var response: DataResponse<Data?>?
+        var response: DataResponse<Data?, Error>?
 
         // When
         AF.upload(

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -413,8 +413,8 @@ class ContentTypeValidationTestCase: BaseTestCase {
         let expectation1 = expectation(description: "request should be stubbed and return 204 status code")
         let expectation2 = expectation(description: "download should be stubbed and return 204 status code")
 
-        var requestResponse: DataResponse<Data?>?
-        var downloadResponse: DownloadResponse<URL?>?
+        var requestResponse: DataResponse<Data?, Error>?
+        var downloadResponse: DownloadResponse<URL?, Error>?
 
         // When
         manager.request(urlString, method: .delete)


### PR DESCRIPTION
### Goals :soccer:
Add failure constraint to `*Response`

This PR builds on top of https://github.com/Alamofire/Alamofire/pull/2891 & https://github.com/Alamofire/Alamofire/pull/2892
and is an attempt at breaking up https://github.com/Alamofire/Alamofire/pull/2864