### PR TITLE
Make AlamofireExtension More Public

### DIFF
--- a/Source/AlamofireExtended.swift
+++ b/Source/AlamofireExtended.swift
@@ -28,10 +28,14 @@ public struct AlamofireExtension<ExtendedType> {
     /// Stores the type or meta-type of any extended type.
     public private(set) var type: ExtendedType
 
+    /// Create an instance from the provided value.
+    ///
+    /// - Parameter type: Instance being extended.
     public init(_ type: ExtendedType) {
         self.type = type
     }
 
+    /// Get and set properties through a `WritableKeyPath` subscript for `@dynamicMemberLookup`.
     public subscript<Property>(dynamicMember keyPath: WritableKeyPath<ExtendedType, Property>) -> Property {
         get { type[keyPath: keyPath] }
         set { type[keyPath: keyPath] = newValue }

--- a/Source/AlamofireExtended.swift
+++ b/Source/AlamofireExtended.swift
@@ -23,12 +23,18 @@
 //
 
 /// Type that acts as a generic extension point for all `AlamofireExtended` types.
+@dynamicMemberLookup
 public struct AlamofireExtension<ExtendedType> {
-    /// Stores the type or metatype of any extended type.
-    let type: ExtendedType
+    /// Stores the type or meta-type of any extended type.
+    public private(set) var type: ExtendedType
 
-    init(_ type: ExtendedType) {
+    public init(_ type: ExtendedType) {
         self.type = type
+    }
+
+    public subscript<Property>(dynamicMember keyPath: WritableKeyPath<ExtendedType, Property>) -> Property {
+        get { type[keyPath: keyPath] }
+        set { type[keyPath: keyPath] = newValue }
     }
 }
 


### PR DESCRIPTION
### Goals :soccer:
This PR improves `AlamofireExtension` in two ways:
1. Makes the `type` property and `init` `public` so they can be used by AlamofireImage.
2. Adds `@dynamicMemberLookup` conformance so property accesses can be transparent.

### Implementation Details :construction:
Updated the type member attributes, added `@dynamicMemberLookup` conformance.

### Testing Details :mag:
No additional tests, just those which touch the `af` extension point already.
