### PR TITLE
Response test host error fix

### DIFF
--- a/Tests/AFError+AlamofireTests.swift
+++ b/Tests/AFError+AlamofireTests.swift
@@ -174,6 +174,11 @@ extension AFError {
         if case let .urlRequestValidationFailed(reason) = self, reason.isBodyDataInGETRequest { return true }
         return false
     }
+    
+    var isHostURLError: Bool {
+        guard let errorCode = (underlyingError as? URLError)?.code else { return false }
+    	return [.cannotConnectToHost, .cannotFindHost].contains(errorCode)
+    }
 }
 
 // MARK: -

--- a/Tests/AFError+AlamofireTests.swift
+++ b/Tests/AFError+AlamofireTests.swift
@@ -177,7 +177,7 @@ extension AFError {
     
     var isHostURLError: Bool {
         guard let errorCode = (underlyingError as? URLError)?.code else { return false }
-    	return [.cannotConnectToHost, .cannotFindHost].contains(errorCode)
+        return [.cannotConnectToHost, .cannotFindHost].contains(errorCode)
     }
 }
 

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -71,7 +71,7 @@ final class ResponseTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertNotNil(response?.error)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual(response?.hasHostURLError, true)
+        XCTAssertEqual(response?.error?.isHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -124,7 +124,7 @@ final class ResponseDataTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual(response?.hasHostURLError, true)
+        XCTAssertEqual(response?.error?.isHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -177,7 +177,7 @@ final class ResponseStringTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual(response?.hasHostURLError, true)
+        XCTAssertEqual(response?.error?.isHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -230,7 +230,7 @@ final class ResponseJSONTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual(response?.hasHostURLError, true)
+        XCTAssertEqual(response?.error?.isHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 
@@ -369,7 +369,7 @@ final class ResponseJSONDecodableTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual(response?.hasHostURLError, true)
+        XCTAssertEqual(response?.error?.isHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -426,7 +426,7 @@ final class ResponseMapTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual(response?.hasHostURLError, true)
+        XCTAssertEqual(response?.error?.isHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -518,7 +518,7 @@ final class ResponseTryMapTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.asAFError?.isSessionTaskError, true)
-        XCTAssertTrue(urlHostErrorCodes.contains(response!.error!.asAFError!.urlErrorCode))
+        XCTAssertEqual(response?.error?.asAFError?.isHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -675,24 +675,4 @@ final class ResponseTryMapErrorTestCase: BaseTestCase {
         XCTAssertEqual(underlyingError.asAFError?.isHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
-}
-
-private extension DataResponse where Failure == AFError {
-    var hasHostURLError: Bool? {
-        return error?.isHostURLError
-    }
-}
-
-private extension AFError {
-    var isHostURLError: Bool {
-        return urlHostErrorCodes.contains(urlErrorCode)
-    }
-    
-    var urlErrorCode : URLError.Code {
-        return (underlyingError as? URLError)?.code ?? .unknown
-    }
-}
-
-private var urlHostErrorCodes : Set<URLError.Code> {
-    return Set<URLError.Code>([.cannotConnectToHost, .cannotFindHost])
 }

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -71,7 +71,7 @@ final class ResponseTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertNotNil(response?.error)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotConnectToHost)
+        XCTAssertEqual(response?.hasHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -124,7 +124,7 @@ final class ResponseDataTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotConnectToHost)
+        XCTAssertEqual(response?.hasHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -177,7 +177,7 @@ final class ResponseStringTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotConnectToHost)
+        XCTAssertEqual(response?.hasHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -230,7 +230,7 @@ final class ResponseJSONTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotConnectToHost)
+        XCTAssertEqual(response?.hasHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 
@@ -369,7 +369,7 @@ final class ResponseJSONDecodableTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotConnectToHost)
+        XCTAssertEqual(response?.hasHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -426,7 +426,7 @@ final class ResponseMapTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotConnectToHost)
+        XCTAssertEqual(response?.hasHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -518,7 +518,7 @@ final class ResponseTryMapTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.asAFError?.isSessionTaskError, true)
-        XCTAssertEqual((response?.error?.asAFError?.underlyingError as? URLError)?.code, .cannotConnectToHost)
+        XCTAssertTrue(urlHostErrorCodes.contains(response!.error!.asAFError!.urlErrorCode))
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -672,8 +672,27 @@ final class ResponseTryMapErrorTestCase: BaseTestCase {
         else { XCTFail(); return }
 
         XCTAssertEqual(underlyingError.asAFError?.isSessionTaskError, true)
-        XCTAssertEqual((underlyingError.asAFError?.underlyingError as? URLError)?.code, .cannotConnectToHost)
-
+        XCTAssertEqual(underlyingError.asAFError?.isHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
+}
+
+private extension DataResponse where Failure == AFError {
+    var hasHostURLError: Bool? {
+        return error?.isHostURLError
+    }
+}
+
+private extension AFError {
+    var isHostURLError: Bool {
+        return urlHostErrorCodes.contains(urlErrorCode)
+    }
+    
+    var urlErrorCode : URLError.Code {
+        return (underlyingError as? URLError)?.code ?? .unknown
+    }
+}
+
+private var urlHostErrorCodes : Set<URLError.Code> {
+    return Set<URLError.Code>([.cannotConnectToHost, .cannotFindHost])
 }

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -71,7 +71,7 @@ final class ResponseTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertNotNil(response?.error)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotFindHost)
+        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotConnectToHost)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -124,7 +124,7 @@ final class ResponseDataTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotFindHost)
+        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotConnectToHost)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -177,7 +177,7 @@ final class ResponseStringTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotFindHost)
+        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotConnectToHost)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -230,7 +230,7 @@ final class ResponseJSONTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotFindHost)
+        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotConnectToHost)
         XCTAssertNotNil(response?.metrics)
     }
 
@@ -369,7 +369,7 @@ final class ResponseJSONDecodableTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotFindHost)
+        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotConnectToHost)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -426,7 +426,7 @@ final class ResponseMapTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotFindHost)
+        XCTAssertEqual((response?.error?.underlyingError as? URLError)?.code, .cannotConnectToHost)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -518,7 +518,7 @@ final class ResponseTryMapTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.asAFError?.isSessionTaskError, true)
-        XCTAssertEqual((response?.error?.asAFError?.underlyingError as? URLError)?.code, .cannotFindHost)
+        XCTAssertEqual((response?.error?.asAFError?.underlyingError as? URLError)?.code, .cannotConnectToHost)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -672,7 +672,7 @@ final class ResponseTryMapErrorTestCase: BaseTestCase {
         else { XCTFail(); return }
 
         XCTAssertEqual(underlyingError.asAFError?.isSessionTaskError, true)
-        XCTAssertEqual((underlyingError.asAFError?.underlyingError as? URLError)?.code, .cannotFindHost)
+        XCTAssertEqual((underlyingError.asAFError?.underlyingError as? URLError)?.code, .cannotConnectToHost)
 
         XCTAssertNotNil(response?.metrics)
     }


### PR DESCRIPTION
### Issue Link :link:
For certain unit tests, an expected host connection failure can occur for different reasons depending on how the test is run. Previously the test were only checking for one host connection failure condition which would cause these test to fail on certain systems

### Goals :soccer:
Allow unit tests which expect host connection failures to succeed on all systems.

### Implementation Details :construction:
Modified tests so they can accept from multiple reasons for why the host connection may have failed

### Testing Details :mag:
Tested locally by running the unit tests, full verification will need to happen in the continuous integration phase