### PR TITLE
Add DataPreprocessor API

### DIFF
--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -162,7 +162,7 @@ public enum AFError: Error {
     case sessionDeinitialized
     /// `Session` was explicitly invalidated, possibly with the `Error` produced by the underlying `URLSession`.
     case sessionInvalidated(error: Error?)
-    /// `Request` was explcitly cancelled.
+    /// `Request` was explicitly cancelled.
     case explicitlyCancelled
     /// `URLConvertible` type failed to create a valid `URL`.
     case invalidURL(url: URLConvertible)

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -64,7 +64,7 @@ public protocol DownloadResponseSerializerProtocol {
 
 /// A serializer that can handle both data and download responses.
 public protocol ResponseSerializer: DataResponseSerializerProtocol & DownloadResponseSerializerProtocol {
-    /// `DataPreprocessor` closure used to prepare incoming `Data` for serialization.
+    /// `DataPreprocessor` used to prepare incoming `Data` for serialization.
     var dataPreprocessor: DataPreprocessor { get }
     /// `HTTPMethod`s for which empty response bodies are considered appropriate.
     var emptyRequestMethods: Set<HTTPMethod> { get }

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -80,20 +80,24 @@ public protocol DataPreprocessor {
 }
 
 /// `DataPreprocessor` that returns passed `Data` without any transform.
-struct Passthrough: DataPreprocessor {
-    func preprocess(_ data: Data) throws -> Data { return data }
+public struct PassthroughPreprocessor: DataPreprocessor {
+    public init() { }
+
+    public func preprocess(_ data: Data) throws -> Data { return data }
 }
 
 /// `DataPreprocessor` that trims Google's typical `)]}',\n` XSSI JSON header.
-struct XSSI: DataPreprocessor {
-    func preprocess(_ data: Data) throws -> Data {
+public struct GoogleXSSIPreprocessor: DataPreprocessor {
+    public init() { }
+
+    public func preprocess(_ data: Data) throws -> Data {
         return (data.prefix(6) == Data(")]}',\n".utf8)) ? data.dropFirst(6) : data
     }
 }
 
 extension ResponseSerializer {
-    /// Default `DataPreprocessor` that merely passes `Data` through.
-    public static var defaultDataPreprocessor: DataPreprocessor { return Passthrough() }
+    /// Default `DataPreprocessor`. `PassthroughPreprocessor` by default.
+    public static var defaultDataPreprocessor: DataPreprocessor { return PassthroughPreprocessor() }
     /// Default `HTTPMethod`s for which empty response bodies are considered appropriate. `[.head]` by default.
     public static var defaultEmptyRequestMethods: Set<HTTPMethod> { return [.head] }
     /// HTTP response codes for which empty response bodies are considered appropriate. `[204, 205]` by default.

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -1408,6 +1408,32 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
     }
 }
 
+final class DataPreprocessorTests: BaseTestCase {
+    func testThatPassthroughPreprocessorPassesDataThrough() {
+        // Given
+        let preprocessor = PassthroughPreprocessor()
+        let data = Data("data".utf8)
+        
+        // When
+        let result = Result { try preprocessor.preprocess(data) }
+        
+        // Then
+        XCTAssertEqual(data, result.value, "Preprocessed data should equal original data.")
+    }
+    
+    func testThatGoogleXSSIPreprocessorProperlyPreprocessesData() {
+        // Given
+        let preprocessor = GoogleXSSIPreprocessor()
+        let data = Data(")]}',\nabcd".utf8)
+        
+        // When
+        let result = Result { try preprocessor.preprocess(data) }
+        
+        // Then
+        XCTAssertEqual(result.value.map { String(decoding: $0, as: UTF8.self) }, "abcd")
+    }
+}
+
 extension HTTPURLResponse {
     convenience init(statusCode: Int, headers: HTTPHeaders? = nil) {
         let url = URL(string: "https://httpbin.org/get")!

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -1278,7 +1278,7 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
             return data.dropFirst()
         }
     }
-    
+
     struct Throwing: DataPreprocessor {
         struct Error: Swift.Error { }
 
@@ -1286,7 +1286,7 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
             throw Error()
         }
     }
-    
+
     func testThatDataResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
         // Given
         let preprocessor = DropFirst()
@@ -1316,7 +1316,7 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
         XCTAssertNil(result.value)
         XCTAssertNotNil(result.error)
     }
-    
+
     func testThatStringResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
         // Given
         let preprocessor = DropFirst()
@@ -1346,7 +1346,7 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
         XCTAssertNil(result.value)
         XCTAssertNotNil(result.error)
     }
-    
+
     func testThatJSONResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
         // Given
         let preprocessor = DropFirst()
@@ -1376,7 +1376,7 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
         XCTAssertNil(result.value)
         XCTAssertNotNil(result.error)
     }
-    
+
     func testThatDecodableResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
         // Given
         let preprocessor = DropFirst()

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -1432,6 +1432,18 @@ final class DataPreprocessorTests: BaseTestCase {
         // Then
         XCTAssertEqual(result.value.map { String(decoding: $0, as: UTF8.self) }, "abcd")
     }
+    
+    func testThatGoogleXSSIPreprocessorDoesNotChangeDataIfPrefixDoesNotMatch() {
+        // Given
+        let preprocessor = GoogleXSSIPreprocessor()
+        let data = Data("abcd".utf8)
+        
+        // When
+        let result = Result { try preprocessor.preprocess(data) }
+        
+        // Then
+        XCTAssertEqual(result.value.map { String(decoding: $0, as: UTF8.self) }, "abcd")
+    }
 }
 
 extension HTTPURLResponse {

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -154,37 +154,6 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertEqual(result.value?.count, 0)
     }
 
-    func testThatDataResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
-        // Given
-        let preprocessor: ResponseSerializer.DataPreprocessor =  { data in data.dropFirst() }
-        let serializer = DataResponseSerializer(dataPreprocessor: preprocessor)
-        let data = Data("abcd".utf8)
-
-        // When
-        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
-
-        // Then
-        XCTAssertTrue(result.isSuccess)
-        XCTAssertEqual(result.value, Data("bcd".utf8))
-        XCTAssertNil(result.error)
-    }
-
-    func testThatDataResponseSerializerProperlyReceivesErrorFromFailingDataPreprocessor() {
-        // Given
-        struct Error: Swift.Error { }
-        let preprocessor: ResponseSerializer.DataPreprocessor = { _ in throw Error() }
-        let serializer = DataResponseSerializer(dataPreprocessor: preprocessor)
-        let data = Data("abcd".utf8)
-
-        // When
-        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
-
-        // Then
-        XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-    }
-
     // MARK: StringResponseSerializer
 
     func testThatStringResponseSerializerFailsWhenDataIsNil() {
@@ -395,37 +364,6 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertEqual(result.value, "")
     }
 
-    func testThatStringResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
-        // Given
-        let preprocessor: ResponseSerializer.DataPreprocessor =  { data in data.dropFirst() }
-        let serializer = StringResponseSerializer(dataPreprocessor: preprocessor)
-        let data = Data("abcd".utf8)
-
-        // When
-        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
-
-        // Then
-        XCTAssertTrue(result.isSuccess)
-        XCTAssertEqual(result.value, "bcd")
-        XCTAssertNil(result.error)
-    }
-
-    func testThatStringResponseSerializerProperlyReceivesErrorFromFailingDataPreprocessor() {
-        // Given
-        struct Error: Swift.Error { }
-        let preprocessor: ResponseSerializer.DataPreprocessor = { _ in throw Error() }
-        let serializer = StringResponseSerializer(dataPreprocessor: preprocessor)
-        let data = Data("abcd".utf8)
-
-        // When
-        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
-
-        // Then
-        XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-    }
-
     // MARK: JSONResponseSerializer
 
     func testThatJSONResponseSerializerFailsWhenDataIsNil() {
@@ -586,37 +524,6 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.value)
         XCTAssertNil(result.error)
         XCTAssertEqual(result.value as? NSNull, NSNull())
-    }
-
-    func testThatJSONResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
-        // Given
-        let preprocessor: ResponseSerializer.DataPreprocessor =  { data in data.dropFirst() }
-        let serializer = JSONResponseSerializer(dataPreprocessor: preprocessor)
-        let data = Data("1\"abcd\"".utf8)
-
-        // When
-        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
-
-        // Then
-        XCTAssertTrue(result.isSuccess)
-        XCTAssertEqual(result.value as? String, "abcd")
-        XCTAssertNil(result.error)
-    }
-
-    func testThatJSONResponseSerializerProperlyReceivesErrorFromFailingDataPreprocessor() {
-        // Given
-        struct Error: Swift.Error { }
-        let preprocessor: ResponseSerializer.DataPreprocessor = { _ in throw Error() }
-        let serializer = JSONResponseSerializer(dataPreprocessor: preprocessor)
-        let data = Data("1\"abcd\"".utf8)
-
-        // When
-        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
-
-        // Then
-        XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
     }
 }
 
@@ -852,37 +759,6 @@ final class DecodableResponseSerializerTests: BaseTestCase {
             XCTFail("error should not be nil")
         }
     }
-
-    func testThatDecodableResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
-        // Given
-        let preprocessor: ResponseSerializer.DataPreprocessor =  { data in data.dropFirst() }
-        let serializer = DecodableResponseSerializer<DecodableValue>(dataPreprocessor: preprocessor)
-        let data = Data("1{\"string\":\"string\"}".utf8)
-
-        // When
-        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
-
-        // Then
-        XCTAssertTrue(result.isSuccess)
-        XCTAssertEqual(result.value?.string, "string")
-        XCTAssertNil(result.error)
-    }
-
-    func testThatDecodableResponseSerializerProperlyReceivesErrorFromFailingDataPreprocessor() {
-        // Given
-        struct Error: Swift.Error { }
-        let preprocessor: ResponseSerializer.DataPreprocessor = { _ in throw Error() }
-        let serializer = DecodableResponseSerializer<DecodableValue>(dataPreprocessor: preprocessor)
-        let data = Data("1{\"string\":\"string\"}".utf8)
-
-        // When
-        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
-
-        // Then
-        XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-    }
 }
 
 // MARK: -
@@ -1049,7 +925,6 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
             XCTFail("error should not be nil")
         }
     }
-
 
     func testThatStringResponseSerializerFailsWhenFileURLIsInvalid() {
         // Given
@@ -1372,7 +1247,7 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
     }
 }
 
-final class CustomResponseSerializerTestCases: BaseTestCase {
+final class CustomResponseSerializerTests: BaseTestCase {
     func testThatCustomResponseSerializersCanBeWrittenWithoutCompilerIssues() {
         // Given
         final class UselessResponseSerializer: ResponseSerializer {
@@ -1394,6 +1269,142 @@ final class CustomResponseSerializerTestCases: BaseTestCase {
 
         // Then
         XCTAssertNotNil(data)
+    }
+}
+
+final class DataPreprocessorSerializationTests: BaseTestCase {
+    struct DropFirst: DataPreprocessor {
+        func preprocess(_ data: Data) throws -> Data {
+            return data.dropFirst()
+        }
+    }
+    
+    struct Throwing: DataPreprocessor {
+        struct Error: Swift.Error { }
+
+        func preprocess(_ data: Data) throws -> Data {
+            throw Error()
+        }
+    }
+    
+    func testThatDataResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
+        // Given
+        let preprocessor = DropFirst()
+        let serializer = DataResponseSerializer(dataPreprocessor: preprocessor)
+        let data = Data("abcd".utf8)
+
+        // When
+        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(result.value, Data("bcd".utf8))
+        XCTAssertNil(result.error)
+    }
+
+    func testThatDataResponseSerializerProperlyReceivesErrorFromFailingDataPreprocessor() {
+        // Given
+        let preprocessor = Throwing()
+        let serializer = DataResponseSerializer(dataPreprocessor: preprocessor)
+        let data = Data("abcd".utf8)
+
+        // When
+        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertNil(result.value)
+        XCTAssertNotNil(result.error)
+    }
+    
+    func testThatStringResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
+        // Given
+        let preprocessor = DropFirst()
+        let serializer = StringResponseSerializer(dataPreprocessor: preprocessor)
+        let data = Data("abcd".utf8)
+
+        // When
+        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(result.value, "bcd")
+        XCTAssertNil(result.error)
+    }
+
+    func testThatStringResponseSerializerProperlyReceivesErrorFromFailingDataPreprocessor() {
+        // Given
+        let preprocessor = Throwing()
+        let serializer = StringResponseSerializer(dataPreprocessor: preprocessor)
+        let data = Data("abcd".utf8)
+
+        // When
+        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertNil(result.value)
+        XCTAssertNotNil(result.error)
+    }
+    
+    func testThatJSONResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
+        // Given
+        let preprocessor = DropFirst()
+        let serializer = JSONResponseSerializer(dataPreprocessor: preprocessor)
+        let data = Data("1\"abcd\"".utf8)
+
+        // When
+        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(result.value as? String, "abcd")
+        XCTAssertNil(result.error)
+    }
+
+    func testThatJSONResponseSerializerProperlyReceivesErrorFromFailingDataPreprocessor() {
+        // Given
+        let preprocessor = Throwing()
+        let serializer = JSONResponseSerializer(dataPreprocessor: preprocessor)
+        let data = Data("1\"abcd\"".utf8)
+
+        // When
+        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertNil(result.value)
+        XCTAssertNotNil(result.error)
+    }
+    
+    func testThatDecodableResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
+        // Given
+        let preprocessor = DropFirst()
+        let serializer = DecodableResponseSerializer<DecodableResponseSerializerTests.DecodableValue>(dataPreprocessor: preprocessor)
+        let data = Data("1{\"string\":\"string\"}".utf8)
+
+        // When
+        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(result.value?.string, "string")
+        XCTAssertNil(result.error)
+    }
+
+    func testThatDecodableResponseSerializerProperlyReceivesErrorFromFailingDataPreprocessor() {
+        // Given
+        let preprocessor = Throwing()
+        let serializer = DecodableResponseSerializer<DecodableResponseSerializerTests.DecodableValue>(dataPreprocessor: preprocessor)
+        let data = Data("1{\"string\":\"string\"}".utf8)
+
+        // When
+        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertNil(result.value)
+        XCTAssertNotNil(result.error)
     }
 }
 

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -119,10 +119,7 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(result.value)
         XCTAssertNil(result.error)
-
-        if let data = result.value {
-            XCTAssertEqual(data.count, 0)
-        }
+        XCTAssertEqual(result.value?.count, 0)
     }
 
     func testThatDataResponseSerializerSucceedsWhenDataIsNilWithGETRequestAnd205ResponseStatusCode() {
@@ -138,10 +135,7 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(result.value)
         XCTAssertNil(result.error)
-
-        if let data = result.value {
-            XCTAssertEqual(data.count, 0)
-        }
+        XCTAssertEqual(result.value?.count, 0)
     }
 
     func testThatDataResponseSerializerSucceedsWhenDataIsNilWithHEADRequestAnd200ResponseStatusCode() {
@@ -157,10 +151,38 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(result.value)
         XCTAssertNil(result.error)
+        XCTAssertEqual(result.value?.count, 0)
+    }
 
-        if let data = result.value {
-            XCTAssertEqual(data.count, 0)
-        }
+    func testThatDataResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
+        // Given
+        let preprocessor: ResponseSerializer.DataPreprocessor =  { data in data.dropFirst() }
+        let serializer = DataResponseSerializer(dataPreprocessor: preprocessor)
+        let data = Data("abcd".utf8)
+
+        // When
+        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(result.value, Data("bcd".utf8))
+        XCTAssertNil(result.error)
+    }
+
+    func testThatDataResponseSerializerProperlyReceivesErrorFromFailingDataPreprocessor() {
+        // Given
+        struct Error: Swift.Error { }
+        let preprocessor: ResponseSerializer.DataPreprocessor = { _ in throw Error() }
+        let serializer = DataResponseSerializer(dataPreprocessor: preprocessor)
+        let data = Data("abcd".utf8)
+
+        // When
+        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertNil(result.value)
+        XCTAssertNotNil(result.error)
     }
 
     // MARK: StringResponseSerializer
@@ -338,10 +360,7 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(result.value)
         XCTAssertNil(result.error)
-
-        if let string = result.value {
-            XCTAssertEqual(string, "")
-        }
+        XCTAssertEqual(result.value, "")
     }
 
     func testThatStringResponseSerializerSucceedsWhenDataIsNilWithGETRequestAnd205ResponseStatusCode() {
@@ -357,10 +376,7 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(result.value)
         XCTAssertNil(result.error)
-
-        if let string = result.value {
-            XCTAssertEqual(string, "")
-        }
+        XCTAssertEqual(result.value, "")
     }
 
     func testThatStringResponseSerializerSucceedsWhenDataIsNilWithHEADRequestAnd200ResponseStatusCode() {
@@ -376,10 +392,38 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(result.value)
         XCTAssertNil(result.error)
+        XCTAssertEqual(result.value, "")
+    }
 
-        if let string = result.value {
-            XCTAssertEqual(string, "")
-        }
+    func testThatStringResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
+        // Given
+        let preprocessor: ResponseSerializer.DataPreprocessor =  { data in data.dropFirst() }
+        let serializer = StringResponseSerializer(dataPreprocessor: preprocessor)
+        let data = Data("abcd".utf8)
+
+        // When
+        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(result.value, "bcd")
+        XCTAssertNil(result.error)
+    }
+
+    func testThatStringResponseSerializerProperlyReceivesErrorFromFailingDataPreprocessor() {
+        // Given
+        struct Error: Swift.Error { }
+        let preprocessor: ResponseSerializer.DataPreprocessor = { _ in throw Error() }
+        let serializer = StringResponseSerializer(dataPreprocessor: preprocessor)
+        let data = Data("abcd".utf8)
+
+        // When
+        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertNil(result.value)
+        XCTAssertNotNil(result.error)
     }
 
     // MARK: JSONResponseSerializer
@@ -509,12 +553,7 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(result.value)
         XCTAssertNil(result.error)
-
-        if let json = result.value as? NSNull {
-            XCTAssertEqual(json, NSNull())
-        } else {
-            XCTFail("json should not be nil")
-        }
+        XCTAssertEqual(result.value as? NSNull, NSNull())
     }
 
     func testThatJSONResponseSerializerSucceedsWhenDataIsNilWithGETRequestAnd205ResponseStatusCode() {
@@ -530,12 +569,7 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(result.value)
         XCTAssertNil(result.error)
-
-        if let json = result.value as? NSNull {
-            XCTAssertEqual(json, NSNull())
-        } else {
-            XCTFail("json should not be nil")
-        }
+        XCTAssertEqual(result.value as? NSNull, NSNull())
     }
 
     func testThatJSONResponseSerializerSucceedsWhenDataIsNilWithHEADRequestAnd200ResponseStatusCode() {
@@ -551,12 +585,38 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(result.value)
         XCTAssertNil(result.error)
+        XCTAssertEqual(result.value as? NSNull, NSNull())
+    }
 
-        if let json = result.value as? NSNull {
-            XCTAssertEqual(json, NSNull())
-        } else {
-            XCTFail("json should not be nil")
-        }
+    func testThatJSONResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
+        // Given
+        let preprocessor: ResponseSerializer.DataPreprocessor =  { data in data.dropFirst() }
+        let serializer = JSONResponseSerializer(dataPreprocessor: preprocessor)
+        let data = Data("1\"abcd\"".utf8)
+
+        // When
+        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(result.value as? String, "abcd")
+        XCTAssertNil(result.error)
+    }
+
+    func testThatJSONResponseSerializerProperlyReceivesErrorFromFailingDataPreprocessor() {
+        // Given
+        struct Error: Swift.Error { }
+        let preprocessor: ResponseSerializer.DataPreprocessor = { _ in throw Error() }
+        let serializer = JSONResponseSerializer(dataPreprocessor: preprocessor)
+        let data = Data("1\"abcd\"".utf8)
+
+        // When
+        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertNil(result.value)
+        XCTAssertNotNil(result.error)
     }
 }
 
@@ -792,6 +852,37 @@ final class DecodableResponseSerializerTests: BaseTestCase {
             XCTFail("error should not be nil")
         }
     }
+
+    func testThatDecodableResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
+        // Given
+        let preprocessor: ResponseSerializer.DataPreprocessor =  { data in data.dropFirst() }
+        let serializer = DecodableResponseSerializer<DecodableValue>(dataPreprocessor: preprocessor)
+        let data = Data("1{\"string\":\"string\"}".utf8)
+
+        // When
+        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(result.value?.string, "string")
+        XCTAssertNil(result.error)
+    }
+
+    func testThatDecodableResponseSerializerProperlyReceivesErrorFromFailingDataPreprocessor() {
+        // Given
+        struct Error: Swift.Error { }
+        let preprocessor: ResponseSerializer.DataPreprocessor = { _ in throw Error() }
+        let serializer = DecodableResponseSerializer<DecodableValue>(dataPreprocessor: preprocessor)
+        let data = Data("1{\"string\":\"string\"}".utf8)
+
+        // When
+        let result = Result { try serializer.serialize(request: nil, response: nil, data: data, error: nil) }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertNil(result.value)
+        XCTAssertNotNil(result.error)
+    }
 }
 
 // MARK: -
@@ -935,12 +1026,7 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(result.value)
         XCTAssertNil(result.error)
-
-        if let data = result.value {
-            XCTAssertEqual(data.count, 0)
-        } else {
-            XCTFail("data should not be nil")
-        }
+        XCTAssertEqual(result.value?.count, 0)
     }
 
     // MARK: Tests - String Response Serializer
@@ -1135,10 +1221,7 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(result.value)
         XCTAssertNil(result.error)
-
-        if let string = result.value {
-            XCTAssertEqual(string, "")
-        }
+        XCTAssertEqual(result.value, "")
     }
 
     // MARK: Tests - JSON Response Serializer
@@ -1285,9 +1368,7 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
         XCTAssertNotNil(result.value)
         XCTAssertNil(result.error)
 
-        if let json = result.value as? NSNull {
-            XCTAssertEqual(json, NSNull())
-        }
+        XCTAssertEqual(result.value as? NSNull, NSNull())
     }
 }
 


### PR DESCRIPTION
### Issue Link :link:
This is a generalized solution to #2683.

### Goals :soccer:
This PR adds the `DataPreprocessor` API to all response serializers, to allow easy access to raw `Data` before serialization, to do things like stripping XSSI strings.

### Implementation Details :construction:
`DataPreprocessor` is just a closure that each serializer can have set. By default it just passes `Data` through, so it should have minimal impact for anyone not using the API. It also supports throwing, so errors can be returned as well.

### Testing Details :mag:
Additional tests were added to the various `DataResponseSerializer` cases, as all serialization flows through those methods.
