### PR TITLE
Compact Unwind Warnings on watchOS

### DIFF
--- a/Alamofire.podspec
+++ b/Alamofire.podspec
@@ -18,4 +18,6 @@ Pod::Spec.new do |s|
   s.source_files = 'Source/*.swift'
 
   s.frameworks = 'CFNetwork'
+
+  s.watchos.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-Wl,-no_compact_unwind' }
 end

--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -1659,6 +1659,11 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					CFNetwork,
+					"-Wl,-no_compact_unwind",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.alamofire.Alamofire.watchOS;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -1677,6 +1682,11 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					CFNetwork,
+					"-Wl,-no_compact_unwind",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.alamofire.Alamofire.watchOS;
 				SDKROOT = watchos;


### PR DESCRIPTION
### Issue Link :link:
I'm seeing compact unwind warnings on watchOS with Xcode 11.3.1.

<img width="1288" alt="Screen Shot 2020-02-25 at 6 47 52 PM" src="https://user-images.githubusercontent.com/169110/75309085-d2532800-5804-11ea-9111-a8f882885442.png">

### Goals :soccer:
To eliminate the compiler warnings on watchOS.

### Implementation Details :construction:
The only solution I've been able to find over the past year or so when this occurs is to disable the compact unwind warnings themselves. If anyone else has more information on how to resolve this properly, I'm all ears. We've done this on some of our internal project and haven't run into issues due to disabling them yet.
