### PR TITLE
add index style serialization array nested dictionary

### DIFF
--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -85,14 +85,19 @@ public struct URLEncoding: ParameterEncoding {
         case brackets
         /// No brackets are appended. The key is encoded as is.
         case noBrackets
+        
+        case index
 
-        func encode(key: String) -> String {
+        func encode(key: String, index: Int) -> String {
             switch self {
             case .brackets:
                 return "\(key)[]"
             case .noBrackets:
                 return key
+            case .index:
+                return "\(key)[\(index)]"
             }
+            
         }
     }
 
@@ -193,8 +198,8 @@ public struct URLEncoding: ParameterEncoding {
                 components += queryComponents(fromKey: "\(key)[\(nestedKey)]", value: value)
             }
         } else if let array = value as? [Any] {
-            for value in array {
-                components += queryComponents(fromKey: arrayEncoding.encode(key: key), value: value)
+            for (index, value) in array.enumerated() {
+                components += queryComponents(fromKey: arrayEncoding.encode(key: key, index: index), value: value)
             }
         } else if let value = value as? NSNumber {
             if value.isBool {

--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -205,6 +205,22 @@ class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             XCTFail("Test encountered unexpected error: \(error)")
         }
     }
+    
+    func testURLParameterEncodeArrayNestedDictionaryValueParameterWithIndex() {
+        do {
+            // Given
+            let encoding = URLEncoding(arrayEncoding: .index)
+            let parameters = ["foo": ["a", 1, true, ["bar": 2], ["qux": 3],  ["quy": ["quz": 3]]]]
+
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+
+            // Then
+            XCTAssertEqual(urlRequest.url?.query, "foo%5B0%5D=a&foo%5B1%5D=1&foo%5B2%5D=1&foo%5B3%5D%5Bbar%5D=2&foo%5B4%5D%5Bqux%5D=3&foo%5B5%5D%5Bquy%5D%5Bquz%5D=3")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
+    }
 
     func testURLParameterEncodeStringKeyArrayValueParameterWithoutBrackets() {
         do {


### PR DESCRIPTION
### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->
#1839 #2431 
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
There is no real specification for how to URL encode collection parameters like arrays and
dictionaries.

for: `["foo": ["a", 1, true, ["bar": 2], ["qux": 3],  ["quy": ["quz": 3]]]]`

1. default `.brackets` encode is:

` foo[]=a&foo[]=1&foo[]=1&foo[][bar]=2&foo[][qux]=3&foo[][quy]`[quz]=3

2. `.noBrackets` encode is: 

`foo=a&foo=1&foo=1&foo[bar]=2&foo[qux]=3&foo[quy][quz]=3`

3. [jQuery](https://api.jquery.com/jQuery.param/#example-1) >=1.4 and Node.js package  [query-string](https://www.npmjs.com/package/query-string) provide index style. 

`foo[0]=a&foo[1]=1&foo[2]=1&foo[3][bar]=2&foo[4][qux]=3&foo[5][quy][quz]=3`

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
A new `ArrayEncoding` enumeration is added to `URLEncoding`. The cases are `.brackets` and `.noBrackets` and `.index `
The `arrayEncoding` passed to `init` is used to control the array key serialization in `URLEncoding.queryComponents`.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
The new tests are named like the existing tests, with an appended suffix:

- `testURLParameterEncodeArrayNestedDictionaryValueParameterWithIndex`

tests pass.
