### PR TITLE
Add Internal URLRequest Validation API

### DIFF
--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -861,6 +861,7 @@ open class Session {
     func performSetupOperations(for request: Request, convertible: URLRequestConvertible) {
         do {
             let initialRequest = try convertible.asURLRequest()
+            try initialRequest.validate()
             rootQueue.async { request.didCreateInitialURLRequest(initialRequest) }
 
             guard !request.isCancelled else { return }
@@ -869,6 +870,7 @@ open class Session {
                 adapter.adapt(initialRequest, for: self) { result in
                     do {
                         let adaptedRequest = try result.get()
+                        try adaptedRequest.validate()
 
                         self.rootQueue.async {
                             request.didAdaptInitialRequest(initialRequest, to: adaptedRequest)

--- a/Source/URLRequest+Alamofire.swift
+++ b/Source/URLRequest+Alamofire.swift
@@ -30,4 +30,10 @@ public extension URLRequest {
         get { return httpMethod.flatMap(HTTPMethod.init) }
         set { httpMethod = newValue?.rawValue }
     }
+
+    func validate() throws {
+        if method == .get, let bodyData = httpBody {
+            throw AFError.urlRequestValidationFailed(reason: .bodyDataInGETRequest(bodyData))
+        }
+    }
 }

--- a/Tests/AFError+AlamofireTests.swift
+++ b/Tests/AFError+AlamofireTests.swift
@@ -168,6 +168,13 @@ extension AFError {
         if case let .responseValidationFailed(reason) = self, reason.isUnacceptableStatusCode { return true }
         return false
     }
+
+    // URLRequestValidationFailure
+
+    var isBodyDataInGETRequest: Bool {
+        if case let .urlRequestValidationFailed(reason) = self, reason.isBodyDataInGETRequest { return true }
+        return false
+    }
 }
 
 // MARK: -
@@ -371,6 +378,13 @@ extension AFError.ServerTrustFailureReason {
 
     var isPublicKeyPinningFailed: Bool {
         if case .publicKeyPinningFailed = self { return true }
+        return false
+    }
+}
+
+extension AFError.URLRequestValidationFailureReason {
+    var isBodyDataInGETRequest: Bool {
+        if case .bodyDataInGETRequest = self { return true }
         return false
     }
 }

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -1413,34 +1413,34 @@ final class DataPreprocessorTests: BaseTestCase {
         // Given
         let preprocessor = PassthroughPreprocessor()
         let data = Data("data".utf8)
-        
+
         // When
         let result = Result { try preprocessor.preprocess(data) }
-        
+
         // Then
         XCTAssertEqual(data, result.value, "Preprocessed data should equal original data.")
     }
-    
+
     func testThatGoogleXSSIPreprocessorProperlyPreprocessesData() {
         // Given
         let preprocessor = GoogleXSSIPreprocessor()
         let data = Data(")]}',\nabcd".utf8)
-        
+
         // When
         let result = Result { try preprocessor.preprocess(data) }
-        
+
         // Then
         XCTAssertEqual(result.value.map { String(decoding: $0, as: UTF8.self) }, "abcd")
     }
-    
+
     func testThatGoogleXSSIPreprocessorDoesNotChangeDataIfPrefixDoesNotMatch() {
         // Given
         let preprocessor = GoogleXSSIPreprocessor()
         let data = Data("abcd".utf8)
-        
+
         // When
         let result = Result { try preprocessor.preprocess(data) }
-        
+
         // Then
         XCTAssertEqual(result.value.map { String(decoding: $0, as: UTF8.self) }, "abcd")
     }


### PR DESCRIPTION
### Issue Link :link:
Similar to fix offered in #2887.

### Goals :soccer:
This PR adds API to our internal `URLRequest` processing that will throw an error when attempting to make a `GET` request that has body data. This is both to fix existing issues with this behavior, as `URLSession` doesn't automatically add `Content-Length` in this case, breaking servers and middleboxes, but it has also become a `URLSession` error in the 2019 OSes. 

### Implementation Details :construction:
This PR adds a `validate()` method to our internal `URLRequest` extensions (so this validation is not extensible by users, they can do that as part of `URLRequestConvertible`), as well as a new `AFError` case and `Reason` type. `validate()` is called after initial `URLRequest` creation and after adaptation.

### Testing Details :mag:
Tests have been added for both initial and adapted request cases.
