### PR TITLE
Refactor Reachability

### DIFF
--- a/Example/Source/MasterViewController.swift
+++ b/Example/Source/MasterViewController.swift
@@ -90,7 +90,7 @@ class MasterViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if indexPath.section == 3 && indexPath.row == 0 {
-            print("Reachability Status: \(reachability.networkReachabilityStatus)")
+            print("Reachability Status: \(reachability.status)")
             tableView.deselectRow(at: indexPath, animated: true)
         }
     }
@@ -98,12 +98,10 @@ class MasterViewController: UITableViewController {
     // MARK: - Private - Reachability
 
     private func monitorReachability() {
-        reachability = NetworkReachabilityManager(host: "www.apple.com")
+        reachability = NetworkReachabilityManager()
 
-        reachability.listener = { status in
+        reachability.startListening { status in
             print("Reachability Status Changed: \(status)")
         }
-
-        reachability.startListening()
     }
 }

--- a/Example/Source/MasterViewController.swift
+++ b/Example/Source/MasterViewController.swift
@@ -98,9 +98,7 @@ class MasterViewController: UITableViewController {
     // MARK: - Private - Reachability
 
     private func monitorReachability() {
-        reachability = NetworkReachabilityManager()
-
-        reachability.startListening { status in
+        NetworkReachabilityManager.default.startListening { status in
             print("Reachability Status Changed: \(status)")
         }
     }

--- a/Example/Source/MasterViewController.swift
+++ b/Example/Source/MasterViewController.swift
@@ -98,7 +98,7 @@ class MasterViewController: UITableViewController {
     // MARK: - Private - Reachability
 
     private func monitorReachability() {
-        NetworkReachabilityManager.default.startListening { status in
+        NetworkReachabilityManager.default?.startListening { status in
             print("Reachability Status Changed: \(status)")
         }
     }

--- a/Example/iOS Example.xcodeproj/xcshareddata/xcschemes/iOS Example.xcscheme
+++ b/Example/iOS Example.xcodeproj/xcshareddata/xcschemes/iOS Example.xcscheme
@@ -65,7 +65,7 @@
          <EnvironmentVariable
             key = "OS_ACTIVITY_MODE"
             value = "disable"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>

--- a/Source/NetworkReachabilityManager.swift
+++ b/Source/NetworkReachabilityManager.swift
@@ -42,14 +42,26 @@ open class NetworkReachabilityManager {
         case notReachable
         /// The network is reachable on the associated `ConnectionType`.
         case reachable(ConnectionType)
-    }
 
-    /// Defines the various connection types detected by reachability flags.
-    public enum ConnectionType {
-        /// The connection type is either over Ethernet or WiFi.
-        case ethernetOrWiFi
-        /// The connection type is a WWAN connection.
-        case wwan
+        init(_ flags: SCNetworkReachabilityFlags) {
+            guard flags.isActuallyReachable else { self = .notReachable; return }
+
+            var networkStatus: NetworkReachabilityStatus = .reachable(.ethernetOrWiFi)
+
+            #if os(iOS)
+                if flags.isCellular { networkStatus = .reachable(.cellular) }
+            #endif
+
+            self = networkStatus
+        }
+
+        /// Defines the various connection types detected by reachability flags.
+        public enum ConnectionType {
+            /// The connection type is either over Ethernet or WiFi.
+            case ethernetOrWiFi
+            /// The connection type is a cellular connection.
+            case cellular
+        }
     }
 
     /// A closure executed when the network reachability status changes. The closure takes a single argument: the
@@ -59,74 +71,77 @@ open class NetworkReachabilityManager {
     // MARK: - Properties
 
     /// Whether the network is currently reachable.
-    open var isReachable: Bool { return isReachableOnWWAN || isReachableOnEthernetOrWiFi }
+    open var isReachable: Bool { return isReachableOnCellular || isReachableOnEthernetOrWiFi }
 
     /// Whether the network is currently reachable over the WWAN interface.
-    open var isReachableOnWWAN: Bool { return networkReachabilityStatus == .reachable(.wwan) }
+    open var isReachableOnCellular: Bool { return status == .reachable(.cellular) }
 
     /// Whether the network is currently reachable over Ethernet or WiFi interface.
-    open var isReachableOnEthernetOrWiFi: Bool { return networkReachabilityStatus == .reachable(.ethernetOrWiFi) }
+    open var isReachableOnEthernetOrWiFi: Bool { return status == .reachable(.ethernetOrWiFi) }
 
-    /// The current network reachability status.
-    open var networkReachabilityStatus: NetworkReachabilityStatus {
-        guard let flags = self.flags else { return .unknown }
-        return networkReachabilityStatusForFlags(flags)
-    }
+    /// `DispatchQueue` on which listeners will be called. `.main` by default.
+    public let listenerQueue: DispatchQueue
 
-    /// The dispatch queue to execute the `listener` closure on.
-    open var listenerQueue: DispatchQueue = DispatchQueue.main
-
-    /// A closure executed when the network reachability status changes.
-    open var listener: Listener?
+    /// `DispatchQueue` on which reachability will update.
+    public let reachabilityQueue = DispatchQueue(label: "org.alamofire.reachabilityQueue")
 
     /// Flags of the current reachability type, if any.
     open var flags: SCNetworkReachabilityFlags? {
         var flags = SCNetworkReachabilityFlags()
 
-        if SCNetworkReachabilityGetFlags(reachability, &flags) {
-            return flags
-        }
-
-        return nil
+        return (SCNetworkReachabilityGetFlags(reachability, &flags)) ? flags : nil
     }
 
-    private let reachability: SCNetworkReachability
+    /// The current network reachability status.
+    open var status: NetworkReachabilityStatus {
+        guard let flags = flags else { return .unknown }
+
+        return NetworkReachabilityStatus(flags)
+    }
+
+    /// A closure executed when the network reachability status changes.
+    private var listener: Listener?
+
     /// Reachability flags of the previous reachability state.
-    open var previousFlags: SCNetworkReachabilityFlags
+    private var previousStatus: NetworkReachabilityStatus?
+
+    /// `SCNetworkReachibility` instance providing notifications.
+    private let reachability: SCNetworkReachability
 
     // MARK: - Initialization
 
     /// Creates an instance with the specified host.
     ///
-    /// - Parameter host: Host used to evaluate network reachability. Must not include the scheme (i.e. `https`).
-    public convenience init?(host: String) {
+    /// - Note: This value should *not* contain a scheme, just the hostname.
+    ///
+    /// - Parameters:
+    ///   - host:          Host used to evaluate network reachability. Must *not* include the scheme (e.g. `https`).
+    ///   - listenerQueue: `DispatchQueue` on which listeners will be called. `.main` by default.
+    public convenience init?(host: String, listenerQueue: DispatchQueue = .main) {
         guard let reachability = SCNetworkReachabilityCreateWithName(nil, host) else { return nil }
-        self.init(reachability: reachability)
+
+        self.init(reachability: reachability, listenerQueue: listenerQueue)
     }
 
     /// Creates an instance that monitors the address 0.0.0.0.
     ///
     /// Reachability treats the 0.0.0.0 address as a special token that causes it to monitor the general routing
     /// status of the device, both IPv4 and IPv6.
-    public convenience init?() {
-        var address = sockaddr_in()
-        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
-        address.sin_family = sa_family_t(AF_INET)
+    ///
+    /// - Parameter listenerQueue: `DispatchQueue` on which listeners will be called. `.main` by default.
+    public convenience init?(listenerQueue: DispatchQueue = .main) {
+        var zero = sockaddr()
+        zero.sa_len = UInt8(MemoryLayout<sockaddr>.size)
+        zero.sa_family = sa_family_t(AF_INET)
 
-        guard let reachability = withUnsafePointer(to: &address, { pointer in
-            return pointer.withMemoryRebound(to: sockaddr.self, capacity: MemoryLayout<sockaddr>.size) {
-                return SCNetworkReachabilityCreateWithAddress(nil, $0)
-            }
-        }) else { return nil }
+        guard let reachability = SCNetworkReachabilityCreateWithAddress(nil, &zero) else { return nil }
 
-        self.init(reachability: reachability)
+        self.init(reachability: reachability, listenerQueue: listenerQueue)
     }
 
-    private init(reachability: SCNetworkReachability) {
+    private init(reachability: SCNetworkReachability, listenerQueue: DispatchQueue = .main) {
+        self.listenerQueue = listenerQueue
         self.reachability = reachability
-
-        // Set the previous flags to an unreserved value to represent unknown status
-        self.previousFlags = SCNetworkReachabilityFlags(rawValue: 1 << 30)
     }
 
     deinit {
@@ -139,84 +154,123 @@ open class NetworkReachabilityManager {
     ///
     /// - Returns: `true` if listening was started successfully, `false` otherwise.
     @discardableResult
-    open func startListening() -> Bool {
-        var context = SCNetworkReachabilityContext(version: 0, info: nil, retain: nil, release: nil, copyDescription: nil)
-        context.info = Unmanaged.passUnretained(self).toOpaque()
+    open func startListening(onUpdatePerforming listener: @escaping Listener) -> Bool {
+        stopListening()
 
-        let callbackEnabled = SCNetworkReachabilitySetCallback(
-            reachability,
-            { (_, flags, info) in
-                let reachability = Unmanaged<NetworkReachabilityManager>.fromOpaque(info!).takeUnretainedValue()
-                reachability.notifyListener(flags)
-            },
-            &context
-        )
+        self.listener = listener
 
-        let queueEnabled = SCNetworkReachabilitySetDispatchQueue(reachability, listenerQueue)
+        var context = SCNetworkReachabilityContext(version: 0,
+                                                   info: Unmanaged.passRetained(self).toOpaque(),
+                                                   retain: nil,
+                                                   release: nil,
+                                                   copyDescription: nil)
+        let callback: SCNetworkReachabilityCallBack = { (target, flags, info) in
+            guard let info = info else { return }
 
-        listenerQueue.async {
-            guard let flags = self.flags else { return }
-            self.notifyListener(flags)
+            let instance = Unmanaged<NetworkReachabilityManager>.fromOpaque(info).takeUnretainedValue()
+            instance.notifyListener(flags)
         }
 
-        return callbackEnabled && queueEnabled
+        let queueAdded = SCNetworkReachabilitySetDispatchQueue(reachability, reachabilityQueue)
+        let callbackAdded = SCNetworkReachabilitySetCallback(reachability, callback, &context)
+
+        // Manually call listener to give initial state, since the framework may not.
+        if let currentFlags = flags {
+            reachabilityQueue.async {
+                self.notifyListener(currentFlags)
+            }
+        }
+
+        return callbackAdded && queueAdded
     }
 
     /// Stops listening for changes in network reachability status.
     open func stopListening() {
         SCNetworkReachabilitySetCallback(reachability, nil, nil)
         SCNetworkReachabilitySetDispatchQueue(reachability, nil)
+        previousStatus = nil
+        listener = nil
     }
 
     // MARK: - Internal - Listener Notification
 
     func notifyListener(_ flags: SCNetworkReachabilityFlags) {
-        guard previousFlags != flags else { return }
-        previousFlags = flags
+        print(flags.description)
+        let newStatus = NetworkReachabilityStatus(flags)
+        guard previousStatus != newStatus else { return }
 
-        listener?(networkReachabilityStatusForFlags(flags))
-    }
+        previousStatus = newStatus
 
-    // MARK: - Internal - Network Reachability Status
-
-    func networkReachabilityStatusForFlags(_ flags: SCNetworkReachabilityFlags) -> NetworkReachabilityStatus {
-        guard isNetworkReachable(with: flags) else { return .notReachable }
-
-        var networkStatus: NetworkReachabilityStatus = .reachable(.ethernetOrWiFi)
-
-    #if os(iOS)
-        if flags.contains(.isWWAN) { networkStatus = .reachable(.wwan) }
-    #endif
-
-        return networkStatus
-    }
-
-    func isNetworkReachable(with flags: SCNetworkReachabilityFlags) -> Bool {
-        let isReachable = flags.contains(.reachable)
-        let needsConnection = flags.contains(.connectionRequired)
-        let canConnectAutomatically = flags.contains(.connectionOnDemand) || flags.contains(.connectionOnTraffic)
-        let canConnectWithoutUserInteraction = canConnectAutomatically && !flags.contains(.interventionRequired)
-
-        return isReachable && (!needsConnection || canConnectWithoutUserInteraction)
+        listenerQueue.async { self.listener?(newStatus) }
     }
 }
 
 // MARK: -
 
-extension NetworkReachabilityManager.NetworkReachabilityStatus: Equatable {
-    public static func ==(
-        lhs: NetworkReachabilityManager.NetworkReachabilityStatus,
-        rhs: NetworkReachabilityManager.NetworkReachabilityStatus)
-        -> Bool
-    {
-        switch (lhs, rhs) {
-        case (.unknown, .unknown), (.notReachable, .notReachable):
-            return true
-        case let (.reachable(lhsConnectionType), .reachable(rhsConnectionType)):
-            return lhsConnectionType == rhsConnectionType
-        default:
-            return false
-        }
+extension NetworkReachabilityManager.NetworkReachabilityStatus: Equatable { }
+
+extension SCNetworkReachabilityFlags {
+    var isReachable: Bool { return contains(.reachable) }
+    var isConnectionRequired: Bool { return contains(.connectionRequired) }
+    var canConnectAutomatically: Bool { return contains(.connectionOnDemand) || contains(.connectionOnTraffic) }
+    var canConnectWithoutUserInteraction: Bool { return canConnectAutomatically && !contains(.interventionRequired) }
+    var isActuallyReachable: Bool { return isReachable && (!isConnectionRequired || canConnectWithoutUserInteraction) }
+    #if os(iOS)
+    var isCellular: Bool { return contains(.isWWAN) }
+    #endif
+}
+
+extension SCNetworkReachabilityFlags {
+    var isOnWWANFlagSet: Bool {
+        #if os(iOS)
+        return contains(.isWWAN)
+        #else
+        return false
+        #endif
+    }
+    var isReachableFlagSet: Bool {
+        return contains(.reachable)
+    }
+    var isConnectionRequiredFlagSet: Bool {
+        return contains(.connectionRequired)
+    }
+    var isInterventionRequiredFlagSet: Bool {
+        return contains(.interventionRequired)
+    }
+    var isConnectionOnTrafficFlagSet: Bool {
+        return contains(.connectionOnTraffic)
+    }
+    var isConnectionOnDemandFlagSet: Bool {
+        return contains(.connectionOnDemand)
+    }
+    var isConnectionOnTrafficOrDemandFlagSet: Bool {
+        return !intersection([.connectionOnTraffic, .connectionOnDemand]).isEmpty
+    }
+    var isTransientConnectionFlagSet: Bool {
+        return contains(.transientConnection)
+    }
+    var isLocalAddressFlagSet: Bool {
+        return contains(.isLocalAddress)
+    }
+    var isDirectFlagSet: Bool {
+        return contains(.isDirect)
+    }
+    var isConnectionRequiredAndTransientFlagSet: Bool {
+        return intersection([.connectionRequired, .transientConnection]) == [.connectionRequired, .transientConnection]
+    }
+
+    var description: String {
+        let W = isOnWWANFlagSet ? "W" : "-"
+        let R = isReachableFlagSet ? "R" : "-"
+        let c = isConnectionRequiredFlagSet ? "c" : "-"
+        let t = isTransientConnectionFlagSet ? "t" : "-"
+        let i = isInterventionRequiredFlagSet ? "i" : "-"
+        let C = isConnectionOnTrafficFlagSet ? "C" : "-"
+        let D = isConnectionOnDemandFlagSet ? "D" : "-"
+        let l = isLocalAddressFlagSet ? "l" : "-"
+        let d = isDirectFlagSet ? "d" : "-"
+
+        return "\(W)\(R) \(c)\(t)\(i)\(C)\(D)\(l)\(d)"
     }
 }
 

--- a/Source/RequestInterceptor.swift
+++ b/Source/RequestInterceptor.swift
@@ -83,7 +83,7 @@ public protocol RequestRetrier {
     ///   - request:    `Request` that failed due to the provided `Error`.
     ///   - session:    `Session` that produced the `Request`.
     ///   - error:      `Error` encountered while executing the `Request`.
-    ///   - completion: Completion closure to be executed when a retry decision has been deterined.
+    ///   - completion: Completion closure to be executed when a retry decision has been determined.
     func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void)
 }
 

--- a/Tests/NetworkReachabilityManagerTests.swift
+++ b/Tests/NetworkReachabilityManagerTests.swift
@@ -80,12 +80,6 @@ final class NetworkReachabilityManagerTestCase: BaseTestCase {
         XCTAssertEqual(manager?.isReachableOnEthernetOrWiFi, true)
     }
 
-    func testMany() {
-        for _ in 0..<100 {
-            testThatZeroManagerCanBeProperlyRestarted()
-        }
-    }
-
     func testThatZeroManagerCanBeProperlyRestarted() {
         // Given
         let manager = NetworkReachabilityManager()

--- a/Tests/NetworkReachabilityManagerTests.swift
+++ b/Tests/NetworkReachabilityManagerTests.swift
@@ -27,7 +27,7 @@ import Foundation
 import SystemConfiguration
 import XCTest
 
-class NetworkReachabilityManagerTestCase: BaseTestCase {
+final class NetworkReachabilityManagerTestCase: BaseTestCase {
 
     // MARK: - Tests - Initialization
 
@@ -52,9 +52,9 @@ class NetworkReachabilityManagerTestCase: BaseTestCase {
         let manager = NetworkReachabilityManager(host: "localhost")
 
         // Then
-        XCTAssertEqual(manager?.networkReachabilityStatus, .reachable(.ethernetOrWiFi))
+        XCTAssertEqual(manager?.status, .reachable(.ethernetOrWiFi))
         XCTAssertEqual(manager?.isReachable, true)
-        XCTAssertEqual(manager?.isReachableOnWWAN, false)
+        XCTAssertEqual(manager?.isReachableOnCellular, false)
         XCTAssertEqual(manager?.isReachableOnEthernetOrWiFi, true)
     }
 
@@ -63,9 +63,9 @@ class NetworkReachabilityManagerTestCase: BaseTestCase {
         let manager = NetworkReachabilityManager(host: "localhost")
 
         // Then
-        XCTAssertEqual(manager?.networkReachabilityStatus, .reachable(.ethernetOrWiFi))
+        XCTAssertEqual(manager?.status, .reachable(.ethernetOrWiFi))
         XCTAssertEqual(manager?.isReachable, true)
-        XCTAssertEqual(manager?.isReachableOnWWAN, false)
+        XCTAssertEqual(manager?.isReachableOnCellular, false)
         XCTAssertEqual(manager?.isReachableOnEthernetOrWiFi, true)
     }
 
@@ -74,9 +74,9 @@ class NetworkReachabilityManagerTestCase: BaseTestCase {
         let manager = NetworkReachabilityManager()
 
         // Then
-        XCTAssertEqual(manager?.networkReachabilityStatus, .reachable(.ethernetOrWiFi))
+        XCTAssertEqual(manager?.status, .reachable(.ethernetOrWiFi))
         XCTAssertEqual(manager?.isReachable, true)
-        XCTAssertEqual(manager?.isReachableOnWWAN, false)
+        XCTAssertEqual(manager?.isReachableOnCellular, false)
         XCTAssertEqual(manager?.isReachableOnEthernetOrWiFi, true)
     }
 
@@ -114,14 +114,12 @@ class NetworkReachabilityManagerTestCase: BaseTestCase {
         let expectation = self.expectation(description: "listener closure should be executed")
         var networkReachabilityStatus: NetworkReachabilityManager.NetworkReachabilityStatus?
 
-        manager.listener = { status in
+        // When
+        manager.startListening { status in
             guard networkReachabilityStatus == nil else { return }
             networkReachabilityStatus = status
             expectation.fulfill()
         }
-
-        // When
-        manager.startListening()
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
@@ -135,13 +133,11 @@ class NetworkReachabilityManagerTestCase: BaseTestCase {
 
         var networkReachabilityStatus: NetworkReachabilityManager.NetworkReachabilityStatus?
 
-        manager?.listener = { status in
+        // When
+        manager?.startListening { status in
             networkReachabilityStatus = status
             expectation.fulfill()
         }
-
-        // When
-        manager?.startListening()
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
@@ -150,101 +146,93 @@ class NetworkReachabilityManagerTestCase: BaseTestCase {
 
     // MARK: - Tests - Network Reachability Status
 
-    func testThatManagerReturnsNotReachableStatusWhenReachableFlagIsAbsent() {
+    func testThatStatusIsNotReachableStatusWhenReachableFlagIsAbsent() {
         // Given
-        let manager = NetworkReachabilityManager()
         let flags: SCNetworkReachabilityFlags = [.connectionOnDemand]
 
         // When
-        let networkReachabilityStatus = manager?.networkReachabilityStatusForFlags(flags)
+        let status = NetworkReachabilityManager.NetworkReachabilityStatus(flags)
 
         // Then
-        XCTAssertEqual(networkReachabilityStatus, .notReachable)
+        XCTAssertEqual(status, .notReachable)
     }
 
-    func testThatManagerReturnsNotReachableStatusWhenConnectionIsRequired() {
+    func testThatStatusIsNotReachableStatusWhenConnectionIsRequired() {
         // Given
-        let manager = NetworkReachabilityManager()
         let flags: SCNetworkReachabilityFlags = [.reachable, .connectionRequired]
 
         // When
-        let networkReachabilityStatus = manager?.networkReachabilityStatusForFlags(flags)
+        let status = NetworkReachabilityManager.NetworkReachabilityStatus(flags)
 
         // Then
-        XCTAssertEqual(networkReachabilityStatus, .notReachable)
+        XCTAssertEqual(status, .notReachable)
     }
 
-    func testThatManagerReturnsNotReachableStatusWhenInterventionIsRequired() {
+    func testThatStatusIsNotReachableStatusWhenInterventionIsRequired() {
         // Given
-        let manager = NetworkReachabilityManager()
         let flags: SCNetworkReachabilityFlags = [.reachable, .connectionRequired, .interventionRequired]
 
         // When
-        let networkReachabilityStatus = manager?.networkReachabilityStatusForFlags(flags)
+        let status = NetworkReachabilityManager.NetworkReachabilityStatus(flags)
 
         // Then
-        XCTAssertEqual(networkReachabilityStatus, .notReachable)
+        XCTAssertEqual(status, .notReachable)
     }
 
-    func testThatManagerReturnsReachableOnWiFiStatusWhenConnectionIsNotRequired() {
+    func testThatStatusIsReachableOnWiFiStatusWhenConnectionIsNotRequired() {
         // Given
-        let manager = NetworkReachabilityManager()
         let flags: SCNetworkReachabilityFlags = [.reachable]
 
         // When
-        let networkReachabilityStatus = manager?.networkReachabilityStatusForFlags(flags)
+        let status = NetworkReachabilityManager.NetworkReachabilityStatus(flags)
 
         // Then
-        XCTAssertEqual(networkReachabilityStatus, .reachable(.ethernetOrWiFi))
+        XCTAssertEqual(status, .reachable(.ethernetOrWiFi))
     }
 
-    func testThatManagerReturnsReachableOnWiFiStatusWhenConnectionIsOnDemand() {
+    func testThatStatusIsReachableOnWiFiStatusWhenConnectionIsOnDemand() {
         // Given
-        let manager = NetworkReachabilityManager()
         let flags: SCNetworkReachabilityFlags = [.reachable, .connectionRequired, .connectionOnDemand]
 
         // When
-        let networkReachabilityStatus = manager?.networkReachabilityStatusForFlags(flags)
+        let status = NetworkReachabilityManager.NetworkReachabilityStatus(flags)
 
         // Then
-        XCTAssertEqual(networkReachabilityStatus, .reachable(.ethernetOrWiFi))
+        XCTAssertEqual(status, .reachable(.ethernetOrWiFi))
     }
 
-    func testThatManagerReturnsReachableOnWiFiStatusWhenConnectionIsOnTraffic() {
+    func testThatStatusIsReachableOnWiFiStatusWhenConnectionIsOnTraffic() {
         // Given
-        let manager = NetworkReachabilityManager()
         let flags: SCNetworkReachabilityFlags = [.reachable, .connectionRequired, .connectionOnTraffic]
 
         // When
-        let networkReachabilityStatus = manager?.networkReachabilityStatusForFlags(flags)
+        let status = NetworkReachabilityManager.NetworkReachabilityStatus(flags)
 
         // Then
-        XCTAssertEqual(networkReachabilityStatus, .reachable(.ethernetOrWiFi))
+        XCTAssertEqual(status, .reachable(.ethernetOrWiFi))
     }
 
 #if os(iOS)
-    func testThatManagerReturnsReachableOnWWANStatusWhenIsWWAN() {
+    func testThatStatusIsReachableOnCellularStatusWhenIsWWAN() {
         // Given
-        let manager = NetworkReachabilityManager()
         let flags: SCNetworkReachabilityFlags = [.reachable, .isWWAN]
 
         // When
-        let networkReachabilityStatus = manager?.networkReachabilityStatusForFlags(flags)
+        let status = NetworkReachabilityManager.NetworkReachabilityStatus(flags)
 
         // Then
-        XCTAssertEqual(networkReachabilityStatus, .reachable(.wwan))
+        XCTAssertEqual(status, .reachable(.cellular))
     }
 
-    func testThatManagerReturnsNotReachableOnWWANStatusWhenIsWWANAndConnectionIsRequired() {
+    func testThatStatusIsNotReachableOnCellularStatusWhenIsWWANAndConnectionIsRequired() {
         // Given
-        let manager = NetworkReachabilityManager()
         let flags: SCNetworkReachabilityFlags = [.reachable, .isWWAN, .connectionRequired]
 
         // When
-        let networkReachabilityStatus = manager?.networkReachabilityStatusForFlags(flags)
+        let status = NetworkReachabilityManager.NetworkReachabilityStatus(flags)
 
         // Then
-        XCTAssertEqual(networkReachabilityStatus, .notReachable)
+        XCTAssertEqual(status, .notReachable)
     }
 #endif
 }

--- a/Tests/NetworkReachabilityManagerTests.swift
+++ b/Tests/NetworkReachabilityManagerTests.swift
@@ -80,6 +80,58 @@ final class NetworkReachabilityManagerTestCase: BaseTestCase {
         XCTAssertEqual(manager?.isReachableOnEthernetOrWiFi, true)
     }
 
+    func testMany() {
+        for _ in 0..<100 {
+            testThatZeroManagerCanBeProperlyRestarted()
+        }
+    }
+
+    func testThatZeroManagerCanBeProperlyRestarted() {
+        // Given
+        let manager = NetworkReachabilityManager()
+        let first = expectation(description: "first listener notified")
+        let second = expectation(description: "second listener notified")
+
+        // When
+        manager?.startListening { (status) in
+            first.fulfill()
+        }
+        wait(for: [first], timeout: timeout)
+
+        manager?.stopListening()
+
+        manager?.startListening { (status) in
+            second.fulfill()
+        }
+        wait(for: [second], timeout: timeout)
+
+        // Then
+        XCTAssertEqual(manager?.status, .reachable(.ethernetOrWiFi))
+    }
+
+    func testThatHostManagerCanBeProperlyRestarted() {
+        // Given
+        let manager = NetworkReachabilityManager(host: "localhost")
+        let first = expectation(description: "first listener notified")
+        let second = expectation(description: "second listener notified")
+
+        // When
+        manager?.startListening { (status) in
+            first.fulfill()
+        }
+        wait(for: [first], timeout: timeout)
+
+        manager?.stopListening()
+
+        manager?.startListening { (status) in
+            second.fulfill()
+        }
+        wait(for: [second], timeout: timeout)
+
+        // Then
+        XCTAssertEqual(manager?.status, .reachable(.ethernetOrWiFi))
+    }
+
     func testThatHostManagerCanBeDeinitialized() {
         // Given
         var manager: NetworkReachabilityManager? = NetworkReachabilityManager(host: "localhost")
@@ -102,7 +154,7 @@ final class NetworkReachabilityManagerTestCase: BaseTestCase {
         XCTAssertNil(manager)
     }
 
-    // MARK: - Tests - Listener
+    // MARK: - Listener
 
     func testThatHostManagerIsNotifiedWhenStartListeningIsCalled() {
         // Given
@@ -144,7 +196,7 @@ final class NetworkReachabilityManagerTestCase: BaseTestCase {
         XCTAssertEqual(networkReachabilityStatus, .reachable(.ethernetOrWiFi))
     }
 
-    // MARK: - Tests - Network Reachability Status
+    // MARK: - NetworkReachabilityStatus
 
     func testThatStatusIsNotReachableStatusWhenReachableFlagIsAbsent() {
         // Given
@@ -212,7 +264,7 @@ final class NetworkReachabilityManagerTestCase: BaseTestCase {
         XCTAssertEqual(status, .reachable(.ethernetOrWiFi))
     }
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
     func testThatStatusIsReachableOnCellularStatusWhenIsWWAN() {
         // Given
         let flags: SCNetworkReachabilityFlags = [.reachable, .isWWAN]


### PR DESCRIPTION
# Goals :soccer:
This PR refactors our `SCNetworkReachability` wrapper to simplify usage, adopt more modern styling, and fix a bug.

### Implementation Details :construction:
There are a few changes in here:
- Moved `ConnectionType` inside `NetworkReachabilityStatus`, since the types are related.
- Added `default` static instance (using the zero address) so users don't have to create an instance in the common case.
- Renamed usages of `WWAN` to `Cellular`, since that's what it actually means.
- Rewrote `DispatchQueue` handling to separate the queue used for reachability notifications and listener callbacks. Notifications are now always on a background queue and the listener queue is now customizable when listening is started, while defaulting to `.main`.
- Lifetime management has been updated: `startListening` now calls `stopListening` to clear any state before setting up a new `SCNetworkReachabilityContext`.
- The zero address initializer has been simplified to no longer require memory rebounding.
- Various status computations have been moved to initializers or convenience properties, rather than methods on the manager itself.
- Added support for the cellular checks on tvOS because they're technically supported, so why not.

### Testing Details :mag:
Added some lifecycle tests where the manager is started, stopped, and started again, and updated other tests that calculate the reachability status.
