### PR TITLE
Fix Swift PM Semantic Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Once you have your Swift package set up, adding Alamofire as a dependency is as 
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.0.0")
+    .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.0.0"))
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Once you have your Swift package set up, adding Alamofire as a dependency is as 
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.0")
+    .package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.0.0")
 ]
 ```
 


### PR DESCRIPTION
### Goals :soccer:
Resolve a package manifest parsing error generated by the Swift PM integration snippet from the README.

When the existing package dependency description is added to the manifest, Xcode throws the following error:

```
Failed to parse the manifest file

Invalid semantic version string '5.0'
```

### Implementation Details :construction:
Added two characters to the README.

Per the Apple docs on [Version](https://developer.apple.com/documentation/swift_packages/version), the `patch` value is required.

### Testing Details :mag:
- Copy/paste the old dependency snippet into your `Package.swift` - ❌ 
- Copy/paste the new dependency snippet into your `Package.swift` - ✅ 
