### PR TITLE
Map DataResponse success result by a key path

### DIFF
--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -143,6 +143,7 @@ extension DataResponse {
                                                  result: result.map(transform))
     }
 
+    #if !swift(>=5.2)
     /// Similar to `func map<NewSuccess>(_ transform: (Success) -> NewSuccess) -> DataResponse<NewSuccess, Failure>`,
     /// but uses a key path instead of a closure
     ///
@@ -163,6 +164,7 @@ extension DataResponse {
                                                  serializationDuration: serializationDuration,
                                                  result: result.map { $0[keyPath: keyPath] } )
     }
+    #endif
 
     /// Evaluates the given closure when the result of this `DataResponse` is a success, passing the unwrapped result
     /// value as a parameter.

--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -143,7 +143,6 @@ extension DataResponse {
                                                  result: result.map(transform))
     }
 
-    #if !swift(>=5.2)
     /// Similar to `func map<NewSuccess>(_ transform: (Success) -> NewSuccess) -> DataResponse<NewSuccess, Failure>`,
     /// but uses a key path instead of a closure
     ///
@@ -164,7 +163,6 @@ extension DataResponse {
                                                  serializationDuration: serializationDuration,
                                                  result: result.map { $0[keyPath: keyPath] } )
     }
-    #endif
 
     /// Evaluates the given closure when the result of this `DataResponse` is a success, passing the unwrapped result
     /// value as a parameter.

--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -143,6 +143,27 @@ extension DataResponse {
                                                  result: result.map(transform))
     }
 
+    /// Similar to `func map<NewSuccess>(_ transform: (Success) -> NewSuccess) -> DataResponse<NewSuccess, Failure>`,
+    /// but uses a key path instead of a closure
+    ///
+    /// For example:
+    ///
+    ///     let possibleData: DataResponse<Data> = ...
+    ///     let possibleInt = possibleData.map(\.count)
+    ///
+    /// - parameter keyPath: A key path for the success value of the instance's result.
+    ///
+    /// - returns: A `DataResponse` whose result wraps the value for the given key path. If this instance's
+    ///            result is a failure, returns a response wrapping the same failure.
+    public func map<NewSuccess>(_ keyPath: KeyPath<Success, NewSuccess>) -> DataResponse<NewSuccess, Failure> {
+        return DataResponse<NewSuccess, Failure>(request: request,
+                                                 response: response,
+                                                 data: data,
+                                                 metrics: metrics,
+                                                 serializationDuration: serializationDuration,
+                                                 result: result.map { $0[keyPath: keyPath] } )
+    }
+
     /// Evaluates the given closure when the result of this `DataResponse` is a success, passing the unwrapped result
     /// value as a parameter.
     ///

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -405,6 +405,7 @@ final class ResponseMapTestCase: BaseTestCase {
         XCTAssertNotNil(response?.metrics)
     }
 
+    #if !swift(>=5.2)
     func testThatMapTransformsSuccessValueByKeyPath() {
         // Given
         let urlString = "https://httpbin.org/base64/SFRUUEJJTiBpcyBhd2Vzb21l"
@@ -428,6 +429,7 @@ final class ResponseMapTestCase: BaseTestCase {
         XCTAssertEqual(response?.result.success, 18)
         XCTAssertNotNil(response?.metrics)
     }
+    #endif
 
     func testThatMapPreservesFailureError() {
         // Given

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -405,7 +405,6 @@ final class ResponseMapTestCase: BaseTestCase {
         XCTAssertNotNil(response?.metrics)
     }
 
-    #if !swift(>=5.2)
     func testThatMapTransformsSuccessValueByKeyPath() {
         // Given
         let urlString = "https://httpbin.org/base64/SFRUUEJJTiBpcyBhd2Vzb21l"
@@ -429,7 +428,6 @@ final class ResponseMapTestCase: BaseTestCase {
         XCTAssertEqual(response?.result.success, 18)
         XCTAssertNotNil(response?.metrics)
     }
-    #endif
 
     func testThatMapPreservesFailureError() {
         // Given

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -405,6 +405,30 @@ final class ResponseMapTestCase: BaseTestCase {
         XCTAssertNotNil(response?.metrics)
     }
 
+    func testThatMapTransformsSuccessValueByKeyPath() {
+        // Given
+        let urlString = "https://httpbin.org/base64/SFRUUEJJTiBpcyBhd2Vzb21l"
+        let expectation = self.expectation(description: "request should succeed")
+
+        var response: DataResponse<Int, AFError>?
+
+        // When
+        AF.request(urlString).responseString { resp in
+            response = resp.map(\.count)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertEqual(response?.result.isSuccess, true)
+        XCTAssertEqual(response?.result.success, 18)
+        XCTAssertNotNil(response?.metrics)
+    }
+
     func testThatMapPreservesFailureError() {
         // Given
         let urlString = "https://invalid-url-here.org/this/does/not/exist"


### PR DESCRIPTION
Hello.
Thank you for Alamofire.

### Goals :soccer:
Found the following example for `func map<NewSuccess>(_ transform: (Success) -> NewSuccess) -> DataResponse<NewSuccess, Failure>` in the documentation for this function:

```
let possibleData: DataResponse<Data> = ...
let possibleInt = possibleData.map { $0.count }
```

As for me, there should be also `let possibleInt = possibleData.map(\.count)`.

### Implementation Details :construction:
Added a new function `func map<NewSuccess>(_ keyPath: KeyPath<Success, NewSuccess>) -> DataResponse<NewSuccess, Failure>` to `DataResponse`. This function is similar to `func map<NewSuccess>(_ transform: (Success) -> NewSuccess) -> DataResponse<NewSuccess, Failure>`, the only difference is the mapping function.

### Testing Details :mag:
Added `ResponseMapTestCase.testThatMapTransformsSuccessValueByKeyPath`.