### PR TITLE
Make bundle id per platform

### DIFF
--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -1744,7 +1744,7 @@
 					"-framework",
 					CFNetwork,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = org.alamofire.Alamofire;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.alamofire.Alamofire.${PLATFORM_NAME}";
 				PRODUCT_NAME = Alamofire;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
@@ -1807,7 +1807,7 @@
 					"-framework",
 					CFNetwork,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = org.alamofire.Alamofire;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.alamofire.Alamofire.${PLATFORM_NAME}";
 				PRODUCT_NAME = Alamofire;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";


### PR DESCRIPTION
### Issue Link :link:
https://github.com/Alamofire/Alamofire/issues/2925

### Goals :soccer:
Fixing an issue when submitting a binary to the App Store:
ITMS-90806: CFBundleIdentifier collision - Each bundle must have a unique bundle identifier. The bundle identifier 'org.cocoapods.Alamofire' is used in the bundles '[Alamofire.framework, Alamofire.framework]'

### Implementation Details :construction:
Add platform name to Project bundle identifier