### PR TITLE
Ubiquitous AFError

### DIFF
--- a/Example/Source/DetailViewController.swift
+++ b/Example/Source/DetailViewController.swift
@@ -76,7 +76,7 @@ class DetailViewController: UITableViewController {
 
         let start = CACurrentMediaTime()
 
-        let requestComplete: (HTTPURLResponse?, Result<String, Error>) -> Void = { response, result in
+        let requestComplete: (HTTPURLResponse?, Result<String, AFError>) -> Void = { response, result in
             let end = CACurrentMediaTime()
             self.elapsedTime = end - start
 

--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -203,7 +203,7 @@ public enum AFError: Error {
     ///  `URLRequestConvertible` threw an error in `asURLRequest()`.
     case createURLRequestFailed(error: Error)
     /// `SessionDelegate` threw an error while attempting to move downloaded file to destination URL.
-    case downloadedFileMoveFailed(error: Error, destination: URL)
+    case downloadedFileMoveFailed(error: Error, source: URL, destination: URL)
     /// `URLSessionTask` completed with error.
     case sessionTaskFailed(error: Error)
 }
@@ -383,7 +383,7 @@ extension AFError {
             return error
         case .createURLRequestFailed(let error):
             return error
-        case .downloadedFileMoveFailed(let error, _):
+        case .downloadedFileMoveFailed(let error, _, _):
             return error
         case .sessionTaskFailed(let error):
             return error
@@ -418,8 +418,15 @@ extension AFError {
         return reason.failedStringEncoding
     }
 
-    public var destination: URL? {
-        guard case .downloadedFileMoveFailed(_, let destination) = self else { return nil }
+    /// The `source` URL of a `.downloadedFileMoveFailed` error.
+    public var sourceURL: URL? {
+        guard case .downloadedFileMoveFailed(_, let source, _) = self else { return nil }
+        return source
+    }
+
+    /// The `destination` URL of a `.downloadedFileMoveFailed` error.
+    public var destinationURL: URL? {
+        guard case .downloadedFileMoveFailed(_, _, let destination) = self else { return nil }
         return destination
     }
 }
@@ -664,8 +671,13 @@ extension AFError: LocalizedError {
             return "Uploadable creation failed with error: \(error.localizedDescription)"
         case .createURLRequestFailed(let error):
             return "URLRequest creation failed with error: \(error.localizedDescription)"
-        case .downloadedFileMoveFailed(let error, let destination):
-            return "Moving downloaded file to \(destination) failed with error: \(error.localizedDescription)"
+        case .downloadedFileMoveFailed(let error, let source, let destination):
+            return """
+                   Moving downloaded file failed
+                   from: \(source)
+                   to: \(destination)
+                   error: \(error.localizedDescription)
+                   """
         case .sessionTaskFailed(let error):
             return "URLSessionTask failed with error: \(error.localizedDescription)"
         }

--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -215,7 +215,7 @@ extension Error {
     }
 
     /// Casts the instance as `AFError` or returns `defaultAFError`
-    func afError(or defaultAFError: @autoclosure () -> AFError) -> AFError {
+    func asAFError(default defaultAFError: @autoclosure () -> AFError) -> AFError {
         return self as? AFError ?? defaultAFError()
     }
 }

--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -203,7 +203,7 @@ public enum AFError: Error {
     ///  `URLRequestConvertible` threw an error in `asURLRequest()`
     case createURLRequestFailed(error: Error)
     /// `SessionDelegate` threw an error while attempting to move downloaded file to destination URL
-    case moveDownloadFailed(error: Error, destination: URL)
+    case downloadedFileMoveFailed(error: Error, destination: URL)
     /// `URLSessionTask` completed with error
     case sessionTaskFailed(error: Error)
 }
@@ -320,7 +320,7 @@ extension AFError {
     /// Returns whether the instance is `moveDownloadFailed`. When `true`, the `destination` and `underlyingError` properties will
     /// contain the associated values.
     public var isMoveDownloadError: Bool {
-        if case .moveDownloadFailed = self { return true }
+        if case .downloadedFileMoveFailed = self { return true }
         return false
     }
     /// Returns whether the instance is `createURLRequestFailed`. When `true`, the `underlyingError` property will
@@ -374,7 +374,7 @@ extension AFError {
             return error
         case .createURLRequestFailed(let error):
             return error
-        case .moveDownloadFailed(let error, _):
+        case .downloadedFileMoveFailed(let error, _):
             return error
         case .sessionTaskFailed(let error):
             return error
@@ -408,7 +408,7 @@ extension AFError {
     }
     
     public var destination: URL? {
-        guard case .moveDownloadFailed(_, let destination) = self else { return nil }
+        guard case .downloadedFileMoveFailed(_, let destination) = self else { return nil }
         return destination
     }
 }
@@ -556,7 +556,7 @@ extension AFError: LocalizedError {
             return "Creating uploadable failed with error: \(error.localizedDescription)"
         case let .createURLRequestFailed(error):
             return "Creating URLRequest failed with error: \(error.localizedDescription)"
-        case let .moveDownloadFailed(error, destination):
+        case let .downloadedFileMoveFailed(error, destination):
             return "Moving download to \(destination) failed with error: \(error.localizedDescription)"
         case let .sessionTaskFailed(error):
             return "URLSessionTask failed with error: \(error.localizedDescription)"

--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -317,9 +317,9 @@ extension AFError {
         return false
     }
 
-    /// Returns whether the instance is `moveDownloadFailed`. When `true`, the `destination` and `underlyingError` properties will
+    /// Returns whether the instance is `downloadedFileMoveFailed`. When `true`, the `destination` and `underlyingError` properties will
     /// contain the associated values.
-    public var isMoveDownloadError: Bool {
+    public var isDownloadedFileMoveError: Bool {
         if case .downloadedFileMoveFailed = self { return true }
         return false
     }

--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -170,7 +170,6 @@ public enum AFError: Error {
     /// The underlying reason the `.urlRequestValidationFailed`
     public enum URLRequestValidationFailureReason {
         case bodyDataInGETRequest(Data)
-        case customValidationFailed(error: Error)
     }
 
     /// `Request` was explicitly cancelled.
@@ -365,8 +364,6 @@ extension AFError {
             return error
         case .responseSerializationFailed(let reason):
             return reason.underlyingError
-        case .urlRequestValidationFailed(let reason):
-            return reason.underlyingError
         case .responseValidationFailed(let reason):
             return reason.underlyingError
         case .serverTrustEvaluationFailed(let reason):
@@ -457,13 +454,6 @@ extension AFError.MultipartEncodingFailureReason {
         default:
             return nil
         }
-    }
-}
-
-extension AFError.URLRequestValidationFailureReason {
-    var underlyingError: Error? {
-        guard case let .customValidationFailed(error) = self else { return nil }
-        return error
     }
 }
 
@@ -724,8 +714,6 @@ extension AFError.URLRequestValidationFailureReason {
             Invalid URLRequest with a GET method that had body data:
             \(String(decoding: data, as: UTF8.self))
             """
-        case let .customValidationFailed(error):
-            return "Custom URLRequest validation failed with error: \(error.localizedDescription)"
         }
     }
 }

--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -63,7 +63,7 @@ public enum AFError: Error {
         case missingURL
         /// JSON serialization failed with an underlying system error during the encoding process.
         case jsonEncodingFailed(error: Error)
-        /// Custom encoding failed
+        /// Custom parameter encoding failed due to the associated `Error`.
         case customEncodingFailed(error: Error)
     }
 
@@ -95,7 +95,7 @@ public enum AFError: Error {
         case unacceptableContentType(acceptableContentTypes: [String], responseContentType: String)
         /// The response status code was not acceptable.
         case unacceptableStatusCode(code: Int)
-        /// Custom validation failed
+        /// Custom response validation failed due to the associated `Error`.
         case customValidationFailed(error: Error)
     }
 
@@ -162,7 +162,7 @@ public enum AFError: Error {
         case certificatePinningFailed(host: String, trust: SecTrust, pinnedCertificates: [SecCertificate], serverCertificates: [SecCertificate])
         /// Public key pinning failed.
         case publicKeyPinningFailed(host: String, trust: SecTrust, pinnedKeys: [SecKey], serverKeys: [SecKey])
-        /// Custom evaluation failed.
+        /// Custom server trust evaluation failed due to the associated `Error`.
         case customEvaluationFailed(error: Error)
         
     }

--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -214,6 +214,11 @@ extension Error {
     public var asAFError: AFError? {
         return self as? AFError
     }
+    
+    /// Casts the instance as `AFError` or returns `defaultAFError`
+    func afError(or defaultAFError: @autoclosure () -> AFError) -> AFError {
+        return self as? AFError ?? defaultAFError()
+    }
 }
 
 // MARK: - Error Booleans
@@ -721,73 +726,6 @@ extension AFError.URLRequestValidationFailureReason {
             """
         case let .customValidationFailed(error):
             return "Custom URLRequest validation failed with error: \(error.localizedDescription)"
-        }
-    }
-}
-
-extension AFError {
-    
-    init(responseSerializationError error: Error) {
-        if case let AFError.responseSerializationFailed(reason) = error {
-            self = .responseSerializationFailed(reason: reason)
-        } else {
-            self = .responseSerializationFailed(reason: .customSerializationFailed(error: error))
-        }
-    }
-    
-    init(createUploadableError error: Error) {
-        if case let AFError.createUploadableFailed(underlyingError) = error {
-            self = .createUploadableFailed(error: underlyingError)
-        } else {
-            self = .createUploadableFailed(error: error)
-        }
-    }
-    
-    init(createURLRequestError error: Error) {
-        if case let AFError.createURLRequestFailed(underlyingError) = error {
-            self = .createURLRequestFailed(error: underlyingError)
-        } else {
-            self = .createURLRequestFailed(error: error)
-        }
-    }
-    
-    init(urlRequestValidationError error: Error) {
-        if case let AFError.urlRequestValidationFailed(reason) = error {
-            self = .urlRequestValidationFailed(reason: reason)
-        } else {
-            self = .urlRequestValidationFailed(reason: .customValidationFailed(error: error))
-        }
-    }
-    
-    init(responseValidationError error: Error) {
-        if case let AFError.responseValidationFailed(reason) = error {
-            self = .responseValidationFailed(reason: reason)
-        } else {
-            self = .responseValidationFailed(reason: .customValidationFailed(error: error))
-        }
-    }
-    
-    init(requestAdaptationError error: Error) {
-        if case let AFError.requestAdaptationFailed(underlyingError) = error {
-            self = .requestAdaptationFailed(error: underlyingError)
-        } else {
-            self = .requestAdaptationFailed(error: error)
-        }
-    }
-    
-    init(serverTrustError error: Error) {
-        if case let AFError.serverTrustEvaluationFailed(reason) = error {
-            self = .serverTrustEvaluationFailed(reason: reason)
-        } else {
-            self = .serverTrustEvaluationFailed(reason: .customEvaluationFailed(error: error))
-        }
-    }
-    
-    init(requestRetryError error: Error) {
-        if case let AFError.requestRetryFailed(retryError, originalError) = error {
-            self = .requestRetryFailed(retryError: retryError, originalError: originalError)
-        } else {
-            self = .requestRetryFailed(retryError: error, originalError: nil)
         }
     }
 }

--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -164,7 +164,7 @@ public enum AFError: Error {
         case publicKeyPinningFailed(host: String, trust: SecTrust, pinnedKeys: [SecKey], serverKeys: [SecKey])
         /// Custom server trust evaluation failed due to the associated `Error`.
         case customEvaluationFailed(error: Error)
-        
+
     }
 
     /// The underlying reason the `.urlRequestValidationFailed`
@@ -213,7 +213,7 @@ extension Error {
     public var asAFError: AFError? {
         return self as? AFError
     }
-    
+
     /// Casts the instance as `AFError` or returns `defaultAFError`
     func afError(or defaultAFError: @autoclosure () -> AFError) -> AFError {
         return self as? AFError ?? defaultAFError()
@@ -302,21 +302,21 @@ extension AFError {
         if case .requestRetryFailed = self { return true }
         return false
     }
-    
+
     /// Returns whether the instance is `createUploadableFailed`. When `true`, the `underlyingError` property will
     /// contain the associated value.
     public var isCreateUploadableError: Bool {
         if case .createUploadableFailed = self { return true }
         return false
     }
-    
+
     /// Returns whether the instance is `createURLRequestFailed`. When `true`, the `underlyingError` property will
     /// contain the associated value.
     public var isCreateURLRequestError: Bool {
         if case .createURLRequestFailed = self { return true }
         return false
     }
-    
+
     /// Returns whether the instance is `moveDownloadFailed`. When `true`, the `destination` and `underlyingError` properties will
     /// contain the associated values.
     public var isMoveDownloadError: Bool {
@@ -329,7 +329,7 @@ extension AFError {
         if case .sessionTaskFailed = self { return true }
         return false
     }
-    
+
 }
 
 // MARK: - Convenience Properties
@@ -406,7 +406,7 @@ extension AFError {
         guard case .responseSerializationFailed(let reason) = self else { return nil }
         return reason.failedStringEncoding
     }
-    
+
     public var destination: URL? {
         guard case .downloadedFileMoveFailed(_, let destination) = self else { return nil }
         return destination
@@ -476,7 +476,7 @@ extension AFError.ResponseValidationFailureReason {
         guard case .unacceptableStatusCode(let code) = self else { return nil }
         return code
     }
-    
+
     var underlyingError: Error? {
         guard case let .customValidationFailed(error) = self else { return nil }
         return error

--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -214,6 +214,14 @@ extension Error {
         return self as? AFError
     }
 
+    /// Returns the instance cast as an `AFError`. If casting fails, a `fatalError` with the specified `message` is thrown.
+    public func asAFError(orFailWith message: @autoclosure () -> String, file: StaticString = #file, line: UInt = #line) -> AFError {
+        guard let afError = self as? AFError else {
+            fatalError(message(), file: file, line: line)
+        }
+        return afError
+    }
+
     /// Casts the instance as `AFError` or returns `defaultAFError`
     func asAFError(or defaultAFError: @autoclosure () -> AFError) -> AFError {
         return self as? AFError ?? defaultAFError()

--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -198,13 +198,13 @@ public enum AFError: Error {
     case sessionInvalidated(error: Error?)
     /// `URLRequest` failed validation.
     case urlRequestValidationFailed(reason: URLRequestValidationFailureReason)
-    ///  `UploadableConvertible` threw an error in `createUploadable()`
+    ///  `UploadableConvertible` threw an error in `createUploadable()`.
     case createUploadableFailed(error: Error)
-    ///  `URLRequestConvertible` threw an error in `asURLRequest()`
+    ///  `URLRequestConvertible` threw an error in `asURLRequest()`.
     case createURLRequestFailed(error: Error)
-    /// `SessionDelegate` threw an error while attempting to move downloaded file to destination URL
+    /// `SessionDelegate` threw an error while attempting to move downloaded file to destination URL.
     case downloadedFileMoveFailed(error: Error, destination: URL)
-    /// `URLSessionTask` completed with error
+    /// `URLSessionTask` completed with error.
     case sessionTaskFailed(error: Error)
 }
 

--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -638,7 +638,7 @@ extension AFError: LocalizedError {
             return reason.localizedDescription
         case .requestRetryFailed(let retryError, let originalError):
             return """
-                   Request retry failed with retry error: \(retryError.localizedDescription),\
+                   Request retry failed with retry error: \(retryError.localizedDescription), \
                    original error: \(originalError.localizedDescription)
                    """
         case .sessionDeinitialized:
@@ -653,11 +653,11 @@ extension AFError: LocalizedError {
         case .urlRequestValidationFailed(let reason):
             return "URLRequest validation failed due to reason: \(reason.localizedDescription)"
         case .createUploadableFailed(let error):
-            return "Creating uploadable failed with error: \(error.localizedDescription)"
+            return "Uploadable creation failed with error: \(error.localizedDescription)"
         case .createURLRequestFailed(let error):
-            return "Creating URLRequest failed with error: \(error.localizedDescription)"
+            return "URLRequest creation failed with error: \(error.localizedDescription)"
         case .downloadedFileMoveFailed(let error, let destination):
-            return "Moving download to \(destination) failed with error: \(error.localizedDescription)"
+            return "Moving downloaded file to \(destination) failed with error: \(error.localizedDescription)"
         case .sessionTaskFailed(let error):
             return "URLSessionTask failed with error: \(error.localizedDescription)"
         }
@@ -745,7 +745,7 @@ extension AFError.ResponseSerializationFailureReason {
         case .decodingFailed(let error):
             return "Response could not be decoded because of error:\n\(error.localizedDescription)"
         case .customSerializationFailed(let error):
-            return "Custom response could not be serialized because of error:\n\(error.localizedDescription)"
+            return "Custom response serializer failed with error:\n\(error.localizedDescription)"
         }
     }
 }
@@ -801,7 +801,7 @@ extension AFError.ServerTrustFailureReason {
         case .publicKeyPinningFailed(let host, _, _, _):
             return "Public key pinning failed for host \(host)."
         case .customEvaluationFailed(let error):
-            return "Custom evaluation failed with error: \(error.localizedDescription)"
+            return "Custom trust evaluation failed with error: \(error.localizedDescription)"
         }
     }
 }

--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -185,7 +185,7 @@ public enum AFError: Error {
     /// `RequestAdapter` threw an error during adaptation.
     case requestAdaptationFailed(error: Error)
     /// `RequestRetrier` threw an error during the request retry process.
-    case requestRetryFailed(retryError: Error, originalError: Error?)
+    case requestRetryFailed(retryError: Error, originalError: Error)
     /// Response validation failed.
     case responseValidationFailed(reason: ResponseValidationFailureReason)
     /// Response serialization failed.
@@ -539,7 +539,7 @@ extension AFError: LocalizedError {
         case .requestRetryFailed(let retryError, let originalError):
             return """
                    Request retry failed with retry error: \(retryError.localizedDescription),\
-                   \(originalError.map{ " original error: \($0.localizedDescription)" } ?? "")
+                   original error: \(originalError.localizedDescription)
                    """
         case .sessionDeinitialized:
             return """

--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -215,7 +215,7 @@ extension Error {
     }
 
     /// Casts the instance as `AFError` or returns `defaultAFError`
-    func asAFError(default defaultAFError: @autoclosure () -> AFError) -> AFError {
+    func asAFError(or defaultAFError: @autoclosure () -> AFError) -> AFError {
         return self as? AFError ?? defaultAFError()
     }
 }

--- a/Source/EventMonitor.swift
+++ b/Source/EventMonitor.swift
@@ -101,13 +101,13 @@ public protocol EventMonitor {
     func request(_ request: Request, didCreateInitialURLRequest urlRequest: URLRequest)
 
     /// Event called when the attempt to create a `URLRequest` from a `Request`'s original `URLRequestConvertible` value fails.
-    func request(_ request: Request, didFailToCreateURLRequestWithError error: Error)
+    func request(_ request: Request, didFailToCreateURLRequestWithError error: AFError)
 
     /// Event called when a `RequestAdapter` adapts the `Request`'s initial `URLRequest`.
     func request(_ request: Request, didAdaptInitialRequest initialRequest: URLRequest, to adaptedRequest: URLRequest)
 
     /// Event called when a `RequestAdapter` fails to adapt the `Request`'s initial `URLRequest`.
-    func request(_ request: Request, didFailToAdaptURLRequest initialRequest: URLRequest, withError error: Error)
+    func request(_ request: Request, didFailToAdaptURLRequest initialRequest: URLRequest, withError error: AFError)
 
     /// Event called when a final `URLRequest` is created for a `Request`.
     func request(_ request: Request, didCreateURLRequest urlRequest: URLRequest)
@@ -119,11 +119,11 @@ public protocol EventMonitor {
     func request(_ request: Request, didGatherMetrics metrics: URLSessionTaskMetrics)
 
     /// Event called when a `Request` fails due to an error created by Alamofire. e.g. When certificat pinning fails.
-    func request(_ request: Request, didFailTask task: URLSessionTask, earlyWithError error: Error)
+    func request(_ request: Request, didFailTask task: URLSessionTask, earlyWithError error: AFError)
 
     /// Event called when a `Request`'s task completes, possibly with an error. A `Request` may receive this event
     /// multiple times if it is retried.
-    func request(_ request: Request, didCompleteTask task: URLSessionTask, with error: Error?)
+    func request(_ request: Request, didCompleteTask task: URLSessionTask, with error: AFError?)
 
     /// Event called when a `Request` is about to be retried.
     func requestIsRetrying(_ request: Request)
@@ -159,10 +159,10 @@ public protocol EventMonitor {
                  withResult result: Request.ValidationResult)
 
     /// Event called when a `DataRequest` creates a `DataResponse<Data?>` value without calling a `ResponseSerializer`.
-    func request(_ request: DataRequest, didParseResponse response: DataResponse<Data?, Error>)
+    func request(_ request: DataRequest, didParseResponse response: DataResponse<Data?, AFError>)
 
-    /// Event called when a `DataRequest` calls a `ResponseSerializer` and creates a generic `DataResponse<Value, Failure>`.
-    func request<Value, Failure: Error>(_ request: DataRequest, didParseResponse response: DataResponse<Value, Failure>)
+    /// Event called when a `DataRequest` calls a `ResponseSerializer` and creates a generic `DataResponse<Value, AFError>`.
+    func request<Value>(_ request: DataRequest, didParseResponse response: DataResponse<Value, AFError>)
 
     // MARK: UploadRequest Events
 
@@ -170,7 +170,7 @@ public protocol EventMonitor {
     func request(_ request: UploadRequest, didCreateUploadable uploadable: UploadRequest.Uploadable)
 
     /// Event called when an `UploadRequest` failes to create its `Uploadable` value due to an error.
-    func request(_ request: UploadRequest, didFailToCreateUploadableWithError error: Error)
+    func request(_ request: UploadRequest, didFailToCreateUploadableWithError error: AFError)
 
     /// Event called when an `UploadRequest` provides the `InputStream` from its `Uploadable` value. This only occurs if
     /// the `InputStream` does not wrap a `Data` value or file `URL`.
@@ -179,7 +179,7 @@ public protocol EventMonitor {
     // MARK: DownloadRequest Events
 
     /// Event called when a `DownloadRequest`'s `URLSessionDownloadTask` finishes and the temporary file has been moved.
-    func request(_ request: DownloadRequest, didFinishDownloadingUsing task: URLSessionTask, with result: Result<URL, Error>)
+    func request(_ request: DownloadRequest, didFinishDownloadingUsing task: URLSessionTask, with result: Result<URL, AFError>)
 
     /// Event called when a `DownloadRequest`'s `Destination` closure is called and creates the destination URL the
     /// downloaded file will be moved to.
@@ -192,11 +192,11 @@ public protocol EventMonitor {
                  fileURL: URL?,
                  withResult result: Request.ValidationResult)
 
-    /// Event called when a `DownloadRequest` creates a `DownloadResponse<URL?>` without calling a `ResponseSerializer`.
-    func request(_ request: DownloadRequest, didParseResponse response: DownloadResponse<URL?, Error>)
+    /// Event called when a `DownloadRequest` creates a `DownloadResponse<URL?, AFError>` without calling a `ResponseSerializer`.
+    func request(_ request: DownloadRequest, didParseResponse response: DownloadResponse<URL?, AFError>)
 
-    /// Event called when a `DownloadRequest` calls a `DownloadResponseSerializer` and creates a generic `DownloadResponse<Value, Failure>`
-    func request<Value, Failure: Error>(_ request: DownloadRequest, didParseResponse response: DownloadResponse<Value, Failure>)
+    /// Event called when a `DownloadRequest` calls a `DownloadResponseSerializer` and creates a generic `DownloadResponse<Value, AFError>`
+    func request<Value>(_ request: DownloadRequest, didParseResponse response: DownloadResponse<Value, AFError>)
 }
 
 extension EventMonitor {
@@ -241,18 +241,18 @@ extension EventMonitor {
                            downloadTask: URLSessionDownloadTask,
                            didFinishDownloadingTo location: URL) { }
     public func request(_ request: Request, didCreateInitialURLRequest urlRequest: URLRequest) { }
-    public func request(_ request: Request, didFailToCreateURLRequestWithError error: Error) { }
+    public func request(_ request: Request, didFailToCreateURLRequestWithError error: AFError) { }
     public func request(_ request: Request,
                         didAdaptInitialRequest initialRequest: URLRequest,
                         to adaptedRequest: URLRequest) { }
     public func request(_ request: Request,
                         didFailToAdaptURLRequest initialRequest: URLRequest,
-                        withError error: Error) { }
+                        withError error: AFError) { }
     public func request(_ request: Request, didCreateURLRequest urlRequest: URLRequest) { }
     public func request(_ request: Request, didCreateTask task: URLSessionTask) { }
     public func request(_ request: Request, didGatherMetrics metrics: URLSessionTaskMetrics) { }
-    public func request(_ request: Request, didFailTask task: URLSessionTask, earlyWithError error: Error) { }
-    public func request(_ request: Request, didCompleteTask task: URLSessionTask, with error: Error?) { }
+    public func request(_ request: Request, didFailTask task: URLSessionTask, earlyWithError error: AFError) { }
+    public func request(_ request: Request, didCompleteTask task: URLSessionTask, with error: AFError?) { }
     public func requestIsRetrying(_ request: Request) { }
     public func requestDidFinish(_ request: Request) { }
     public func requestDidResume(_ request: Request) { }
@@ -266,20 +266,20 @@ extension EventMonitor {
                         response: HTTPURLResponse,
                         data: Data?,
                         withResult result: Request.ValidationResult) { }
-    public func request(_ request: DataRequest, didParseResponse response: DataResponse<Data?, Error>) { }
-    public func request<Value, Failure: Error>(_ request: DataRequest, didParseResponse response: DataResponse<Value, Failure>) { }
+    public func request(_ request: DataRequest, didParseResponse response: DataResponse<Data?, AFError>) { }
+    public func request<Value>(_ request: DataRequest, didParseResponse response: DataResponse<Value, AFError>) { }
     public func request(_ request: UploadRequest, didCreateUploadable uploadable: UploadRequest.Uploadable) { }
-    public func request(_ request: UploadRequest, didFailToCreateUploadableWithError error: Error) { }
+    public func request(_ request: UploadRequest, didFailToCreateUploadableWithError error: AFError) { }
     public func request(_ request: UploadRequest, didProvideInputStream stream: InputStream) { }
-    public func request(_ request: DownloadRequest, didFinishDownloadingUsing task: URLSessionTask, with result: Result<URL, Error>) { }
+    public func request(_ request: DownloadRequest, didFinishDownloadingUsing task: URLSessionTask, with result: Result<URL, AFError>) { }
     public func request(_ request: DownloadRequest, didCreateDestinationURL url: URL) { }
     public func request(_ request: DownloadRequest,
                         didValidateRequest urlRequest: URLRequest?,
                         response: HTTPURLResponse,
                         fileURL: URL?,
                         withResult result: Request.ValidationResult) { }
-    public func request(_ request: DownloadRequest, didParseResponse response: DownloadResponse<URL?, Error>) { }
-    public func request<Value, Failure: Error>(_ request: DownloadRequest, didParseResponse response: DownloadResponse<Value, Failure>) { }
+    public func request(_ request: DownloadRequest, didParseResponse response: DownloadResponse<URL?, AFError>) { }
+    public func request<Value>(_ request: DownloadRequest, didParseResponse response: DownloadResponse<Value, AFError>) { }
 }
 
 /// An `EventMonitor` which can contain multiple `EventMonitor`s and calls their methods on their queues.
@@ -401,7 +401,7 @@ public final class CompositeEventMonitor: EventMonitor {
         performEvent { $0.request(request, didCreateInitialURLRequest: urlRequest) }
     }
 
-    public func request(_ request: Request, didFailToCreateURLRequestWithError error: Error) {
+    public func request(_ request: Request, didFailToCreateURLRequestWithError error: AFError) {
         performEvent { $0.request(request, didFailToCreateURLRequestWithError: error) }
     }
 
@@ -409,7 +409,7 @@ public final class CompositeEventMonitor: EventMonitor {
         performEvent { $0.request(request, didAdaptInitialRequest: initialRequest, to: adaptedRequest) }
     }
 
-    public func request(_ request: Request, didFailToAdaptURLRequest initialRequest: URLRequest, withError error: Error) {
+    public func request(_ request: Request, didFailToAdaptURLRequest initialRequest: URLRequest, withError error: AFError) {
         performEvent { $0.request(request, didFailToAdaptURLRequest: initialRequest, withError: error) }
     }
 
@@ -425,11 +425,11 @@ public final class CompositeEventMonitor: EventMonitor {
         performEvent { $0.request(request, didGatherMetrics: metrics) }
     }
 
-    public func request(_ request: Request, didFailTask task: URLSessionTask, earlyWithError error: Error) {
+    public func request(_ request: Request, didFailTask task: URLSessionTask, earlyWithError error: AFError) {
         performEvent { $0.request(request, didFailTask: task, earlyWithError: error) }
     }
 
-    public func request(_ request: Request, didCompleteTask task: URLSessionTask, with error: Error?) {
+    public func request(_ request: Request, didCompleteTask task: URLSessionTask, with error: AFError?) {
         performEvent { $0.request(request, didCompleteTask: task, with: error) }
     }
 
@@ -478,11 +478,11 @@ public final class CompositeEventMonitor: EventMonitor {
         }
     }
 
-    public func request(_ request: DataRequest, didParseResponse response: DataResponse<Data?, Error>) {
+    public func request(_ request: DataRequest, didParseResponse response: DataResponse<Data?, AFError>) {
         performEvent { $0.request(request, didParseResponse: response) }
     }
 
-    public func request<Value, Failure: Error>(_ request: DataRequest, didParseResponse response: DataResponse<Value, Failure>) {
+    public func request<Value>(_ request: DataRequest, didParseResponse response: DataResponse<Value, AFError>) {
         performEvent { $0.request(request, didParseResponse: response) }
     }
 
@@ -490,7 +490,7 @@ public final class CompositeEventMonitor: EventMonitor {
         performEvent { $0.request(request, didCreateUploadable: uploadable) }
     }
 
-    public func request(_ request: UploadRequest, didFailToCreateUploadableWithError error: Error) {
+    public func request(_ request: UploadRequest, didFailToCreateUploadableWithError error: AFError) {
         performEvent { $0.request(request, didFailToCreateUploadableWithError: error) }
     }
 
@@ -498,7 +498,7 @@ public final class CompositeEventMonitor: EventMonitor {
         performEvent { $0.request(request, didProvideInputStream: stream) }
     }
 
-    public func request(_ request: DownloadRequest, didFinishDownloadingUsing task: URLSessionTask, with result: Result<URL, Error>) {
+    public func request(_ request: DownloadRequest, didFinishDownloadingUsing task: URLSessionTask, with result: Result<URL, AFError>) {
         performEvent { $0.request(request, didFinishDownloadingUsing: task, with: result) }
     }
 
@@ -518,11 +518,11 @@ public final class CompositeEventMonitor: EventMonitor {
                                   withResult: result) }
     }
 
-    public func request(_ request: DownloadRequest, didParseResponse response: DownloadResponse<URL?, Error>) {
+    public func request(_ request: DownloadRequest, didParseResponse response: DownloadResponse<URL?, AFError>) {
         performEvent { $0.request(request, didParseResponse: response) }
     }
 
-    public func request<Value, Failure: Error>(_ request: DownloadRequest, didParseResponse response: DownloadResponse<Value, Failure>) {
+    public func request<Value>(_ request: DownloadRequest, didParseResponse response: DownloadResponse<Value, AFError>) {
         performEvent { $0.request(request, didParseResponse: response) }
     }
 }
@@ -575,13 +575,13 @@ open class ClosureEventMonitor: EventMonitor {
     open var requestDidCreateInitialURLRequest: ((Request, URLRequest) -> Void)?
 
     /// Closure called on the `request(_:didFailToCreateURLRequestWithError:)` event.
-    open var requestDidFailToCreateURLRequestWithError: ((Request, Error) -> Void)?
+    open var requestDidFailToCreateURLRequestWithError: ((Request, AFError) -> Void)?
 
     /// Closure called on the `request(_:didAdaptInitialRequest:to:)` event.
     open var requestDidAdaptInitialRequestToAdaptedRequest: ((Request, URLRequest, URLRequest) -> Void)?
 
     /// Closure called on the `request(_:didFailToAdaptURLRequest:withError:)` event.
-    open var requestDidFailToAdaptURLRequestWithError: ((Request, URLRequest, Error) -> Void)?
+    open var requestDidFailToAdaptURLRequestWithError: ((Request, URLRequest, AFError) -> Void)?
 
     /// Closure called on the `request(_:didCreateURLRequest:)` event.
     open var requestDidCreateURLRequest: ((Request, URLRequest) -> Void)?
@@ -593,10 +593,10 @@ open class ClosureEventMonitor: EventMonitor {
     open var requestDidGatherMetrics: ((Request, URLSessionTaskMetrics) -> Void)?
 
     /// Closure called on the `request(_:didFailTask:earlyWithError:)` event.
-    open var requestDidFailTaskEarlyWithError: ((Request, URLSessionTask, Error) -> Void)?
+    open var requestDidFailTaskEarlyWithError: ((Request, URLSessionTask, AFError) -> Void)?
 
     /// Closure called on the `request(_:didCompleteTask:with:)` event.
-    open var requestDidCompleteTaskWithError: ((Request, URLSessionTask, Error?) -> Void)?
+    open var requestDidCompleteTaskWithError: ((Request, URLSessionTask, AFError?) -> Void)?
 
     /// Closure called on the `requestIsRetrying(_:)` event.
     open var requestIsRetrying: ((Request) -> Void)?
@@ -626,19 +626,19 @@ open class ClosureEventMonitor: EventMonitor {
     open var requestDidValidateRequestResponseDataWithResult: ((DataRequest, URLRequest?, HTTPURLResponse, Data?, Request.ValidationResult) -> Void)?
 
     /// Closure called on the `request(_:didParseResponse:)` event.
-    open var requestDidParseResponse: ((DataRequest, DataResponse<Data?, Error>) -> Void)?
+    open var requestDidParseResponse: ((DataRequest, DataResponse<Data?, AFError>) -> Void)?
 
     /// Closure called on the `request(_:didCreateUploadable:)` event.
     open var requestDidCreateUploadable: ((UploadRequest, UploadRequest.Uploadable) -> Void)?
 
     /// Closure called on the `request(_:didFailToCreateUploadableWithError:)` event.
-    open var requestDidFailToCreateUploadableWithError: ((UploadRequest, Error) -> Void)?
+    open var requestDidFailToCreateUploadableWithError: ((UploadRequest, AFError) -> Void)?
 
     /// Closure called on the `request(_:didProvideInputStream:)` event.
     open var requestDidProvideInputStream: ((UploadRequest, InputStream) -> Void)?
 
     /// Closure called on the `request(_:didFinishDownloadingUsing:with:)` event.
-    open var requestDidFinishDownloadingUsingTaskWithResult: ((DownloadRequest, URLSessionTask, Result<URL, Error>) -> Void)?
+    open var requestDidFinishDownloadingUsingTaskWithResult: ((DownloadRequest, URLSessionTask, Result<URL, AFError>) -> Void)?
 
     /// Closure called on the `request(_:didCreateDestinationURL:)` event.
     open var requestDidCreateDestinationURL: ((DownloadRequest, URL) -> Void)?
@@ -647,7 +647,7 @@ open class ClosureEventMonitor: EventMonitor {
     open var requestDidValidateRequestResponseFileURLWithResult: ((DownloadRequest, URLRequest?, HTTPURLResponse, URL?, Request.ValidationResult) -> Void)?
 
     /// Closure called on the `request(_:didParseResponse:)` event.
-    open var requestDidParseDownloadResponse: ((DownloadRequest, DownloadResponse<URL?, Error>) -> Void)?
+    open var requestDidParseDownloadResponse: ((DownloadRequest, DownloadResponse<URL?, AFError>) -> Void)?
 
     public let queue: DispatchQueue
 
@@ -730,7 +730,7 @@ open class ClosureEventMonitor: EventMonitor {
         requestDidCreateInitialURLRequest?(request, urlRequest)
     }
 
-    open func request(_ request: Request, didFailToCreateURLRequestWithError error: Error) {
+    open func request(_ request: Request, didFailToCreateURLRequestWithError error: AFError) {
         requestDidFailToCreateURLRequestWithError?(request, error)
     }
 
@@ -738,7 +738,7 @@ open class ClosureEventMonitor: EventMonitor {
         requestDidAdaptInitialRequestToAdaptedRequest?(request, initialRequest, adaptedRequest)
     }
 
-    open func request(_ request: Request, didFailToAdaptURLRequest initialRequest: URLRequest, withError error: Error) {
+    open func request(_ request: Request, didFailToAdaptURLRequest initialRequest: URLRequest, withError error: AFError) {
         requestDidFailToAdaptURLRequestWithError?(request, initialRequest, error)
     }
 
@@ -754,11 +754,11 @@ open class ClosureEventMonitor: EventMonitor {
         requestDidGatherMetrics?(request, metrics)
     }
 
-    open func request(_ request: Request, didFailTask task: URLSessionTask, earlyWithError error: Error) {
+    open func request(_ request: Request, didFailTask task: URLSessionTask, earlyWithError error: AFError) {
         requestDidFailTaskEarlyWithError?(request, task, error)
     }
 
-    open func request(_ request: Request, didCompleteTask task: URLSessionTask, with error: Error?) {
+    open func request(_ request: Request, didCompleteTask task: URLSessionTask, with error: AFError?) {
         requestDidCompleteTaskWithError?(request, task, error)
     }
 
@@ -802,7 +802,7 @@ open class ClosureEventMonitor: EventMonitor {
         requestDidValidateRequestResponseDataWithResult?(request, urlRequest, response, data, result)
     }
 
-    open func request(_ request: DataRequest, didParseResponse response: DataResponse<Data?, Error>) {
+    open func request(_ request: DataRequest, didParseResponse response: DataResponse<Data?, AFError>) {
         requestDidParseResponse?(request, response)
     }
 
@@ -810,7 +810,7 @@ open class ClosureEventMonitor: EventMonitor {
         requestDidCreateUploadable?(request, uploadable)
     }
 
-    open func request(_ request: UploadRequest, didFailToCreateUploadableWithError error: Error) {
+    open func request(_ request: UploadRequest, didFailToCreateUploadableWithError error: AFError) {
         requestDidFailToCreateUploadableWithError?(request, error)
     }
 
@@ -818,7 +818,7 @@ open class ClosureEventMonitor: EventMonitor {
         requestDidProvideInputStream?(request, stream)
     }
 
-    open func request(_ request: DownloadRequest, didFinishDownloadingUsing task: URLSessionTask, with result: Result<URL, Error>) {
+    open func request(_ request: DownloadRequest, didFinishDownloadingUsing task: URLSessionTask, with result: Result<URL, AFError>) {
         requestDidFinishDownloadingUsingTaskWithResult?(request, task, result)
     }
 
@@ -838,7 +838,7 @@ open class ClosureEventMonitor: EventMonitor {
                                                             result)
     }
 
-    open func request(_ request: DownloadRequest, didParseResponse response: DownloadResponse<URL?, Error>) {
+    open func request(_ request: DownloadRequest, didParseResponse response: DownloadResponse<URL?, AFError>) {
         requestDidParseDownloadResponse?(request, response)
     }
 

--- a/Source/Notifications.swift
+++ b/Source/Notifications.swift
@@ -109,7 +109,7 @@ public final class AlamofireNotifications: EventMonitor {
         NotificationCenter.default.postNotification(named: Request.didCancelTaskNotification, with: request)
     }
 
-    public func request(_ request: Request, didCompleteTask task: URLSessionTask, with error: Error?) {
+    public func request(_ request: Request, didCompleteTask task: URLSessionTask, with error: AFError?) {
         NotificationCenter.default.postNotification(named: Request.didCompleteTaskNotification, with: request)
     }
 }

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -111,8 +111,8 @@ public class Request {
         var metrics: [URLSessionTaskMetrics] = []
         /// Number of times any retriers provided retried the `Request`.
         var retryCount = 0
-        /// Final `Error` for the `Request`, whether from various internal Alamofire calls or as a result of a `task`.
-        var error: Error?
+        /// Final `AFError` for the `Request`, whether from various internal Alamofire calls or as a result of a `task`.
+        var error: AFError?
     }
 
     /// Protected `MutableState` value that provides threadsafe access to state values.
@@ -233,7 +233,7 @@ public class Request {
     // MARK: Error
 
     /// `Error` returned from Alamofire internally, from the network request directly, or any validators executed.
-    fileprivate(set) public var error: Error? {
+    fileprivate(set) public var error: AFError? {
         get { return protectedMutableState.directValue.error }
         set { protectedMutableState.write { $0.error = newValue } }
     }
@@ -279,8 +279,8 @@ public class Request {
     ///
     /// - Note: Triggers retry.
     ///
-    /// - Parameter error: `Error` thrown from the failed creation.
-    func didFailToCreateURLRequest(with error: Error) {
+    /// - Parameter error: `AFError` thrown from the failed creation.
+    func didFailToCreateURLRequest(with error: AFError) {
         self.error = error
 
         eventMonitor?.request(self, didFailToCreateURLRequestWithError: error)
@@ -307,8 +307,8 @@ public class Request {
     ///
     /// - Parameters:
     ///   - request: The `URLRequest` the adapter was called with.
-    ///   - error:   The `Error` returned by the `RequestAdapter`.
-    func didFailToAdaptURLRequest(_ request: URLRequest, withError error: Error) {
+    ///   - error:   The `AFError` returned by the `RequestAdapter`.
+    func didFailToAdaptURLRequest(_ request: URLRequest, withError error: AFError) {
         self.error = error
 
         eventMonitor?.request(self, didFailToAdaptURLRequest: request, withError: error)
@@ -397,8 +397,8 @@ public class Request {
     ///
     /// - Parameters:
     ///   - task:  The `URLSessionTask` which failed.
-    ///   - error: The early failure `Error`.
-    func didFailTask(_ task: URLSessionTask, earlyWithError error: Error) {
+    ///   - error: The early failure `AFError`.
+    func didFailTask(_ task: URLSessionTask, earlyWithError error: AFError) {
         self.error = error
 
         // Task will still complete, so didCompleteTask(_:with:) will handle retry.
@@ -411,9 +411,9 @@ public class Request {
     ///
     /// - Parameters:
     ///   - task:  The `URLSessionTask` which completed.
-    ///   - error: The `Error` `task` may have completed with. If `error` has already been set on the instance, this
+    ///   - error: The `AFError` `task` may have completed with. If `error` has already been set on the instance, this
     ///            value is ignored.
-    func didCompleteTask(_ task: URLSessionTask, with error: Error?) {
+    func didCompleteTask(_ task: URLSessionTask, with error: AFError?) {
         self.error = self.error ?? error
         protectedValidators.directValue.forEach { $0() }
 
@@ -434,14 +434,16 @@ public class Request {
     /// Called to determine whether retry will be triggered for the particular error, or whether the instance should
     /// call `finish()`.
     ///
-    /// - Parameter error: The possible `Error` which may trigger retry.
-    func retryOrFinish(error: Error?) {
+    /// - Parameter error: The possible `AFError` which may trigger retry.
+    func retryOrFinish(error: AFError?) {
         guard let error = error, let delegate = delegate else { finish(); return }
 
         delegate.retryResult(for: self, dueTo: error) { retryResult in
             switch retryResult {
-            case .doNotRetry, .doNotRetryWithError:
-                self.finish(error: retryResult.error)
+            case .doNotRetry:
+                self.finish()
+            case .doNotRetryWithError(let error):
+                self.finish(error: AFError(requestRetryError: error))
             case .retry, .retryWithDelay:
                 delegate.retryRequest(self, withDelay: retryResult.delay)
             }
@@ -451,7 +453,7 @@ public class Request {
     /// Finishes this `Request` and starts the response serializers.
     ///
     /// - Parameter error: The possible `Error` with which the instance will finish.
-    func finish(error: Error? = nil) {
+    func finish(error: AFError? = nil) {
         if let error = error { self.error = error }
 
         // Start response handlers
@@ -907,7 +909,7 @@ public protocol RequestDelegate: AnyObject {
     ///   - request:    `Request` which failed.
     ///   - error:      `Error` which produced the failure.
     ///   - completion: Closure taking the `RetryResult` for evaluation.
-    func retryResult(for request: Request, dueTo error: Error, completion: @escaping (RetryResult) -> Void)
+    func retryResult(for request: Request, dueTo error: AFError, completion: @escaping (RetryResult) -> Void)
 
     /// Asynchronously retry the `Request`.
     ///
@@ -1168,7 +1170,7 @@ public class DownloadRequest: Request {
     /// - Parameters:
     ///   - task:   `URLSessionTask` that finished the download.
     ///   - result: `Result` of the automatic move to `destination`.
-    func didFinishDownloading(using task: URLSessionTask, with result: Result<URL, Error>) {
+    func didFinishDownloading(using task: URLSessionTask, with result: Result<URL, AFError>) {
         eventMonitor?.request(self, didFinishDownloadingUsing: task, with: result)
 
         switch result {
@@ -1381,8 +1383,8 @@ public class UploadRequest: DataRequest {
 
     /// Called when the `Uploadable` value could not be created.
     ///
-    /// - Parameter error: `Error` produced by the failure.
-    func didFailToCreateUploadable(with error: Error) {
+    /// - Parameter error: `AFError` produced by the failure.
+    func didFailToCreateUploadable(with error: AFError) {
         self.error = error
 
         eventMonitor?.request(self, didFailToCreateUploadableWithError: error)

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1012,7 +1012,7 @@ public class DataRequest: Request {
 
             let result = validation(self.request, response, self.data)
 
-            if case .failure(let error) = result { self.error = error }
+            if case .failure(let error) = result { self.error = error.afError(or: .responseValidationFailed(reason: .customValidationFailed(error: error))) }
 
             self.eventMonitor?.request(self,
                                        didValidateRequest: self.request,
@@ -1297,7 +1297,7 @@ public class DownloadRequest: Request {
 
             let result = validation(self.request, response, self.fileURL)
 
-            if case .failure(let error) = result { self.error = error }
+            if case .failure(let error) = result { self.error = error.afError(or: AFError.responseValidationFailed(reason: .customValidationFailed(error: error))) }
 
             self.eventMonitor?.request(self,
                                        didValidateRequest: self.request,

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1015,7 +1015,7 @@ public class DataRequest: Request {
 
             let result = validation(self.request, response, self.data)
 
-            if case .failure(let error) = result { self.error = error.asAFError(default: .responseValidationFailed(reason: .customValidationFailed(error: error))) }
+            if case .failure(let error) = result { self.error = error.asAFError(or: .responseValidationFailed(reason: .customValidationFailed(error: error))) }
 
             self.eventMonitor?.request(self,
                                        didValidateRequest: self.request,
@@ -1300,7 +1300,7 @@ public class DownloadRequest: Request {
 
             let result = validation(self.request, response, self.fileURL)
 
-            if case .failure(let error) = result { self.error = error.asAFError(default: .responseValidationFailed(reason: .customValidationFailed(error: error))) }
+            if case .failure(let error) = result { self.error = error.asAFError(or: .responseValidationFailed(reason: .customValidationFailed(error: error))) }
 
             self.eventMonitor?.request(self,
                                        didValidateRequest: self.request,

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -443,6 +443,9 @@ public class Request {
             case .doNotRetry:
                 self.finish()
             case .doNotRetryWithError(let retryError):
+                guard let retryError = retryError.asAFError else {
+                    fatalError("Received retryError was not already AFError")
+                }
                 self.finish(error: retryError)
             case .retry, .retryWithDelay:
                 delegate.retryRequest(self, withDelay: retryResult.delay)

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -443,7 +443,7 @@ public class Request {
             case .doNotRetry:
                 self.finish()
             case .doNotRetryWithError(let retryError):
-                self.finish(error: retryError.afError(or: .requestRetryFailed(retryError: retryError, originalError: nil)))
+                self.finish(error: retryError)
             case .retry, .retryWithDelay:
                 delegate.retryRequest(self, withDelay: retryResult.delay)
             }

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -442,8 +442,8 @@ public class Request {
             switch retryResult {
             case .doNotRetry:
                 self.finish()
-            case .doNotRetryWithError(let error):
-                self.finish(error: AFError(requestRetryError: error))
+            case .doNotRetryWithError(let retryError):
+                self.finish(error: retryError.afError(or: .requestRetryFailed(retryError: retryError, originalError: nil)))
             case .retry, .retryWithDelay:
                 delegate.retryRequest(self, withDelay: retryResult.delay)
             }

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1012,7 +1012,7 @@ public class DataRequest: Request {
 
             let result = validation(self.request, response, self.data)
 
-            if case .failure(let error) = result { self.error = error.afError(or: .responseValidationFailed(reason: .customValidationFailed(error: error))) }
+            if case .failure(let error) = result { self.error = error.asAFError(default: .responseValidationFailed(reason: .customValidationFailed(error: error))) }
 
             self.eventMonitor?.request(self,
                                        didValidateRequest: self.request,
@@ -1297,7 +1297,7 @@ public class DownloadRequest: Request {
 
             let result = validation(self.request, response, self.fileURL)
 
-            if case .failure(let error) = result { self.error = error.afError(or: AFError.responseValidationFailed(reason: .customValidationFailed(error: error))) }
+            if case .failure(let error) = result { self.error = error.asAFError(default: .responseValidationFailed(reason: .customValidationFailed(error: error))) }
 
             self.eventMonitor?.request(self,
                                        didValidateRequest: self.request,

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -443,10 +443,7 @@ public class Request {
             case .doNotRetry:
                 self.finish()
             case .doNotRetryWithError(let retryError):
-                guard let retryError = retryError.asAFError else {
-                    fatalError("Received retryError was not already AFError")
-                }
-                self.finish(error: retryError)
+                self.finish(error: retryError.asAFError(orFailWith: "Received retryError was not already AFError"))
             case .retry, .retryWithDelay:
                 delegate.retryRequest(self, withDelay: retryResult.delay)
             }

--- a/Source/RequestInterceptor.swift
+++ b/Source/RequestInterceptor.swift
@@ -46,7 +46,7 @@ public enum RetryResult {
     /// Do not retry.
     case doNotRetry
     /// Do not retry due to the associated `AFError`.
-    case doNotRetryWithError(AFError)
+    case doNotRetryWithError(Error)
 }
 
 extension RetryResult {
@@ -64,7 +64,7 @@ extension RetryResult {
         }
     }
 
-    var error: AFError? {
+    var error: Error? {
         guard case .doNotRetryWithError(let error) = self else { return nil }
         return error
     }

--- a/Source/RequestInterceptor.swift
+++ b/Source/RequestInterceptor.swift
@@ -45,8 +45,8 @@ public enum RetryResult {
     case retryWithDelay(TimeInterval)
     /// Do not retry.
     case doNotRetry
-    /// Do not retry due to the associated `Error`.
-    case doNotRetryWithError(Error)
+    /// Do not retry due to the associated `AFError`.
+    case doNotRetryWithError(AFError)
 }
 
 extension RetryResult {

--- a/Source/RequestInterceptor.swift
+++ b/Source/RequestInterceptor.swift
@@ -64,7 +64,7 @@ extension RetryResult {
         }
     }
 
-    var error: Error? {
+    var error: AFError? {
         guard case .doNotRetryWithError(let error) = self else { return nil }
         return error
     }

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -260,7 +260,7 @@ extension DataRequest {
                         didComplete = { completionHandler(response) }
 
                     case .doNotRetryWithError(let retryError):
-                        let result: Result<Serializer.SerializedObject, AFError> = .failure(retryError.afError(or: .requestRetryFailed(retryError: retryError, originalError: nil)))
+                        let result: Result<Serializer.SerializedObject, AFError> = .failure(retryError)
 
                         let response = DataResponse(request: self.request,
                                                     response: self.response,
@@ -381,7 +381,7 @@ extension DownloadRequest {
                         didComplete = { completionHandler(response) }
 
                     case .doNotRetryWithError(let retryError):
-                        let result: Result<T.SerializedObject, AFError> = .failure(retryError.afError(or: .requestRetryFailed(retryError: retryError, originalError: nil)))
+                        let result: Result<T.SerializedObject, AFError> = .failure(retryError)
 
                         let response = DownloadResponse(request: self.request,
                                                         response: self.response,

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -224,7 +224,9 @@ extension DataRequest {
                     data: self.data,
                     error: self.error
                 )
-            }.mapError { AFError(responseSerializationError: $0) }
+            }.mapError { error in
+                error.afError(or: .responseSerializationFailed(reason: .customSerializationFailed(error: error)))
+            }
 
             let end = CFAbsoluteTimeGetCurrent()
             // End work that should be on the serialization queue.
@@ -258,7 +260,7 @@ extension DataRequest {
                         didComplete = { completionHandler(response) }
 
                     case .doNotRetryWithError(let retryError):
-                        let result: Result<Serializer.SerializedObject, AFError> = .failure(AFError(requestRetryError: retryError))
+                        let result: Result<Serializer.SerializedObject, AFError> = .failure(retryError.afError(or: .requestRetryFailed(retryError: retryError, originalError: nil)))
 
                         let response = DataResponse(request: self.request,
                                                     response: self.response,
@@ -343,7 +345,9 @@ extension DownloadRequest {
                     fileURL: self.fileURL,
                     error: self.error
                 )
-            }.mapError { AFError(responseSerializationError: $0) }
+            }.mapError { error in
+                error.afError(or: .responseSerializationFailed(reason: .customSerializationFailed(error: error)))
+            }
             let end = CFAbsoluteTimeGetCurrent()
             // End work that should be on the serialization queue.
 
@@ -377,7 +381,7 @@ extension DownloadRequest {
                         didComplete = { completionHandler(response) }
 
                     case .doNotRetryWithError(let retryError):
-                        let result: Result<T.SerializedObject, AFError> = .failure(AFError(requestRetryError: retryError))
+                        let result: Result<T.SerializedObject, AFError> = .failure(retryError.afError(or: .requestRetryFailed(retryError: retryError, originalError: nil)))
 
                         let response = DownloadResponse(request: self.request,
                                                         response: self.response,

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -225,7 +225,7 @@ extension DataRequest {
                     error: self.error
                 )
             }.mapError { error in
-                error.afError(or: .responseSerializationFailed(reason: .customSerializationFailed(error: error)))
+                error.asAFError(default: .responseSerializationFailed(reason: .customSerializationFailed(error: error)))
             }
 
             let end = CFAbsoluteTimeGetCurrent()
@@ -346,7 +346,7 @@ extension DownloadRequest {
                     error: self.error
                 )
             }.mapError { error in
-                error.afError(or: .responseSerializationFailed(reason: .customSerializationFailed(error: error)))
+                error.asAFError(default: .responseSerializationFailed(reason: .customSerializationFailed(error: error)))
             }
             let end = CFAbsoluteTimeGetCurrent()
             // End work that should be on the serialization queue.

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -260,7 +260,7 @@ extension DataRequest {
                         didComplete = { completionHandler(response) }
 
                     case .doNotRetryWithError(let retryError):
-                        let result: Result<Serializer.SerializedObject, AFError> = .failure(retryError)
+                        let result: Result<Serializer.SerializedObject, AFError> = .failure(retryError.asAFError(default: .requestRetryFailed(retryError: retryError, originalError: serializerError)))
 
                         let response = DataResponse(request: self.request,
                                                     response: self.response,
@@ -381,7 +381,7 @@ extension DownloadRequest {
                         didComplete = { completionHandler(response) }
 
                     case .doNotRetryWithError(let retryError):
-                        let result: Result<T.SerializedObject, AFError> = .failure(retryError)
+                        let result: Result<T.SerializedObject, AFError> = .failure(retryError.asAFError(default: .requestRetryFailed(retryError: retryError, originalError: serializerError)))
 
                         let response = DownloadResponse(request: self.request,
                                                         response: self.response,

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -260,7 +260,7 @@ extension DataRequest {
                         didComplete = { completionHandler(response) }
 
                     case .doNotRetryWithError(let retryError):
-                        let result: Result<Serializer.SerializedObject, AFError> = .failure(retryError.asAFError(or: .requestRetryFailed(retryError: retryError, originalError: serializerError)))
+                        let result: Result<Serializer.SerializedObject, AFError> = .failure(retryError.asAFError(orFailWith: "Received retryError was not already AFError"))
 
                         let response = DataResponse(request: self.request,
                                                     response: self.response,
@@ -381,7 +381,7 @@ extension DownloadRequest {
                         didComplete = { completionHandler(response) }
 
                     case .doNotRetryWithError(let retryError):
-                        let result: Result<T.SerializedObject, AFError> = .failure(retryError.asAFError(or: .requestRetryFailed(retryError: retryError, originalError: serializerError)))
+                        let result: Result<T.SerializedObject, AFError> = .failure(retryError.asAFError(orFailWith: "Received retryError was not already AFError"))
 
                         let response = DownloadResponse(request: self.request,
                                                         response: self.response,

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -225,7 +225,7 @@ extension DataRequest {
                     error: self.error
                 )
             }.mapError { error in
-                error.asAFError(default: .responseSerializationFailed(reason: .customSerializationFailed(error: error)))
+                error.asAFError(or: .responseSerializationFailed(reason: .customSerializationFailed(error: error)))
             }
 
             let end = CFAbsoluteTimeGetCurrent()
@@ -260,7 +260,7 @@ extension DataRequest {
                         didComplete = { completionHandler(response) }
 
                     case .doNotRetryWithError(let retryError):
-                        let result: Result<Serializer.SerializedObject, AFError> = .failure(retryError.asAFError(default: .requestRetryFailed(retryError: retryError, originalError: serializerError)))
+                        let result: Result<Serializer.SerializedObject, AFError> = .failure(retryError.asAFError(or: .requestRetryFailed(retryError: retryError, originalError: serializerError)))
 
                         let response = DataResponse(request: self.request,
                                                     response: self.response,
@@ -346,7 +346,7 @@ extension DownloadRequest {
                     error: self.error
                 )
             }.mapError { error in
-                error.asAFError(default: .responseSerializationFailed(reason: .customSerializationFailed(error: error)))
+                error.asAFError(or: .responseSerializationFailed(reason: .customSerializationFailed(error: error)))
             }
             let end = CFAbsoluteTimeGetCurrent()
             // End work that should be on the serialization queue.
@@ -381,7 +381,7 @@ extension DownloadRequest {
                         didComplete = { completionHandler(response) }
 
                     case .doNotRetryWithError(let retryError):
-                        let result: Result<T.SerializedObject, AFError> = .failure(retryError.asAFError(default: .requestRetryFailed(retryError: retryError, originalError: serializerError)))
+                        let result: Result<T.SerializedObject, AFError> = .failure(retryError.asAFError(or: .requestRetryFailed(retryError: retryError, originalError: serializerError)))
 
                         let response = DownloadResponse(request: self.request,
                                                         response: self.response,

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -859,9 +859,9 @@ open class Session {
     }
 
     func performSetupOperations(for request: Request, convertible: URLRequestConvertible) {
-        
+
         let initialRequest: URLRequest
-        
+
         do {
             initialRequest = try convertible.asURLRequest()
             try initialRequest.validate()
@@ -869,21 +869,21 @@ open class Session {
             rootQueue.async { request.didFailToCreateURLRequest(with: error.afError(or: .createURLRequestFailed(error: error))) }
             return
         }
-        
+
         rootQueue.async { request.didCreateInitialURLRequest(initialRequest) }
-        
+
         guard !request.isCancelled else { return }
-        
+
         guard let adapter = adapter(for: request) else {
             rootQueue.async { self.didCreateURLRequest(initialRequest, for: request) }
             return
         }
-        
+
         adapter.adapt(initialRequest, for: self) { result in
             do {
                 let adaptedRequest = try result.get()
                 try adaptedRequest.validate()
-                
+
                 self.rootQueue.async {
                     request.didAdaptInitialRequest(initialRequest, to: adaptedRequest)
                     self.didCreateURLRequest(adaptedRequest, for: request)

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -864,15 +864,9 @@ open class Session {
         
         do {
             initialRequest = try convertible.asURLRequest()
-        } catch {
-            rootQueue.async { request.didFailToCreateURLRequest(with: error.afError(or: .createURLRequestFailed(error: error))) }
-            return
-        }
-        
-        do {
             try initialRequest.validate()
         } catch {
-            rootQueue.async { request.didFailToCreateURLRequest(with: error as! AFError) }
+            rootQueue.async { request.didFailToCreateURLRequest(with: error.afError(or: .createURLRequestFailed(error: error))) }
             return
         }
         
@@ -886,7 +880,6 @@ open class Session {
         }
         
         adapter.adapt(initialRequest, for: self) { result in
-            
             do {
                 let adaptedRequest = try result.get()
                 try adaptedRequest.validate()

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -838,7 +838,7 @@ open class Session {
 
                 self.performSetupOperations(for: request, convertible: request.convertible)
             } catch {
-                self.rootQueue.async { request.didFailToCreateUploadable(with: AFError(createUploadableError: error)) }
+                self.rootQueue.async { request.didFailToCreateUploadable(with: error.afError(or: .createUploadableFailed(error: error))) }
             }
         }
     }
@@ -865,14 +865,14 @@ open class Session {
         do {
             initialRequest = try convertible.asURLRequest()
         } catch {
-            rootQueue.async { request.didFailToCreateURLRequest(with: AFError(createURLRequestError: error)) }
+            rootQueue.async { request.didFailToCreateURLRequest(with: error.afError(or: .createURLRequestFailed(error: error))) }
             return
         }
         
         do {
             try initialRequest.validate()
         } catch {
-            rootQueue.async { request.didFailToCreateURLRequest(with: AFError(urlRequestValidationError: error)) }
+            rootQueue.async { request.didFailToCreateURLRequest(with: error.afError(or: .urlRequestValidationFailed(reason: .customValidationFailed(error: error)))) }
             return
         }
         
@@ -896,7 +896,7 @@ open class Session {
                     self.didCreateURLRequest(adaptedRequest, for: request)
                 }
             } catch {
-                self.rootQueue.async { request.didFailToAdaptURLRequest(initialRequest, withError: AFError(requestAdaptationError: error)) }
+                self.rootQueue.async { request.didFailToAdaptURLRequest(initialRequest, withError: error.afError(or: .requestAdaptationFailed(error: error))) }
             }
         }
     }

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -888,7 +888,7 @@ open class Session {
                     self.didCreateURLRequest(adaptedRequest, for: request)
                 }
             } catch {
-                self.rootQueue.async { request.didFailToAdaptURLRequest(initialRequest, withError: error.asAFError(or: .requestAdaptationFailed(error: error))) }
+                self.rootQueue.async { request.didFailToAdaptURLRequest(initialRequest, withError: .requestAdaptationFailed(error: error)) }
             }
         }
     }

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -838,7 +838,7 @@ open class Session {
 
                 self.performSetupOperations(for: request, convertible: request.convertible)
             } catch {
-                self.rootQueue.async { request.didFailToCreateUploadable(with: error.afError(or: .createUploadableFailed(error: error))) }
+                self.rootQueue.async { request.didFailToCreateUploadable(with: error.asAFError(default: .createUploadableFailed(error: error))) }
             }
         }
     }
@@ -866,7 +866,7 @@ open class Session {
             initialRequest = try convertible.asURLRequest()
             try initialRequest.validate()
         } catch {
-            rootQueue.async { request.didFailToCreateURLRequest(with: error.afError(or: .createURLRequestFailed(error: error))) }
+            rootQueue.async { request.didFailToCreateURLRequest(with: error.asAFError(default: .createURLRequestFailed(error: error))) }
             return
         }
 
@@ -889,7 +889,7 @@ open class Session {
                     self.didCreateURLRequest(adaptedRequest, for: request)
                 }
             } catch {
-                self.rootQueue.async { request.didFailToAdaptURLRequest(initialRequest, withError: error.afError(or: .requestAdaptationFailed(error: error))) }
+                self.rootQueue.async { request.didFailToAdaptURLRequest(initialRequest, withError: error.asAFError(default: .requestAdaptationFailed(error: error))) }
             }
         }
     }

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -838,7 +838,7 @@ open class Session {
 
                 self.performSetupOperations(for: request, convertible: request.convertible)
             } catch {
-                self.rootQueue.async { request.didFailToCreateUploadable(with: error.asAFError(default: .createUploadableFailed(error: error))) }
+                self.rootQueue.async { request.didFailToCreateUploadable(with: error.asAFError(or: .createUploadableFailed(error: error))) }
             }
         }
     }
@@ -866,7 +866,7 @@ open class Session {
             initialRequest = try convertible.asURLRequest()
             try initialRequest.validate()
         } catch {
-            rootQueue.async { request.didFailToCreateURLRequest(with: error.asAFError(default: .createURLRequestFailed(error: error))) }
+            rootQueue.async { request.didFailToCreateURLRequest(with: error.asAFError(or: .createURLRequestFailed(error: error))) }
             return
         }
 
@@ -889,7 +889,7 @@ open class Session {
                     self.didCreateURLRequest(adaptedRequest, for: request)
                 }
             } catch {
-                self.rootQueue.async { request.didFailToAdaptURLRequest(initialRequest, withError: error.asAFError(default: .requestAdaptationFailed(error: error))) }
+                self.rootQueue.async { request.didFailToAdaptURLRequest(initialRequest, withError: error.asAFError(or: .requestAdaptationFailed(error: error))) }
             }
         }
     }

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -859,7 +859,6 @@ open class Session {
     }
 
     func performSetupOperations(for request: Request, convertible: URLRequestConvertible) {
-
         let initialRequest: URLRequest
 
         do {
@@ -989,6 +988,7 @@ extension Session: RequestDelegate {
         retrier.retry(request, for: self, dueTo: error) { retryResult in
             self.rootQueue.async {
                 guard let retryResultError = retryResult.error else { completion(retryResult); return }
+
                 let retryError = AFError.requestRetryFailed(retryError: retryResultError, originalError: error)
                 completion(.doNotRetryWithError(retryError))
             }

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -989,8 +989,8 @@ extension Session: RequestDelegate {
         retrier.retry(request, for: self, dueTo: error) { retryResult in
             self.rootQueue.async {
                 guard let retryResultError = retryResult.error else { completion(retryResult); return }
-
-                completion(.doNotRetryWithError(retryResultError))
+                let retryError = AFError.requestRetryFailed(retryError: retryResultError, originalError: error)
+                completion(.doNotRetryWithError(retryError))
             }
         }
     }

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -990,8 +990,7 @@ extension Session: RequestDelegate {
             self.rootQueue.async {
                 guard let retryResultError = retryResult.error else { completion(retryResult); return }
 
-                let retryError = AFError.requestRetryFailed(retryError: retryResultError, originalError: error)
-                completion(.doNotRetryWithError(retryError))
+                completion(.doNotRetryWithError(retryResultError))
             }
         }
     }

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -872,7 +872,7 @@ open class Session {
         do {
             try initialRequest.validate()
         } catch {
-            rootQueue.async { request.didFailToCreateURLRequest(with: error.afError(or: .urlRequestValidationFailed(reason: .customValidationFailed(error: error)))) }
+            rootQueue.async { request.didFailToCreateURLRequest(with: error as! AFError) }
             return
         }
         

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -838,7 +838,7 @@ open class Session {
 
                 self.performSetupOperations(for: request, convertible: request.convertible)
             } catch {
-                self.rootQueue.async { request.didFailToCreateUploadable(with: error) }
+                self.rootQueue.async { request.didFailToCreateUploadable(with: AFError(createUploadableError: error)) }
             }
         }
     }
@@ -859,33 +859,45 @@ open class Session {
     }
 
     func performSetupOperations(for request: Request, convertible: URLRequestConvertible) {
+        
+        let initialRequest: URLRequest
+        
         do {
-            let initialRequest = try convertible.asURLRequest()
-            try initialRequest.validate()
-            rootQueue.async { request.didCreateInitialURLRequest(initialRequest) }
-
-            guard !request.isCancelled else { return }
-
-            if let adapter = adapter(for: request) {
-                adapter.adapt(initialRequest, for: self) { result in
-                    do {
-                        let adaptedRequest = try result.get()
-                        try adaptedRequest.validate()
-
-                        self.rootQueue.async {
-                            request.didAdaptInitialRequest(initialRequest, to: adaptedRequest)
-                            self.didCreateURLRequest(adaptedRequest, for: request)
-                        }
-                    } catch {
-                        let adaptError = AFError.requestAdaptationFailed(error: error)
-                        self.rootQueue.async { request.didFailToAdaptURLRequest(initialRequest, withError: adaptError) }
-                    }
-                }
-            } else {
-                rootQueue.async { self.didCreateURLRequest(initialRequest, for: request) }
-            }
+            initialRequest = try convertible.asURLRequest()
         } catch {
-            rootQueue.async { request.didFailToCreateURLRequest(with: error) }
+            rootQueue.async { request.didFailToCreateURLRequest(with: AFError(createURLRequestError: error)) }
+            return
+        }
+        
+        do {
+            try initialRequest.validate()
+        } catch {
+            rootQueue.async { request.didFailToCreateURLRequest(with: AFError(urlRequestValidationError: error)) }
+            return
+        }
+        
+        rootQueue.async { request.didCreateInitialURLRequest(initialRequest) }
+        
+        guard !request.isCancelled else { return }
+        
+        guard let adapter = adapter(for: request) else {
+            rootQueue.async { self.didCreateURLRequest(initialRequest, for: request) }
+            return
+        }
+        
+        adapter.adapt(initialRequest, for: self) { result in
+            
+            do {
+                let adaptedRequest = try result.get()
+                try adaptedRequest.validate()
+                
+                self.rootQueue.async {
+                    request.didAdaptInitialRequest(initialRequest, to: adaptedRequest)
+                    self.didCreateURLRequest(adaptedRequest, for: request)
+                }
+            } catch {
+                self.rootQueue.async { request.didFailToAdaptURLRequest(initialRequest, withError: AFError(requestAdaptationError: error)) }
+            }
         }
     }
 
@@ -975,7 +987,7 @@ extension Session: RequestDelegate {
         activeRequests.remove(request)
     }
 
-    public func retryResult(for request: Request, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
+    public func retryResult(for request: Request, dueTo error: AFError, completion: @escaping (RetryResult) -> Void) {
         guard let retrier = retrier(for: request) else {
             rootQueue.async { completion(.doNotRetry) }
             return

--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -117,7 +117,7 @@ extension SessionDelegate: URLSessionTaskDelegate {
 
             return (.useCredential, URLCredential(trust: trust), nil)
         } catch {
-            return (.cancelAuthenticationChallenge, nil, error.afError(or: .serverTrustEvaluationFailed(reason: .customEvaluationFailed(error: error))))
+            return (.cancelAuthenticationChallenge, nil, error.asAFError(default: .serverTrustEvaluationFailed(reason: .customEvaluationFailed(error: error))))
         }
     }
 
@@ -193,7 +193,7 @@ extension SessionDelegate: URLSessionTaskDelegate {
     open func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         eventMonitor?.urlSession(session, task: task, didCompleteWithError: error)
 
-        stateProvider?.request(for: task)?.didCompleteTask(task, with: error?.afError(or: .sessionTaskFailed(error: error!)))
+        stateProvider?.request(for: task)?.didCompleteTask(task, with: error.map{ $0.asAFError(default: .sessionTaskFailed(error: $0)) })
 
         stateProvider?.didCompleteTask(task)
     }

--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -299,7 +299,7 @@ extension SessionDelegate: URLSessionDownloadDelegate {
 
             request.didFinishDownloading(using: downloadTask, with: .success(destination))
         } catch {
-            request.didFinishDownloading(using: downloadTask, with: .failure(AFError.downloadedFileMoveFailed(error: error, destination: destination)))
+            request.didFinishDownloading(using: downloadTask, with: .failure(.downloadedFileMoveFailed(error: error, source: location, destination: destination)))
         }
     }
 }

--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -117,7 +117,7 @@ extension SessionDelegate: URLSessionTaskDelegate {
 
             return (.useCredential, URLCredential(trust: trust), nil)
         } catch {
-            return (.cancelAuthenticationChallenge, nil, AFError(serverTrustError: error))
+            return (.cancelAuthenticationChallenge, nil, error.afError(or: .serverTrustEvaluationFailed(reason: .customEvaluationFailed(error: error))))
         }
     }
 
@@ -193,7 +193,7 @@ extension SessionDelegate: URLSessionTaskDelegate {
     open func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         eventMonitor?.urlSession(session, task: task, didCompleteWithError: error)
 
-        stateProvider?.request(for: task)?.didCompleteTask(task, with: error.map{ (error as? AFError) ?? AFError.sessionTaskFailed(error: $0) })
+        stateProvider?.request(for: task)?.didCompleteTask(task, with: error?.afError(or: .sessionTaskFailed(error: error!)))
 
         stateProvider?.didCompleteTask(task)
     }

--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -299,7 +299,7 @@ extension SessionDelegate: URLSessionDownloadDelegate {
 
             request.didFinishDownloading(using: downloadTask, with: .success(destination))
         } catch {
-            request.didFinishDownloading(using: downloadTask, with: .failure(AFError.moveDownloadFailed(error: error, destination: destination)))
+            request.didFinishDownloading(using: downloadTask, with: .failure(AFError.downloadedFileMoveFailed(error: error, destination: destination)))
         }
     }
 }

--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -117,7 +117,7 @@ extension SessionDelegate: URLSessionTaskDelegate {
 
             return (.useCredential, URLCredential(trust: trust), nil)
         } catch {
-            return (.cancelAuthenticationChallenge, nil, error.asAFError(default: .serverTrustEvaluationFailed(reason: .customEvaluationFailed(error: error))))
+            return (.cancelAuthenticationChallenge, nil, error.asAFError(or: .serverTrustEvaluationFailed(reason: .customEvaluationFailed(error: error))))
         }
     }
 
@@ -193,7 +193,7 @@ extension SessionDelegate: URLSessionTaskDelegate {
     open func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         eventMonitor?.urlSession(session, task: task, didCompleteWithError: error)
 
-        stateProvider?.request(for: task)?.didCompleteTask(task, with: error.map{ $0.asAFError(default: .sessionTaskFailed(error: $0)) })
+        stateProvider?.request(for: task)?.didCompleteTask(task, with: error.map{ $0.asAFError(or: .sessionTaskFailed(error: $0)) })
 
         stateProvider?.didCompleteTask(task)
     }

--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -31,7 +31,7 @@ extension Request {
     fileprivate typealias ErrorReason = AFError.ResponseValidationFailureReason
 
     /// Used to represent whether a validation succeeded or failed.
-    public typealias ValidationResult = Result<Void, Error>
+    public typealias ValidationResult = Result<Void, AFError>
 
     fileprivate struct MIMEType {
         let type: String

--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -31,7 +31,7 @@ extension Request {
     fileprivate typealias ErrorReason = AFError.ResponseValidationFailureReason
 
     /// Used to represent whether a validation succeeded or failed.
-    public typealias ValidationResult = Result<Void, AFError>
+    public typealias ValidationResult = Result<Void, Error>
 
     fileprivate struct MIMEType {
         let type: String

--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -65,7 +65,7 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
         // Given
         let expectation = self.expectation(description: "\(urlString) 401")
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         manager.request(urlString)
@@ -89,7 +89,7 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
         // Given
         let expectation = self.expectation(description: "\(urlString) 200")
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         manager.request(urlString)
@@ -115,7 +115,7 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
         let expectation = self.expectation(description: "\(urlString) 200")
         let headers: HTTPHeaders = [.authorization(username: user, password: password)]
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         manager.request(urlString, headers: headers)
@@ -149,7 +149,7 @@ class HTTPDigestAuthenticationTestCase: AuthenticationTestCase {
         // Given
         let expectation = self.expectation(description: "\(urlString) 401")
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         manager.request(urlString)
@@ -173,7 +173,7 @@ class HTTPDigestAuthenticationTestCase: AuthenticationTestCase {
         // Given
         let expectation = self.expectation(description: "\(urlString) 200")
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         manager.request(urlString)

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -83,7 +83,7 @@ class DownloadResponseTestCase: BaseTestCase {
         let destination: DownloadRequest.Destination = { _, _ in (fileURL, []) }
 
         let expectation = self.expectation(description: "Download request should download data to file: \(urlString)")
-        var response: DownloadResponse<URL?, Error>?
+        var response: DownloadResponse<URL?, AFError>?
 
         // When
         AF.download(urlString, to: destination)
@@ -120,7 +120,7 @@ class DownloadResponseTestCase: BaseTestCase {
         let destination: DownloadRequest.Destination = { _, _ in (fileURL, []) }
 
         let expectation = self.expectation(description: "Cancelled download request should not download data to file")
-        var response: DownloadResponse<URL?, Error>?
+        var response: DownloadResponse<URL?, AFError>?
 
         // When
         AF.download(urlString, to: destination)
@@ -146,7 +146,7 @@ class DownloadResponseTestCase: BaseTestCase {
         let expectation = self.expectation(description: "Bytes download progress should be reported: \(urlString)")
 
         var progressValues: [Double] = []
-        var response: DownloadResponse<URL?, Error>?
+        var response: DownloadResponse<URL?, AFError>?
 
         // When
         AF.download(urlString)
@@ -189,7 +189,7 @@ class DownloadResponseTestCase: BaseTestCase {
         let destination: DownloadRequest.Destination = { _, _ in (fileURL, []) }
 
         let expectation = self.expectation(description: "Download request should download data to file")
-        var response: DownloadResponse<URL?, Error>?
+        var response: DownloadResponse<URL?, AFError>?
 
         // When
         AF.download(urlString, parameters: parameters, to: destination)
@@ -227,7 +227,7 @@ class DownloadResponseTestCase: BaseTestCase {
         let destination: DownloadRequest.Destination = { _, _ in (fileURL, []) }
 
         let expectation = self.expectation(description: "Download request should download data to file: \(fileURL)")
-        var response: DownloadResponse<URL?, Error>?
+        var response: DownloadResponse<URL?, AFError>?
 
         // When
         AF.download(urlString, headers: headers, to: destination)
@@ -262,7 +262,7 @@ class DownloadResponseTestCase: BaseTestCase {
         let fileURL = testDirectoryURL.appendingPathComponent("some/random/folder/test_output.json")
 
         let expectation = self.expectation(description: "Download request should download data but fail to move file")
-        var response: DownloadResponse<URL?, Error>?
+        var response: DownloadResponse<URL?, AFError>?
 
         // When
         AF.download("https://httpbin.org/get", to: { _, _ in (fileURL, [])})
@@ -280,7 +280,7 @@ class DownloadResponseTestCase: BaseTestCase {
         XCTAssertNil(response?.resumeData)
         XCTAssertNotNil(response?.error)
 
-        if let error = response?.error as? CocoaError {
+        if let error = response?.error?.asAFError?.underlyingError as? CocoaError {
             XCTAssertEqual(error.code, .fileNoSuchFile)
         } else {
             XCTFail("error should not be nil")
@@ -292,7 +292,7 @@ class DownloadResponseTestCase: BaseTestCase {
         let fileURL = testDirectoryURL.appendingPathComponent("some/random/folder/test_output.json")
 
         let expectation = self.expectation(description: "Download request should download data to file: \(fileURL)")
-        var response: DownloadResponse<URL?, Error>?
+        var response: DownloadResponse<URL?, AFError>?
 
         // When
         AF.download("https://httpbin.org/get", to: { _, _ in (fileURL, [.createIntermediateDirectories])})
@@ -321,7 +321,7 @@ class DownloadResponseTestCase: BaseTestCase {
             try "random_data".write(to: fileURL, atomically: true, encoding: .utf8)
 
             let expectation = self.expectation(description: "Download should complete but fail to move file")
-            var response: DownloadResponse<URL?, Error>?
+            var response: DownloadResponse<URL?, AFError>?
 
             // When
             AF.download("https://httpbin.org/get", to: { _, _ in (fileURL, [])})
@@ -341,7 +341,7 @@ class DownloadResponseTestCase: BaseTestCase {
             XCTAssertNil(response?.resumeData)
             XCTAssertNotNil(response?.error)
 
-            if let error = response?.error as? CocoaError {
+            if let error = response?.error?.asAFError?.underlyingError as? CocoaError {
                 XCTAssertEqual(error.code, .fileWriteFileExists)
             } else {
                 XCTFail("error should not be nil")
@@ -359,7 +359,7 @@ class DownloadResponseTestCase: BaseTestCase {
         let fileURL = directoryURL.appendingPathComponent("test_output.json")
 
         let expectation = self.expectation(description: "Download should complete and move file to URL: \(fileURL)")
-        var response: DownloadResponse<URL?, Error>?
+        var response: DownloadResponse<URL?, AFError>?
 
         // When
         AF.download("https://httpbin.org/get", to: { _, _ in (fileURL, [.removePreviousFile, .createIntermediateDirectories])})
@@ -496,7 +496,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         let expectation = self.expectation(description: "Download should be cancelled")
         var cancelled = false
 
-        var response: DownloadResponse<URL?, Error>?
+        var response: DownloadResponse<URL?, AFError>?
 
         // When
         let download = AF.download(urlString)
@@ -530,7 +530,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         let expectation = self.expectation(description: "Download should be cancelled")
         var cancelled = false
 
-        var response: DownloadResponse<URL?, Error>?
+        var response: DownloadResponse<URL?, AFError>?
 
         // When
         let download = AF.download(urlString)
@@ -566,7 +566,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         let expectation = self.expectation(description: "Download should be cancelled")
         var cancelled = false
 
-        var response: DownloadResponse<Any, Error>?
+        var response: DownloadResponse<Any, AFError>?
 
         // When
         let download = AF.download(urlString)
@@ -603,7 +603,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         let expectation1 = self.expectation(description: "Download should be cancelled")
         var cancelled = false
 
-        var response1: DownloadResponse<Data, Error>?
+        var response1: DownloadResponse<Data, AFError>?
 
         // When
         let download = AF.download(urlString)
@@ -630,7 +630,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         let expectation2 = self.expectation(description: "Download should complete")
 
         var progressValues: [Double] = []
-        var response2: DownloadResponse<Data, Error>?
+        var response2: DownloadResponse<Data, AFError>?
 
         AF.download(resumingWith: resumeData)
             .downloadProgress { progress in
@@ -663,7 +663,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         let expectation = self.expectation(description: "Download should be cancelled")
         var cancelled = false
         var receivedResumeData: Data?
-        var response: DownloadResponse<URL?, Error>?
+        var response: DownloadResponse<URL?, AFError>?
 
         // When
         let download = AF.download(urlString)
@@ -705,7 +705,7 @@ class DownloadResponseMapTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DownloadResponse<String, Error>?
+        var response: DownloadResponse<String, AFError>?
 
         // When
         AF.download(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -734,7 +734,7 @@ class DownloadResponseMapTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail with 404")
 
-        var response: DownloadResponse<String, Error>?
+        var response: DownloadResponse<String, AFError>?
 
         // When
         AF.download(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -757,8 +757,8 @@ class DownloadResponseMapTestCase: BaseTestCase {
 
 // MARK: -
 
-class DownloadResponseFlatMapTestCase: BaseTestCase {
-    func testThatFlatMapTransformsSuccessValue() {
+class DownloadResponseTryMapTestCase: BaseTestCase {
+    func testThatTryMapTransformsSuccessValue() {
         // Given
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
@@ -787,7 +787,7 @@ class DownloadResponseFlatMapTestCase: BaseTestCase {
         XCTAssertNotNil(response?.metrics)
     }
 
-    func testThatFlatMapCatchesTransformationError() {
+    func testThatTryMapCatchesTransformationError() {
         // Given
         struct TransformError: Error {}
 
@@ -821,7 +821,7 @@ class DownloadResponseFlatMapTestCase: BaseTestCase {
         XCTAssertNotNil(response?.metrics)
     }
 
-    func testThatFlatMapPreservesFailureError() {
+    func testThatTryMapPreservesFailureError() {
         // Given
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail with 404")
@@ -853,7 +853,7 @@ class DownloadResponseMapErrorTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should not succeed")
 
-        var response: DownloadResponse<Any, Error>?
+        var response: DownloadResponse<Any, TestError>?
 
         // When
         AF.download(urlString).responseJSON { resp in
@@ -874,7 +874,7 @@ class DownloadResponseMapErrorTestCase: BaseTestCase {
         XCTAssertNotNil(response?.error)
         XCTAssertEqual(response?.result.isFailure, true)
 
-        guard let error = response?.error as? TestError, case .error = error else { XCTFail(); return }
+        guard let error = response?.error, case TestError.error = error else { XCTFail(); return }
 
         XCTAssertNotNil(response?.metrics)
     }
@@ -884,7 +884,7 @@ class DownloadResponseMapErrorTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DownloadResponse<Data, Error>?
+        var response: DownloadResponse<Data, TestError>?
 
         // When
         AF.download(urlString).responseData { resp in
@@ -906,8 +906,8 @@ class DownloadResponseMapErrorTestCase: BaseTestCase {
 
 // MARK: -
 
-class DownloadResponseFlatMapErrorTestCase: BaseTestCase {
-    func testThatFlatMapErrorPreservesSuccessValue() {
+class DownloadResponseTryMapErrorTestCase: BaseTestCase {
+    func testThatTryMapErrorPreservesSuccessValue() {
         // Given
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
@@ -932,7 +932,7 @@ class DownloadResponseFlatMapErrorTestCase: BaseTestCase {
         XCTAssertNotNil(response?.metrics)
     }
 
-    func testThatFlatMapErrorCatchesTransformationError() {
+    func testThatTryMapErrorCatchesTransformationError() {
         // Given
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail")
@@ -964,7 +964,7 @@ class DownloadResponseFlatMapErrorTestCase: BaseTestCase {
         XCTAssertNotNil(response?.metrics)
     }
 
-    func testThatFlatMapErrorTransformsError() {
+    func testThatTryMapErrorTransformsError() {
         // Given
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail")
@@ -986,7 +986,7 @@ class DownloadResponseFlatMapErrorTestCase: BaseTestCase {
         XCTAssertNil(response?.resumeData)
         XCTAssertNotNil(response?.error)
         XCTAssertEqual(response?.result.isFailure, true)
-        guard let error = response?.error as? TestError, case .error = error else { XCTFail(); return }
+        guard let error = response?.error as? TestError, case TestError.error = error else { XCTFail(); return }
 
         XCTAssertNotNil(response?.metrics)
     }

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -280,7 +280,7 @@ class DownloadResponseTestCase: BaseTestCase {
         XCTAssertNil(response?.resumeData)
         XCTAssertNotNil(response?.error)
 
-        if let error = response?.error?.asAFError?.underlyingError as? CocoaError {
+        if let error = response?.error?.underlyingError as? CocoaError {
             XCTAssertEqual(error.code, .fileNoSuchFile)
         } else {
             XCTFail("error should not be nil")
@@ -341,7 +341,7 @@ class DownloadResponseTestCase: BaseTestCase {
             XCTAssertNil(response?.resumeData)
             XCTAssertNotNil(response?.error)
 
-            if let error = response?.error?.asAFError?.underlyingError as? CocoaError {
+            if let error = response?.error?.underlyingError as? CocoaError {
                 XCTAssertEqual(error.code, .fileWriteFileExists)
             } else {
                 XCTFail("error should not be nil")
@@ -986,7 +986,7 @@ class DownloadResponseTryMapErrorTestCase: BaseTestCase {
         XCTAssertNil(response?.resumeData)
         XCTAssertNotNil(response?.error)
         XCTAssertEqual(response?.result.isFailure, true)
-        guard let error = response?.error as? TestError, case TestError.error = error else { XCTFail(); return }
+        guard let error = response?.error, case TestError.error = error else { XCTFail(); return }
 
         XCTAssertNotNil(response?.metrics)
     }

--- a/Tests/RedirectHandlerTests.swift
+++ b/Tests/RedirectHandlerTests.swift
@@ -39,7 +39,7 @@ final class RedirectHandlerTestCase: BaseTestCase {
         // Given
         let session = Session()
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
         let expectation = self.expectation(description: "Request should redirect to \(redirectURLString)")
 
         // When
@@ -64,7 +64,7 @@ final class RedirectHandlerTestCase: BaseTestCase {
         // Given
         let session = Session()
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
         let expectation = self.expectation(description: "Request should NOT redirect to \(redirectURLString)")
 
         // When
@@ -91,7 +91,7 @@ final class RedirectHandlerTestCase: BaseTestCase {
         let redirectURLString = "https://www.nike.com"
         let redirectURLRequest = URLRequest(url: URL(string: redirectURLString)!)
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
         let expectation = self.expectation(description: "Request should redirect to \(redirectURLString)")
 
         // When
@@ -120,7 +120,7 @@ final class RedirectHandlerTestCase: BaseTestCase {
         // Given
         let session = Session(redirectHandler: Redirector.follow)
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
         let expectation = self.expectation(description: "Request should redirect to \(redirectURLString)")
 
         // When
@@ -145,7 +145,7 @@ final class RedirectHandlerTestCase: BaseTestCase {
         // Given
         let session = Session(redirectHandler: Redirector.doNotFollow)
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
         let expectation = self.expectation(description: "Request should NOT redirect to \(redirectURLString)")
 
         // When
@@ -174,7 +174,7 @@ final class RedirectHandlerTestCase: BaseTestCase {
         let redirector = Redirector(behavior: .modify { _, _, _ in redirectURLRequest })
         let session = Session(redirectHandler: redirector)
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
         let expectation = self.expectation(description: "Request should redirect to \(redirectURLString)")
 
         // When
@@ -201,7 +201,7 @@ final class RedirectHandlerTestCase: BaseTestCase {
         // Given
         let session = Session(redirectHandler: Redirector.doNotFollow)
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
         let expectation = self.expectation(description: "Request should redirect to \(redirectURLString)")
 
         // When

--- a/Tests/RequestInterceptorTests.swift
+++ b/Tests/RequestInterceptorTests.swift
@@ -501,7 +501,7 @@ final class InterceptorTestCase: BaseTestCase {
 
         // Then
         XCTAssertEqual(result, RetryResult(doNotRetryWithError: RetryError()))
-        XCTAssertTrue(result.error is RetryError)
+        XCTAssertTrue(result.error?.underlyingError is RetryError)
         XCTAssertFalse(retrier2Called)
     }
 }

--- a/Tests/RequestInterceptorTests.swift
+++ b/Tests/RequestInterceptorTests.swift
@@ -29,6 +29,12 @@ import XCTest
 fileprivate struct MockError: Error {}
 fileprivate struct RetryError: Error {}
 
+extension RetryResult {
+    fileprivate init(doNotRetryWithError error: Error) {
+        self = .doNotRetryWithError(.requestRetryFailed(retryError: error, originalError: error))
+    }
+}
+
 // MARK: -
 
 final class RetryResultTestCase: BaseTestCase {
@@ -37,7 +43,7 @@ final class RetryResultTestCase: BaseTestCase {
         let retry = RetryResult.retry
         let retryWithDelay = RetryResult.retryWithDelay(1.0)
         let doNotRetry = RetryResult.doNotRetry
-        let doNotRetryWithError = RetryResult.doNotRetryWithError(MockError())
+        let doNotRetryWithError = RetryResult(doNotRetryWithError: MockError())
 
         // Then
         XCTAssertTrue(retry.retryRequired)
@@ -51,7 +57,7 @@ final class RetryResultTestCase: BaseTestCase {
         let retry = RetryResult.retry
         let retryWithDelay = RetryResult.retryWithDelay(1.0)
         let doNotRetry = RetryResult.doNotRetry
-        let doNotRetryWithError = RetryResult.doNotRetryWithError(MockError())
+        let doNotRetryWithError = RetryResult(doNotRetryWithError: MockError())
 
         // Then
         XCTAssertEqual(retry.delay, nil)
@@ -65,13 +71,13 @@ final class RetryResultTestCase: BaseTestCase {
         let retry = RetryResult.retry
         let retryWithDelay = RetryResult.retryWithDelay(1.0)
         let doNotRetry = RetryResult.doNotRetry
-        let doNotRetryWithError = RetryResult.doNotRetryWithError(MockError())
+        let doNotRetryWithError = RetryResult(doNotRetryWithError: MockError())
 
         // Then
         XCTAssertNil(retry.error)
         XCTAssertNil(retryWithDelay.error)
         XCTAssertNil(doNotRetry.error)
-        XCTAssertTrue(doNotRetryWithError.error is MockError)
+        XCTAssertTrue(doNotRetryWithError.error?.asAFError?.underlyingError is MockError)
     }
 }
 
@@ -484,7 +490,7 @@ final class InterceptorTestCase: BaseTestCase {
 
         var retrier2Called = false
 
-        let retrier1 = Retrier { _, _, _, completion in completion(.doNotRetryWithError(RetryError())) }
+        let retrier1 = Retrier { _, _, _, completion in completion(RetryResult(doNotRetryWithError: RetryError())) }
         let retrier2 = Retrier { _, _, _, completion in retrier2Called = true; completion(.doNotRetry) }
         let interceptor = Interceptor(retriers: [retrier1, retrier2])
 
@@ -494,7 +500,7 @@ final class InterceptorTestCase: BaseTestCase {
         interceptor.retry(request, for: session, dueTo: MockError()) { result = $0 }
 
         // Then
-        XCTAssertEqual(result, .doNotRetryWithError(RetryError()))
+        XCTAssertEqual(result, RetryResult(doNotRetryWithError: RetryError()))
         XCTAssertTrue(result.error is RetryError)
         XCTAssertFalse(retrier2Called)
     }

--- a/Tests/RequestInterceptorTests.swift
+++ b/Tests/RequestInterceptorTests.swift
@@ -484,7 +484,7 @@ final class InterceptorTestCase: BaseTestCase {
 
         var retrier2Called = false
 
-        let retrier1 = Retrier { _, _, _, completion in completion(RetryResult.doNotRetryWithError(RetryError())) }
+        let retrier1 = Retrier { _, _, _, completion in completion(.doNotRetryWithError(RetryError())) }
         let retrier2 = Retrier { _, _, _, completion in retrier2Called = true; completion(.doNotRetry) }
         let interceptor = Interceptor(retriers: [retrier1, retrier2])
 

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -668,8 +668,8 @@ final class RequestResponseTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        XCTAssertEqual(response1?.error?.underlyingError?.asAFError?.isExplicitlyCancelledError, true)
-        XCTAssertEqual(response2?.error?.underlyingError?.asAFError?.isExplicitlyCancelledError, true)
+        XCTAssertEqual(response1?.error?.isExplicitlyCancelledError, true)
+        XCTAssertEqual(response2?.error?.isExplicitlyCancelledError, true)
     }
 
     func testThatAppendingResponseSerializerToCompletedRequestInsideCompletionResumesRequest() {

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -31,7 +31,7 @@ final class RequestResponseTestCase: BaseTestCase {
         // Given
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "GET request should succeed: \(urlString)")
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"])
@@ -57,7 +57,7 @@ final class RequestResponseTestCase: BaseTestCase {
         let expectation = self.expectation(description: "Bytes download progress should be reported: \(urlString)")
 
         var progressValues: [Double] = []
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         AF.request(urlString)
@@ -103,7 +103,7 @@ final class RequestResponseTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         AF.request(urlString, method: .post, parameters: parameters)
@@ -155,7 +155,7 @@ final class RequestResponseTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         AF.request(urlString, method: .post, parameters: parameters)
@@ -188,7 +188,7 @@ final class RequestResponseTestCase: BaseTestCase {
         let queue = DispatchQueue(label: "org.alamofire.testSerializationQueue")
         let manager = Session(serializationQueue: queue)
         let expectation = self.expectation(description: "request should complete")
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         manager.request("https://httpbin.org/get").responseJSON { (resp) in
@@ -208,7 +208,7 @@ final class RequestResponseTestCase: BaseTestCase {
         let serializationQueue = DispatchQueue(label: "org.alamofire.testSerializationQueue")
         let manager = Session(requestQueue: requestQueue, serializationQueue: serializationQueue)
         let expectation = self.expectation(description: "request should complete")
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         manager.request("https://httpbin.org/get").responseJSON { (resp) in
@@ -228,11 +228,11 @@ final class RequestResponseTestCase: BaseTestCase {
         // Given
         let parameters = HTTPBinParameters(property: "one")
         let expect = expectation(description: "request should complete")
-        var receivedResponse: DataResponse<HTTPBinResponse, Error>?
+        var receivedResponse: DataResponse<HTTPBinResponse, AFError>?
 
         // When
         AF.request("https://httpbin.org/post", method: .post, parameters: parameters, encoder: JSONParameterEncoder.default)
-          .responseDecodable { (response: DataResponse<HTTPBinResponse, Error>) in
+          .responseDecodable { (response: DataResponse<HTTPBinResponse, AFError>) in
               receivedResponse = response
               expect.fulfill()
           }
@@ -247,11 +247,11 @@ final class RequestResponseTestCase: BaseTestCase {
         // Given
         let parameters = HTTPBinParameters(property: "one")
         let expect = expectation(description: "request should complete")
-        var receivedResponse: DataResponse<HTTPBinResponse, Error>?
+        var receivedResponse: DataResponse<HTTPBinResponse, AFError>?
 
         // When
         AF.request("https://httpbin.org/get", method: .get, parameters: parameters)
-          .responseDecodable { (response: DataResponse<HTTPBinResponse, Error>) in
+          .responseDecodable { (response: DataResponse<HTTPBinResponse, AFError>) in
               receivedResponse = response
               expect.fulfill()
           }
@@ -266,11 +266,11 @@ final class RequestResponseTestCase: BaseTestCase {
         // Given
         let parameters = HTTPBinParameters(property: "one")
         let expect = expectation(description: "request should complete")
-        var receivedResponse: DataResponse<HTTPBinResponse, Error>?
+        var receivedResponse: DataResponse<HTTPBinResponse, AFError>?
 
         // When
         AF.request("https://httpbin.org/post", method: .post, parameters: parameters)
-            .responseDecodable { (response: DataResponse<HTTPBinResponse, Error>) in
+            .responseDecodable { (response: DataResponse<HTTPBinResponse, AFError>) in
                 receivedResponse = response
                 expect.fulfill()
         }
@@ -644,8 +644,8 @@ final class RequestResponseTestCase: BaseTestCase {
         // Given
         let session = Session()
 
-        var response1: DataResponse<Any, Error>?
-        var response2: DataResponse<Any, Error>?
+        var response1: DataResponse<Any, AFError>?
+        var response2: DataResponse<Any, AFError>?
 
         let expect = expectation(description: "both response serializer completions should be called")
         expect.expectedFulfillmentCount = 2
@@ -668,17 +668,17 @@ final class RequestResponseTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        XCTAssertEqual(response1?.error?.asAFError?.isExplicitlyCancelledError, true)
-        XCTAssertEqual(response2?.error?.asAFError?.isExplicitlyCancelledError, true)
+        XCTAssertEqual(response1?.error?.underlyingError?.asAFError?.isExplicitlyCancelledError, true)
+        XCTAssertEqual(response2?.error?.underlyingError?.asAFError?.isExplicitlyCancelledError, true)
     }
 
     func testThatAppendingResponseSerializerToCompletedRequestInsideCompletionResumesRequest() {
         // Given
         let session = Session()
 
-        var response1: DataResponse<Any, Error>?
-        var response2: DataResponse<Any, Error>?
-        var response3: DataResponse<Any, Error>?
+        var response1: DataResponse<Any, AFError>?
+        var response2: DataResponse<Any, AFError>?
+        var response3: DataResponse<Any, AFError>?
 
         let expect = expectation(description: "both response serializer completions should be called")
         expect.expectedFulfillmentCount = 3
@@ -714,9 +714,9 @@ final class RequestResponseTestCase: BaseTestCase {
         let session = Session()
         let request = session.request(URLRequest.makeHTTPBinRequest())
 
-        var response1: DataResponse<Any, Error>?
-        var response2: DataResponse<Any, Error>?
-        var response3: DataResponse<Any, Error>?
+        var response1: DataResponse<Any, AFError>?
+        var response2: DataResponse<Any, AFError>?
+        var response3: DataResponse<Any, AFError>?
 
         // When
         let expect1 = expectation(description: "response serializer 1 completion should be called")

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -232,7 +232,7 @@ final class RequestResponseTestCase: BaseTestCase {
 
         // When
         AF.request("https://httpbin.org/post", method: .post, parameters: parameters, encoder: JSONParameterEncoder.default)
-          .responseDecodable { (response: DataResponse<HTTPBinResponse, AFError>) in
+        .responseDecodable(of: HTTPBinResponse.self) { response in
               receivedResponse = response
               expect.fulfill()
           }
@@ -251,7 +251,7 @@ final class RequestResponseTestCase: BaseTestCase {
 
         // When
         AF.request("https://httpbin.org/get", method: .get, parameters: parameters)
-          .responseDecodable { (response: DataResponse<HTTPBinResponse, AFError>) in
+        .responseDecodable(of: HTTPBinResponse.self) { response in
               receivedResponse = response
               expect.fulfill()
           }
@@ -270,7 +270,7 @@ final class RequestResponseTestCase: BaseTestCase {
 
         // When
         AF.request("https://httpbin.org/post", method: .post, parameters: parameters)
-            .responseDecodable { (response: DataResponse<HTTPBinResponse, AFError>) in
+        .responseDecodable(of: HTTPBinResponse.self) { response in
                 receivedResponse = response
                 expect.fulfill()
         }

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -541,7 +541,7 @@ class ResponseMapErrorTestCase: BaseTestCase {
 
             expectation.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -32,7 +32,7 @@ class ResponseTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).response { resp in
@@ -55,7 +55,7 @@ class ResponseTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail with 404")
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).response { resp in
@@ -82,7 +82,7 @@ class ResponseDataTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Data, Error>?
+        var response: DataResponse<Data, AFError>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
@@ -106,7 +106,7 @@ class ResponseDataTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail with 404")
 
-        var response: DataResponse<Data, Error>?
+        var response: DataResponse<Data, AFError>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
@@ -133,7 +133,7 @@ class ResponseStringTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<String, Error>?
+        var response: DataResponse<String, AFError>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseString { resp in
@@ -157,7 +157,7 @@ class ResponseStringTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail with 404")
 
-        var response: DataResponse<String, Error>?
+        var response: DataResponse<String, AFError>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseString { resp in
@@ -184,7 +184,7 @@ class ResponseJSONTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -208,7 +208,7 @@ class ResponseJSONTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail")
 
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -231,7 +231,7 @@ class ResponseJSONTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -264,7 +264,7 @@ class ResponseJSONTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/post"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         AF.request(urlString, method: .post, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -299,10 +299,10 @@ class ResponseJSONDecodableTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<HTTPBinResponse, Error>?
+        var response: DataResponse<HTTPBinResponse, AFError>?
 
         // When
-        AF.request(urlString, parameters: [:]).responseDecodable { (resp: DataResponse<HTTPBinResponse, Error>) in
+        AF.request(urlString, parameters: [:]).responseDecodable { (resp: DataResponse<HTTPBinResponse, AFError>) in
             response = resp
             expectation.fulfill()
         }
@@ -323,7 +323,7 @@ class ResponseJSONDecodableTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<HTTPBinResponse, Error>?
+        var response: DataResponse<HTTPBinResponse, AFError>?
 
         // When
         AF.request(urlString, parameters: [:]).responseDecodable(of: HTTPBinResponse.self) {
@@ -347,10 +347,10 @@ class ResponseJSONDecodableTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail")
 
-        var response: DataResponse<HTTPBinResponse, Error>?
+        var response: DataResponse<HTTPBinResponse, AFError>?
 
         // When
-        AF.request(urlString, parameters: [:]).responseDecodable { (resp: DataResponse<HTTPBinResponse, Error>) in
+        AF.request(urlString, parameters: [:]).responseDecodable { (resp: DataResponse<HTTPBinResponse, AFError>) in
             response = resp
             expectation.fulfill()
         }
@@ -374,7 +374,7 @@ class ResponseMapTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<String, Error>?
+        var response: DataResponse<String, AFError>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -402,7 +402,7 @@ class ResponseMapTestCase: BaseTestCase {
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
         let expectation = self.expectation(description: "request should fail with 404")
 
-        var response: DataResponse<String, Error>?
+        var response: DataResponse<String, AFError>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
@@ -631,7 +631,7 @@ class ResponseTryMapErrorTestCase: BaseTestCase {
             XCTFail("tryMapError should catch the transformation error")
         }
 
-        XCTAssertNotNil(response.metrics)
+        XCTAssertNotNil(response?.metrics)
     }
 
     func testThatTryMapErrorTransformsError() {

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -302,7 +302,7 @@ class ResponseJSONDecodableTestCase: BaseTestCase {
         var response: DataResponse<HTTPBinResponse, AFError>?
 
         // When
-        AF.request(urlString, parameters: [:]).responseDecodable { (resp: DataResponse<HTTPBinResponse, AFError>) in
+        AF.request(urlString, parameters: [:]).responseDecodable(of: HTTPBinResponse.self) { resp in
             response = resp
             expectation.fulfill()
         }
@@ -350,7 +350,7 @@ class ResponseJSONDecodableTestCase: BaseTestCase {
         var response: DataResponse<HTTPBinResponse, AFError>?
 
         // When
-        AF.request(urlString, parameters: [:]).responseDecodable { (resp: DataResponse<HTTPBinResponse, AFError>) in
+        AF.request(urlString, parameters: [:]).responseDecodable(of: HTTPBinResponse.self) { resp in
             response = resp
             expectation.fulfill()
         }

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -541,7 +541,7 @@ class ResponseMapErrorTestCase: BaseTestCase {
 
             expectation.fulfill()
         }
-
+        
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
@@ -549,7 +549,7 @@ class ResponseMapErrorTestCase: BaseTestCase {
         XCTAssertNil(response?.response)
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
-        guard let error = response?.error, case .error = error else { XCTFail(); return }
+        guard let error = response?.error, case TestError.error = error else { XCTFail(); return }
 
         XCTAssertNotNil(response?.metrics)
     }

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -549,7 +549,7 @@ class ResponseMapErrorTestCase: BaseTestCase {
         XCTAssertNil(response?.response)
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
-        guard let error = response?.error, case TestError.error = error else { XCTFail(); return }
+        guard let error = response?.error, case .error = error else { XCTFail(); return }
 
         XCTAssertNotNil(response?.metrics)
     }

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -631,7 +631,7 @@ class ResponseTryMapErrorTestCase: BaseTestCase {
             XCTFail("tryMapError should catch the transformation error")
         }
 
-        XCTAssertNotNil(response?.metrics)
+        XCTAssertNotNil(response.metrics)
     }
 
     func testThatTryMapErrorTransformsError() {

--- a/Tests/SessionDelegateTests.swift
+++ b/Tests/SessionDelegateTests.swift
@@ -45,7 +45,7 @@ class SessionDelegateTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "Request should redirect to \(redirectURLString)")
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         manager.request(urlString)
@@ -73,7 +73,7 @@ class SessionDelegateTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "Request should redirect to \(redirectURLString)")
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         manager.request(urlString)
@@ -103,7 +103,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var resumedTaskRequest: Request?
         var completedTaskRequest: Request?
         var completedRequest: Request?
-        var requestResponse: DataResponse<Data?, Error>?
+        var requestResponse: DataResponse<Data?, AFError>?
         let expect = expectation(description: "request should complete")
 
         // When
@@ -157,7 +157,7 @@ class SessionDelegateTestCase: BaseTestCase {
         var resumedTaskRequest: Request?
         var completedTaskRequest: Request?
         var completedRequest: Request?
-        var requestResponse: DownloadResponse<URL?, Error>?
+        var requestResponse: DownloadResponse<URL?, AFError>?
         let expect = expectation(description: "request should complete")
 
         // When

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -1190,8 +1190,8 @@ final class SessionTestCase: BaseTestCase {
         }
 
         if let error = response?.result.error {
-            XCTAssertTrue(error.isRequestRetryError)
-            XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "/invalid/url/2")
+            XCTAssertTrue(error.isInvalidURLError)
+            XCTAssertEqual(error.urlConvertible as? String, "/invalid/url/2")
         } else {
             XCTFail("error should not be nil")
         }
@@ -1283,15 +1283,9 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(errors.count, 2)
 
         for (index, error) in errors.enumerated() {
-            XCTAssertTrue(error.isRequestRetryError)
-            XCTAssertEqual(error.localizedDescription.starts(with: "Request retry failed with retry error"), true)
-
-            if case let .requestRetryFailed(retryError, originalError) = error {
-                XCTAssertEqual(try retryError.asAFError?.urlConvertible?.asURL().absoluteString, "/invalid/url/\(index + 1)")
-                XCTAssertTrue(originalError.localizedDescription.starts(with: "JSON could not be serialized"))
-            } else {
-                XCTFail("Error failure reason should be response serialization failure")
-            }
+            XCTAssertTrue(error.isInvalidURLError)
+            XCTAssertEqual(error.localizedDescription.starts(with: "URL is not valid"), true)
+            XCTAssertEqual(try error.urlConvertible?.asURL().absoluteString, "/invalid/url/\(index + 1)")
         }
     }
 

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -321,9 +321,9 @@ final class SessionTestCase: BaseTestCase {
         let brotliExpectation = expectation(description: "brotli request should complete")
         let gzipExpectation = expectation(description: "gzip request should complete")
         let deflateExpectation = expectation(description: "deflate request should complete")
-        var brotliResponse: DataResponse<Any, Error>?
-        var gzipResponse: DataResponse<Any, Error>?
-        var deflateResponse: DataResponse<Any, Error>?
+        var brotliResponse: DataResponse<Any, AFError>?
+        var gzipResponse: DataResponse<Any, AFError>?
+        var deflateResponse: DataResponse<Any, AFError>?
 
         // When
         AF.request(brotliURL).responseJSON { response in
@@ -391,7 +391,7 @@ final class SessionTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "\(url)")
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         let request = session.request(urlRequest)
@@ -408,7 +408,7 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertTrue(request.isCancelled)
         XCTAssertTrue((request.task == nil) || (request.task?.state == .canceling || request.task?.state == .completed))
 
-        guard let error = request.error?.asAFError, case .explicitlyCancelled = error else {
+        guard let error = request.error, case .explicitlyCancelled = error else {
             XCTFail("Request should have an .explicitlyCancelled error.")
             return
         }
@@ -423,7 +423,7 @@ final class SessionTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "\(url)")
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         let request = session.request(urlRequest)
@@ -442,7 +442,7 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertTrue(request.isCancelled)
         XCTAssertTrue((request.task == nil) || (request.task?.state == .canceling || request.task?.state == .completed))
 
-        guard let error = request.error?.asAFError, case .explicitlyCancelled = error else {
+        guard let error = request.error, case .explicitlyCancelled = error else {
             XCTFail("Request should have an .explicitlyCancelled error.")
             return
         }
@@ -457,7 +457,7 @@ final class SessionTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "\(url)")
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         let request = session.request(urlRequest)
@@ -475,7 +475,7 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertTrue(request.isCancelled)
         XCTAssertTrue((request.task == nil) || (request.task?.state == .canceling || request.task?.state == .completed))
 
-        guard let error = request.error?.asAFError, case .explicitlyCancelled = error else {
+        guard let error = request.error, case .explicitlyCancelled = error else {
             XCTFail("Request should have an .explicitlyCancelled error.")
             return
         }
@@ -530,7 +530,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
         let expectation = self.expectation(description: "Request should fail with error")
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         session.request("https://httpbin.org/get/äëïöü").response { resp in
@@ -546,7 +546,7 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertNotNil(response?.error)
 
-        if let error = response?.error?.asAFError {
+        if let error = response?.error {
             XCTAssertTrue(error.isInvalidURLError)
             XCTAssertEqual(error.urlConvertible as? String, "https://httpbin.org/get/äëïöü")
         } else {
@@ -559,7 +559,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
         let expectation = self.expectation(description: "Download should fail with error")
 
-        var response: DownloadResponse<URL?, Error>?
+        var response: DownloadResponse<URL?, AFError>?
 
         // When
         session.download("https://httpbin.org/get/äëïöü").response { resp in
@@ -576,7 +576,7 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertNil(response?.resumeData)
         XCTAssertNotNil(response?.error)
 
-        if let error = response?.error?.asAFError {
+        if let error = response?.error {
             XCTAssertTrue(error.isInvalidURLError)
             XCTAssertEqual(error.urlConvertible as? String, "https://httpbin.org/get/äëïöü")
         } else {
@@ -589,7 +589,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
         let expectation = self.expectation(description: "Upload should fail with error")
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         session.upload(Data(), to: "https://httpbin.org/get/äëïöü").response { resp in
@@ -605,7 +605,7 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertNotNil(response?.error)
 
-        if let error = response?.error?.asAFError {
+        if let error = response?.error {
             XCTAssertTrue(error.isInvalidURLError)
             XCTAssertEqual(error.urlConvertible as? String, "https://httpbin.org/get/äëïöü")
         } else {
@@ -618,7 +618,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
         let expectation = self.expectation(description: "Upload should fail with error")
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         session.upload(URL(fileURLWithPath: "/invalid"), to: "https://httpbin.org/get/äëïöü").response { resp in
@@ -634,7 +634,7 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertNotNil(response?.error)
 
-        if let error = response?.error?.asAFError {
+        if let error = response?.error {
             XCTAssertTrue(error.isInvalidURLError)
             XCTAssertEqual(error.urlConvertible as? String, "https://httpbin.org/get/äëïöü")
         } else {
@@ -647,7 +647,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
         let expectation = self.expectation(description: "Upload should fail with error")
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         session.upload(InputStream(data: Data()), to: "https://httpbin.org/get/äëïöü").response { resp in
@@ -663,7 +663,7 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertNotNil(response?.error)
 
-        if let error = response?.error?.asAFError {
+        if let error = response?.error {
             XCTAssertTrue(error.isInvalidURLError)
             XCTAssertEqual(error.urlConvertible as? String, "https://httpbin.org/get/äëïöü")
         } else {
@@ -858,7 +858,7 @@ final class SessionTestCase: BaseTestCase {
 
         // Then
         for request in requests {
-            if let error = request.error?.asAFError {
+            if let error = request.error {
                 XCTAssertTrue(error.isRequestAdaptationError)
                 XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "")
             } else {
@@ -876,7 +876,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         let request = session.request("https://httpbin.org/basic-auth/user/password", interceptor: handler)
@@ -909,7 +909,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session(interceptor: sessionHandler)
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         let request = session.request("https://httpbin.org/basic-auth/user/password", interceptor: requestHandler)
@@ -948,7 +948,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         session.request("https://httpbin.org/basic-auth/user/password", interceptor: handler)
@@ -982,7 +982,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DownloadResponse<Any, Error>?
+        var response: DownloadResponse<Any, AFError>?
 
         let destination: DownloadRequest.Destination = { _, _ in
             let fileURL = self.testDirectoryURL.appendingPathComponent("test-output.json")
@@ -1017,7 +1017,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session(interceptor: handler)
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
 
         let uploadData = Data("upload data".utf8)
 
@@ -1051,7 +1051,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session(interceptor: handler)
 
         let expectation = self.expectation(description: "request should eventually succeed")
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         let request = session.request("https://httpbin.org/basic-auth/user/password")
@@ -1084,7 +1084,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session(interceptor: handler)
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         let request = session.request("https://httpbin.org/basic-auth/user/password")
@@ -1108,7 +1108,7 @@ final class SessionTestCase: BaseTestCase {
             XCTAssertTrue(session.activeRequests.isEmpty)
         }
 
-        if let error = response?.result.error?.asAFError {
+        if let error = response?.result.error {
             XCTAssertTrue(error.isRequestAdaptationError)
             XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "/adapt/error/2")
         } else {
@@ -1125,7 +1125,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session(interceptor: handler)
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         let request = session.request("https://httpbin.org/basic-auth/user/password")
@@ -1149,7 +1149,7 @@ final class SessionTestCase: BaseTestCase {
             XCTAssertTrue(session.activeRequests.isEmpty)
         }
 
-        if let error = response?.result.error?.asAFError {
+        if let error = response?.result.error {
             XCTAssertTrue(error.isRequestAdaptationError)
             XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "/adapt/error/2")
         } else {
@@ -1165,7 +1165,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session(interceptor: handler)
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         let request = session.request("https://httpbin.org/basic-auth/user/password")
@@ -1189,7 +1189,7 @@ final class SessionTestCase: BaseTestCase {
             XCTAssertTrue(session.activeRequests.isEmpty)
         }
 
-        if let error = response?.result.error?.asAFError {
+        if let error = response?.result.error {
             XCTAssertTrue(error.isRequestRetryError)
             XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "/invalid/url/2")
         } else {
@@ -1207,7 +1207,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         let request = session.request("https://httpbin.org/image/jpeg", interceptor: handler)
@@ -1231,7 +1231,7 @@ final class SessionTestCase: BaseTestCase {
             XCTAssertTrue(session.activeRequests.isEmpty)
         }
 
-        if let error = response?.error?.asAFError {
+        if let error = response?.error {
             XCTAssertTrue(error.isResponseSerializationError)
             XCTAssertTrue(error.localizedDescription.starts(with: "JSON could not be serialized"))
         } else {
@@ -1247,10 +1247,10 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let json1Expectation = self.expectation(description: "request should eventually fail")
-        var json1Response: DataResponse<Any, Error>?
+        var json1Response: DataResponse<Any, AFError>?
 
         let json2Expectation = self.expectation(description: "request should eventually fail")
-        var json2Response: DataResponse<Any, Error>?
+        var json2Response: DataResponse<Any, AFError>?
 
         // When
         let request = session.request("https://httpbin.org/image/jpeg", interceptor: handler)
@@ -1279,7 +1279,7 @@ final class SessionTestCase: BaseTestCase {
             XCTAssertTrue(session.activeRequests.isEmpty)
         }
 
-        let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error?.asAFError }
+        let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error }
         XCTAssertEqual(errors.count, 2)
 
         for (index, error) in errors.enumerated() {
@@ -1288,7 +1288,7 @@ final class SessionTestCase: BaseTestCase {
 
             if case let .requestRetryFailed(retryError, originalError) = error {
                 XCTAssertEqual(try retryError.asAFError?.urlConvertible?.asURL().absoluteString, "/invalid/url/\(index + 1)")
-                XCTAssertTrue(originalError.localizedDescription.starts(with: "JSON could not be serialized"))
+                XCTAssertEqual(originalError?.localizedDescription.starts(with: "JSON could not be serialized"), true)
             } else {
                 XCTFail("Error failure reason should be response serialization failure")
             }
@@ -1301,10 +1301,10 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let json1Expectation = self.expectation(description: "request should eventually fail")
-        var json1Response: DataResponse<Any, Error>?
+        var json1Response: DataResponse<Any, AFError>?
 
         let json2Expectation = self.expectation(description: "request should eventually fail")
-        var json2Response: DataResponse<Any, Error>?
+        var json2Response: DataResponse<Any, AFError>?
 
         // When
         let request = session.request("https://httpbin.org/image/jpeg", interceptor: handler)
@@ -1333,7 +1333,7 @@ final class SessionTestCase: BaseTestCase {
             XCTAssertTrue(session.activeRequests.isEmpty)
         }
 
-        let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error?.asAFError }
+        let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error }
         XCTAssertEqual(errors.count, 2)
 
         for error in errors {
@@ -1356,10 +1356,10 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let json1Expectation = self.expectation(description: "request should eventually fail")
-        var json1Response: DataResponse<Any, Error>?
+        var json1Response: DataResponse<Any, AFError>?
 
         let json2Expectation = self.expectation(description: "request should eventually fail")
-        var json2Response: DataResponse<Any, Error>?
+        var json2Response: DataResponse<Any, AFError>?
 
         // When
         let request = session.request("https://httpbin.org/image/jpeg", interceptor: handler)
@@ -1388,7 +1388,7 @@ final class SessionTestCase: BaseTestCase {
             XCTAssertTrue(session.activeRequests.isEmpty)
         }
 
-        let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error?.asAFError }
+        let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error }
         XCTAssertEqual(errors.count, 2)
 
         for error in errors {
@@ -1411,10 +1411,10 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let json1Expectation = self.expectation(description: "request should eventually fail")
-        var json1Response: DownloadResponse<Any, Error>?
+        var json1Response: DownloadResponse<Any, AFError>?
 
         let json2Expectation = self.expectation(description: "request should eventually fail")
-        var json2Response: DownloadResponse<Any, Error>?
+        var json2Response: DownloadResponse<Any, AFError>?
 
         // When
         let request = session.download("https://httpbin.org/image/jpeg", interceptor: handler)
@@ -1443,7 +1443,7 @@ final class SessionTestCase: BaseTestCase {
             XCTAssertTrue(session.activeRequests.isEmpty)
         }
 
-        let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error?.asAFError }
+        let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error }
         XCTAssertEqual(errors.count, 2)
 
         for error in errors {
@@ -1462,7 +1462,7 @@ final class SessionTestCase: BaseTestCase {
             invalidationExpectation.fulfill()
         }
         var session: Session? = Session(startRequestsImmediately: false, eventMonitors: [events])
-        var error: Error?
+        var error: AFError?
         let requestExpectation = expectation(description: "request should complete")
 
         // When
@@ -1475,7 +1475,7 @@ final class SessionTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        assertErrorIsAFError(error) { XCTAssertTrue($0.isSessionDeinitializedError) }
+        XCTAssertEqual(error?.isSessionDeinitializedError, true)
     }
 
     // MARK: Tests - Request Cancellation
@@ -1486,7 +1486,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let expectation = self.expectation(description: "request should complete")
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
         var completionCallCount = 0
 
         // When
@@ -1525,7 +1525,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let expectation = self.expectation(description: "request should complete")
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         let request = session.request("https://httpbin.org/get").responseJSON { resp in
@@ -1548,7 +1548,7 @@ final class SessionCancellationTestCase: BaseTestCase {
         // Given
         let count = 100
         let session = Session()
-        var responses: [DataResponse<Data?, Error>] = []
+        var responses: [DataResponse<Data?, AFError>] = []
         let completion = expectation(description: "all requests should finish")
         completion.expectedFulfillmentCount = count
         let cancellation = expectation(description: "cancel all requests should be called")
@@ -1568,7 +1568,7 @@ final class SessionCancellationTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout)
 
         // Then
-        XCTAssertTrue(responses.allSatisfy { $0.error?.asAFError?.isExplicitlyCancelledError == true })
+        XCTAssertTrue(responses.allSatisfy { $0.error?.isExplicitlyCancelledError == true })
         assert(on: session.rootQueue) {
             XCTAssertTrue(session.requestTaskMap.isEmpty, "requestTaskMap should be empty but has \(session.requestTaskMap.count) items")
             XCTAssertTrue(session.activeRequests.isEmpty, "activeRequests should be empty but has \(session.activeRequests.count) items")
@@ -1580,7 +1580,7 @@ final class SessionCancellationTestCase: BaseTestCase {
         let count = 100
         let session = Session(startRequestsImmediately: false)
         let request = URLRequest.makeHTTPBinRequest(path: "delay/1")
-        var responses: [DataResponse<Data?, Error>] = []
+        var responses: [DataResponse<Data?, AFError>] = []
         let completion = expectation(description: "all requests should finish")
         completion.expectedFulfillmentCount = count
         let cancellation = expectation(description: "cancel all requests should be called")
@@ -1599,7 +1599,7 @@ final class SessionCancellationTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout)
 
         // Then
-        XCTAssertTrue(responses.allSatisfy { $0.error?.asAFError?.isExplicitlyCancelledError == true })
+        XCTAssertTrue(responses.allSatisfy { $0.error?.isExplicitlyCancelledError == true })
         assert(on: session.rootQueue) {
             XCTAssertTrue(session.requestTaskMap.isEmpty, "requestTaskMap should be empty but has \(session.requestTaskMap.count) items")
             XCTAssertTrue(session.activeRequests.isEmpty, "activeRequests should be empty but has \(session.activeRequests.count) items")
@@ -1633,7 +1633,7 @@ final class SessionCancellationTestCase: BaseTestCase {
             }
         }
 
-        var received: DataResponse<Data?, Error>?
+        var received: DataResponse<Data?, AFError>?
 
         // When
         session.request(request).validate().response { (response) in
@@ -1644,7 +1644,7 @@ final class SessionCancellationTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout)
 
         // Then
-        XCTAssertTrue(received?.error?.asAFError?.isExplicitlyCancelledError == true)
+        XCTAssertTrue(received?.error?.isExplicitlyCancelledError == true)
         assert(on: session.rootQueue) {
             XCTAssertTrue(session.requestTaskMap.isEmpty, "requestTaskMap should be empty but has \(session.requestTaskMap.count) items")
             XCTAssertTrue(session.activeRequests.isEmpty, "activeRequests should be empty but has \(session.activeRequests.count) items")
@@ -1657,7 +1657,7 @@ final class SessionCancellationTestCase: BaseTestCase {
         var request = URLRequest.makeHTTPBinRequest()
         request.httpBody = Data("invalid".utf8)
         let expect = expectation(description: "request should complete")
-        var response: DataResponse<HTTPBinResponse, Error>?
+        var response: DataResponse<HTTPBinResponse, AFError>?
 
         // When
         session.request(request).responseDecodable(of: HTTPBinResponse.self) { resp in
@@ -1669,7 +1669,7 @@ final class SessionCancellationTestCase: BaseTestCase {
 
         // Then
         XCTAssertEqual(response?.result.isFailure, true)
-        XCTAssertEqual(response?.error?.asAFError?.isBodyDataInGETRequest, true)
+        XCTAssertEqual(response?.error?.isBodyDataInGETRequest, true)
     }
 
     func testThatAdaptedGETRequestsWithBodyDataAreConsideredInvalid() {
@@ -1687,7 +1687,7 @@ final class SessionCancellationTestCase: BaseTestCase {
         let session = Session(interceptor: InvalidAdapter())
         let request = URLRequest.makeHTTPBinRequest()
         let expect = expectation(description: "request should complete")
-        var response: DataResponse<HTTPBinResponse, Error>?
+        var response: DataResponse<HTTPBinResponse, AFError>?
 
         // When
         session.request(request).responseDecodable(of: HTTPBinResponse.self) { resp in
@@ -1699,7 +1699,7 @@ final class SessionCancellationTestCase: BaseTestCase {
 
         // Then
         XCTAssertEqual(response?.result.isFailure, true)
-        XCTAssertEqual(response?.error?.asAFError?.underlyingError?.asAFError?.isBodyDataInGETRequest, true)
+        XCTAssertEqual(response?.error?.underlyingError?.asAFError?.isBodyDataInGETRequest, true)
     }
 }
 
@@ -1754,7 +1754,7 @@ final class SessionConfigurationHeadersTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "request should complete successfully")
 
-        var response: DataResponse<Any, Error>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         session.request("https://httpbin.org/headers")

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -859,8 +859,8 @@ final class SessionTestCase: BaseTestCase {
         // Then
         for request in requests {
             if let error = request.error {
-                XCTAssertTrue(error.isRequestAdaptationError)
-                XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "")
+                XCTAssertTrue(error.isInvalidURLError)
+                XCTAssertEqual(error.urlConvertible as? String, "")
             } else {
                 XCTFail("error should not be nil")
             }
@@ -1109,8 +1109,8 @@ final class SessionTestCase: BaseTestCase {
         }
 
         if let error = response?.result.error {
-            XCTAssertTrue(error.isRequestAdaptationError)
-            XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "/adapt/error/2")
+            XCTAssertTrue(error.isInvalidURLError)
+            XCTAssertEqual(error.urlConvertible as? String, "/adapt/error/2")
         } else {
             XCTFail("error should not be nil")
         }
@@ -1150,8 +1150,8 @@ final class SessionTestCase: BaseTestCase {
         }
 
         if let error = response?.result.error {
-            XCTAssertTrue(error.isRequestAdaptationError)
-            XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "/adapt/error/2")
+            XCTAssertTrue(error.isInvalidURLError)
+            XCTAssertEqual(error.urlConvertible as? String, "/adapt/error/2")
         } else {
             XCTFail("error should not be nil")
         }
@@ -1392,8 +1392,8 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(errors.count, 2)
 
         for error in errors {
-            XCTAssertTrue(error.isRequestAdaptationError)
-            XCTAssertEqual(error.localizedDescription, "Request adaption failed with error: URL is not valid: /adapt/error/2")
+            XCTAssertTrue(error.isInvalidURLError)
+            XCTAssertEqual(error.localizedDescription, "URL is not valid: /adapt/error/2")
         }
     }
 
@@ -1447,8 +1447,8 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(errors.count, 2)
 
         for error in errors {
-            XCTAssertTrue(error.isRequestAdaptationError)
-            XCTAssertEqual(error.localizedDescription, "Request adaption failed with error: URL is not valid: /adapt/error/2")
+            XCTAssertTrue(error.isInvalidURLError)
+            XCTAssertEqual(error.localizedDescription, "URL is not valid: /adapt/error/2")
         }
     }
 
@@ -1699,7 +1699,7 @@ final class SessionCancellationTestCase: BaseTestCase {
 
         // Then
         XCTAssertEqual(response?.result.isFailure, true)
-        XCTAssertEqual(response?.error?.underlyingError?.asAFError?.isBodyDataInGETRequest, true)
+        XCTAssertEqual(response?.error?.isBodyDataInGETRequest, true)
     }
 }
 

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -859,8 +859,8 @@ final class SessionTestCase: BaseTestCase {
         // Then
         for request in requests {
             if let error = request.error {
-                XCTAssertTrue(error.isInvalidURLError)
-                XCTAssertEqual(error.urlConvertible as? String, "")
+                XCTAssertTrue(error.isRequestAdaptationError)
+                XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "")
             } else {
                 XCTFail("error should not be nil")
             }
@@ -1109,8 +1109,8 @@ final class SessionTestCase: BaseTestCase {
         }
 
         if let error = response?.result.error {
-            XCTAssertTrue(error.isInvalidURLError)
-            XCTAssertEqual(error.urlConvertible as? String, "/adapt/error/2")
+            XCTAssertTrue(error.isRequestAdaptationError)
+            XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "/adapt/error/2")
         } else {
             XCTFail("error should not be nil")
         }
@@ -1150,8 +1150,8 @@ final class SessionTestCase: BaseTestCase {
         }
 
         if let error = response?.result.error {
-            XCTAssertTrue(error.isInvalidURLError)
-            XCTAssertEqual(error.urlConvertible as? String, "/adapt/error/2")
+            XCTAssertTrue(error.isRequestAdaptationError)
+            XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "/adapt/error/2")
         } else {
             XCTFail("error should not be nil")
         }
@@ -1392,8 +1392,8 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(errors.count, 2)
 
         for error in errors {
-            XCTAssertTrue(error.isInvalidURLError)
-            XCTAssertEqual(error.localizedDescription, "URL is not valid: /adapt/error/2")
+            XCTAssertTrue(error.isRequestAdaptationError)
+            XCTAssertEqual(error.localizedDescription, "Request adaption failed with error: URL is not valid: /adapt/error/2")
         }
     }
 
@@ -1447,8 +1447,8 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(errors.count, 2)
 
         for error in errors {
-            XCTAssertTrue(error.isInvalidURLError)
-            XCTAssertEqual(error.localizedDescription, "URL is not valid: /adapt/error/2")
+            XCTAssertTrue(error.isRequestAdaptationError)
+            XCTAssertEqual(error.localizedDescription, "Request adaption failed with error: URL is not valid: /adapt/error/2")
         }
     }
 
@@ -1699,7 +1699,7 @@ final class SessionCancellationTestCase: BaseTestCase {
 
         // Then
         XCTAssertEqual(response?.result.isFailure, true)
-        XCTAssertEqual(response?.error?.isBodyDataInGETRequest, true)
+        XCTAssertEqual(response?.error?.underlyingError?.asAFError?.isBodyDataInGETRequest, true)
     }
 }
 

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -1281,11 +1281,11 @@ final class SessionTestCase: BaseTestCase {
 
         let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error?.asAFError }
         XCTAssertEqual(errors.count, 2)
-        
+
         for (index, error) in errors.enumerated() {
             XCTAssertTrue(error.isRequestRetryError)
             XCTAssertEqual(error.localizedDescription.starts(with: "Request retry failed with retry error"), true)
-            
+
             if case let .requestRetryFailed(retryError, originalError) = error {
                 XCTAssertEqual(try retryError.asAFError?.urlConvertible?.asURL().absoluteString, "/invalid/url/\(index + 1)")
                 XCTAssertTrue(originalError.localizedDescription.starts(with: "JSON could not be serialized"))

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -1288,7 +1288,7 @@ final class SessionTestCase: BaseTestCase {
 
             if case let .requestRetryFailed(retryError, originalError) = error {
                 XCTAssertEqual(try retryError.asAFError?.urlConvertible?.asURL().absoluteString, "/invalid/url/\(index + 1)")
-                XCTAssertEqual(originalError?.localizedDescription.starts(with: "JSON could not be serialized"), true)
+                XCTAssertTrue(originalError.localizedDescription.starts(with: "JSON could not be serialized"))
             } else {
                 XCTFail("Error failure reason should be response serialization failure")
             }

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -83,9 +83,9 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error)
 
-        if let error = error as? URLError {
+        if let error = error?.asAFError?.underlyingError as? URLError {
             XCTAssertEqual(error.code, .serverCertificateUntrusted)
-        } else if let error = error as NSError? {
+        } else if let error = error?.asAFError?.underlyingError as NSError? {
             XCTAssertEqual(error.domain, kCFErrorDomainCFNetwork as String)
             XCTAssertEqual(error.code, Int(CFNetworkErrors.cfErrorHTTPSProxyConnectionFailure.rawValue))
         } else {

--- a/Tests/URLProtocolTests.swift
+++ b/Tests/URLProtocolTests.swift
@@ -145,7 +145,7 @@ class URLProtocolTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "GET request should succeed")
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         manager.request(urlRequest)

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -180,7 +180,7 @@ class UploadDataTestCase: BaseTestCase {
         let data = Data("Lorem ipsum dolor sit amet".utf8)
 
         let expectation = self.expectation(description: "Upload request should succeed: \(urlString)")
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         AF.upload(data, to: urlString)
@@ -208,7 +208,7 @@ class UploadDataTestCase: BaseTestCase {
         var uploadProgressValues: [Double] = []
         var downloadProgressValues: [Double] = []
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         AF.upload(data, to: urlString)
@@ -273,7 +273,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         let expectation = self.expectation(description: "multipart form data upload should succeed")
 
         var formData: MultipartFormData?
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         AF.upload(
@@ -315,7 +315,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         formData.append(uploadData, withName: "upload_data")
 
         let expectation = self.expectation(description: "multipart form data upload should succeed")
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         AF.upload(multipartFormData: formData, with: urlRequest).response { resp in
@@ -346,7 +346,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         let japaneseData = Data("日本語".utf8)
 
         let expectation = self.expectation(description: "multipart form data upload should succeed")
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         AF.upload(
@@ -384,7 +384,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         let japaneseData = Data("日本語".utf8)
 
         let expectation = self.expectation(description: "multipart form data upload should succeed")
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         let request = AF.upload(
@@ -417,7 +417,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         let expectation = self.expectation(description: "multipart form data upload should succeed")
 
         var formData: MultipartFormData?
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         let request = AF.upload(
@@ -457,7 +457,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         let japaneseData = Data("日本語".utf8)
 
         let expectation = self.expectation(description: "multipart form data upload should succeed")
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         let request = AF.upload(
@@ -489,7 +489,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         let uploadData = Data("upload_data".utf8)
 
         let expectation = self.expectation(description: "multipart form data upload should succeed")
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
         var formData: MultipartFormData?
 
         // When
@@ -544,7 +544,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         var request: URLRequest?
         var response: HTTPURLResponse?
         var data: Data?
-        var error: Error?
+        var error: AFError?
 
         // When
         let upload = manager.upload(
@@ -592,7 +592,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         var uploadProgressValues: [Double] = []
         var downloadProgressValues: [Double] = []
 
-        var response: DataResponse<Data?, Error>?
+        var response: DataResponse<Data?, AFError>?
 
         // When
         AF.upload(

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -756,7 +756,7 @@ class AutomaticValidationTestCase: BaseTestCase {
 
 private enum ValidationError: Error {
     case missingData, missingFile, fileReadFailed
-    var error: AFError { return AFError(responseValidationError: self) }
+    var error: AFError { return .responseValidationFailed(reason: .customValidationFailed(error: self)) }
 }
 
 extension DataRequest {
@@ -768,7 +768,7 @@ extension DataRequest {
     }
 
     func validate(with error: Error) -> Self {
-        return validate { _, _, _ in .failure(AFError(responseValidationError: error)) }
+        return validate { _, _, _ in .failure(error as? AFError ?? .responseValidationFailed(reason: .customValidationFailed(error: error))) }
     }
 }
 
@@ -789,7 +789,7 @@ extension DownloadRequest {
     }
 
     func validate(with error: Error) -> Self {
-        return validate { (_, _, _) in .failure(AFError(responseValidationError: error)) }
+        return validate { _, _, _ in .failure(error as? AFError ?? .responseValidationFailed(reason: .customValidationFailed(error: error))) }
     }
 }
 

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -767,7 +767,7 @@ extension DataRequest {
     }
 
     func validate(with error: Error) -> Self {
-        return validate { _, _, _ in .failure(error as? AFError ?? .responseValidationFailed(reason: .customValidationFailed(error: error))) }
+        return validate { _, _, _ in .failure(error) }
     }
 }
 


### PR DESCRIPTION
### Goals :soccer:
This is an attempt to make `AFError` the default concrete error type for `Request` and `*Response` types.
This assumes that `*Response` types have been made doubly generic and therefore builds on this PR: https://github.com/Alamofire/Alamofire/pull/2893
@jshier suggested this would be a good use case for making `*Response` doubly generic:
> If we do make the types doubly generic, we should also consider wrapping all errors in AFError, so that the final type is always *Response<T, AFError>, which can then be easily mapped to other error types.
https://github.com/Alamofire/Alamofire/pull/2864#issuecomment-511498432

### Implementation Details :construction:
This PR proposes a rather significant architecture change, which modifies many throwing functions into functions that return `Result`.
This makes it much easier to propagate typed errors, but the potential impact of this needs to be evaluated.

There are also a few new `AFError` members to handle cases where errors were thrown but not wrapped in `AFError`

The `AFResult` and `AF*Response` typealiases now have `AFError` as the concrete failure type.

### Testing Details :mag:
I held off on updating the tests until we've had a chance to discuss the architecture changes.
