### PR TITLE
Remove public access modifier for internal class _URLEncodedFormEncoder

### DIFF
--- a/Source/URLEncodedFormEncoder.swift
+++ b/Source/URLEncodedFormEncoder.swift
@@ -411,11 +411,11 @@ final class _URLEncodedFormEncoder {
     private let dataEncoding: URLEncodedFormEncoder.DataEncoding
     private let dateEncoding: URLEncodedFormEncoder.DateEncoding
 
-    public init(context: URLEncodedFormContext,
-                codingPath: [CodingKey] = [],
-                boolEncoding: URLEncodedFormEncoder.BoolEncoding,
-                dataEncoding: URLEncodedFormEncoder.DataEncoding,
-                dateEncoding: URLEncodedFormEncoder.DateEncoding) {
+    init(context: URLEncodedFormContext,
+         codingPath: [CodingKey] = [],
+         boolEncoding: URLEncodedFormEncoder.BoolEncoding,
+         dataEncoding: URLEncodedFormEncoder.DataEncoding,
+         dateEncoding: URLEncodedFormEncoder.DateEncoding) {
         self.context = context
         self.codingPath = codingPath
         self.boolEncoding = boolEncoding


### PR DESCRIPTION
### Goals :soccer:

Ensure consistency within the public API.

### Implementation Details :construction:

When testing out [`swift-api-inventory`](https://github.com/swiftdocorg/swift-doc#swift-api-inventory) on Alamofire, I saw this line in the output, which stuck out because of the leading underscore:

```swift
init _URLEncodedFormEncoder(context: URLEncodedFormContext, codingPath: [CodingKey], boolEncoding: URLEncodedFormEncoder.BoolEncoding, dataEncoding: URLEncodedFormEncoder.DataEncoding, dateEncoding: URLEncodedFormEncoder.DateEncoding)
```

Looking at the source, `_URLEncodedFormEncoder` is an internal type, but the initializer showed up in the inventory because of its `public` access modifier.

https://github.com/Alamofire/Alamofire/blob/262fc46a273c4e01483aee933a8230b4b253ef49/Source/URLEncodedFormEncoder.swift#L403-L414

This change removes `public` to give that initializer an implicit `internal` access level to match its enclosing type `_URLEncodedFormEncoder`. 

### Testing Details :mag:

I ran the test suite locally and await the CI to finish to confirm that this change doesn't break anything. For this kind of issue, it seems like a linter rule would be more appropriate than a unit test. Reading through [SwiftLint's list of rules](https://realm.github.io/SwiftLint/rule-directory.html), I didn't see anything that does this yet. I'll ask around to see if folks think that would be helpful, and if so, write that up.
