### PR TITLE
Add AF*Response, AFResult types, update tests to use AFError

### DIFF
--- a/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire iOS.xcscheme
+++ b/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire iOS.xcscheme
@@ -40,10 +40,26 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F8111E3219A95C8B0040E7D1"
+            BuildableName = "Alamofire.framework"
+            BlueprintName = "Alamofire iOS"
+            ReferencedContainer = "container:Alamofire.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "SWIFT_DETERMINISTIC_HASHING"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -65,29 +81,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F8111E3219A95C8B0040E7D1"
-            BuildableName = "Alamofire.framework"
-            BlueprintName = "Alamofire iOS"
-            ReferencedContainer = "container:Alamofire.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "SWIFT_DETERMINISTIC_HASHING"
-            value = "1"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "OS_ACTIVITY_MODE"
-            value = "disable"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -108,8 +101,6 @@
             ReferencedContainer = "container:Alamofire.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire macOS.xcscheme
+++ b/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire macOS.xcscheme
@@ -59,11 +59,6 @@
             value = "1"
             isEnabled = "YES">
          </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "OS_ACTIVITY_MODE"
-            value = "disable"
-            isEnabled = "YES">
-         </EnvironmentVariable>
       </EnvironmentVariables>
       <CodeCoverageTargets>
          <BuildableReference

--- a/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire tvOS.xcscheme
+++ b/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire tvOS.xcscheme
@@ -40,10 +40,26 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4CF626EE1BA7CB3E0011A099"
+            BuildableName = "Alamofire.framework"
+            BlueprintName = "Alamofire tvOS"
+            ReferencedContainer = "container:Alamofire.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "SWIFT_DETERMINISTIC_HASHING"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -65,29 +81,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4CF626EE1BA7CB3E0011A099"
-            BuildableName = "Alamofire.framework"
-            BlueprintName = "Alamofire tvOS"
-            ReferencedContainer = "container:Alamofire.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "SWIFT_DETERMINISTIC_HASHING"
-            value = "1"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "OS_ACTIVITY_MODE"
-            value = "disable"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -108,8 +101,6 @@
             ReferencedContainer = "container:Alamofire.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -24,7 +24,12 @@
 
 import Foundation
 
-/// Used to store all data associated with a serialized response of a data or upload request.
+/// Default type of `DataResponse` returned by Alamofire, with an `AFError` `Failure` type.
+public typealias AFDataResponse<Success> = DataResponse<Success, AFError>
+/// Default type of `DownloadResponse` returned by Alamofire, with an `AFError` `Failure` type.
+public typealias AFDownloadResponse<Success> = DownloadResponse<Success, AFError>
+
+/// Type used to store all values associated with a serialized response of a `DataRequest` or `UploadRequest`.
 public struct DataResponse<Success, Failure: Error> {
     /// The URL request sent to the server.
     public let request: URLRequest?
@@ -50,13 +55,13 @@ public struct DataResponse<Success, Failure: Error> {
     /// Returns the associated error value if the result if it is a failure, `nil` otherwise.
     public var error: Failure? { return result.failure }
 
-    /// Creates a `DataResponse` instance with the specified parameters derviced from the response serialization.
+    /// Creates a `DataResponse` instance with the specified parameters derived from the response serialization.
     ///
     /// - Parameters:
     ///   - request:               The `URLRequest` sent to the server.
     ///   - response:              The `HTTPURLResponse` from the server.
     ///   - data:                  The `Data` returned by the server.
-    ///   - metrics:               The `URLSessionTaskMetrics` of the serialized response.
+    ///   - metrics:               The `URLSessionTaskMetrics` of the `DataRequest` or `UploadRequest`.
     ///   - serializationDuration: The duration taken by serialization.
     ///   - result:                The `Result` of response serialization.
     public init(request: URLRequest?,
@@ -84,7 +89,7 @@ extension DataResponse: CustomStringConvertible, CustomDebugStringConvertible {
     }
 
     /// The debug textual representation used when written to an output stream, which includes the URL request, the URL
-    /// response, the server data, the duration of the network and serializatino actions, and the response serialization
+    /// response, the server data, the duration of the network and serialization actions, and the response serialization
     /// result.
     public var debugDescription: String {
         let requestDescription = request.map { "\($0.httpMethod!) \($0)" } ?? "nil"
@@ -238,10 +243,10 @@ public struct DownloadResponse<Success, Failure: Error> {
     /// - Parameters:
     ///   - request:               The `URLRequest` sent to the server.
     ///   - response:              The `HTTPURLResponse` from the server.
-    ///   - temporaryURL:          The temporary destinatio `URL` of the data returned from the server.
+    ///   - temporaryURL:          The temporary destination `URL` of the data returned from the server.
     ///   - destinationURL:        The final destination `URL` of the data returned from the server, if it was moved.
     ///   - resumeData:            The resume `Data` generated if the request was cancelled.
-    ///   - metrics:               The `URLSessionTaskMetrics` of the serialized response.
+    ///   - metrics:               The `URLSessionTaskMetrics` of the `DownloadRequest`.
     ///   - serializationDuration: The duration taken by serialization.
     ///   - result:                The `Result` of response serialization.
     public init(request: URLRequest?,

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -176,10 +176,10 @@ extension DataRequest {
     ///
     /// - Returns:             The request.
     @discardableResult
-    public func response(queue: DispatchQueue = .main, completionHandler: @escaping (DataResponse<Data?, AFError>) -> Void) -> Self {
+    public func response(queue: DispatchQueue = .main, completionHandler: @escaping (AFDataResponse<Data?>) -> Void) -> Self {
         appendResponseSerializer {
             // Start work that should be on the serialization queue.
-            let result = Result<Data?, AFError>(value: self.data, error: self.error)
+            let result = AFResult<Data?>(value: self.data, error: self.error)
             // End work that should be on the serialization queue.
 
             self.underlyingQueue.async {
@@ -210,12 +210,12 @@ extension DataRequest {
     @discardableResult
     public func response<Serializer: DataResponseSerializerProtocol>(queue: DispatchQueue = .main,
                                                                      responseSerializer: Serializer,
-                                                                     completionHandler: @escaping (DataResponse<Serializer.SerializedObject, AFError>) -> Void)
+                                                                     completionHandler: @escaping (AFDataResponse<Serializer.SerializedObject>) -> Void)
         -> Self {
         appendResponseSerializer {
             // Start work that should be on the serialization queue.
             let start = CFAbsoluteTimeGetCurrent()
-            let result: Result<Serializer.SerializedObject, AFError> = Result {
+            let result: AFResult<Serializer.SerializedObject> = Result {
                 try responseSerializer.serialize(request: self.request,
                                                  response: self.response,
                                                  data: self.data,
@@ -256,7 +256,7 @@ extension DataRequest {
                         didComplete = { completionHandler(response) }
 
                     case let .doNotRetryWithError(retryError):
-                        let result: Result<Serializer.SerializedObject, AFError> = .failure(retryError.asAFError(orFailWith: "Received retryError was not already AFError"))
+                        let result: AFResult<Serializer.SerializedObject> = .failure(retryError.asAFError(orFailWith: "Received retryError was not already AFError"))
 
                         let response = DataResponse(request: self.request,
                                                     response: self.response,
@@ -288,11 +288,11 @@ extension DownloadRequest {
     /// - Returns:             The request.
     @discardableResult
     public func response(queue: DispatchQueue = .main,
-                         completionHandler: @escaping (DownloadResponse<URL?, AFError>) -> Void)
+                         completionHandler: @escaping (AFDownloadResponse<URL?>) -> Void)
         -> Self {
         appendResponseSerializer {
             // Start work that should be on the serialization queue.
-            let result = Result<URL?, AFError>(value: self.fileURL, error: self.error)
+            let result = AFResult<URL?>(value: self.fileURL, error: self.error)
             // End work that should be on the serialization queue.
 
             self.underlyingQueue.async {
@@ -325,12 +325,12 @@ extension DownloadRequest {
     @discardableResult
     public func response<T: DownloadResponseSerializerProtocol>(queue: DispatchQueue = .main,
                                                                 responseSerializer: T,
-                                                                completionHandler: @escaping (DownloadResponse<T.SerializedObject, AFError>) -> Void)
+                                                                completionHandler: @escaping (AFDownloadResponse<T.SerializedObject>) -> Void)
         -> Self {
         appendResponseSerializer {
             // Start work that should be on the serialization queue.
             let start = CFAbsoluteTimeGetCurrent()
-            let result: Result<T.SerializedObject, AFError> = Result {
+            let result: AFResult<T.SerializedObject> = Result {
                 try responseSerializer.serializeDownload(request: self.request,
                                                          response: self.response,
                                                          fileURL: self.fileURL,
@@ -371,7 +371,7 @@ extension DownloadRequest {
                         didComplete = { completionHandler(response) }
 
                     case let .doNotRetryWithError(retryError):
-                        let result: Result<T.SerializedObject, AFError> = .failure(retryError.asAFError(orFailWith: "Received retryError was not already AFError"))
+                        let result: AFResult<T.SerializedObject> = .failure(retryError.asAFError(orFailWith: "Received retryError was not already AFError"))
 
                         let response = DownloadResponse(request: self.request,
                                                         response: self.response,
@@ -406,7 +406,7 @@ extension DataRequest {
     /// - Returns:             The request.
     @discardableResult
     public func responseData(queue: DispatchQueue = .main,
-                             completionHandler: @escaping (DataResponse<Data, AFError>) -> Void)
+                             completionHandler: @escaping (AFDataResponse<Data>) -> Void)
         -> Self {
         return response(queue: queue,
                         responseSerializer: DataResponseSerializer(),
@@ -463,7 +463,7 @@ extension DownloadRequest {
     /// - Returns:             The request.
     @discardableResult
     public func responseData(queue: DispatchQueue = .main,
-                             completionHandler: @escaping (DownloadResponse<Data, AFError>) -> Void)
+                             completionHandler: @escaping (AFDownloadResponse<Data>) -> Void)
         -> Self {
         return response(queue: queue,
                         responseSerializer: DataResponseSerializer(),
@@ -545,7 +545,7 @@ extension DataRequest {
     @discardableResult
     public func responseString(queue: DispatchQueue = .main,
                                encoding: String.Encoding? = nil,
-                               completionHandler: @escaping (DataResponse<String, AFError>) -> Void) -> Self {
+                               completionHandler: @escaping (AFDataResponse<String>) -> Void) -> Self {
         return response(queue: queue,
                         responseSerializer: StringResponseSerializer(encoding: encoding),
                         completionHandler: completionHandler)
@@ -565,7 +565,7 @@ extension DownloadRequest {
     @discardableResult
     public func responseString(queue: DispatchQueue = .main,
                                encoding: String.Encoding? = nil,
-                               completionHandler: @escaping (DownloadResponse<String, AFError>) -> Void)
+                               completionHandler: @escaping (AFDownloadResponse<String>) -> Void)
         -> Self {
         return response(queue: queue,
                         responseSerializer: StringResponseSerializer(encoding: encoding),
@@ -635,7 +635,7 @@ extension DataRequest {
     @discardableResult
     public func responseJSON(queue: DispatchQueue = .main,
                              options: JSONSerialization.ReadingOptions = .allowFragments,
-                             completionHandler: @escaping (DataResponse<Any, AFError>) -> Void) -> Self {
+                             completionHandler: @escaping (AFDataResponse<Any>) -> Void) -> Self {
         return response(queue: queue,
                         responseSerializer: JSONResponseSerializer(options: options),
                         completionHandler: completionHandler)
@@ -654,7 +654,7 @@ extension DownloadRequest {
     @discardableResult
     public func responseJSON(queue: DispatchQueue = .main,
                              options: JSONSerialization.ReadingOptions = .allowFragments,
-                             completionHandler: @escaping (DownloadResponse<Any, AFError>) -> Void)
+                             completionHandler: @escaping (AFDownloadResponse<Any>) -> Void)
         -> Self {
         return response(queue: queue,
                         responseSerializer: JSONResponseSerializer(options: options),
@@ -771,7 +771,7 @@ extension DataRequest {
     public func responseDecodable<T: Decodable>(of type: T.Type = T.self,
                                                 queue: DispatchQueue = .main,
                                                 decoder: DataDecoder = JSONDecoder(),
-                                                completionHandler: @escaping (DataResponse<T, AFError>) -> Void) -> Self {
+                                                completionHandler: @escaping (AFDataResponse<T>) -> Void) -> Self {
         return response(queue: queue,
                         responseSerializer: DecodableResponseSerializer(decoder: decoder),
                         completionHandler: completionHandler)

--- a/Source/Result+Alamofire.swift
+++ b/Source/Result+Alamofire.swift
@@ -24,8 +24,8 @@
 
 import Foundation
 
-/// `Result` that always has an `Error` `Failure` type.
-public typealias AFResult<T> = Result<T, Error>
+/// Default type of `Result` returned by Alamofire, with an `AFError` `Failure` type.
+public typealias AFResult<Success> = Result<Success, AFError>
 
 // MARK: - Internal APIs
 

--- a/Tests/BaseTestCase.swift
+++ b/Tests/BaseTestCase.swift
@@ -44,29 +44,6 @@ class BaseTestCase: XCTestCase {
         return bundle.url(forResource: fileName, withExtension: ext)!
     }
 
-    func assertErrorIsAFError(_ error: Error?,
-                              file: StaticString = #file,
-                              line: UInt = #line,
-                              evaluation: (_ error: AFError) -> Void) {
-        guard let error = error?.asAFError else {
-            XCTFail("error is not an AFError", file: file, line: line)
-            return
-        }
-
-        evaluation(error)
-    }
-
-    func assertErrorIsServerTrustEvaluationError(_ error: Error?, file: StaticString = #file, line: UInt = #line, evaluation: (_ reason: AFError.ServerTrustFailureReason) -> Void) {
-        assertErrorIsAFError(error, file: file, line: line) { error in
-            guard case let .serverTrustEvaluationFailed(reason) = error else {
-                XCTFail("error is not .serverTrustEvaluationFailed", file: file, line: line)
-                return
-            }
-
-            evaluation(reason)
-        }
-    }
-
     /// Runs assertions on a particular `DispatchQueue`.
     ///
     /// - Parameters:

--- a/Tests/MultipartFormDataTests.swift
+++ b/Tests/MultipartFormDataTests.swift
@@ -793,14 +793,8 @@ class MultipartFormDataFailureTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(encodingError, "encoding error should not be nil")
 
-        if let error = encodingError?.asAFError {
-            XCTAssertTrue(error.isBodyPartFilenameInvalid)
-
-            let expectedFailureReason = "The URL provided does not have a valid filename: \(fileURL)"
-            XCTAssertEqual(error.localizedDescription, expectedFailureReason, "failure reason does not match expected value")
-        } else {
-            XCTFail("Error should be AFError.")
-        }
+        XCTAssertEqual(encodingError?.asAFError?.isBodyPartFilenameInvalid, true)
+        XCTAssertEqual(encodingError?.asAFError?.url, fileURL)
     }
 
     func testThatAppendingFileBodyPartThatIsNotFileURLReturnsError() {
@@ -820,15 +814,8 @@ class MultipartFormDataFailureTestCase: BaseTestCase {
 
         // Then
         XCTAssertNotNil(encodingError, "encoding error should not be nil")
-
-        if let error = encodingError?.asAFError {
-            XCTAssertTrue(error.isBodyPartURLInvalid)
-
-            let expectedFailureReason = "The URL provided is not a file URL: \(fileURL)"
-            XCTAssertEqual(error.localizedDescription, expectedFailureReason, "error failure reason does not match expected value")
-        } else {
-            XCTFail("Error should be AFError.")
-        }
+        XCTAssertEqual(encodingError?.asAFError?.isBodyPartURLInvalid, true)
+        XCTAssertEqual(encodingError?.asAFError?.url, fileURL)
     }
 
     func testThatAppendingFileBodyPartThatIsNotReachableReturnsError() {
@@ -850,11 +837,8 @@ class MultipartFormDataFailureTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(encodingError, "encoding error should not be nil")
 
-        if let error = encodingError?.asAFError {
-            XCTAssertTrue(error.isBodyPartFileNotReachableWithError)
-        } else {
-            XCTFail("Error should be AFError.")
-        }
+        XCTAssertEqual(encodingError?.asAFError?.isBodyPartFileNotReachableWithError, true)
+        XCTAssertEqual(encodingError?.asAFError?.url, fileURL)
     }
 
     func testThatAppendingFileBodyPartThatIsDirectoryReturnsError() {
@@ -874,15 +858,8 @@ class MultipartFormDataFailureTestCase: BaseTestCase {
 
         // Then
         XCTAssertNotNil(encodingError, "encoding error should not be nil")
-
-        if let error = encodingError?.asAFError {
-            XCTAssertTrue(error.isBodyPartFileIsDirectory)
-
-            let expectedFailureReason = "The URL provided is a directory: \(directoryURL)"
-            XCTAssertEqual(error.localizedDescription, expectedFailureReason, "error failure reason does not match expected value")
-        } else {
-            XCTFail("Error should be AFError.")
-        }
+        XCTAssertEqual(encodingError?.asAFError?.isBodyPartFileIsDirectory, true)
+        XCTAssertEqual(encodingError?.asAFError?.url, directoryURL)
     }
 
     func testThatWritingEncodedDataToExistingFileURLFails() {
@@ -913,10 +890,7 @@ class MultipartFormDataFailureTestCase: BaseTestCase {
         // Then
         XCTAssertNil(writerError, "writer error should be nil")
         XCTAssertNotNil(encodingError, "encoding error should not be nil")
-
-        if let encodingError = encodingError?.asAFError {
-            XCTAssertTrue(encodingError.isOutputStreamFileAlreadyExists)
-        }
+        XCTAssertEqual(encodingError?.asAFError?.isOutputStreamFileAlreadyExists, true)
     }
 
     func testThatWritingEncodedDataToBadURLFails() {
@@ -938,9 +912,6 @@ class MultipartFormDataFailureTestCase: BaseTestCase {
 
         // Then
         XCTAssertNotNil(encodingError, "encoding error should not be nil")
-
-        if let encodingError = encodingError?.asAFError {
-            XCTAssertTrue(encodingError.isOutputStreamURLInvalid)
-        }
+        XCTAssertEqual(encodingError?.asAFError?.isOutputStreamURLInvalid, true)
     }
 }

--- a/Tests/ParameterEncoderTests.swift
+++ b/Tests/ParameterEncoderTests.swift
@@ -226,7 +226,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "a=a")
+        XCTAssertEqual(result.success, "a=a")
     }
 
     func testEncoderCanEncodeDouble() {
@@ -238,7 +238,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "a=1.0")
+        XCTAssertEqual(result.success, "a=1.0")
     }
 
     func testEncoderCanEncodeFloat() {
@@ -250,7 +250,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "a=1.0")
+        XCTAssertEqual(result.success, "a=1.0")
     }
 
     func testEncoderCanEncodeInt8() {
@@ -262,7 +262,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "a=1")
+        XCTAssertEqual(result.success, "a=1")
     }
 
     func testEncoderCanEncodeInt16() {
@@ -274,7 +274,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "a=1")
+        XCTAssertEqual(result.success, "a=1")
     }
 
     func testEncoderCanEncodeInt32() {
@@ -286,7 +286,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "a=1")
+        XCTAssertEqual(result.success, "a=1")
     }
 
     func testEncoderCanEncodeInt64() {
@@ -298,7 +298,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "a=1")
+        XCTAssertEqual(result.success, "a=1")
     }
 
     func testEncoderCanEncodeUInt() {
@@ -310,7 +310,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "a=1")
+        XCTAssertEqual(result.success, "a=1")
     }
 
     func testEncoderCanEncodeUInt8() {
@@ -322,7 +322,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "a=1")
+        XCTAssertEqual(result.success, "a=1")
     }
 
     func testEncoderCanEncodeUInt16() {
@@ -334,7 +334,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "a=1")
+        XCTAssertEqual(result.success, "a=1")
     }
 
     func testEncoderCanEncodeUInt32() {
@@ -346,7 +346,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "a=1")
+        XCTAssertEqual(result.success, "a=1")
     }
 
     func testEncoderCanEncodeUInt64() {
@@ -358,7 +358,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "a=1")
+        XCTAssertEqual(result.success, "a=1")
     }
 
     func testThatNestedDictionariesHaveBracketedKeys() {
@@ -370,7 +370,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "a%5Bb%5D=b")
+        XCTAssertEqual(result.success, "a%5Bb%5D=b")
     }
 
     func testThatEncodableStructCanBeEncoded() {
@@ -383,7 +383,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
 
         // Then
         let expected = "four%5B%5D=1&four%5B%5D=2&four%5B%5D=3&three=1&one=one&two=2&five%5Ba%5D=a&six%5Ba%5D%5Bb%5D=b&seven%5Ba%5D=a"
-        XCTAssertQueryEqual(result.value, expected)
+        XCTAssertQueryEqual(result.success, expected)
     }
 
     func testThatManuallyEncodableStructCanBeEncoded() {
@@ -396,7 +396,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
 
         // Then
         let expected = "root%5B%5D%5B%5D=1&root%5B%5D%5B%5D=2&root%5B%5D%5B%5D=3&root%5B%5D%5Ba%5D%5Bstring%5D=string&root%5B%5D%5B%5D%5B%5D=1&root%5B%5D%5B%5D%5B%5D=2&root%5B%5D%5B%5D%5B%5D=3"
-        XCTAssertQueryEqual(result.value, expected)
+        XCTAssertQueryEqual(result.success, expected)
     }
 
     func testThatEncodableClassWithNoInheritanceCanBeEncoded() {
@@ -408,7 +408,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertQueryEqual(result.value, "two=2&one=one&three=1")
+        XCTAssertQueryEqual(result.success, "two=2&one=one&three=1")
     }
 
     func testThatEncodableSubclassCanBeEncoded() {
@@ -421,7 +421,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
 
         // Then
         let expected = "four%5B%5D=1&four%5B%5D=2&four%5B%5D=3&two=2&five%5Ba%5D=a&five%5Bb%5D=b&three=1&one=one"
-        XCTAssertQueryEqual(result.value, expected)
+        XCTAssertQueryEqual(result.success, expected)
     }
 
     func testThatManuallyEncodableSubclassCanBeEncoded() {
@@ -434,7 +434,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
 
         // Then
         let expected = "five%5Ba%5D=a&five%5Bb%5D=b&four%5Bfour%5D=one&four%5Bfive%5D=2"
-        XCTAssertQueryEqual(result.value, expected)
+        XCTAssertQueryEqual(result.success, expected)
     }
 
     func testThatARootArrayCannotBeEncoded() {
@@ -482,7 +482,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertQueryEqual(result.value, "array=1&array=2")
+        XCTAssertQueryEqual(result.success, "array=1&array=2")
     }
 
     func testThatBoolsCanBeLiteralEncoded() {
@@ -494,7 +494,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "bool=true")
+        XCTAssertEqual(result.success, "bool=true")
     }
 
     func testThatDataCanBeEncoded() {
@@ -506,7 +506,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "data=ZGF0YQ%3D%3D")
+        XCTAssertEqual(result.success, "data=ZGF0YQ%3D%3D")
     }
 
     func testThatCustomDataEncodingFailsWhenErrorIsThrown() {
@@ -521,7 +521,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertTrue(result.error is DataEncodingError)
+        XCTAssertTrue(result.failure is DataEncodingError)
     }
 
     func testThatDatesCanBeEncoded() {
@@ -533,7 +533,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "date=123.456")
+        XCTAssertEqual(result.success, "date=123.456")
     }
 
     func testThatDatesCanBeEncodedAsSecondsSince1970() {
@@ -545,7 +545,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "date=978307323.456")
+        XCTAssertEqual(result.success, "date=978307323.456")
     }
 
     func testThatDatesCanBeEncodedAsMillisecondsSince1970() {
@@ -557,7 +557,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "date=978307323456.0")
+        XCTAssertEqual(result.success, "date=978307323456.0")
     }
 
     func testThatDatesCanBeEncodedAsISO8601Formatted() {
@@ -569,7 +569,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "date=2001-01-01T00%3A02%3A03Z")
+        XCTAssertEqual(result.success, "date=2001-01-01T00%3A02%3A03Z")
     }
 
     func testThatDatesCanBeEncodedAsFormatted() {
@@ -585,7 +585,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "date=2001-01-01%2000%3A02%3A03.4560")
+        XCTAssertEqual(result.success, "date=2001-01-01%2000%3A02%3A03.4560")
     }
 
     func testThatDatesCanBeEncodedAsCustomFormatted() {
@@ -597,7 +597,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "date=123.456")
+        XCTAssertEqual(result.success, "date=123.456")
     }
 
     func testEncoderThrowsErrorWhenCustomDateEncodingFails() {
@@ -612,7 +612,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertTrue(result.error is DateEncodingError)
+        XCTAssertTrue(result.failure is DateEncodingError)
     }
 
     func testThatKeysCanBeEncodedIntoSnakeCase() {
@@ -624,7 +624,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(paramters) }
 
         // Then
-        XCTAssertEqual(result.value, "one_two_three=oneTwoThree")
+        XCTAssertEqual(result.success, "one_two_three=oneTwoThree")
     }
 
     func testThatKeysCanBeEncodedIntoKebabCase() {
@@ -636,7 +636,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(paramters) }
 
         // Then
-        XCTAssertEqual(result.value, "one-two-three=oneTwoThree")
+        XCTAssertEqual(result.success, "one-two-three=oneTwoThree")
     }
 
     func testThatKeysCanBeEncodedIntoACapitalizedString() {
@@ -648,7 +648,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(paramters) }
 
         // Then
-        XCTAssertEqual(result.value, "OneTwoThree=oneTwoThree")
+        XCTAssertEqual(result.success, "OneTwoThree=oneTwoThree")
     }
 
     func testThatKeysCanBeEncodedIntoALowercasedString() {
@@ -660,7 +660,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(paramters) }
 
         // Then
-        XCTAssertEqual(result.value, "onetwothree=oneTwoThree")
+        XCTAssertEqual(result.success, "onetwothree=oneTwoThree")
     }
 
     func testThatKeysCanBeEncodedIntoAnUppercasedString() {
@@ -672,7 +672,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(paramters) }
 
         // Then
-        XCTAssertEqual(result.value, "ONETWOTHREE=oneTwoThree")
+        XCTAssertEqual(result.success, "ONETWOTHREE=oneTwoThree")
     }
 
     func testThatKeysCanBeCustomEncoded() {
@@ -684,7 +684,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(paramters) }
 
         // Then
-        XCTAssertEqual(result.value, "A=oneTwoThree")
+        XCTAssertEqual(result.success, "A=oneTwoThree")
     }
 
     func testThatSpacesCanBeEncodedAsPluses() {
@@ -696,7 +696,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "spaces=replace+with+spaces")
+        XCTAssertEqual(result.success, "spaces=replace+with+spaces")
     }
 
     func testThatEscapedCharactersCanBeCustomized() {
@@ -710,7 +710,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "allowed=%3F%2F")
+        XCTAssertEqual(result.success, "allowed=%3F%2F")
     }
 
     func testThatUnreservedCharactersAreNotPercentEscaped() {
@@ -724,7 +724,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertQueryEqual(result.value,
+        XCTAssertQueryEqual(result.success,
                             "uppercase=ABCDEFGHIJKLMNOPQRSTUVWXYZ&numbers=0123456789&lowercase=abcdefghijklmnopqrstuvwxyz")
     }
 
@@ -739,7 +739,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "reserved=%3A%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D")
+        XCTAssertEqual(result.success, "reserved=%3A%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D")
     }
 
     func testThatIllegalASCIICharactersArePercentEscaped() {
@@ -751,7 +751,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "illegal=%20%22%23%25%3C%3E%5B%5D%5C%5E%60%7B%7D%7C")
+        XCTAssertEqual(result.success, "illegal=%20%22%23%25%3C%3E%5B%5D%5C%5E%60%7B%7D%7C")
     }
 
     func testThatAmpersandsInKeysAndValuesArePercentEscaped() {
@@ -763,7 +763,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertQueryEqual(result.value, "foobar=bazqux&foo%26bar=baz%26qux")
+        XCTAssertQueryEqual(result.success, "foobar=bazqux&foo%26bar=baz%26qux")
     }
 
     func testThatQuestionMarksInKeysAndValuesAreNotPercentEscaped() {
@@ -775,7 +775,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "?foo?=?bar?")
+        XCTAssertEqual(result.success, "?foo?=?bar?")
     }
 
     func testThatSlashesInKeysAndValuesAreNotPercentEscaped() {
@@ -787,7 +787,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "foo=/bar/baz/qux")
+        XCTAssertEqual(result.success, "foo=/bar/baz/qux")
     }
 
     func testThatSpacesInKeysAndValuesArePercentEscaped() {
@@ -799,7 +799,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "%20foo%20=%20bar%20")
+        XCTAssertEqual(result.success, "%20foo%20=%20bar%20")
     }
 
     func testThatPlusesInKeysAndValuesArePercentEscaped() {
@@ -811,7 +811,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "%2Bfoo%2B=%2Bbar%2B")
+        XCTAssertEqual(result.success, "%2Bfoo%2B=%2Bbar%2B")
     }
 
     func testThatPercentsInKeysAndValuesArePercentEscaped() {
@@ -823,7 +823,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let result = Result<String, Error> { try encoder.encode(parameters) }
 
         // Then
-        XCTAssertEqual(result.value, "percent%25=%2525")
+        XCTAssertEqual(result.success, "percent%25=%2525")
     }
 
     func testThatNonLatinCharactersArePercentEscaped() {
@@ -842,7 +842,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
                                        "japanese=%E6%97%A5%E6%9C%AC%E8%AA%9E",
                                        "french=fran%C3%A7ais",
                                        "emoji=%F0%9F%98%83"].joined(separator: "&")
-        XCTAssertQueryEqual(result.value, expectedParameterValues)
+        XCTAssertQueryEqual(result.success, expectedParameterValues)
     }
 
     func testStringWithThousandsOfChineseCharactersIsPercentEscaped() {
@@ -858,7 +858,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let escaped = String(repeating: "%E4%B8%80%E4%BA%8C%E4%B8%89%E5%9B%9B%E4%BA%94%E5%85%AD%E4%B8%83%E5%85%AB%E4%B9%9D%E5%8D%81",
                              count: repeatedCount)
         let expected = "chinese=\(escaped)"
-        XCTAssertEqual(result.value, expected)
+        XCTAssertEqual(result.success, expected)
     }
 }
 

--- a/Tests/RequestInterceptorTests.swift
+++ b/Tests/RequestInterceptorTests.swift
@@ -279,7 +279,7 @@ final class InterceptorTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertEqual(result.value, urlRequest)
+        XCTAssertEqual(result.success, urlRequest)
     }
 
     func testThatInterceptorCanAdaptRequestWithOneAdapter() {
@@ -297,7 +297,7 @@ final class InterceptorTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertTrue(result.error is MockError)
+        XCTAssertTrue(result.failure is MockError)
     }
 
     func testThatInterceptorCanAdaptRequestWithMultipleAdapters() {
@@ -316,7 +316,7 @@ final class InterceptorTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertTrue(result.error is MockError)
+        XCTAssertTrue(result.failure is MockError)
     }
 
     func testThatInterceptorCanAdaptRequestAsynchronously() {
@@ -345,7 +345,7 @@ final class InterceptorTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertTrue(result.error is MockError)
+        XCTAssertTrue(result.failure is MockError)
     }
 
     func testThatInterceptorCanRetryRequestWithNoRetriers() {

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -117,7 +117,7 @@ final class RequestResponseTestCase: BaseTestCase {
         XCTAssertNotNil(response?.response)
         XCTAssertNotNil(response?.data)
 
-        if let json = response?.result.value as? [String: Any], let form = json["form"] as? [String: String] {
+        if let json = response?.result.success as? [String: Any], let form = json["form"] as? [String: String] {
             XCTAssertEqual(form["french"], parameters["french"])
             XCTAssertEqual(form["japanese"], parameters["japanese"])
             XCTAssertEqual(form["arabic"], parameters["arabic"])
@@ -168,7 +168,7 @@ final class RequestResponseTestCase: BaseTestCase {
         XCTAssertNotNil(response?.data)
         XCTAssertEqual(response?.result.isSuccess, true)
 
-        if let json = response?.result.value as? [String: Any], let form = json["form"] as? [String: String] {
+        if let json = response?.result.success as? [String: Any], let form = json["form"] as? [String: String] {
             XCTAssertEqual(form["email"], parameters["email"])
             XCTAssertEqual(form["png_image"], parameters["png_image"])
             XCTAssertEqual(form["jpeg_image"], parameters["jpeg_image"])
@@ -236,7 +236,7 @@ final class RequestResponseTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        XCTAssertEqual(receivedResponse?.result.value?.data, "{\"property\":\"one\"}")
+        XCTAssertEqual(receivedResponse?.result.success?.data, "{\"property\":\"one\"}")
     }
 
     func testThatRequestsCanPassEncodableParametersAsAURLQuery() {
@@ -255,7 +255,7 @@ final class RequestResponseTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        XCTAssertEqual(receivedResponse?.result.value?.args, ["property": "one"])
+        XCTAssertEqual(receivedResponse?.result.success?.args, ["property": "one"])
     }
 
     func testThatRequestsCanPassEncodableParametersAsURLEncodedBodyData() {
@@ -274,7 +274,7 @@ final class RequestResponseTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        XCTAssertEqual(receivedResponse?.result.value?.form, ["property": "one"])
+        XCTAssertEqual(receivedResponse?.result.success?.form, ["property": "one"])
     }
 
     // MARK: Lifetime Events

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -43,8 +43,8 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
     }
 
     func testThatDataResponseSerializerFailsWhenDataIsNil() {
@@ -56,14 +56,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
     func testThatDataResponseSerializerFailsWhenErrorIsNotNil() {
@@ -75,14 +70,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
     func testThatDataResponseSerializerFailsWhenDataIsNilWithNonEmptyResponseStatusCode() {
@@ -95,14 +85,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure, "result is failure should be true")
-        XCTAssertNil(result.value, "result value should be nil")
-        XCTAssertNotNil(result.error, "result error should not be nil")
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success, "result value should be nil")
+        XCTAssertNotNil(result.failure, "result error should not be nil")
+        XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
     func testThatDataResponseSerializerSucceedsWhenDataIsNilWithGETRequestAnd204ResponseStatusCode() {
@@ -116,9 +101,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
-        XCTAssertEqual(result.value?.count, 0)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
+        XCTAssertEqual(result.success?.count, 0)
     }
 
     func testThatDataResponseSerializerSucceedsWhenDataIsNilWithGETRequestAnd205ResponseStatusCode() {
@@ -132,9 +117,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
-        XCTAssertEqual(result.value?.count, 0)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
+        XCTAssertEqual(result.success?.count, 0)
     }
 
     func testThatDataResponseSerializerSucceedsWhenDataIsNilWithHEADRequestAnd200ResponseStatusCode() {
@@ -148,9 +133,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
-        XCTAssertEqual(result.value?.count, 0)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
+        XCTAssertEqual(result.success?.count, 0)
     }
 
     // MARK: StringResponseSerializer
@@ -164,14 +149,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
     func testThatStringResponseSerializerFailsWhenDataIsEmpty() {
@@ -183,14 +163,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
     func testThatStringResponseSerializerSucceedsWithUTF8DataAndNoProvidedEncoding() {
@@ -202,8 +177,8 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
     }
 
     func testThatStringResponseSerializerSucceedsWithUTF8DataAndUTF8ProvidedEncoding() {
@@ -215,8 +190,8 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
     }
 
     func testThatStringResponseSerializerSucceedsWithUTF8DataUsingResponseTextEncodingName() {
@@ -229,8 +204,8 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
     }
 
     func testThatStringResponseSerializerFailsWithUTF32DataAndUTF8ProvidedEncoding() {
@@ -243,15 +218,10 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError, let failedEncoding = error.failedStringEncoding {
-            XCTAssertTrue(error.isStringSerializationFailed)
-            XCTAssertEqual(failedEncoding, .utf8)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isStringSerializationFailed, true)
+        XCTAssertEqual(result.failure?.asAFError?.failedStringEncoding, .utf8)
     }
 
     func testThatStringResponseSerializerFailsWithUTF32DataAndUTF8ResponseEncoding() {
@@ -265,15 +235,10 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError, let failedEncoding = error.failedStringEncoding {
-            XCTAssertTrue(error.isStringSerializationFailed)
-            XCTAssertEqual(failedEncoding, .utf8)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isStringSerializationFailed, true)
+        XCTAssertEqual(result.failure?.asAFError?.failedStringEncoding, .utf8)
     }
 
     func testThatStringResponseSerializerFailsWhenErrorIsNotNil() {
@@ -285,14 +250,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
     func testThatStringResponseSerializerFailsWhenDataIsNilWithNonEmptyResponseStatusCode() {
@@ -305,14 +265,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
     func testThatStringResponseSerializerSucceedsWhenDataIsNilWithGETRequestAnd204ResponseStatusCode() {
@@ -326,9 +281,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
-        XCTAssertEqual(result.value, "")
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
+        XCTAssertEqual(result.success, "")
     }
 
     func testThatStringResponseSerializerSucceedsWhenDataIsNilWithGETRequestAnd205ResponseStatusCode() {
@@ -342,9 +297,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
-        XCTAssertEqual(result.value, "")
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
+        XCTAssertEqual(result.success, "")
     }
 
     func testThatStringResponseSerializerSucceedsWhenDataIsNilWithHEADRequestAnd200ResponseStatusCode() {
@@ -358,9 +313,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
-        XCTAssertEqual(result.value, "")
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
+        XCTAssertEqual(result.success, "")
     }
 
     // MARK: JSONResponseSerializer
@@ -374,14 +329,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
     func testThatJSONResponseSerializerFailsWhenDataIsEmpty() {
@@ -393,14 +343,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
     func testThatJSONResponseSerializerSucceedsWhenDataIsValidJSON() {
@@ -413,8 +358,8 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
     }
 
     func testThatJSONResponseSerializerFailsWhenDataIsInvalidJSON() {
@@ -427,15 +372,10 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError, let underlyingError = error.underlyingError as? CocoaError {
-            XCTAssertTrue(error.isJSONSerializationFailed)
-            XCTAssertEqual(underlyingError.errorCode, 3840)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isJSONSerializationFailed, true)
+        XCTAssertEqual((result.failure?.asAFError?.underlyingError as? CocoaError)?.code, .propertyListReadCorrupt)
     }
 
     func testThatJSONResponseSerializerFailsWhenErrorIsNotNil() {
@@ -447,14 +387,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
     func testThatJSONResponseSerializerFailsWhenDataIsNilWithNonEmptyResponseStatusCode() {
@@ -467,14 +402,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
     func testThatJSONResponseSerializerSucceedsWhenDataIsNilWithGETRequestAnd204ResponseStatusCode() {
@@ -488,9 +418,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
-        XCTAssertEqual(result.value as? NSNull, NSNull())
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
+        XCTAssertEqual(result.success as? NSNull, NSNull())
     }
 
     func testThatJSONResponseSerializerSucceedsWhenDataIsNilWithGETRequestAnd205ResponseStatusCode() {
@@ -504,9 +434,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
-        XCTAssertEqual(result.value as? NSNull, NSNull())
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
+        XCTAssertEqual(result.success as? NSNull, NSNull())
     }
 
     func testThatJSONResponseSerializerSucceedsWhenDataIsNilWithHEADRequestAnd200ResponseStatusCode() {
@@ -520,9 +450,9 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
-        XCTAssertEqual(result.value as? NSNull, NSNull())
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
+        XCTAssertEqual(result.success as? NSNull, NSNull())
     }
 }
 
@@ -555,14 +485,9 @@ final class DecodableResponseSerializerTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
     func testThatDecodableResponseSerializerFailsWhenDataIsEmpty() {
@@ -574,14 +499,9 @@ final class DecodableResponseSerializerTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
     func testThatDecodableResponseSerializerSucceedsWhenDataIsValidJSON() {
@@ -594,9 +514,9 @@ final class DecodableResponseSerializerTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertEqual(result.value?.string, "string")
-        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.success)
+        XCTAssertEqual(result.success?.string, "string")
+        XCTAssertNil(result.failure)
     }
 
     func testThatDecodableResponseSerializerFailsWhenDataIsInvalidRepresentation() {
@@ -609,8 +529,8 @@ final class DecodableResponseSerializerTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
     }
 
     func testThatDecodableResponseSerializerFailsWhenErrorIsNotNil() {
@@ -622,14 +542,9 @@ final class DecodableResponseSerializerTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
     func testThatDecodableResponseSerializerFailsWhenDataIsNilWithNonEmptyResponseStatusCode() {
@@ -642,14 +557,9 @@ final class DecodableResponseSerializerTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
     func testThatDecodableResponseSerializerSucceedsWhenDataIsNilWithEmptyResponseStatusCode() {
@@ -662,8 +572,8 @@ final class DecodableResponseSerializerTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
     }
 
     func testThatDecodableResponseSerializerSucceedsWhenDataIsNilWithEmptyTypeAndEmptyResponseStatusCode() {
@@ -676,8 +586,8 @@ final class DecodableResponseSerializerTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
     }
 
     func testThatDecodableResponseSerializerSucceedsWhenDataIsNilWithGETRequestAnd204ResponseStatusCode() {
@@ -691,8 +601,8 @@ final class DecodableResponseSerializerTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
     }
 
     func testThatDecodableResponseSerializerSucceedsWhenDataIsNilWithGETRequestAnd205ResponseStatusCode() {
@@ -706,8 +616,8 @@ final class DecodableResponseSerializerTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
     }
 
     func testThatDecodableResponseSerializerSucceedsWhenDataIsNilWithHEADRequestAnd200ResponseStatusCode() {
@@ -721,8 +631,8 @@ final class DecodableResponseSerializerTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
     }
 
     func testThatDecodableResponseSerializerSucceedsWhenDataIsNilWithEmptyResponseConformingTypeAndEmptyResponseStatusCode() {
@@ -735,8 +645,8 @@ final class DecodableResponseSerializerTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
     }
 
     func testThatDecodableResponseSerializerFailsWhenDataIsNilWithEmptyResponseNonconformingTypeAndEmptyResponseStatusCode() {
@@ -749,14 +659,9 @@ final class DecodableResponseSerializerTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInvalidEmptyResponse)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInvalidEmptyResponse, true)
     }
 }
 
@@ -788,8 +693,8 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
     }
 
     func testThatDataResponseSerializerFailsWhenFileDataIsEmpty() {
@@ -801,14 +706,9 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
     func testThatDataResponseSerializerFailsWhenFileURLIsNil() {
@@ -820,14 +720,9 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputFileNil)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputFileNil, true)
     }
 
     func testThatDataResponseSerializerFailsWhenFileURLIsInvalid() {
@@ -839,14 +734,9 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputFileReadFailed)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputFileReadFailed, true)
     }
 
     func testThatDataResponseSerializerFailsWhenErrorIsNotNil() {
@@ -858,14 +748,9 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputFileNil)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputFileNil, true)
     }
 
     func testThatDataResponseSerializerFailsWhenFileURLIsNilWithNonEmptyResponseStatusCode() {
@@ -878,14 +763,9 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputFileNil)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputFileNil, true)
     }
 
     func testThatDataResponseSerializerSucceedsWhenDataIsNilWithEmptyResponseStatusCode() {
@@ -898,9 +778,9 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
-        XCTAssertEqual(result.value?.count, 0)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
+        XCTAssertEqual(result.success?.count, 0)
     }
 
     // MARK: Tests - String Response Serializer
@@ -914,14 +794,9 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputFileNil)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputFileNil, true)
     }
 
     func testThatStringResponseSerializerFailsWhenFileURLIsInvalid() {
@@ -933,14 +808,9 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertEqual(result.isSuccess, false)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputFileReadFailed)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputFileReadFailed, true)
     }
 
     func testThatStringResponseSerializerFailsWhenFileDataIsEmpty() {
@@ -952,14 +822,9 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
     func testThatStringResponseSerializerSucceedsWithUTF8DataAndNoProvidedEncoding() {
@@ -971,8 +836,8 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
     }
 
     func testThatStringResponseSerializerSucceedsWithUTF8DataAndUTF8ProvidedEncoding() {
@@ -984,8 +849,8 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
     }
 
     func testThatStringResponseSerializerSucceedsWithUTF8DataUsingResponseTextEncodingName() {
@@ -998,8 +863,8 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
     }
 
     func testThatStringResponseSerializerFailsWithUTF32DataAndUTF8ProvidedEncoding() {
@@ -1011,15 +876,10 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError, let failedEncoding = error.failedStringEncoding {
-            XCTAssertTrue(error.isStringSerializationFailed)
-            XCTAssertEqual(failedEncoding, .utf8)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isStringSerializationFailed, true)
+        XCTAssertEqual(result.failure?.asAFError?.failedStringEncoding, .utf8)
     }
 
     func testThatStringResponseSerializerFailsWithUTF32DataAndUTF8ResponseEncoding() {
@@ -1032,15 +892,10 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError, let failedEncoding = error.failedStringEncoding {
-            XCTAssertTrue(error.isStringSerializationFailed)
-            XCTAssertEqual(failedEncoding, .utf8)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isStringSerializationFailed, true)
+        XCTAssertEqual(result.failure?.asAFError?.failedStringEncoding, .utf8)
     }
 
     func testThatStringResponseSerializerFailsWhenErrorIsNotNil() {
@@ -1052,14 +907,9 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputFileNil)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputFileNil, true)
     }
 
     func testThatStringResponseSerializerFailsWhenDataIsNilWithNonEmptyResponseStatusCode() {
@@ -1072,14 +922,9 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputFileNil)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputFileNil, true)
     }
 
     func testThatStringResponseSerializerSucceedsWhenDataIsNilWithEmptyResponseStatusCode() {
@@ -1092,9 +937,9 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
-        XCTAssertEqual(result.value, "")
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
+        XCTAssertEqual(result.success, "")
     }
 
     // MARK: Tests - JSON Response Serializer
@@ -1108,14 +953,9 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputFileNil)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputFileNil, true)
     }
 
     func testThatJSONResponseSerializerFailsWhenFileURLIsInvalid() {
@@ -1127,14 +967,9 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputFileReadFailed)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputFileReadFailed, true)
     }
 
     func testThatJSONResponseSerializerFailsWhenFileDataIsEmpty() {
@@ -1146,14 +981,9 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputDataNilOrZeroLength)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
     func testThatJSONResponseSerializerSucceedsWhenDataIsValidJSON() {
@@ -1165,8 +995,8 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
     }
 
     func testThatJSONResponseSerializerFailsWhenDataIsInvalidJSON() {
@@ -1178,15 +1008,10 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError, let underlyingError = error.underlyingError as? CocoaError {
-            XCTAssertTrue(error.isJSONSerializationFailed)
-            XCTAssertEqual(underlyingError.errorCode, 3840)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isJSONSerializationFailed, true)
+        XCTAssertEqual((result.failure?.asAFError?.underlyingError as? CocoaError)?.code, .propertyListReadCorrupt)
     }
 
     func testThatJSONResponseSerializerFailsWhenErrorIsNotNil() {
@@ -1198,14 +1023,9 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputFileNil)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputFileNil, true)
     }
 
     func testThatJSONResponseSerializerFailsWhenDataIsNilWithNonEmptyResponseStatusCode() {
@@ -1218,14 +1038,9 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
-
-        if let error = result.error?.asAFError {
-            XCTAssertTrue(error.isInputFileNil)
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
+        XCTAssertEqual(result.failure?.asAFError?.isInputFileNil, true)
     }
 
     func testThatJSONResponseSerializerSucceedsWhenDataIsNilWithEmptyResponseStatusCode() {
@@ -1238,10 +1053,10 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.value)
-        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.success)
+        XCTAssertNil(result.failure)
 
-        XCTAssertEqual(result.value as? NSNull, NSNull())
+        XCTAssertEqual(result.success as? NSNull, NSNull())
     }
 }
 
@@ -1296,8 +1111,8 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertEqual(result.value, Data("bcd".utf8))
-        XCTAssertNil(result.error)
+        XCTAssertEqual(result.success, Data("bcd".utf8))
+        XCTAssertNil(result.failure)
     }
 
     func testThatDataResponseSerializerProperlyReceivesErrorFromFailingDataPreprocessor() {
@@ -1311,8 +1126,8 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
     }
 
     func testThatStringResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
@@ -1326,8 +1141,8 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertEqual(result.value, "bcd")
-        XCTAssertNil(result.error)
+        XCTAssertEqual(result.success, "bcd")
+        XCTAssertNil(result.failure)
     }
 
     func testThatStringResponseSerializerProperlyReceivesErrorFromFailingDataPreprocessor() {
@@ -1341,8 +1156,8 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
     }
 
     func testThatJSONResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
@@ -1356,8 +1171,8 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertEqual(result.value as? String, "abcd")
-        XCTAssertNil(result.error)
+        XCTAssertEqual(result.success as? String, "abcd")
+        XCTAssertNil(result.failure)
     }
 
     func testThatJSONResponseSerializerProperlyReceivesErrorFromFailingDataPreprocessor() {
@@ -1371,8 +1186,8 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
     }
 
     func testThatDecodableResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
@@ -1386,8 +1201,8 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertEqual(result.value?.string, "string")
-        XCTAssertNil(result.error)
+        XCTAssertEqual(result.success?.string, "string")
+        XCTAssertNil(result.failure)
     }
 
     func testThatDecodableResponseSerializerProperlyReceivesErrorFromFailingDataPreprocessor() {
@@ -1401,8 +1216,8 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertNil(result.value)
-        XCTAssertNotNil(result.error)
+        XCTAssertNil(result.success)
+        XCTAssertNotNil(result.failure)
     }
 }
 
@@ -1416,7 +1231,7 @@ final class DataPreprocessorTests: BaseTestCase {
         let result = Result { try preprocessor.preprocess(data) }
 
         // Then
-        XCTAssertEqual(data, result.value, "Preprocessed data should equal original data.")
+        XCTAssertEqual(data, result.success, "Preprocessed data should equal original data.")
     }
 
     func testThatGoogleXSSIPreprocessorProperlyPreprocessesData() {
@@ -1428,7 +1243,7 @@ final class DataPreprocessorTests: BaseTestCase {
         let result = Result { try preprocessor.preprocess(data) }
 
         // Then
-        XCTAssertEqual(result.value.map { String(decoding: $0, as: UTF8.self) }, "abcd")
+        XCTAssertEqual(result.success.map { String(decoding: $0, as: UTF8.self) }, "abcd")
     }
 
     func testThatGoogleXSSIPreprocessorDoesNotChangeDataIfPrefixDoesNotMatch() {
@@ -1440,7 +1255,7 @@ final class DataPreprocessorTests: BaseTestCase {
         let result = Result { try preprocessor.preprocess(data) }
 
         // Then
-        XCTAssertEqual(result.value.map { String(decoding: $0, as: UTF8.self) }, "abcd")
+        XCTAssertEqual(result.success.map { String(decoding: $0, as: UTF8.self) }, "abcd")
     }
 }
 

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -53,7 +53,7 @@ class ResponseTestCase: BaseTestCase {
     func testThatResponseReturnsFailureResultWithOptionalDataAndError() {
         // Given
         let urlString = "https://invalid-url-here.org/this/does/not/exist"
-        let expectation = self.expectation(description: "request should fail with 404")
+        let expectation = self.expectation(description: "request should fail with invalid hostname error")
 
         var response: DataResponse<Data?, AFError>?
 
@@ -70,6 +70,8 @@ class ResponseTestCase: BaseTestCase {
         XCTAssertNil(response?.response)
         XCTAssertNil(response?.data)
         XCTAssertNotNil(response?.error)
+        XCTAssertEqual(response?.error?.isSessionTaskError, true)
+        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotFindHost)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -121,6 +123,8 @@ class ResponseDataTestCase: BaseTestCase {
         XCTAssertNil(response?.response)
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
+        XCTAssertEqual(response?.error?.isSessionTaskError, true)
+        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotFindHost)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -172,6 +176,8 @@ class ResponseStringTestCase: BaseTestCase {
         XCTAssertNil(response?.response)
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
+        XCTAssertEqual(response?.error?.isSessionTaskError, true)
+        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotFindHost)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -223,6 +229,8 @@ class ResponseJSONTestCase: BaseTestCase {
         XCTAssertNil(response?.response)
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
+        XCTAssertEqual(response?.error?.isSessionTaskError, true)
+        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotFindHost)
         XCTAssertNotNil(response?.metrics)
     }
 
@@ -250,7 +258,7 @@ class ResponseJSONTestCase: BaseTestCase {
         XCTAssertNotNil(response?.metrics)
 
         if
-            let responseDictionary = response?.result.value as? [String: Any],
+            let responseDictionary = response?.result.success as? [String: Any],
             let args = responseDictionary["args"] as? [String: String] {
             XCTAssertEqual(args, ["foo": "bar"], "args should match parameters")
         } else {
@@ -282,7 +290,7 @@ class ResponseJSONTestCase: BaseTestCase {
         XCTAssertNotNil(response?.metrics)
 
         if
-            let responseDictionary = response?.result.value as? [String: Any],
+            let responseDictionary = response?.result.success as? [String: Any],
             let form = responseDictionary["form"] as? [String: String] {
             XCTAssertEqual(form, ["foo": "bar"], "form should match parameters")
         } else {
@@ -312,7 +320,7 @@ class ResponseJSONDecodableTestCase: BaseTestCase {
         XCTAssertNotNil(response?.response)
         XCTAssertNotNil(response?.data)
         XCTAssertEqual(response?.result.isSuccess, true)
-        XCTAssertEqual(response?.result.value?.url, "https://httpbin.org/get")
+        XCTAssertEqual(response?.result.success?.url, "https://httpbin.org/get")
         XCTAssertNotNil(response?.metrics)
     }
 
@@ -336,7 +344,7 @@ class ResponseJSONDecodableTestCase: BaseTestCase {
         XCTAssertNotNil(response?.response)
         XCTAssertNotNil(response?.data)
         XCTAssertEqual(response?.result.isSuccess, true)
-        XCTAssertEqual(response?.result.value?.url, "https://httpbin.org/get")
+        XCTAssertEqual(response?.result.success?.url, "https://httpbin.org/get")
         XCTAssertNotNil(response?.metrics)
     }
 
@@ -360,6 +368,8 @@ class ResponseJSONDecodableTestCase: BaseTestCase {
         XCTAssertNil(response?.response)
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
+        XCTAssertEqual(response?.error?.isSessionTaskError, true)
+        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotFindHost)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -391,7 +401,7 @@ class ResponseMapTestCase: BaseTestCase {
         XCTAssertNotNil(response?.response)
         XCTAssertNotNil(response?.data)
         XCTAssertEqual(response?.result.isSuccess, true)
-        XCTAssertEqual(response?.result.value, "bar")
+        XCTAssertEqual(response?.result.success, "bar")
         XCTAssertNotNil(response?.metrics)
     }
 
@@ -415,6 +425,8 @@ class ResponseMapTestCase: BaseTestCase {
         XCTAssertNil(response?.response)
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
+        XCTAssertEqual(response?.error?.isSessionTaskError, true)
+        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotFindHost)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -446,7 +458,7 @@ class ResponseTryMapTestCase: BaseTestCase {
         XCTAssertNotNil(response?.response)
         XCTAssertNotNil(response?.data)
         XCTAssertEqual(response?.result.isSuccess, true)
-        XCTAssertEqual(response?.result.value, "bar")
+        XCTAssertEqual(response?.result.success, "bar")
         XCTAssertNotNil(response?.metrics)
     }
 
@@ -476,7 +488,7 @@ class ResponseTryMapTestCase: BaseTestCase {
         XCTAssertNotNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
 
-        if let error = response?.result.error {
+        if let error = response?.result.failure {
             XCTAssertTrue(error is TransformError)
         } else {
             XCTFail("tryMap should catch the transformation error")
@@ -505,6 +517,8 @@ class ResponseTryMapTestCase: BaseTestCase {
         XCTAssertNil(response?.response)
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
+        XCTAssertEqual(response?.error?.asAFError?.isSessionTaskError, true)
+        XCTAssertEqual((response?.error?.asAFError?.underlyingError as? URLError)?.code, .cannotFindHost)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -623,7 +637,7 @@ class ResponseTryMapErrorTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
 
-        if let error = response?.result.error {
+        if let error = response?.result.failure {
             XCTAssertTrue(error is TransformationError)
         } else {
             XCTFail("tryMapError should catch the transformation error")
@@ -653,7 +667,12 @@ class ResponseTryMapErrorTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
 
-        guard let error = response?.error as? TestError, case .error = error else { XCTFail(); return }
+        guard let error = response?.error as? TestError,
+            case let .error(underlyingError) = error
+        else { XCTFail(); return }
+
+        XCTAssertEqual(underlyingError.asAFError?.isSessionTaskError, true)
+        XCTAssertEqual((underlyingError.asAFError?.underlyingError as? URLError)?.code, .cannotFindHost)
 
         XCTAssertNotNil(response?.metrics)
     }

--- a/Tests/Result+Alamofire.swift
+++ b/Tests/Result+Alamofire.swift
@@ -34,12 +34,12 @@ extension Result {
         return !isSuccess
     }
 
-    var value: Success? {
+    var success: Success? {
         guard case let .success(value) = self else { return nil }
         return value
     }
 
-    var error: Failure? {
+    var failure: Failure? {
         guard case let .failure(error) = self else { return nil }
         return error
     }

--- a/Tests/ServerTrustEvaluatorTests.swift
+++ b/Tests/ServerTrustEvaluatorTests.swift
@@ -503,9 +503,7 @@ class ServerTrustPolicyPerformDefaultEvaluationTestCase: ServerTrustPolicyTestCa
 
         // Then
         XCTAssertFalse(result.isSuccess, "server trust should not pass evaluation")
-        assertErrorIsAFError(result.error) { error in
-            XCTAssertTrue(error.isServerTrustEvaluationError)
-        }
+        XCTAssertEqual(result.failure?.asAFError?.isServerTrustEvaluationError, true)
     }
 }
 

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -402,11 +402,7 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertNotNil(response, "response should not be nil")
         XCTAssertTrue(request.isCancelled)
         XCTAssertTrue((request.task == nil) || (request.task?.state == .canceling || request.task?.state == .completed))
-
-        guard let error = request.error, case .explicitlyCancelled = error else {
-            XCTFail("Request should have an .explicitlyCancelled error.")
-            return
-        }
+        XCTAssertEqual(request.error?.isExplicitlyCancelledError, true)
     }
 
     func testSetStartRequestsImmediatelyToFalseAndResumeThenCancelRequestHasCorrectOutput() {
@@ -435,11 +431,7 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertNotNil(response, "response should not be nil")
         XCTAssertTrue(request.isCancelled)
         XCTAssertTrue((request.task == nil) || (request.task?.state == .canceling || request.task?.state == .completed))
-
-        guard let error = request.error, case .explicitlyCancelled = error else {
-            XCTFail("Request should have an .explicitlyCancelled error.")
-            return
-        }
+        XCTAssertEqual(request.error?.isExplicitlyCancelledError, true)
     }
 
     func testSetStartRequestsImmediatelyToFalseAndCancelThenResumeRequestDoesntCreateTaskAndStaysCancelled() {
@@ -468,11 +460,7 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertNotNil(response, "response should not be nil")
         XCTAssertTrue(request.isCancelled)
         XCTAssertTrue((request.task == nil) || (request.task?.state == .canceling || request.task?.state == .completed))
-
-        guard let error = request.error, case .explicitlyCancelled = error else {
-            XCTFail("Request should have an .explicitlyCancelled error.")
-            return
-        }
+        XCTAssertEqual(request.error?.isExplicitlyCancelledError, true)
     }
 
     // MARK: Tests - Deinitialization
@@ -539,13 +527,8 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertNil(response?.response)
         XCTAssertNil(response?.data)
         XCTAssertNotNil(response?.error)
-
-        if let error = response?.error {
-            XCTAssertTrue(error.isInvalidURLError)
-            XCTAssertEqual(error.urlConvertible as? String, "https://httpbin.org/get/äëïöü")
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertEqual(response?.error?.isInvalidURLError, true)
+        XCTAssertEqual(response?.error?.urlConvertible as? String, "https://httpbin.org/get/äëïöü")
     }
 
     func testThatDownloadRequestWithInvalidURLStringThrowsResponseHandlerError() {
@@ -569,13 +552,8 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertNil(response?.fileURL)
         XCTAssertNil(response?.resumeData)
         XCTAssertNotNil(response?.error)
-
-        if let error = response?.error {
-            XCTAssertTrue(error.isInvalidURLError)
-            XCTAssertEqual(error.urlConvertible as? String, "https://httpbin.org/get/äëïöü")
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertEqual(response?.error?.isInvalidURLError, true)
+        XCTAssertEqual(response?.error?.urlConvertible as? String, "https://httpbin.org/get/äëïöü")
     }
 
     func testThatUploadDataRequestWithInvalidURLStringThrowsResponseHandlerError() {
@@ -598,13 +576,8 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertNil(response?.response)
         XCTAssertNil(response?.data)
         XCTAssertNotNil(response?.error)
-
-        if let error = response?.error {
-            XCTAssertTrue(error.isInvalidURLError)
-            XCTAssertEqual(error.urlConvertible as? String, "https://httpbin.org/get/äëïöü")
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertEqual(response?.error?.isInvalidURLError, true)
+        XCTAssertEqual(response?.error?.urlConvertible as? String, "https://httpbin.org/get/äëïöü")
     }
 
     func testThatUploadFileRequestWithInvalidURLStringThrowsResponseHandlerError() {
@@ -627,13 +600,8 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertNil(response?.response)
         XCTAssertNil(response?.data)
         XCTAssertNotNil(response?.error)
-
-        if let error = response?.error {
-            XCTAssertTrue(error.isInvalidURLError)
-            XCTAssertEqual(error.urlConvertible as? String, "https://httpbin.org/get/äëïöü")
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertEqual(response?.error?.isInvalidURLError, true)
+        XCTAssertEqual(response?.error?.urlConvertible as? String, "https://httpbin.org/get/äëïöü")
     }
 
     func testThatUploadStreamRequestWithInvalidURLStringThrowsResponseHandlerError() {
@@ -656,13 +624,8 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertNil(response?.response)
         XCTAssertNil(response?.data)
         XCTAssertNotNil(response?.error)
-
-        if let error = response?.error {
-            XCTAssertTrue(error.isInvalidURLError)
-            XCTAssertEqual(error.urlConvertible as? String, "https://httpbin.org/get/äëïöü")
-        } else {
-            XCTFail("error should not be nil")
-        }
+        XCTAssertEqual(response?.error?.isInvalidURLError, true)
+        XCTAssertEqual(response?.error?.urlConvertible as? String, "https://httpbin.org/get/äëïöü")
     }
 
     // MARK: Tests - Request Adapter
@@ -852,12 +815,8 @@ final class SessionTestCase: BaseTestCase {
 
         // Then
         for request in requests {
-            if let error = request.error {
-                XCTAssertTrue(error.isRequestAdaptationError)
-                XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "")
-            } else {
-                XCTFail("error should not be nil")
-            }
+            XCTAssertEqual(request.error?.isRequestAdaptationError, true)
+            XCTAssertEqual(request.error?.underlyingError?.asAFError?.urlConvertible as? String, "")
         }
     }
 
@@ -1097,16 +1056,11 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCount, 3)
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, false)
+        XCTAssertEqual(request.error?.isRequestAdaptationError, true)
+        XCTAssertEqual(request.error?.underlyingError?.asAFError?.urlConvertible as? String, "/adapt/error/2")
         assert(on: session.rootQueue) {
             XCTAssertTrue(session.requestTaskMap.isEmpty)
             XCTAssertTrue(session.activeRequests.isEmpty)
-        }
-
-        if let error = response?.result.error {
-            XCTAssertTrue(error.isRequestAdaptationError)
-            XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "/adapt/error/2")
-        } else {
-            XCTFail("error should not be nil")
         }
     }
 
@@ -1138,16 +1092,11 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCount, 3)
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, false)
+        XCTAssertEqual(request.error?.isRequestAdaptationError, true)
+        XCTAssertEqual(request.error?.underlyingError?.asAFError?.urlConvertible as? String, "/adapt/error/2")
         assert(on: session.rootQueue) {
             XCTAssertTrue(session.requestTaskMap.isEmpty)
             XCTAssertTrue(session.activeRequests.isEmpty)
-        }
-
-        if let error = response?.result.error {
-            XCTAssertTrue(error.isRequestAdaptationError)
-            XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "/adapt/error/2")
-        } else {
-            XCTFail("error should not be nil")
         }
     }
 
@@ -1183,7 +1132,7 @@ final class SessionTestCase: BaseTestCase {
             XCTAssertTrue(session.activeRequests.isEmpty)
         }
 
-        if let error = response?.result.error {
+        if let error = response?.result.failure {
             XCTAssertTrue(error.isRequestRetryError)
             XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "/invalid/url/2")
         } else {
@@ -1220,16 +1169,11 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCount, 0)
         XCTAssertEqual(request.retryCount, 0)
         XCTAssertEqual(response?.result.isSuccess, false)
+        XCTAssertEqual(response?.error?.isResponseSerializationError, true)
+        XCTAssertEqual((response?.error?.underlyingError as? CocoaError)?.code, .propertyListReadCorrupt)
         assert(on: session.rootQueue) {
             XCTAssertTrue(session.requestTaskMap.isEmpty)
             XCTAssertTrue(session.activeRequests.isEmpty)
-        }
-
-        if let error = response?.error {
-            XCTAssertTrue(error.isResponseSerializationError)
-            XCTAssertTrue(error.localizedDescription.starts(with: "JSON could not be serialized"))
-        } else {
-            XCTFail("error should not be nil")
         }
     }
 
@@ -1273,16 +1217,15 @@ final class SessionTestCase: BaseTestCase {
             XCTAssertTrue(session.activeRequests.isEmpty)
         }
 
-        let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error?.asAFError }
+        let errors = [json1Response, json2Response].compactMap { $0?.error }
+
         XCTAssertEqual(errors.count, 2)
 
         for (index, error) in errors.enumerated() {
             XCTAssertTrue(error.isRequestRetryError)
-            XCTAssertEqual(error.localizedDescription.starts(with: "Request retry failed with retry error"), true)
-
             if case let .requestRetryFailed(retryError, originalError) = error {
-                XCTAssertEqual(try retryError.asAFError?.urlConvertible?.asURL().absoluteString, "/invalid/url/\(index + 1)")
-                XCTAssertTrue(originalError.localizedDescription.starts(with: "JSON could not be serialized"))
+                XCTAssertEqual(retryError.asAFError?.urlConvertible as? String, "/invalid/url/\(index + 1)")
+                XCTAssertEqual((originalError.asAFError?.underlyingError as? CocoaError)?.code, .propertyListReadCorrupt)
             } else {
                 XCTFail("Error failure reason should be response serialization failure")
             }
@@ -1327,12 +1270,12 @@ final class SessionTestCase: BaseTestCase {
             XCTAssertTrue(session.activeRequests.isEmpty)
         }
 
-        let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error }
+        let errors = [json1Response, json2Response].compactMap { $0?.error }
         XCTAssertEqual(errors.count, 2)
 
         for error in errors {
             XCTAssertTrue(error.isResponseSerializationError)
-            XCTAssertTrue(error.localizedDescription.starts(with: "JSON could not be serialized"))
+            XCTAssertEqual((error.underlyingError as? CocoaError)?.code, .propertyListReadCorrupt)
         }
     }
 
@@ -1382,12 +1325,12 @@ final class SessionTestCase: BaseTestCase {
             XCTAssertTrue(session.activeRequests.isEmpty)
         }
 
-        let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error }
+        let errors = [json1Response, json2Response].compactMap { $0?.error }
         XCTAssertEqual(errors.count, 2)
 
         for error in errors {
             XCTAssertTrue(error.isRequestAdaptationError)
-            XCTAssertEqual(error.localizedDescription, "Request adaption failed with error: URL is not valid: /adapt/error/2")
+            XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "/adapt/error/2")
         }
     }
 
@@ -1437,12 +1380,12 @@ final class SessionTestCase: BaseTestCase {
             XCTAssertTrue(session.activeRequests.isEmpty)
         }
 
-        let errors: [AFError] = [json1Response, json2Response].compactMap { $0?.error }
+        let errors = [json1Response, json2Response].compactMap { $0?.error }
         XCTAssertEqual(errors.count, 2)
 
         for error in errors {
             XCTAssertTrue(error.isRequestAdaptationError)
-            XCTAssertEqual(error.localizedDescription, "Request adaption failed with error: URL is not valid: /adapt/error/2")
+            XCTAssertEqual(error.underlyingError?.asAFError?.urlConvertible as? String, "/adapt/error/2")
         }
     }
 
@@ -1638,7 +1581,7 @@ final class SessionCancellationTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout)
 
         // Then
-        XCTAssertTrue(received?.error?.isExplicitlyCancelledError == true)
+        XCTAssertEqual(received?.error?.isExplicitlyCancelledError, true)
         assert(on: session.rootQueue) {
             XCTAssertTrue(session.requestTaskMap.isEmpty, "requestTaskMap should be empty but has \(session.requestTaskMap.count) items")
             XCTAssertTrue(session.activeRequests.isEmpty, "activeRequests should be empty but has \(session.activeRequests.count) items")
@@ -1693,6 +1636,7 @@ final class SessionCancellationTestCase: BaseTestCase {
 
         // Then
         XCTAssertEqual(response?.result.isFailure, true)
+        XCTAssertEqual(response?.error?.isRequestAdaptationError, true)
         XCTAssertEqual(response?.error?.underlyingError?.asAFError?.isBodyDataInGETRequest, true)
     }
 }
@@ -1749,11 +1693,11 @@ final class SessionConfigurationHeadersTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "request should complete successfully")
 
-        var response: DataResponse<Any, AFError>?
+        var response: DataResponse<HTTPBinResponse, AFError>?
 
         // When
-        session.request("https://httpbin.org/headers")
-            .responseJSON { closureResponse in
+        session.request("https://httpbin.org/get")
+            .responseDecodable(of: HTTPBinResponse.self) { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
             }
@@ -1761,22 +1705,10 @@ final class SessionConfigurationHeadersTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        if let response = response {
-            XCTAssertNotNil(response.request, "request should not be nil")
-            XCTAssertNotNil(response.response, "response should not be nil")
-            XCTAssertNotNil(response.data, "data should not be nil")
-            XCTAssertTrue(response.result.isSuccess, "result should be a success")
-
-            if
-                let response = response.result.value as? [String: Any],
-                let headers = response["headers"] as? [String: String],
-                let authorization = headers["Authorization"] {
-                XCTAssertEqual(authorization, "Bearer 123456", "authorization header value does not match")
-            } else {
-                XCTFail("failed to extract authorization header value")
-            }
-        } else {
-            XCTFail("response should not be nil")
-        }
+        XCTAssertNotNil(response?.request, "request should not be nil")
+        XCTAssertNotNil(response?.response, "response should not be nil")
+        XCTAssertNotNil(response?.data, "data should not be nil")
+        XCTAssertEqual(response?.result.isSuccess, true)
+        XCTAssertEqual(response?.value?.headers["Authorization"], "Bearer 123456", "Authorization header should match")
     }
 }

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -82,6 +82,7 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
         // Then
         XCTAssertNotNil(error)
+
         if let error = error?.underlyingError as? URLError {
             XCTAssertEqual(error.code, .serverCertificateUntrusted)
         } else if let error = error?.underlyingError as NSError? {
@@ -142,6 +143,7 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
         // Then
         XCTAssertNotNil(error, "error should not be nil")
+
         XCTAssertEqual(error?.isServerTrustEvaluationError, true)
         if case let .serverTrustEvaluationFailed(reason) = error {
             XCTAssertTrue(reason.isHostValidationFailed, "should be .hostValidationFailed")
@@ -208,6 +210,7 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error, "error should not be nil")
         XCTAssertEqual(error?.isServerTrustEvaluationError, true)
+
         if case let .serverTrustEvaluationFailed(reason) = error {
             XCTAssertTrue(reason.isDefaultEvaluationFailed, "should be .defaultEvaluationFailed")
         } else {
@@ -239,6 +242,7 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error, "error should not be nil")
         XCTAssertEqual(error?.isServerTrustEvaluationError, true)
+
         if case let .serverTrustEvaluationFailed(reason) = error {
             XCTAssertTrue(reason.isDefaultEvaluationFailed, "should be .defaultEvaluationFailed")
         } else {
@@ -271,6 +275,7 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error, "error should not be nil")
         XCTAssertEqual(error?.isServerTrustEvaluationError, true)
+
         if case let .serverTrustEvaluationFailed(reason) = error {
             XCTAssertTrue(reason.isDefaultEvaluationFailed, "should be .defaultEvaluationFailed")
         } else {
@@ -305,6 +310,7 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error, "error should not be nil")
         XCTAssertEqual(error?.isServerTrustEvaluationError, true)
+
         if case let .serverTrustEvaluationFailed(reason) = error {
             XCTAssertTrue(reason.isDefaultEvaluationFailed, "should be .defaultEvaluationFailed")
         } else {
@@ -413,6 +419,7 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         // Then
         XCTAssertNotNil(error, "error should not be nil")
         XCTAssertEqual(error?.isServerTrustEvaluationError, true)
+
         if case let .serverTrustEvaluationFailed(reason) = error {
             XCTAssertTrue(reason.isDefaultEvaluationFailed, "should be .defaultEvaluationFailed")
         } else {

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -44,7 +44,7 @@ private struct TestCertificates {
 
 // MARK: -
 
-class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
+final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
     private let expiredURLString = "https://expired.badssl.com/"
     private let expiredHost = "expired.badssl.com"
 
@@ -69,7 +69,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         // Given
         let expectation = self.expectation(description: "\(expiredURLString)")
         let manager = Session(configuration: configuration)
-        var error: Error?
+        var error: AFError?
 
         // When
         manager.request(expiredURLString)
@@ -82,10 +82,9 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
         // Then
         XCTAssertNotNil(error)
-
-        if let error = error?.asAFError?.underlyingError as? URLError {
+        if let error = error?.underlyingError as? URLError {
             XCTAssertEqual(error.code, .serverCertificateUntrusted)
-        } else if let error = error?.asAFError?.underlyingError as NSError? {
+        } else if let error = error?.underlyingError as NSError? {
             XCTAssertEqual(error.domain, kCFErrorDomainCFNetwork as String)
             XCTAssertEqual(error.code, Int(CFNetworkErrors.cfErrorHTTPSProxyConnectionFailure.rawValue))
         } else {
@@ -130,7 +129,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
                               serverTrustManager: ServerTrustManager(evaluators: evaluators))
 
         let expectation = self.expectation(description: "\(expiredURLString)")
-        var error: Error?
+        var error: AFError?
 
         // When
         manager.request(expiredURLString)
@@ -143,11 +142,11 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
         // Then
         XCTAssertNotNil(error, "error should not be nil")
-
-        if let error = error?.asAFError {
-            XCTAssertTrue(error.isServerTrustEvaluationError, "should be .certificatePinningFailed")
+        XCTAssertEqual(error?.isServerTrustEvaluationError, true)
+        if case let .serverTrustEvaluationFailed(reason) = error {
+            XCTAssertTrue(reason.isHostValidationFailed, "should be .hostValidationFailed")
         } else {
-            XCTFail("error should be an AFError")
+            XCTFail("error should be .serverTrustEvaluationFailed")
         }
     }
 
@@ -195,7 +194,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
                               serverTrustManager: ServerTrustManager(evaluators: evaluators))
 
         let expectation = self.expectation(description: "\(expiredURLString)")
-        var error: Error?
+        var error: AFError?
 
         // When
         manager.request(expiredURLString)
@@ -208,11 +207,11 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
         // Then
         XCTAssertNotNil(error, "error should not be nil")
-
-        if let error = error?.asAFError {
-            XCTAssertTrue(error.isServerTrustEvaluationError, "should be .certificatePinningFailed")
+        XCTAssertEqual(error?.isServerTrustEvaluationError, true)
+        if case let .serverTrustEvaluationFailed(reason) = error {
+            XCTAssertTrue(reason.isDefaultEvaluationFailed, "should be .defaultEvaluationFailed")
         } else {
-            XCTFail("error should be an AFError")
+            XCTFail("error should be .serverTrustEvaluationFailed")
         }
     }
 
@@ -226,7 +225,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
                               serverTrustManager: ServerTrustManager(evaluators: evaluators))
 
         let expectation = self.expectation(description: "\(revokedURLString)")
-        var error: Error?
+        var error: AFError?
 
         // When
         manager.request(revokedURLString)
@@ -239,11 +238,11 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
         // Then
         XCTAssertNotNil(error, "error should not be nil")
-
-        if let error = error?.asAFError {
-            XCTAssertTrue(error.isServerTrustEvaluationError, "should be .certificatePinningFailed")
+        XCTAssertEqual(error?.isServerTrustEvaluationError, true)
+        if case let .serverTrustEvaluationFailed(reason) = error {
+            XCTAssertTrue(reason.isDefaultEvaluationFailed, "should be .defaultEvaluationFailed")
         } else {
-            XCTFail("error should be an AFError")
+            XCTFail("error should be .serverTrustEvaluationFailed")
         }
     }
 
@@ -258,7 +257,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
                               serverTrustManager: ServerTrustManager(evaluators: evaluators))
 
         let expectation = self.expectation(description: "\(expiredURLString)")
-        var error: Error?
+        var error: AFError?
 
         // When
         manager.request(expiredURLString)
@@ -271,11 +270,11 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
         // Then
         XCTAssertNotNil(error, "error should not be nil")
-
-        if let error = error?.asAFError {
-            XCTAssertTrue(error.isServerTrustEvaluationError, "should be .certificatePinningFailed")
+        XCTAssertEqual(error?.isServerTrustEvaluationError, true)
+        if case let .serverTrustEvaluationFailed(reason) = error {
+            XCTAssertTrue(reason.isDefaultEvaluationFailed, "should be .defaultEvaluationFailed")
         } else {
-            XCTFail("error should be an AFError")
+            XCTFail("error should be .serverTrustEvaluationFailed")
         }
     }
 
@@ -292,7 +291,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
                               serverTrustManager: ServerTrustManager(evaluators: evaluators))
 
         let expectation = self.expectation(description: "\(expiredURLString)")
-        var error: Error?
+        var error: AFError?
 
         // When
         manager.request(expiredURLString)
@@ -305,11 +304,11 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
         // Then
         XCTAssertNotNil(error, "error should not be nil")
-
-        if let error = error?.asAFError {
-            XCTAssertTrue(error.isServerTrustEvaluationError, "should be .certificatePinningFailed")
+        XCTAssertEqual(error?.isServerTrustEvaluationError, true)
+        if case let .serverTrustEvaluationFailed(reason) = error {
+            XCTAssertTrue(reason.isDefaultEvaluationFailed, "should be .defaultEvaluationFailed")
         } else {
-            XCTFail("error should be an AFError")
+            XCTFail("error should be .serverTrustEvaluationFailed")
         }
     }
 
@@ -400,7 +399,7 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
                               serverTrustManager: ServerTrustManager(evaluators: evaluators))
 
         let expectation = self.expectation(description: "\(expiredURLString)")
-        var error: Error?
+        var error: AFError?
 
         // When
         manager.request(expiredURLString)
@@ -413,11 +412,11 @@ class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
         // Then
         XCTAssertNotNil(error, "error should not be nil")
-
-        if let error = error?.asAFError {
-            XCTAssertTrue(error.isServerTrustEvaluationError, "should be .certificatePinningFailed")
+        XCTAssertEqual(error?.isServerTrustEvaluationError, true)
+        if case let .serverTrustEvaluationFailed(reason) = error {
+            XCTAssertTrue(reason.isDefaultEvaluationFailed, "should be .defaultEvaluationFailed")
         } else {
-            XCTFail("error should be an AFError")
+            XCTFail("error should be .serverTrustEvaluationFailed")
         }
     }
 

--- a/Tests/URLProtocolTests.swift
+++ b/Tests/URLProtocolTests.swift
@@ -121,7 +121,7 @@ class URLProtocolTestCase: BaseTestCase {
             let configuration: URLSessionConfiguration = {
                 let configuration = URLSessionConfiguration.default
                 configuration.protocolClasses = [ProxyURLProtocol.self]
-                configuration.httpAdditionalHeaders = ["Session-Configuration-Header": "foo"]
+                configuration.headers["Session-Configuration-Header"] = "foo"
 
                 return configuration
             }()
@@ -138,8 +138,8 @@ class URLProtocolTestCase: BaseTestCase {
         let url = URL(string: urlString)!
 
         var urlRequest = URLRequest(url: url)
-        urlRequest.httpMethod = HTTPMethod.get.rawValue
-        urlRequest.setValue("foobar", forHTTPHeaderField: "Request-Header")
+        urlRequest.method = .get
+        urlRequest.headers["Request-Header"] = "foobar"
 
         let expectation = self.expectation(description: "GET request should succeed")
 
@@ -159,12 +159,7 @@ class URLProtocolTestCase: BaseTestCase {
         XCTAssertNotNil(response?.response)
         XCTAssertNotNil(response?.data)
         XCTAssertNil(response?.error)
-
-        if let headers = response?.response?.allHeaderFields as? [String: String] {
-            XCTAssertEqual(headers["Request-Header"] ?? headers["request-header"], "foobar")
-            XCTAssertEqual(headers["Session-Configuration-Header"] ?? headers["session-configuration-header"], "foo")
-        } else {
-            XCTFail("headers should not be nil")
-        }
+        XCTAssertEqual(response?.response?.headers["Request-Header"], "foobar")
+        XCTAssertEqual(response?.response?.headers["Session-Configuration-Header"], "foo")
     }
 }

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -26,7 +26,7 @@
 import Foundation
 import XCTest
 
-class StatusCodeValidationTestCase: BaseTestCase {
+final class StatusCodeValidationTestCase: BaseTestCase {
     func testThatValidationForRequestWithAcceptableStatusCodeResponseSucceeds() {
         // Given
         let urlString = "https://httpbin.org/status/200"
@@ -34,8 +34,8 @@ class StatusCodeValidationTestCase: BaseTestCase {
         let expectation1 = expectation(description: "request should return 200 status code")
         let expectation2 = expectation(description: "download should return 200 status code")
 
-        var requestError: Error?
-        var downloadError: Error?
+        var requestError: AFError?
+        var downloadError: AFError?
 
         // When
         AF.request(urlString)
@@ -66,8 +66,8 @@ class StatusCodeValidationTestCase: BaseTestCase {
         let expectation1 = expectation(description: "request should return 404 status code")
         let expectation2 = expectation(description: "download should return 404 status code")
 
-        var requestError: Error?
-        var downloadError: Error?
+        var requestError: AFError?
+        var downloadError: AFError?
 
         // When
         AF.request(urlString)
@@ -91,12 +91,8 @@ class StatusCodeValidationTestCase: BaseTestCase {
         XCTAssertNotNil(downloadError)
 
         for error in [requestError, downloadError] {
-            if let error = error?.asAFError, let statusCode = error.responseCode {
-                XCTAssertTrue(error.isUnacceptableStatusCode)
-                XCTAssertEqual(statusCode, 404)
-            } else {
-                XCTFail("Error should not be nil, should be an AFError, and should have an associated statusCode.")
-            }
+            XCTAssertEqual(error?.isUnacceptableStatusCode, true)
+            XCTAssertEqual(error?.responseCode, 404)
         }
     }
 
@@ -107,8 +103,8 @@ class StatusCodeValidationTestCase: BaseTestCase {
         let expectation1 = expectation(description: "request should return 201 status code")
         let expectation2 = expectation(description: "download should return 201 status code")
 
-        var requestError: Error?
-        var downloadError: Error?
+        var requestError: AFError?
+        var downloadError: AFError?
 
         // When
         AF.request(urlString)
@@ -132,19 +128,15 @@ class StatusCodeValidationTestCase: BaseTestCase {
         XCTAssertNotNil(downloadError)
 
         for error in [requestError, downloadError] {
-            if let error = error?.asAFError, let statusCode = error.responseCode {
-                XCTAssertTrue(error.isUnacceptableStatusCode)
-                XCTAssertEqual(statusCode, 201)
-            } else {
-                XCTFail("Error should not be nil, should be an AFError, and should have an associated statusCode.")
-            }
+            XCTAssertEqual(error?.isUnacceptableStatusCode, true)
+            XCTAssertEqual(error?.responseCode, 201)
         }
     }
 }
 
 // MARK: -
 
-class ContentTypeValidationTestCase: BaseTestCase {
+final class ContentTypeValidationTestCase: BaseTestCase {
     func testThatValidationForRequestWithAcceptableContentTypeResponseSucceeds() {
         // Given
         let urlString = "https://httpbin.org/ip"
@@ -152,8 +144,8 @@ class ContentTypeValidationTestCase: BaseTestCase {
         let expectation1 = expectation(description: "request should succeed and return ip")
         let expectation2 = expectation(description: "download should succeed and return ip")
 
-        var requestError: Error?
-        var downloadError: Error?
+        var requestError: AFError?
+        var downloadError: AFError?
 
         // When
         AF.request(urlString)
@@ -188,8 +180,8 @@ class ContentTypeValidationTestCase: BaseTestCase {
         let expectation1 = expectation(description: "request should succeed and return ip")
         let expectation2 = expectation(description: "download should succeed and return ip")
 
-        var requestError: Error?
-        var downloadError: Error?
+        var requestError: AFError?
+        var downloadError: AFError?
 
         // When
         AF.request(urlString)
@@ -224,8 +216,8 @@ class ContentTypeValidationTestCase: BaseTestCase {
         let expectation1 = expectation(description: "request should succeed and return xml")
         let expectation2 = expectation(description: "download should succeed and return xml")
 
-        var requestError: Error?
-        var downloadError: Error?
+        var requestError: AFError?
+        var downloadError: AFError?
 
         // When
         AF.request(urlString)
@@ -249,13 +241,9 @@ class ContentTypeValidationTestCase: BaseTestCase {
         XCTAssertNotNil(downloadError)
 
         for error in [requestError, downloadError] {
-            if let error = error?.asAFError {
-                XCTAssertTrue(error.isUnacceptableContentType)
-                XCTAssertEqual(error.responseContentType, "application/xml")
-                XCTAssertEqual(error.acceptableContentTypes?.first, "application/octet-stream")
-            } else {
-                XCTFail("error should not be nil")
-            }
+            XCTAssertEqual(error?.isUnacceptableContentType, true)
+            XCTAssertEqual(error?.responseContentType, "application/xml")
+            XCTAssertEqual(error?.acceptableContentTypes?.first, "application/octet-stream")
         }
     }
 
@@ -266,8 +254,8 @@ class ContentTypeValidationTestCase: BaseTestCase {
         let expectation1 = expectation(description: "request should succeed and return xml")
         let expectation2 = expectation(description: "download should succeed and return xml")
 
-        var requestError: Error?
-        var downloadError: Error?
+        var requestError: AFError?
+        var downloadError: AFError?
 
         // When
         AF.request(urlString)
@@ -291,13 +279,9 @@ class ContentTypeValidationTestCase: BaseTestCase {
         XCTAssertNotNil(downloadError)
 
         for error in [requestError, downloadError] {
-            if let error = error?.asAFError {
-                XCTAssertTrue(error.isUnacceptableContentType)
-                XCTAssertEqual(error.responseContentType, "application/xml")
-                XCTAssertTrue(error.acceptableContentTypes?.isEmpty ?? false)
-            } else {
-                XCTFail("error should not be nil")
-            }
+            XCTAssertEqual(error?.isUnacceptableContentType, true)
+            XCTAssertEqual(error?.responseContentType, "application/xml")
+            XCTAssertEqual(error?.acceptableContentTypes?.isEmpty, true)
         }
     }
 
@@ -308,8 +292,8 @@ class ContentTypeValidationTestCase: BaseTestCase {
         let expectation1 = expectation(description: "request should succeed and return no data")
         let expectation2 = expectation(description: "download should succeed and return no data")
 
-        var requestError: Error?
-        var downloadError: Error?
+        var requestError: AFError?
+        var downloadError: AFError?
 
         // When
         AF.request(urlString)
@@ -445,7 +429,7 @@ class ContentTypeValidationTestCase: BaseTestCase {
 
 // MARK: -
 
-class MultipleValidationTestCase: BaseTestCase {
+final class MultipleValidationTestCase: BaseTestCase {
     func testThatValidationForRequestWithAcceptableStatusCodeAndContentTypeResponseSucceeds() {
         // Given
         let urlString = "https://httpbin.org/ip"
@@ -514,12 +498,8 @@ class MultipleValidationTestCase: BaseTestCase {
         XCTAssertNotNil(downloadError)
 
         for error in [requestError, downloadError] {
-            if let error = error {
-                XCTAssertTrue(error.isUnacceptableStatusCode)
-                XCTAssertEqual(error.responseCode, 200)
-            } else {
-                XCTFail("error should not be nil")
-            }
+            XCTAssertEqual(error?.isUnacceptableStatusCode, true)
+            XCTAssertEqual(error?.responseCode, 200)
         }
     }
 
@@ -557,20 +537,16 @@ class MultipleValidationTestCase: BaseTestCase {
         XCTAssertNotNil(downloadError)
 
         for error in [requestError, downloadError] {
-            if let error = error {
-                XCTAssertTrue(error.isUnacceptableContentType)
-                XCTAssertEqual(error.responseContentType, "application/xml")
-                XCTAssertEqual(error.acceptableContentTypes?.first, "application/octet-stream")
-            } else {
-                XCTFail("error should not be nil")
-            }
+            XCTAssertEqual(error?.isUnacceptableContentType, true)
+            XCTAssertEqual(error?.responseContentType, "application/xml")
+            XCTAssertEqual(error?.acceptableContentTypes?.first, "application/octet-stream")
         }
     }
 }
 
 // MARK: -
 
-class AutomaticValidationTestCase: BaseTestCase {
+final class AutomaticValidationTestCase: BaseTestCase {
     func testThatValidationForRequestWithAcceptableStatusCodeAndContentTypeResponseSucceeds() {
         // Given
         let url = URL(string: "https://httpbin.org/ip")!
@@ -633,12 +609,8 @@ class AutomaticValidationTestCase: BaseTestCase {
         XCTAssertNotNil(downloadError)
 
         for error in [requestError, downloadError] {
-            if let error = error, let statusCode = error.responseCode {
-                XCTAssertTrue(error.isUnacceptableStatusCode)
-                XCTAssertEqual(statusCode, 404)
-            } else {
-                XCTFail("error should not be nil")
-            }
+            XCTAssertEqual(error?.isUnacceptableStatusCode, true)
+            XCTAssertEqual(error?.responseCode, 404)
         }
     }
 
@@ -734,13 +706,9 @@ class AutomaticValidationTestCase: BaseTestCase {
         XCTAssertNotNil(downloadError)
 
         for error in [requestError, downloadError] {
-            if let error = error {
-                XCTAssertTrue(error.isUnacceptableContentType)
-                XCTAssertEqual(error.responseContentType, "application/xml")
-                XCTAssertEqual(error.acceptableContentTypes?.first, "application/json")
-            } else {
-                XCTFail("error should not be nil")
-            }
+            XCTAssertEqual(error?.isUnacceptableContentType, true)
+            XCTAssertEqual(error?.responseContentType, "application/xml")
+            XCTAssertEqual(error?.acceptableContentTypes?.first, "application/json")
         }
     }
 }
@@ -787,7 +755,7 @@ extension DownloadRequest {
 
 // MARK: -
 
-class CustomValidationTestCase: BaseTestCase {
+final class CustomValidationTestCase: BaseTestCase {
     func testThatCustomValidationClosureHasAccessToServerResponseData() {
         // Given
         let urlString = "https://httpbin.org/get"
@@ -795,8 +763,8 @@ class CustomValidationTestCase: BaseTestCase {
         let expectation1 = expectation(description: "request should return 200 status code")
         let expectation2 = expectation(description: "download should return 200 status code")
 
-        var requestError: Error?
-        var downloadError: Error?
+        var requestError: AFError?
+        var downloadError: AFError?
 
         // When
         AF.request(urlString)
@@ -839,8 +807,8 @@ class CustomValidationTestCase: BaseTestCase {
         let expectation1 = expectation(description: "request should return 200 status code")
         let expectation2 = expectation(description: "download should return 200 status code")
 
-        var requestError: Error?
-        var downloadError: Error?
+        var requestError: AFError?
+        var downloadError: AFError?
 
         // When
         AF.request(urlString)
@@ -862,8 +830,8 @@ class CustomValidationTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        XCTAssertEqual(requestError?.asAFError?.underlyingError as? ValidationError, ValidationError.missingData)
-        XCTAssertEqual(downloadError?.asAFError?.underlyingError as? ValidationError, ValidationError.missingFile)
+        XCTAssertEqual(requestError?.asAFError?.underlyingError as? ValidationError, .missingData)
+        XCTAssertEqual(downloadError?.asAFError?.underlyingError as? ValidationError, .missingFile)
     }
 
     func testThatValidationExtensionHasAccessToServerResponseData() {
@@ -873,8 +841,8 @@ class CustomValidationTestCase: BaseTestCase {
         let expectation1 = expectation(description: "request should return 200 status code")
         let expectation2 = expectation(description: "download should return 200 status code")
 
-        var requestError: Error?
-        var downloadError: Error?
+        var requestError: AFError?
+        var downloadError: AFError?
 
         // When
         AF.request(urlString)
@@ -905,8 +873,8 @@ class CustomValidationTestCase: BaseTestCase {
         let expectation1 = expectation(description: "request should return 200 status code")
         let expectation2 = expectation(description: "download should return 200 status code")
 
-        var requestError: Error?
-        var downloadError: Error?
+        var requestError: AFError?
+        var downloadError: AFError?
 
         // When
         AF.request(urlString)
@@ -928,7 +896,7 @@ class CustomValidationTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
-        XCTAssertEqual(requestError?.asAFError?.underlyingError as? ValidationError, ValidationError.missingData)
-        XCTAssertEqual(downloadError?.asAFError?.underlyingError as? ValidationError, ValidationError.missingFile)
+        XCTAssertEqual(requestError?.asAFError?.underlyingError as? ValidationError, .missingData)
+        XCTAssertEqual(downloadError?.asAFError?.underlyingError as? ValidationError, .missingFile)
     }
 }


### PR DESCRIPTION
### Goals :soccer:
This PR adds `AFDataResponse` and `AFDownloadResponse`, which don't require an explicit `Failure` type, just defaulting to `AFError`. Additionally, `AFResult` has also been updated to expect an `AFError` `Failure` type as well, as many users have already transitioned to Swift 5's `Result`. These types are used to simplify some of the response APIs.

### Implementation Details :construction:
This PR also refactors a lot of tests to take advantage of the fact that `AFError` is now used directly in most cases and to be more explicit around different errors wrapped in `AFError`.

### Testing Details :mag:
No new tests, just refactors.
