### PR TITLE
Restore Swift 5 Support

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -4,6 +4,7 @@
 --swiftversion 5
 
 # rules
+--enable isEmpty
 --disable andOperator
 
 # format options
@@ -15,7 +16,7 @@
 --exponentcase lowercase
 --exponentgrouping disabled
 --fractiongrouping disabled
---ifdef outdent
+--ifdef no-indent
 --importgrouping testable-top
 --operatorfunc no-space
 --nospaceoperators ..<, ...
@@ -23,3 +24,4 @@
 --stripunusedargs closure-only
 --wraparguments after-first
 --wrapcollections after-first
+--wrapparameters after-first

--- a/Source/AlamofireExtended.swift
+++ b/Source/AlamofireExtended.swift
@@ -23,7 +23,6 @@
 //
 
 /// Type that acts as a generic extension point for all `AlamofireExtended` types.
-@dynamicMemberLookup
 public struct AlamofireExtension<ExtendedType> {
     /// Stores the type or meta-type of any extended type.
     public private(set) var type: ExtendedType
@@ -33,12 +32,6 @@ public struct AlamofireExtension<ExtendedType> {
     /// - Parameter type: Instance being extended.
     public init(_ type: ExtendedType) {
         self.type = type
-    }
-
-    /// Get and set properties through a `WritableKeyPath` subscript for `@dynamicMemberLookup`.
-    public subscript<Property>(dynamicMember keyPath: WritableKeyPath<ExtendedType, Property>) -> Property {
-        get { type[keyPath: keyPath] }
-        set { type[keyPath: keyPath] = newValue }
     }
 }
 

--- a/Source/NetworkReachabilityManager.swift
+++ b/Source/NetworkReachabilityManager.swift
@@ -240,11 +240,11 @@ extension SCNetworkReachabilityFlags {
     var canConnectWithoutUserInteraction: Bool { return canConnectAutomatically && !contains(.interventionRequired) }
     var isActuallyReachable: Bool { return isReachable && (!isConnectionRequired || canConnectWithoutUserInteraction) }
     var isCellular: Bool {
-#if os(iOS) || os(tvOS)
+        #if os(iOS) || os(tvOS)
         return contains(.isWWAN)
-#else
+        #else
         return false
-#endif
+        #endif
     }
 
     /// Human readable `String` for all states, to help with debugging.

--- a/Source/ServerTrustEvaluation.swift
+++ b/Source/ServerTrustEvaluation.swift
@@ -73,9 +73,9 @@ open class ServerTrustManager {
 
 /// A protocol describing the API used to evaluate server trusts.
 public protocol ServerTrustEvaluating {
-#if os(Linux)
-// Implement this once Linux has API for evaluating server trusts.
-#else
+    #if os(Linux)
+    // Implement this once Linux has API for evaluating server trusts.
+    #else
     /// Evaluates the given `SecTrust` value for the given `host`.
     ///
     /// - Parameters:
@@ -84,7 +84,7 @@ public protocol ServerTrustEvaluating {
     ///
     /// - Returns: A `Bool` indicating whether the evaluator considers the `SecTrust` value valid for `host`.
     func evaluate(_ trust: SecTrust, forHost host: String) throws
-#endif
+    #endif
 }
 
 // MARK: - Server Trust Evaluators
@@ -345,9 +345,9 @@ public final class DisabledEvaluator: ServerTrustEvaluating {
 // MARK: - Extensions
 
 public extension Array where Element == ServerTrustEvaluating {
-#if os(Linux)
-// Add this same convenience method for Linux.
-#else
+    #if os(Linux)
+    // Add this same convenience method for Linux.
+    #else
     /// Evaluates the given `SecTrust` value for the given `host`.
     ///
     /// - Parameters:
@@ -360,7 +360,7 @@ public extension Array where Element == ServerTrustEvaluating {
             try evaluator.evaluate(trust, forHost: host)
         }
     }
-#endif
+    #endif
 }
 
 extension Bundle: AlamofireExtended {}

--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -97,7 +97,7 @@ extension Request {
                                            data: Data?)
         -> ValidationResult
         where S.Iterator.Element == String {
-        guard let data = data, data.count > 0 else { return .success(Void()) }
+        guard let data = data, !data.isEmpty else { return .success(Void()) }
 
         guard
             let responseContentType = response.mimeType,

--- a/Tests/NetworkReachabilityManagerTests.swift
+++ b/Tests/NetworkReachabilityManagerTests.swift
@@ -257,7 +257,7 @@ final class NetworkReachabilityManagerTestCase: BaseTestCase {
         XCTAssertEqual(status, .reachable(.ethernetOrWiFi))
     }
 
-#if os(iOS) || os(tvOS)
+    #if os(iOS) || os(tvOS)
     func testThatStatusIsReachableOnCellularStatusWhenIsWWAN() {
         // Given
         let flags: SCNetworkReachabilityFlags = [.reachable, .isWWAN]
@@ -279,5 +279,5 @@ final class NetworkReachabilityManagerTestCase: BaseTestCase {
         // Then
         XCTAssertEqual(status, .notReachable)
     }
-#endif
+    #endif
 }

--- a/Tests/ServerTrustEvaluatorTests.swift
+++ b/Tests/ServerTrustEvaluatorTests.swift
@@ -1396,9 +1396,9 @@ class ServerTrustPolicyCertificatesInBundleTestCase: ServerTrustPolicyTestCase {
         // When
         let certificates = Bundle(for: ServerTrustPolicyCertificatesInBundleTestCase.self).af.certificates
 
-// Then
-// Expectation: 19 well-formed certificates in the test bundle plus 4 invalid certificates.
-#if os(macOS)
+        // Then
+        // Expectation: 19 well-formed certificates in the test bundle plus 4 invalid certificates.
+        #if os(macOS)
         // For some reason, macOS is allowing all certificates to be considered valid. Need to file a
         // rdar demonstrating this behavior.
         if #available(macOS 10.12, *) {
@@ -1406,8 +1406,8 @@ class ServerTrustPolicyCertificatesInBundleTestCase: ServerTrustPolicyTestCase {
         } else {
             XCTAssertEqual(certificates.count, 23, "Expected 23 well-formed certificates")
         }
-#else
+        #else
         XCTAssertEqual(certificates.count, 19, "Expected 19 well-formed certificates")
-#endif
+        #endif
     }
 }

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -274,19 +274,19 @@ final class SessionTestCase: BaseTestCase {
             let versionString = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
 
             let osName: String = {
-#if os(iOS)
+                #if os(iOS)
                 return "iOS"
-#elseif os(watchOS)
+                #elseif os(watchOS)
                 return "watchOS"
-#elseif os(tvOS)
+                #elseif os(tvOS)
                 return "tvOS"
-#elseif os(macOS)
+                #elseif os(macOS)
                 return "macOS"
-#elseif os(Linux)
+                #elseif os(Linux)
                 return "Linux"
-#else
+                #else
                 return "Unknown"
-#endif
+                #endif
             }()
 
             return "\(osName) \(versionString)"
@@ -1683,12 +1683,12 @@ final class SessionConfigurationHeadersTestCase: BaseTestCase {
         executeAuthorizationHeaderTest(for: .ephemeral)
     }
 
-#if os(macOS)
+    #if os(macOS)
     func disabled_testThatBackgroundConfigurationHeadersAreSentWithRequest() {
         // Given, When, Then
         executeAuthorizationHeaderTest(for: .background)
     }
-#endif
+    #endif
 
     private func executeAuthorizationHeaderTest(for type: ConfigurationType) {
         // Given

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -515,7 +515,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
         }
     }
 
-#if os(macOS)
+    #if os(macOS)
     func disabled_testThatUploadingMultipartFormDataOnBackgroundSessionWritesDataToFileToAvoidCrash() {
         // Given
         let manager: Session = {
@@ -564,7 +564,7 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
             return
         }
     }
-#endif
+    #endif
 
     // MARK: Combined Test Execution
 


### PR DESCRIPTION
### Goals :soccer:
This PR restores Swift 5 support by removing `@dynamicMemberLookup` from `AlamofireExtension`.

This PR also brings the project into sync with AFI's SwiftFormat config.

### Implementation Details :construction:
Turns out the `KeyPath` version of the `@dynamicMemberLookup` requirement is only available on Swift 5.1+, so it needed to be removed in general. There was also an implicit return but that was removed along with the subscript.

### Testing Details :mag:
Unfortunately GitHub Actions don't have Xcode 10.3 available, so I had to reinstall it and build locally.
