### PR TITLE
Clarify dropping background support 5.0 migration

### DIFF
--- a/Documentation/Alamofire 5.0 Migration Guide.md
+++ b/Documentation/Alamofire 5.0 Migration Guide.md
@@ -22,7 +22,7 @@ This guide is provided in order to ease the transition of existing applications 
 Most APIs have changed in Alamofire 5, so this list is not complete. While most top level `request` APIs remain the same, nearly every other type has changed in some way. For up to date examples, see our Usage and Advanced Usage documentation.
 
 - `SessionManager` has been renamed to `Session` and its APIs have completely changed.
-- Using a `URLSessionConfiguration` with a background identifier is not possible any more. We're explicitly ensuring Alamofire isn't used with background sessions, in order to prevent ongoing issues around support and surprise on the part of the user.
+- Background `URLSessionConfiguration`s are no longer supported and attempting to use one will result in a fatal runtime error. Alamofire was never designed to work in the background and its closure-based APIs cannot survive a background transition, leading to ongoing issues around background behavior. Explicit background support will be added through dedicated APIs at some point in the future.
 - `SessionDelegate` has been rebuilt and it’s public API completely changed. The various closure overrides have been removed, with most now able to be replaced with specific Alamofire features. If there is a need for control over something the closures used to provide, feel free to open a feature request.
 - `TaskDelegate` and the various `*TaskDelegate` classes have been removed. All `URLSession*Delegate` handling is now performed by `SessionDelegate`.
 - `Result` has been removed. Alamofire now uses Swift’s `Result` type.

--- a/Documentation/Alamofire 5.0 Migration Guide.md
+++ b/Documentation/Alamofire 5.0 Migration Guide.md
@@ -22,6 +22,7 @@ This guide is provided in order to ease the transition of existing applications 
 Most APIs have changed in Alamofire 5, so this list is not complete. While most top level `request` APIs remain the same, nearly every other type has changed in some way. For up to date examples, see our Usage and Advanced Usage documentation.
 
 - `SessionManager` has been renamed to `Session` and its APIs have completely changed.
+- Using a `URLSessionConfiguration` with a background identifier is not possible any more. We're explicitly ensuring Alamofire isn't used with background sessions, in order to prevent ongoing issues around support and surprise on the part of the user.
 - `SessionDelegate` has been rebuilt and it’s public API completely changed. The various closure overrides have been removed, with most now able to be replaced with specific Alamofire features. If there is a need for control over something the closures used to provide, feel free to open a feature request.
 - `TaskDelegate` and the various `*TaskDelegate` classes have been removed. All `URLSession*Delegate` handling is now performed by `SessionDelegate`.
 - `Result` has been removed. Alamofire now uses Swift’s `Result` type.


### PR DESCRIPTION
First of all, congrats on the major release! Thanks a lot for the hard work to make it happen. 

I just migrated our app to v5. Everything went quite smooth except a few usages of background sessions. After some searching I've found [this answer](https://github.com/Alamofire/Alamofire/issues/2971#issuecomment-543847712) and [this PR](https://github.com/Alamofire/Alamofire/pull/2917) indicating that this is no longer possible.

I thought it would it be good to reflect this in the migration guide as well, so I've added a quote from the PR. Please feel free to change the text or write something completely different. 

Btw, how is this behaviour compared to v4? Was it never working, not reliable, or is this due to the new architecture?