### PR TITLE
wrong method used in Documentation Usage.md#manual-authentication

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -619,7 +619,7 @@ If you are communicating with an API that always requires an `Authenticate` or s
 let user = "user"
 let password = "password"
 
-let headers: HTTPHeaders = [.authenticate(username: user, password: password)]
+let headers: HTTPHeaders = [.authorization(username: user, password: password)]
 
 AF.request("https://httpbin.org/basic-auth/user/password", headers: headers)
     .responseJSON { response in


### PR DESCRIPTION
### Issue Link :link:
There seems to be a typo in the current version of the documentation. The example code in  Usage.md#manual-authentication won't compile in Xcode. This commit should fix it.
