### PR TITLE
The Client Certificate Support

### DIFF
--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -79,10 +79,8 @@ extension SessionDelegate: URLSessionTaskDelegate {
         switch challenge.protectionSpace.authenticationMethod {
         case NSURLAuthenticationMethodServerTrust:
             evaluation = attemptServerTrustAuthentication(with: challenge)
-        case NSURLAuthenticationMethodHTTPBasic, NSURLAuthenticationMethodHTTPDigest, NSURLAuthenticationMethodNTLM, NSURLAuthenticationMethodNegotiate:
+        case NSURLAuthenticationMethodHTTPBasic, NSURLAuthenticationMethodHTTPDigest, NSURLAuthenticationMethodNTLM, NSURLAuthenticationMethodNegotiate, NSURLAuthenticationMethodClientCertificate:
             evaluation = attemptCredentialAuthentication(for: challenge, belongingTo: task)
-        // case NSURLAuthenticationMethodClientCertificate:
-        // Alamofire doesn't currently support client certificate validation.
         default:
             evaluation = (.performDefaultHandling, nil, nil)
         }


### PR DESCRIPTION
Add the `NSURLAuthenticationMethodClientCertificate` to the case, just like the `NSURLAuthenticationMethodNTLM`, `NSURLAuthenticationMethodNegotiate`.

### Issue Link :link:
https://github.com/Alamofire/Alamofire/issues/2923

### Goals :soccer:
The client certificate is supported in the last major version, and the performing is just use a function to get the credential which is attached to the target. So, I think the new version is no need to drop this feature.

### Implementation Details :construction:
Just add a case `NSURLAuthenticationMethodClientCertificate` to the `NSURLAuthenticationMethodHTTPBasic`, `NSURLAuthenticationMethodHTTPDigest` and etc.
So, when a `NSURLAuthenticationMethodClientCertificate` authentication challenge coming, the `SessionDelegate` will get the credential from the task or the credential storage.

### Testing Details :mag:
I setup a client credential to the credential storage for my custom protection space, and the TLS can be establish successfully.
