### PR TITLE
Ensure Alamofire Can't Be Used With Background Sessions

### DIFF
--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -55,6 +55,9 @@
 		3113D46B21878227001CCD21 /* HTTPHeadersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3113D46A21878227001CCD21 /* HTTPHeadersTests.swift */; };
 		3113D46C21878227001CCD21 /* HTTPHeadersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3113D46A21878227001CCD21 /* HTTPHeadersTests.swift */; };
 		3113D46D21878227001CCD21 /* HTTPHeadersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3113D46A21878227001CCD21 /* HTTPHeadersTests.swift */; };
+		311A89BF23185BBF003BB714 /* CachedResponseHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFD6B132201338E00FFB5E3 /* CachedResponseHandlerTests.swift */; };
+		311A89C023185BBF003BB714 /* CachedResponseHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFD6B132201338E00FFB5E3 /* CachedResponseHandlerTests.swift */; };
+		311A89C123185BC0003BB714 /* CachedResponseHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFD6B132201338E00FFB5E3 /* CachedResponseHandlerTests.swift */; };
 		311B199020B0D3B40036823B /* MultipartUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311B198F20B0D3B40036823B /* MultipartUpload.swift */; };
 		311B199120B0E3470036823B /* MultipartUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311B198F20B0D3B40036823B /* MultipartUpload.swift */; };
 		311B199220B0E3480036823B /* MultipartUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311B198F20B0D3B40036823B /* MultipartUpload.swift */; };
@@ -1346,6 +1349,7 @@
 				4CF627141BA7CC240011A099 /* BaseTestCase.swift in Sources */,
 				4C7DD7ED224C627300249836 /* Result+Alamofire.swift in Sources */,
 				31727424218BB9A50039FFCC /* HTTPBin.swift in Sources */,
+				311A89C123185BC0003BB714 /* CachedResponseHandlerTests.swift in Sources */,
 				31EBD9C320D1D89D00D1FF34 /* ValidationTests.swift in Sources */,
 				3111CE8620A76370008315E2 /* SessionTests.swift in Sources */,
 				31C2B0F220B271380089BA7C /* TLSEvaluationTests.swift in Sources */,
@@ -1497,6 +1501,7 @@
 				4C256A531B096C770065714F /* BaseTestCase.swift in Sources */,
 				4C7DD7EB224C627300249836 /* Result+Alamofire.swift in Sources */,
 				31727422218BB9A50039FFCC /* HTTPBin.swift in Sources */,
+				311A89BF23185BBF003BB714 /* CachedResponseHandlerTests.swift in Sources */,
 				31EBD9C120D1D89C00D1FF34 /* ValidationTests.swift in Sources */,
 				3111CE8420A7636E008315E2 /* SessionTests.swift in Sources */,
 				31C2B0F020B271370089BA7C /* TLSEvaluationTests.swift in Sources */,
@@ -1531,6 +1536,7 @@
 				F829C6BF1A7A950600A2CD59 /* RequestTests.swift in Sources */,
 				4C7DD7EC224C627300249836 /* Result+Alamofire.swift in Sources */,
 				31727423218BB9A50039FFCC /* HTTPBin.swift in Sources */,
+				311A89C023185BBF003BB714 /* CachedResponseHandlerTests.swift in Sources */,
 				31EBD9C220D1D89C00D1FF34 /* ValidationTests.swift in Sources */,
 				3111CE8520A7636F008315E2 /* SessionTests.swift in Sources */,
 				31C2B0F120B271370089BA7C /* TLSEvaluationTests.swift in Sources */,

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -110,6 +110,8 @@ open class Session {
                 redirectHandler: RedirectHandler? = nil,
                 cachedResponseHandler: CachedResponseHandler? = nil,
                 eventMonitors: [EventMonitor] = []) {
+        precondition(session.configuration.identifier == nil,
+                     "Alamofire does not support background URLSessionConfigurations.")
         precondition(session.delegateQueue.underlyingQueue === rootQueue,
                      "Session(session:) intializer must be passed the DispatchQueue used as the delegateQueue's underlyingQueue as rootQueue.")
 
@@ -173,6 +175,8 @@ open class Session {
                             redirectHandler: RedirectHandler? = nil,
                             cachedResponseHandler: CachedResponseHandler? = nil,
                             eventMonitors: [EventMonitor] = []) {
+        precondition(configuration.identifier == nil, "Alamofire does not support background URLSessionConfigurations.")
+
         let delegateQueue = OperationQueue(maxConcurrentOperationCount: 1, underlyingQueue: rootQueue, name: "org.alamofire.session.sessionDelegateQueue")
         let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: delegateQueue)
 

--- a/Tests/CacheTests.swift
+++ b/Tests/CacheTests.swift
@@ -86,9 +86,11 @@ class CacheTestCase: BaseTestCase {
 
         urlCache = {
             let capacity = 50 * 1024 * 1024 // MBs
-            let urlCache = URLCache(memoryCapacity: capacity, diskCapacity: capacity, diskPath: nil)
-
-            return urlCache
+            if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+                return URLCache(memoryCapacity: capacity, diskCapacity: capacity)
+            } else {
+                return URLCache(memoryCapacity: capacity, diskCapacity: capacity, diskPath: nil)
+            }
         }()
 
         manager = {

--- a/Tests/CachedResponseHandlerTests.swift
+++ b/Tests/CachedResponseHandlerTests.swift
@@ -206,7 +206,13 @@ final class CachedResponseHandlerTestCase: BaseTestCase {
 
     private func session(using handler: CachedResponseHandler? = nil) -> Session {
         let configuration = URLSessionConfiguration.alamofireDefault
-        configuration.urlCache = URLCache(memoryCapacity: 100_000_000, diskCapacity: 100_000_000, diskPath: UUID().uuidString)
+        let capacity = 100_000_000
+        let cache: URLCache
+        if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+            cache = URLCache(memoryCapacity: capacity, diskCapacity: capacity, directory: UUID().uuidString)
+        } else {
+            cache = URLCache(memoryCapacity: capacity, diskCapacity: capacity, diskPath: UUID().uuidString)
+        }
 
         return Session(configuration: configuration, cachedResponseHandler: handler)
     }

--- a/Tests/CachedResponseHandlerTests.swift
+++ b/Tests/CachedResponseHandlerTests.swift
@@ -205,14 +205,16 @@ final class CachedResponseHandlerTestCase: BaseTestCase {
     // MARK: Private - Test Helpers
 
     private func session(using handler: CachedResponseHandler? = nil) -> Session {
-        let configuration = URLSessionConfiguration.alamofireDefault
+        let configuration = URLSessionConfiguration.af.default
         let capacity = 100_000_000
         let cache: URLCache
         if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
-            cache = URLCache(memoryCapacity: capacity, diskCapacity: capacity, directory: UUID().uuidString)
+            let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            cache = URLCache(memoryCapacity: capacity, diskCapacity: capacity, directory: directory)
         } else {
             cache = URLCache(memoryCapacity: capacity, diskCapacity: capacity, diskPath: UUID().uuidString)
         }
+        configuration.urlCache = cache
 
         return Session(configuration: configuration, cachedResponseHandler: handler)
     }

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -1669,7 +1669,7 @@ final class SessionConfigurationHeadersTestCase: BaseTestCase {
         executeAuthorizationHeaderTest(for: .ephemeral)
     }
 #if os(macOS)
-    func testThatBackgroundConfigurationHeadersAreSentWithRequest() {
+    func disabled_testThatBackgroundConfigurationHeadersAreSentWithRequest() {
         // Given, When, Then
         executeAuthorizationHeaderTest(for: .background)
     }

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -526,7 +526,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
     }
 
 #if os(macOS)
-    func testThatUploadingMultipartFormDataOnBackgroundSessionWritesDataToFileToAvoidCrash() {
+    func disabled_testThatUploadingMultipartFormDataOnBackgroundSessionWritesDataToFileToAvoidCrash() {
         // Given
         let manager: Session = {
             let identifier = "org.alamofire.uploadtests.\(UUID().uuidString)"


### PR DESCRIPTION
### Goals :soccer:
This PR adds explicit preconditions to the `Session` initializers to ensure Alamofire isn't used with background sessions, in order to prevent ongoing issues around support and surprise on the part of the user.

### Implementation Details :construction:
Simply adds `precondition` calls which check for the `URLSessionConfiguration.identifier`, which is only set when configured for background sessions.

### Testing Details :mag:
Tests using background sessions have been disabled.
