### PR TITLE
Fix the crash issue on example

### DIFF
--- a/Example/Source/MasterViewController.swift
+++ b/Example/Source/MasterViewController.swift
@@ -43,6 +43,7 @@ class MasterViewController: UITableViewController {
         navigationItem.titleView = titleImageView
         clearsSelectionOnViewWillAppear = true
 
+        reachability = NetworkReachabilityManager.default
         monitorReachability()
     }
 
@@ -94,7 +95,7 @@ class MasterViewController: UITableViewController {
     // MARK: - Private - Reachability
 
     private func monitorReachability() {
-        NetworkReachabilityManager.default?.startListening { status in
+        reachability.startListening { status in
             print("Reachability Status Changed: \(status)")
         }
     }


### PR DESCRIPTION
The reachability is not assigned which can cause app crash when
tap on the Reachability Status row


### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->