### PR TITLE
Unfreeze HTTPMethod

### DIFF
--- a/Source/HTTPMethod.swift
+++ b/Source/HTTPMethod.swift
@@ -22,7 +22,8 @@
 //  THE SOFTWARE.
 //
 
-/// HTTP method definitions.
+/// Type representing HTTP methods. Raw `String` value is stored and compared case-sensitively, so
+/// `HTTPMethod.get != HTTPMethod(rawValue: "get")`.
 ///
 /// See https://tools.ietf.org/html/rfc7231#section-4.3
 public struct HTTPMethod: RawRepresentable, Equatable, Hashable {
@@ -46,11 +47,8 @@ public struct HTTPMethod: RawRepresentable, Equatable, Hashable {
     public static let trace = HTTPMethod(rawValue: "TRACE")
 
     public let rawValue: String
-    
-    /// Creates a new instance with the `uppercased()` version of the specified `rawValue`.
-    /// 
-    /// - Parameter rawValue: The raw `String` value, stored `uppercased`.
+
     public init(rawValue: String) {
-        self.rawValue = rawValue.uppercased()
+        self.rawValue = rawValue
     }
 }

--- a/Source/HTTPMethod.swift
+++ b/Source/HTTPMethod.swift
@@ -25,23 +25,32 @@
 /// HTTP method definitions.
 ///
 /// See https://tools.ietf.org/html/rfc7231#section-4.3
-public enum HTTPMethod: String {
+public struct HTTPMethod: RawRepresentable, Equatable, Hashable {
     /// `CONNECT` method.
-    case connect = "CONNECT"
+    public static let connect = HTTPMethod(rawValue: "CONNECT")
     /// `DELETE` method.
-    case delete  = "DELETE"
+    public static let delete = HTTPMethod(rawValue: "DELETE")
     /// `GET` method.
-    case get     = "GET"
+    public static let get = HTTPMethod(rawValue: "GET")
     /// `HEAD` method.
-    case head    = "HEAD"
+    public static let head = HTTPMethod(rawValue: "HEAD")
     /// `OPTIONS` method.
-    case options = "OPTIONS"
+    public static let options = HTTPMethod(rawValue: "OPTIONS")
     /// `PATCH` method.
-    case patch   = "PATCH"
+    public static let patch = HTTPMethod(rawValue: "PATCH")
     /// `POST` method.
-    case post    = "POST"
+    public static let post = HTTPMethod(rawValue: "POST")
     /// `PUT` method.
-    case put     = "PUT"
+    public static let put = HTTPMethod(rawValue: "PUT")
     /// `TRACE` method.
-    case trace   = "TRACE"
+    public static let trace = HTTPMethod(rawValue: "TRACE")
+
+    public let rawValue: String
+    
+    /// Creates a new instance with the `uppercased()` version of the specified `rawValue`.
+    /// 
+    /// - Parameter rawValue: The raw `String` value, stored `uppercased`.
+    public init(rawValue: String) {
+        self.rawValue = rawValue.uppercased()
+    }
 }

--- a/Source/ParameterEncoder.swift
+++ b/Source/ParameterEncoder.swift
@@ -153,7 +153,7 @@ open class URLEncodedFormParameterEncoder: ParameterEncoder {
             throw AFError.parameterEncoderFailed(reason: .missingRequiredComponent(.url))
         }
 
-        guard let rawMethod = request.httpMethod, let method = HTTPMethod(rawValue: rawMethod) else {
+        guard let method = request.method else {
             let rawValue = request.httpMethod ?? "nil"
             throw AFError.parameterEncoderFailed(reason: .missingRequiredComponent(.httpMethod(rawValue: rawValue)))
         }


### PR DESCRIPTION
### Goals :soccer:
This PR converts `HTTPMethod` from an `enum` into a `struct`. This should allow users to keep using `HTTPMethod` when they have to make calls using methods we don't cover, without having to resort to raw `Strings`s.

### Implementation Details :construction:
`HTTPMethod` is now a `struct` conforming to `RawRepresentable`, `Equatable`, and `Hashable`. No internal changes were necessary except for the use of a no longer optional initializer. All `String`s can be made valid `HTTPMethod`s now, standardizing on the `uppercased()` value of the `String` as the `rawValue`.

### Testing Details :mag:
No tests added, as there's no custom behavior here. Can certainly be added if there's anything that might be necessary.
