### PR TITLE
Fixed crash in Demo app

### DIFF
--- a/Example/Source/MasterViewController.swift
+++ b/Example/Source/MasterViewController.swift
@@ -94,7 +94,8 @@ class MasterViewController: UITableViewController {
     // MARK: - Private - Reachability
 
     private func monitorReachability() {
-        NetworkReachabilityManager.default?.startListening { status in
+        reachability = NetworkReachabilityManager.default
+        reachability?.startListening { status in
             print("Reachability Status Changed: \(status)")
         }
     }


### PR DESCRIPTION
### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->
In demo, when you click on cell "Reachability Status", app crashes due to implicitly unwrapped property being **nil**.

![Screen Shot 2019-09-23 at 15 31 37](https://user-images.githubusercontent.com/43006/65425836-9c55e600-de17-11e9-95ed-14077ef6ad55.png)

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
- Launch demo
- Tap on "Reachability Status"