### PR TITLE
Fix watchOS Memory Leaks

### DIFF
--- a/Alamofire.xcworkspace/contents.xcworkspacedata
+++ b/Alamofire.xcworkspace/contents.xcworkspacedata
@@ -7,4 +7,7 @@
    <FileRef
       location = "group:Example/iOS Example.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:watchOS Example/watchOS Example.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/Documentation/AdvancedUsage.md
+++ b/Documentation/AdvancedUsage.md
@@ -363,6 +363,8 @@ AF.request(...)
     }
 ```
 
+> Due to `FB7624529`, collection of `URLSessionTaskMetrics` on watchOS is currently disabled.
+
 ### `DataRequest`
 `DataRequest` is a subclass of `Request` which encapsulates a `URLSessionDataTask` downloading a server response into `Data` stored in memory. Therefore, it’s important to realize that extremely large downloads may adversely affect system performance. For those types of downloads, using `DownloadRequest` to save the data to disk is recommended.
 

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -818,6 +818,8 @@ AF.request("https://httpbin.org/get").responseJSON { response in
 }
 ```
 
+> Due to `FB7624529`, collection of `URLSessionTaskMetrics` on watchOS is currently disabled.
+
 ### cURL Command Output
 
 Debugging platform issues can be frustrating. Thankfully, Alamofire's `Request` type can produce the equivalent cURL command for easy debugging. Due to the asynchronous nature of Alamofire's `Request` creation, this API has both synchronous and asynchronous versions. To get the cURL command as soon as possible, you can chain the `cURLDescription` onto a request:

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ The following radars have some effect on the current implementation of Alamofire
 - [`rdar://21349340`](http://www.openradar.me/radar?id=5517037090635776) - Compiler throwing warning due to toll-free bridging issue in test case
 - `rdar://26870455` - Background URL Session Configurations do not work in the simulator
 - `rdar://26849668` - Some URLProtocol APIs do not properly handle `URLRequest`
+- `FB7624529` - `urlSession(_:task:didFinishCollecting:)` never called on watchOS
 
 ## Resolved Radars
 
@@ -161,7 +162,12 @@ The following radars have been resolved over time after being filed against the 
   - (Resolved): 9/1/17 in Xcode 9 beta 6.
 - [`rdar://36082113`](http://openradar.appspot.com/radar?id=4942308441063424) - `URLSessionTaskMetrics` failing to link on watchOS 3.0+
   - (Resolved): Just add `CFNetwork` to your linked frameworks.
-  
+
+## Workarounds
+
+- Collection of `URLSessionTaskMetrics` is currently disabled on watchOS due to `FB7624529`.
+- `-no_compact_unwind` linker warning is currently disabled on watchOS due to the persistent existence of the warning.
+
 ## FAQ
 
 ### What's the origin of the name Alamofire?

--- a/Source/RequestTaskMap.swift
+++ b/Source/RequestTaskMap.swift
@@ -129,8 +129,12 @@ struct RequestTaskMap {
 
         switch (events.completed, events.metricsGathered) {
         case (true, _): fatalError("RequestTaskMap consistency error: duplicate completionReceivedForTask call.")
+        #if os(watchOS)
+        default: self[task] = nil; return true
+        #else
         case (false, false): taskEvents[task] = (completed: true, metricsGathered: false); return false
         case (false, true): self[task] = nil; return true
+        #endif
         }
     }
 }

--- a/Source/RequestTaskMap.swift
+++ b/Source/RequestTaskMap.swift
@@ -129,7 +129,7 @@ struct RequestTaskMap {
 
         switch (events.completed, events.metricsGathered) {
         case (true, _): fatalError("RequestTaskMap consistency error: duplicate completionReceivedForTask call.")
-        #if os(watchOS)
+        #if os(watchOS) // watchOS doesn't gather metrics, so unconditionally remove the reference and return true.
         default: self[task] = nil; return true
         #else
         case (false, false): taskEvents[task] = (completed: true, metricsGathered: false); return false

--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -41,6 +41,9 @@ public struct DataResponse<Success, Failure: Error> {
     public let data: Data?
 
     /// The final metrics of the response.
+    ///
+    /// - Note: Due to `FB7624529`, collection of `URLSessionTaskMetrics` on watchOS is currently disabled.`
+    ///
     public let metrics: URLSessionTaskMetrics?
 
     /// The time taken to serialize the response.
@@ -224,6 +227,9 @@ public struct DownloadResponse<Success, Failure: Error> {
     public let resumeData: Data?
 
     /// The final metrics of the response.
+    ///
+    /// - Note: Due to `FB7624529`, collection of `URLSessionTaskMetrics` on watchOS is currently disabled.`
+    ///
     public let metrics: URLSessionTaskMetrics?
 
     /// The time taken to serialize the response.

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -1571,6 +1571,16 @@ final class SessionCancellationTestCase: BaseTestCase {
         final class OnceRetrier: RequestInterceptor {
             private var hasRetried = false
 
+            func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
+                if hasRetried {
+                    var request = urlRequest
+                    request.url = URL.makeHTTPBinURL(path: "delay/1")
+                    completion(.success(request))
+                } else {
+                    completion(.success(urlRequest))
+                }
+            }
+
             func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
                 completion(hasRetried ? .doNotRetry : .retry)
                 hasRetried = true

--- a/watchOS Example/watchOS Example WatchKit App/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/watchOS Example/watchOS Example WatchKit App/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,81 @@
+{
+  "images" : [
+    {
+      "size" : "24x24",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "notificationCenter",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "27.5x27.5",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "notificationCenter",
+      "subtype" : "42mm"
+    },
+    {
+      "size" : "29x29",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "2x"
+    },
+    {
+      "size" : "29x29",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "3x"
+    },
+    {
+      "size" : "40x40",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "appLauncher",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "44x44",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "appLauncher",
+      "subtype" : "40mm"
+    },
+    {
+      "size" : "50x50",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "appLauncher",
+      "subtype" : "44mm"
+    },
+    {
+      "size" : "86x86",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "quickLook",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "98x98",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "quickLook",
+      "subtype" : "42mm"
+    },
+    {
+      "size" : "108x108",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "quickLook",
+      "subtype" : "44mm"
+    },
+    {
+      "idiom" : "watch-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/watchOS Example/watchOS Example WatchKit App/Assets.xcassets/Contents.json
+++ b/watchOS Example/watchOS Example WatchKit App/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/watchOS Example/watchOS Example WatchKit App/Base.lproj/Interface.storyboard
+++ b/watchOS Example/watchOS Example WatchKit App/Base.lproj/Interface.storyboard
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="11134" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="3mp-fW-waa">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="11055"/>
+    </dependencies>
+    <scenes>
+        <!--Interface Controller-->
+        <scene sceneID="aou-V4-d1y">
+            <objects>
+                <hostingController id="3mp-fW-waa" customClass="HostingController"
+                customModuleProvider="target"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/watchOS Example/watchOS Example WatchKit App/Info.plist
+++ b/watchOS Example/watchOS Example WatchKit App/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>watchOS Example WatchKit App</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>WKWatchKitApp</key>
+	<true/>
+</dict>
+</plist>

--- a/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Complication.complicationset/Circular.imageset/Contents.json
+++ b/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Complication.complicationset/Circular.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Complication.complicationset/Contents.json
+++ b/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Complication.complicationset/Contents.json
@@ -1,0 +1,48 @@
+{
+  "assets" : [
+    {
+      "idiom" : "watch",
+      "filename" : "Circular.imageset",
+      "role" : "circular"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Extra Large.imageset",
+      "role" : "extra-large"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Graphic Bezel.imageset",
+      "role" : "graphic-bezel"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Graphic Circular.imageset",
+      "role" : "graphic-circular"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Graphic Corner.imageset",
+      "role" : "graphic-corner"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Graphic Large Rectangular.imageset",
+      "role" : "graphic-large-rectangular"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Modular.imageset",
+      "role" : "modular"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Utilitarian.imageset",
+      "role" : "utilitarian"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Complication.complicationset/Extra Large.imageset/Contents.json
+++ b/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Complication.complicationset/Extra Large.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Bezel.imageset/Contents.json
+++ b/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Bezel.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Circular.imageset/Contents.json
+++ b/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Circular.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Corner.imageset/Contents.json
+++ b/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Corner.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Large Rectangular.imageset/Contents.json
+++ b/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Large Rectangular.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Complication.complicationset/Modular.imageset/Contents.json
+++ b/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Complication.complicationset/Modular.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Complication.complicationset/Utilitarian.imageset/Contents.json
+++ b/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Complication.complicationset/Utilitarian.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Contents.json
+++ b/watchOS Example/watchOS Example WatchKit Extension/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/watchOS Example/watchOS Example WatchKit Extension/ContentView.swift
+++ b/watchOS Example/watchOS Example WatchKit Extension/ContentView.swift
@@ -95,6 +95,18 @@ final class BasicSession: NSObject, URLSessionTaskDelegate {
     
     private var completion: ((Result<Void, Error>) -> Void)?
     
+    override class func responds(to aSelector: Selector!) -> Bool {
+        let didRespond = super.responds(to: aSelector)
+        NSLog("Class did respond to \(aSelector!): \(didRespond)")
+        return didRespond
+    }
+    
+    override func responds(to aSelector: Selector!) -> Bool {
+        let didRespond = super.responds(to: aSelector)
+        NSLog("Instance did respond to \(aSelector!): \(didRespond)")
+        return didRespond
+    }
+    
     func request(_ completion: @escaping (Result<Void, Error>) -> Void) {
         self.completion = completion
         session.dataTask(with: URL(string: "https://httpbin.org/get")!).resume()

--- a/watchOS Example/watchOS Example WatchKit Extension/ContentView.swift
+++ b/watchOS Example/watchOS Example WatchKit Extension/ContentView.swift
@@ -1,0 +1,116 @@
+//
+//  ContentView.swift
+//  watchOS Example WatchKit Extension
+//
+//  Created by Jon Shier on 3/11/20.
+//  Copyright © 2020 Alamofire. All rights reserved.
+//
+
+import Alamofire
+import SwiftUI
+
+struct ContentView: View {
+    @ObservedObject var networking: Networking
+    
+    var body: some View {
+        VStack {
+            Button(action: { self.networking.performRequest() },
+                   label: { Text("Perform Alamofire Request") })
+            Text(networking.alamofireMessage)
+            Button(action: { self.networking.performURLSessionRequest() },
+                   label: { Text("Perform URLSession Request") })
+            Text(networking.urlSessionMessage)
+        }
+    }
+}
+
+struct ContentViewPreviews: PreviewProvider {
+    static let networking = Networking()
+    
+    static var previews: some View {
+        ContentView(networking: networking)
+    }
+}
+
+import Combine
+
+final class Networking: ObservableObject {
+    @Published var alamofireResult: Result<HTTPBinResponse, AFError>?
+    @Published var alamofireMessage: String = "No message."
+    @Published var urlSessionResult: Result<Void, Error>?
+    @Published var urlSessionMessage: String = "No message."
+    
+    private let urlSession = BasicSession()
+    private var storage: Set<AnyCancellable> = []
+    
+    init() {
+        $alamofireResult.map {
+            if case let .success(value) = $0 {
+                return value.url
+            } else {
+                return "No message."
+            }
+        }
+        .assign(to: \.alamofireMessage, on: self)
+        .store(in: &storage)
+        
+        $urlSessionResult.map {
+            if case .success = $0 {
+                return "Success."
+            } else {
+                return "No message."
+            }
+        }
+        .assign(to: \.urlSessionMessage, on: self)
+        .store(in: &storage)
+    }
+    
+    func performRequest() {
+        AF.request("https://httpbin.org/get").responseDecodable(of: HTTPBinResponse.self) { response in
+            self.alamofireResult = response.result
+        }
+    }
+    
+    func performURLSessionRequest() {
+        urlSession.request { result in
+            self.urlSessionResult = result
+        }
+    }
+}
+
+struct HTTPBinResponse: Decodable {
+    let url: String
+}
+
+final class BasicSession: NSObject, URLSessionTaskDelegate {
+    private lazy var session = URLSession(configuration: .default,
+                                          delegate: self,
+                                          delegateQueue: queue)
+    private lazy var queue: OperationQueue = {
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+        
+        return queue
+    }()
+    
+    private var completion: ((Result<Void, Error>) -> Void)?
+    
+    func request(_ completion: @escaping (Result<Void, Error>) -> Void) {
+        self.completion = completion
+        session.dataTask(with: URL(string: "https://httpbin.org/get")!).resume()
+    }
+    
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        DispatchQueue.main.async {
+            if let error = error {
+                self.completion?(.failure(error))
+            } else {
+                self.completion?(.success(()))
+            }
+        }
+    }
+    
+    func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        print("Metrics gathered.")
+    }
+}

--- a/watchOS Example/watchOS Example WatchKit Extension/ContentView.swift
+++ b/watchOS Example/watchOS Example WatchKit Extension/ContentView.swift
@@ -15,11 +15,8 @@ struct ContentView: View {
     var body: some View {
         VStack {
             Button(action: { self.networking.performRequest() },
-                   label: { Text("Perform Alamofire Request") })
-            Text(networking.alamofireMessage)
-            Button(action: { self.networking.performURLSessionRequest() },
-                   label: { Text("Perform URLSession Request") })
-            Text(networking.urlSessionMessage)
+                   label: { Text("Perform Request") })
+            Text(networking.message)
         }
     }
 }
@@ -29,100 +26,5 @@ struct ContentViewPreviews: PreviewProvider {
 
     static var previews: some View {
         ContentView(networking: networking)
-    }
-}
-
-import Combine
-
-final class Networking: ObservableObject {
-    @Published var alamofireResult: Result<HTTPBinResponse, AFError>?
-    @Published var alamofireMessage: String = "No message."
-    @Published var urlSessionResult: Result<Void, Error>?
-    @Published var urlSessionMessage: String = "No message."
-
-    private let urlSession = BasicSession()
-    private var storage: Set<AnyCancellable> = []
-
-    init() {
-        $alamofireResult.map {
-            if case let .success(value) = $0 {
-                return value.url
-            } else {
-                return "No message."
-            }
-        }
-        .assign(to: \.alamofireMessage, on: self)
-        .store(in: &storage)
-
-        $urlSessionResult.map {
-            if case .success = $0 {
-                return "Success."
-            } else {
-                return "No message."
-            }
-        }
-        .assign(to: \.urlSessionMessage, on: self)
-        .store(in: &storage)
-    }
-
-    func performRequest() {
-        AF.request("https://httpbin.org/get").responseDecodable(of: HTTPBinResponse.self) { response in
-            self.alamofireResult = response.result
-        }
-    }
-
-    func performURLSessionRequest() {
-        urlSession.request { result in
-            self.urlSessionResult = result
-        }
-    }
-}
-
-struct HTTPBinResponse: Decodable {
-    let url: String
-}
-
-final class BasicSession: NSObject, URLSessionTaskDelegate {
-    private lazy var session = URLSession(configuration: .default,
-                                          delegate: self,
-                                          delegateQueue: queue)
-    private lazy var queue: OperationQueue = {
-        let queue = OperationQueue()
-        queue.maxConcurrentOperationCount = 1
-
-        return queue
-    }()
-
-    private var completion: ((Result<Void, Error>) -> Void)?
-
-    override class func responds(to aSelector: Selector!) -> Bool {
-        let didRespond = super.responds(to: aSelector)
-        NSLog("Class did respond to \(aSelector!): \(didRespond)")
-        return didRespond
-    }
-
-    override func responds(to aSelector: Selector!) -> Bool {
-        let didRespond = super.responds(to: aSelector)
-        NSLog("Instance did respond to \(aSelector!): \(didRespond)")
-        return didRespond
-    }
-
-    func request(_ completion: @escaping (Result<Void, Error>) -> Void) {
-        self.completion = completion
-        session.dataTask(with: URL(string: "https://httpbin.org/get")!).resume()
-    }
-
-    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        DispatchQueue.main.async {
-            if let error = error {
-                self.completion?(.failure(error))
-            } else {
-                self.completion?(.success(()))
-            }
-        }
-    }
-
-    func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
-        NSLog("Metrics gathered.")
     }
 }

--- a/watchOS Example/watchOS Example WatchKit Extension/ContentView.swift
+++ b/watchOS Example/watchOS Example WatchKit Extension/ContentView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 struct ContentView: View {
     @ObservedObject var networking: Networking
-    
+
     var body: some View {
         VStack {
             Button(action: { self.networking.performRequest() },
@@ -26,7 +26,7 @@ struct ContentView: View {
 
 struct ContentViewPreviews: PreviewProvider {
     static let networking = Networking()
-    
+
     static var previews: some View {
         ContentView(networking: networking)
     }
@@ -39,10 +39,10 @@ final class Networking: ObservableObject {
     @Published var alamofireMessage: String = "No message."
     @Published var urlSessionResult: Result<Void, Error>?
     @Published var urlSessionMessage: String = "No message."
-    
+
     private let urlSession = BasicSession()
     private var storage: Set<AnyCancellable> = []
-    
+
     init() {
         $alamofireResult.map {
             if case let .success(value) = $0 {
@@ -53,7 +53,7 @@ final class Networking: ObservableObject {
         }
         .assign(to: \.alamofireMessage, on: self)
         .store(in: &storage)
-        
+
         $urlSessionResult.map {
             if case .success = $0 {
                 return "Success."
@@ -64,13 +64,13 @@ final class Networking: ObservableObject {
         .assign(to: \.urlSessionMessage, on: self)
         .store(in: &storage)
     }
-    
+
     func performRequest() {
         AF.request("https://httpbin.org/get").responseDecodable(of: HTTPBinResponse.self) { response in
             self.alamofireResult = response.result
         }
     }
-    
+
     func performURLSessionRequest() {
         urlSession.request { result in
             self.urlSessionResult = result
@@ -89,29 +89,29 @@ final class BasicSession: NSObject, URLSessionTaskDelegate {
     private lazy var queue: OperationQueue = {
         let queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
-        
+
         return queue
     }()
-    
+
     private var completion: ((Result<Void, Error>) -> Void)?
-    
+
     override class func responds(to aSelector: Selector!) -> Bool {
         let didRespond = super.responds(to: aSelector)
         NSLog("Class did respond to \(aSelector!): \(didRespond)")
         return didRespond
     }
-    
+
     override func responds(to aSelector: Selector!) -> Bool {
         let didRespond = super.responds(to: aSelector)
         NSLog("Instance did respond to \(aSelector!): \(didRespond)")
         return didRespond
     }
-    
+
     func request(_ completion: @escaping (Result<Void, Error>) -> Void) {
         self.completion = completion
         session.dataTask(with: URL(string: "https://httpbin.org/get")!).resume()
     }
-    
+
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         DispatchQueue.main.async {
             if let error = error {
@@ -121,8 +121,8 @@ final class BasicSession: NSObject, URLSessionTaskDelegate {
             }
         }
     }
-    
+
     func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
-        print("Metrics gathered.")
+        NSLog("Metrics gathered.")
     }
 }

--- a/watchOS Example/watchOS Example WatchKit Extension/ContentView.swift
+++ b/watchOS Example/watchOS Example WatchKit Extension/ContentView.swift
@@ -1,9 +1,25 @@
 //
 //  ContentView.swift
-//  watchOS Example WatchKit Extension
 //
-//  Created by Jon Shier on 3/11/20.
-//  Copyright © 2020 Alamofire. All rights reserved.
+//  Copyright (c) 2020 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import Alamofire

--- a/watchOS Example/watchOS Example WatchKit Extension/ExtensionDelegate.swift
+++ b/watchOS Example/watchOS Example WatchKit Extension/ExtensionDelegate.swift
@@ -9,7 +9,6 @@
 import WatchKit
 
 class ExtensionDelegate: NSObject, WKExtensionDelegate {
-
     func applicationDidFinishLaunching() {
         // Perform any final initialization of your application.
     }
@@ -52,5 +51,4 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
             }
         }
     }
-
 }

--- a/watchOS Example/watchOS Example WatchKit Extension/ExtensionDelegate.swift
+++ b/watchOS Example/watchOS Example WatchKit Extension/ExtensionDelegate.swift
@@ -1,0 +1,56 @@
+//
+//  ExtensionDelegate.swift
+//  watchOS Example WatchKit Extension
+//
+//  Created by Jon Shier on 3/11/20.
+//  Copyright © 2020 Alamofire. All rights reserved.
+//
+
+import WatchKit
+
+class ExtensionDelegate: NSObject, WKExtensionDelegate {
+
+    func applicationDidFinishLaunching() {
+        // Perform any final initialization of your application.
+    }
+
+    func applicationDidBecomeActive() {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillResignActive() {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, etc.
+    }
+
+    func handle(_ backgroundTasks: Set<WKRefreshBackgroundTask>) {
+        // Sent when the system needs to launch the application in the background to process tasks. Tasks arrive in a set, so loop through and process each one.
+        for task in backgroundTasks {
+            // Use a switch statement to check the task type
+            switch task {
+            case let backgroundTask as WKApplicationRefreshBackgroundTask:
+                // Be sure to complete the background task once you’re done.
+                backgroundTask.setTaskCompletedWithSnapshot(false)
+            case let snapshotTask as WKSnapshotRefreshBackgroundTask:
+                // Snapshot tasks have a unique completion call, make sure to set your expiration date
+                snapshotTask.setTaskCompleted(restoredDefaultState: true, estimatedSnapshotExpiration: Date.distantFuture, userInfo: nil)
+            case let connectivityTask as WKWatchConnectivityRefreshBackgroundTask:
+                // Be sure to complete the connectivity task once you’re done.
+                connectivityTask.setTaskCompletedWithSnapshot(false)
+            case let urlSessionTask as WKURLSessionRefreshBackgroundTask:
+                // Be sure to complete the URL session task once you’re done.
+                urlSessionTask.setTaskCompletedWithSnapshot(false)
+            case let relevantShortcutTask as WKRelevantShortcutRefreshBackgroundTask:
+                // Be sure to complete the relevant-shortcut task once you're done.
+                relevantShortcutTask.setTaskCompletedWithSnapshot(false)
+            case let intentDidRunTask as WKIntentDidRunRefreshBackgroundTask:
+                // Be sure to complete the intent-did-run task once you're done.
+                intentDidRunTask.setTaskCompletedWithSnapshot(false)
+            default:
+                // make sure to complete unhandled task types
+                task.setTaskCompletedWithSnapshot(false)
+            }
+        }
+    }
+
+}

--- a/watchOS Example/watchOS Example WatchKit Extension/ExtensionDelegate.swift
+++ b/watchOS Example/watchOS Example WatchKit Extension/ExtensionDelegate.swift
@@ -1,27 +1,30 @@
 //
 //  ExtensionDelegate.swift
-//  watchOS Example WatchKit Extension
 //
-//  Created by Jon Shier on 3/11/20.
-//  Copyright © 2020 Alamofire. All rights reserved.
+//  Copyright (c) 2020 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import WatchKit
 
 class ExtensionDelegate: NSObject, WKExtensionDelegate {
-    func applicationDidFinishLaunching() {
-        // Perform any final initialization of your application.
-    }
-
-    func applicationDidBecomeActive() {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-    }
-
-    func applicationWillResignActive() {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, etc.
-    }
-
     func handle(_ backgroundTasks: Set<WKRefreshBackgroundTask>) {
         // Sent when the system needs to launch the application in the background to process tasks. Tasks arrive in a set, so loop through and process each one.
         for task in backgroundTasks {

--- a/watchOS Example/watchOS Example WatchKit Extension/HostingController.swift
+++ b/watchOS Example/watchOS Example WatchKit Extension/HostingController.swift
@@ -6,13 +6,13 @@
 //  Copyright © 2020 Alamofire. All rights reserved.
 //
 
-import WatchKit
 import Foundation
 import SwiftUI
+import WatchKit
 
 class HostingController: WKHostingController<ContentView> {
     let networking = Networking()
-    
+
     override var body: ContentView {
         ContentView(networking: networking)
     }

--- a/watchOS Example/watchOS Example WatchKit Extension/HostingController.swift
+++ b/watchOS Example/watchOS Example WatchKit Extension/HostingController.swift
@@ -1,0 +1,19 @@
+//
+//  HostingController.swift
+//  watchOS Example WatchKit Extension
+//
+//  Created by Jon Shier on 3/11/20.
+//  Copyright © 2020 Alamofire. All rights reserved.
+//
+
+import WatchKit
+import Foundation
+import SwiftUI
+
+class HostingController: WKHostingController<ContentView> {
+    let networking = Networking()
+    
+    override var body: ContentView {
+        ContentView(networking: networking)
+    }
+}

--- a/watchOS Example/watchOS Example WatchKit Extension/HostingController.swift
+++ b/watchOS Example/watchOS Example WatchKit Extension/HostingController.swift
@@ -1,9 +1,25 @@
 //
 //  HostingController.swift
-//  watchOS Example WatchKit Extension
 //
-//  Created by Jon Shier on 3/11/20.
-//  Copyright © 2020 Alamofire. All rights reserved.
+//  Copyright (c) 2020 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import Foundation

--- a/watchOS Example/watchOS Example WatchKit Extension/Info.plist
+++ b/watchOS Example/watchOS Example WatchKit Extension/Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>watchOS Example WatchKit Extension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>WKAppBundleIdentifier</key>
+			<string>org.alamofire.watchOS-Example.watchkitapp</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.watchkit</string>
+	</dict>
+	<key>WKExtensionDelegateClassName</key>
+	<string>$(PRODUCT_MODULE_NAME).ExtensionDelegate</string>
+	<key>WKWatchOnly</key>
+	<true/>
+</dict>
+</plist>

--- a/watchOS Example/watchOS Example WatchKit Extension/Networking.swift
+++ b/watchOS Example/watchOS Example WatchKit Extension/Networking.swift
@@ -1,9 +1,25 @@
 //
 //  Networking.swift
-//  watchOS Example WatchKit Extension
 //
-//  Created by Jon Shier on 3/14/20.
-//  Copyright © 2020 Alamofire. All rights reserved.
+//  Copyright (c) 2020 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import Alamofire

--- a/watchOS Example/watchOS Example WatchKit Extension/Networking.swift
+++ b/watchOS Example/watchOS Example WatchKit Extension/Networking.swift
@@ -1,0 +1,41 @@
+//
+//  Networking.swift
+//  watchOS Example WatchKit Extension
+//
+//  Created by Jon Shier on 3/14/20.
+//  Copyright © 2020 Alamofire. All rights reserved.
+//
+
+import Alamofire
+import Combine
+
+final class Networking: ObservableObject {
+    @Published var result: Result<HTTPBinResponse, AFError>?
+    @Published var message = "No response."
+
+    private var storage: Set<AnyCancellable> = []
+
+    init() {
+        $result
+            .compactMap { $0 }
+            .map {
+                if case .success = $0 {
+                    return "Successful!"
+                } else {
+                    return "Failed!"
+                }
+            }
+            .assign(to: \.message, on: self)
+            .store(in: &storage)
+    }
+
+    func performRequest() {
+        AF.request("https://httpbin.org/get").responseDecodable(of: HTTPBinResponse.self) { response in
+            self.result = response.result
+        }
+    }
+}
+
+struct HTTPBinResponse: Decodable {
+    let url: String
+}

--- a/watchOS Example/watchOS Example WatchKit Extension/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/watchOS Example/watchOS Example WatchKit Extension/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/watchOS Example/watchOS Example.xcodeproj/project.pbxproj
+++ b/watchOS Example/watchOS Example.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		31338A13241D9B410096C205 /* Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31338A12241D9B410096C205 /* Networking.swift */; };
 		318E330F2419AD1C00BDE48F /* watchOS Example WatchKit App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 318E330E2419AD1C00BDE48F /* watchOS Example WatchKit App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		318E33152419AD1C00BDE48F /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 318E33132419AD1C00BDE48F /* Interface.storyboard */; };
 		318E33172419AD1C00BDE48F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 318E33162419AD1C00BDE48F /* Assets.xcassets */; };
@@ -74,6 +75,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		31338A12241D9B410096C205 /* Networking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Networking.swift; sourceTree = "<group>"; };
 		318E330A2419AD1B00BDE48F /* watchOS Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "watchOS Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		318E330E2419AD1C00BDE48F /* watchOS Example WatchKit App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "watchOS Example WatchKit App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		318E33142419AD1C00BDE48F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Interface.storyboard; sourceTree = "<group>"; };
@@ -134,11 +136,12 @@
 		318E33212419AD1D00BDE48F /* watchOS Example WatchKit Extension */ = {
 			isa = PBXGroup;
 			children = (
-				318E33222419AD1D00BDE48F /* ContentView.swift */,
-				318E33242419AD1D00BDE48F /* HostingController.swift */,
-				318E33262419AD1D00BDE48F /* ExtensionDelegate.swift */,
 				318E33282419AD1D00BDE48F /* Assets.xcassets */,
+				318E33222419AD1D00BDE48F /* ContentView.swift */,
+				318E33262419AD1D00BDE48F /* ExtensionDelegate.swift */,
+				318E33242419AD1D00BDE48F /* HostingController.swift */,
 				318E332D2419AD1D00BDE48F /* Info.plist */,
+				31338A12241D9B410096C205 /* Networking.swift */,
 				318E332A2419AD1D00BDE48F /* Preview Content */,
 			);
 			path = "watchOS Example WatchKit Extension";
@@ -292,6 +295,7 @@
 				318E33252419AD1D00BDE48F /* HostingController.swift in Sources */,
 				318E33232419AD1D00BDE48F /* ContentView.swift in Sources */,
 				318E33272419AD1D00BDE48F /* ExtensionDelegate.swift in Sources */,
+				31338A13241D9B410096C205 /* Networking.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -440,7 +444,7 @@
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"watchOS Example WatchKit Extension/Preview Content\"";
-				DEVELOPMENT_TEAM = 555RUP2XT7;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "watchOS Example WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -464,7 +468,7 @@
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"watchOS Example WatchKit Extension/Preview Content\"";
-				DEVELOPMENT_TEAM = 555RUP2XT7;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "watchOS Example WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -488,7 +492,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 555RUP2XT7;
+				DEVELOPMENT_TEAM = "";
 				IBSC_MODULE = watchOS_Example_WatchKit_Extension;
 				INFOPLIST_FILE = "watchOS Example WatchKit App/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.alamofire.watchOS-Example.watchkitapp";
@@ -507,7 +511,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 555RUP2XT7;
+				DEVELOPMENT_TEAM = "";
 				IBSC_MODULE = watchOS_Example_WatchKit_Extension;
 				INFOPLIST_FILE = "watchOS Example WatchKit App/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.alamofire.watchOS-Example.watchkitapp";
@@ -525,7 +529,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 555RUP2XT7;
+				DEVELOPMENT_TEAM = "";
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.alamofire.watchOS-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -538,7 +542,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 555RUP2XT7;
+				DEVELOPMENT_TEAM = "";
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.alamofire.watchOS-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/watchOS Example/watchOS Example.xcodeproj/project.pbxproj
+++ b/watchOS Example/watchOS Example.xcodeproj/project.pbxproj
@@ -1,0 +1,591 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 51;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		318E330F2419AD1C00BDE48F /* watchOS Example WatchKit App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 318E330E2419AD1C00BDE48F /* watchOS Example WatchKit App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		318E33152419AD1C00BDE48F /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 318E33132419AD1C00BDE48F /* Interface.storyboard */; };
+		318E33172419AD1C00BDE48F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 318E33162419AD1C00BDE48F /* Assets.xcassets */; };
+		318E331E2419AD1D00BDE48F /* watchOS Example WatchKit Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 318E331D2419AD1D00BDE48F /* watchOS Example WatchKit Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		318E33232419AD1D00BDE48F /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318E33222419AD1D00BDE48F /* ContentView.swift */; };
+		318E33252419AD1D00BDE48F /* HostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318E33242419AD1D00BDE48F /* HostingController.swift */; };
+		318E33272419AD1D00BDE48F /* ExtensionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318E33262419AD1D00BDE48F /* ExtensionDelegate.swift */; };
+		318E33292419AD1D00BDE48F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 318E33282419AD1D00BDE48F /* Assets.xcassets */; };
+		318E332C2419AD1D00BDE48F /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 318E332B2419AD1D00BDE48F /* Preview Assets.xcassets */; };
+		318E333D2419AD9500BDE48F /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 318E333C2419AD9500BDE48F /* Alamofire.framework */; };
+		318E333E2419AD9500BDE48F /* Alamofire.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 318E333C2419AD9500BDE48F /* Alamofire.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		318E33102419AD1C00BDE48F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 318E33042419AD1B00BDE48F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 318E330D2419AD1C00BDE48F;
+			remoteInfo = "watchOS Example WatchKit App";
+		};
+		318E331F2419AD1D00BDE48F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 318E33042419AD1B00BDE48F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 318E331C2419AD1D00BDE48F;
+			remoteInfo = "watchOS Example WatchKit Extension";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		318E33332419AD1D00BDE48F /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				318E331E2419AD1D00BDE48F /* watchOS Example WatchKit Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		318E33372419AD1D00BDE48F /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
+			dstSubfolderSpec = 16;
+			files = (
+				318E330F2419AD1C00BDE48F /* watchOS Example WatchKit App.app in Embed Watch Content */,
+			);
+			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		318E333F2419AD9500BDE48F /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				318E333E2419AD9500BDE48F /* Alamofire.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		318E330A2419AD1B00BDE48F /* watchOS Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "watchOS Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		318E330E2419AD1C00BDE48F /* watchOS Example WatchKit App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "watchOS Example WatchKit App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		318E33142419AD1C00BDE48F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Interface.storyboard; sourceTree = "<group>"; };
+		318E33162419AD1C00BDE48F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		318E33182419AD1C00BDE48F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		318E331D2419AD1D00BDE48F /* watchOS Example WatchKit Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "watchOS Example WatchKit Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		318E33222419AD1D00BDE48F /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		318E33242419AD1D00BDE48F /* HostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostingController.swift; sourceTree = "<group>"; };
+		318E33262419AD1D00BDE48F /* ExtensionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDelegate.swift; sourceTree = "<group>"; };
+		318E33282419AD1D00BDE48F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		318E332B2419AD1D00BDE48F /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		318E332D2419AD1D00BDE48F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		318E333C2419AD9500BDE48F /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		318E331A2419AD1D00BDE48F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				318E333D2419AD9500BDE48F /* Alamofire.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		318E33032419AD1B00BDE48F = {
+			isa = PBXGroup;
+			children = (
+				318E33122419AD1C00BDE48F /* watchOS Example WatchKit App */,
+				318E33212419AD1D00BDE48F /* watchOS Example WatchKit Extension */,
+				318E330B2419AD1B00BDE48F /* Products */,
+				318E333B2419AD9500BDE48F /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		318E330B2419AD1B00BDE48F /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				318E330A2419AD1B00BDE48F /* watchOS Example.app */,
+				318E330E2419AD1C00BDE48F /* watchOS Example WatchKit App.app */,
+				318E331D2419AD1D00BDE48F /* watchOS Example WatchKit Extension.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		318E33122419AD1C00BDE48F /* watchOS Example WatchKit App */ = {
+			isa = PBXGroup;
+			children = (
+				318E33132419AD1C00BDE48F /* Interface.storyboard */,
+				318E33162419AD1C00BDE48F /* Assets.xcassets */,
+				318E33182419AD1C00BDE48F /* Info.plist */,
+			);
+			path = "watchOS Example WatchKit App";
+			sourceTree = "<group>";
+		};
+		318E33212419AD1D00BDE48F /* watchOS Example WatchKit Extension */ = {
+			isa = PBXGroup;
+			children = (
+				318E33222419AD1D00BDE48F /* ContentView.swift */,
+				318E33242419AD1D00BDE48F /* HostingController.swift */,
+				318E33262419AD1D00BDE48F /* ExtensionDelegate.swift */,
+				318E33282419AD1D00BDE48F /* Assets.xcassets */,
+				318E332D2419AD1D00BDE48F /* Info.plist */,
+				318E332A2419AD1D00BDE48F /* Preview Content */,
+			);
+			path = "watchOS Example WatchKit Extension";
+			sourceTree = "<group>";
+		};
+		318E332A2419AD1D00BDE48F /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				318E332B2419AD1D00BDE48F /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		318E333B2419AD9500BDE48F /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				318E333C2419AD9500BDE48F /* Alamofire.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		318E33092419AD1B00BDE48F /* watchOS Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 318E33382419AD1D00BDE48F /* Build configuration list for PBXNativeTarget "watchOS Example" */;
+			buildPhases = (
+				318E33082419AD1B00BDE48F /* Resources */,
+				318E33372419AD1D00BDE48F /* Embed Watch Content */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				318E33112419AD1C00BDE48F /* PBXTargetDependency */,
+			);
+			name = "watchOS Example";
+			productName = "watchOS Example";
+			productReference = 318E330A2419AD1B00BDE48F /* watchOS Example.app */;
+			productType = "com.apple.product-type.application.watchapp2-container";
+		};
+		318E330D2419AD1C00BDE48F /* watchOS Example WatchKit App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 318E33342419AD1D00BDE48F /* Build configuration list for PBXNativeTarget "watchOS Example WatchKit App" */;
+			buildPhases = (
+				318E330C2419AD1C00BDE48F /* Resources */,
+				318E33332419AD1D00BDE48F /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				318E33202419AD1D00BDE48F /* PBXTargetDependency */,
+			);
+			name = "watchOS Example WatchKit App";
+			productName = "watchOS Example WatchKit App";
+			productReference = 318E330E2419AD1C00BDE48F /* watchOS Example WatchKit App.app */;
+			productType = "com.apple.product-type.application.watchapp2";
+		};
+		318E331C2419AD1D00BDE48F /* watchOS Example WatchKit Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 318E33302419AD1D00BDE48F /* Build configuration list for PBXNativeTarget "watchOS Example WatchKit Extension" */;
+			buildPhases = (
+				318E33192419AD1D00BDE48F /* Sources */,
+				318E331A2419AD1D00BDE48F /* Frameworks */,
+				318E331B2419AD1D00BDE48F /* Resources */,
+				318E333F2419AD9500BDE48F /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "watchOS Example WatchKit Extension";
+			productName = "watchOS Example WatchKit Extension";
+			productReference = 318E331D2419AD1D00BDE48F /* watchOS Example WatchKit Extension.appex */;
+			productType = "com.apple.product-type.watchkit2-extension";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		318E33042419AD1B00BDE48F /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1130;
+				LastUpgradeCheck = 1130;
+				ORGANIZATIONNAME = Alamofire;
+				TargetAttributes = {
+					318E33092419AD1B00BDE48F = {
+						CreatedOnToolsVersion = 11.3.1;
+					};
+					318E330D2419AD1C00BDE48F = {
+						CreatedOnToolsVersion = 11.3.1;
+					};
+					318E331C2419AD1D00BDE48F = {
+						CreatedOnToolsVersion = 11.3.1;
+					};
+				};
+			};
+			buildConfigurationList = 318E33072419AD1B00BDE48F /* Build configuration list for PBXProject "watchOS Example" */;
+			compatibilityVersion = "Xcode 10.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 318E33032419AD1B00BDE48F;
+			productRefGroup = 318E330B2419AD1B00BDE48F /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				318E33092419AD1B00BDE48F /* watchOS Example */,
+				318E330D2419AD1C00BDE48F /* watchOS Example WatchKit App */,
+				318E331C2419AD1D00BDE48F /* watchOS Example WatchKit Extension */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		318E33082419AD1B00BDE48F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		318E330C2419AD1C00BDE48F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				318E33172419AD1C00BDE48F /* Assets.xcassets in Resources */,
+				318E33152419AD1C00BDE48F /* Interface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		318E331B2419AD1D00BDE48F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				318E332C2419AD1D00BDE48F /* Preview Assets.xcassets in Resources */,
+				318E33292419AD1D00BDE48F /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		318E33192419AD1D00BDE48F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				318E33252419AD1D00BDE48F /* HostingController.swift in Sources */,
+				318E33232419AD1D00BDE48F /* ContentView.swift in Sources */,
+				318E33272419AD1D00BDE48F /* ExtensionDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		318E33112419AD1C00BDE48F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 318E330D2419AD1C00BDE48F /* watchOS Example WatchKit App */;
+			targetProxy = 318E33102419AD1C00BDE48F /* PBXContainerItemProxy */;
+		};
+		318E33202419AD1D00BDE48F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 318E331C2419AD1D00BDE48F /* watchOS Example WatchKit Extension */;
+			targetProxy = 318E331F2419AD1D00BDE48F /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		318E33132419AD1C00BDE48F /* Interface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				318E33142419AD1C00BDE48F /* Base */,
+			);
+			name = Interface.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		318E332E2419AD1D00BDE48F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		318E332F2419AD1D00BDE48F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		318E33312419AD1D00BDE48F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"watchOS Example WatchKit Extension/Preview Content\"";
+				DEVELOPMENT_TEAM = 555RUP2XT7;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "watchOS Example WatchKit Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "org.alamofire.watchOS-Example.watchkitapp.watchkitextension";
+				PRODUCT_NAME = "${TARGET_NAME}";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
+			};
+			name = Debug;
+		};
+		318E33322419AD1D00BDE48F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"watchOS Example WatchKit Extension/Preview Content\"";
+				DEVELOPMENT_TEAM = 555RUP2XT7;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "watchOS Example WatchKit Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "org.alamofire.watchOS-Example.watchkitapp.watchkitextension";
+				PRODUCT_NAME = "${TARGET_NAME}";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
+			};
+			name = Release;
+		};
+		318E33352419AD1D00BDE48F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 555RUP2XT7;
+				IBSC_MODULE = watchOS_Example_WatchKit_Extension;
+				INFOPLIST_FILE = "watchOS Example WatchKit App/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.alamofire.watchOS-Example.watchkitapp";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
+			};
+			name = Debug;
+		};
+		318E33362419AD1D00BDE48F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 555RUP2XT7;
+				IBSC_MODULE = watchOS_Example_WatchKit_Extension;
+				INFOPLIST_FILE = "watchOS Example WatchKit App/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.alamofire.watchOS-Example.watchkitapp";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
+			};
+			name = Release;
+		};
+		318E33392419AD1D00BDE48F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 555RUP2XT7;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.alamofire.watchOS-Example";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		318E333A2419AD1D00BDE48F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 555RUP2XT7;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.alamofire.watchOS-Example";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		318E33072419AD1B00BDE48F /* Build configuration list for PBXProject "watchOS Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				318E332E2419AD1D00BDE48F /* Debug */,
+				318E332F2419AD1D00BDE48F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		318E33302419AD1D00BDE48F /* Build configuration list for PBXNativeTarget "watchOS Example WatchKit Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				318E33312419AD1D00BDE48F /* Debug */,
+				318E33322419AD1D00BDE48F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		318E33342419AD1D00BDE48F /* Build configuration list for PBXNativeTarget "watchOS Example WatchKit App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				318E33352419AD1D00BDE48F /* Debug */,
+				318E33362419AD1D00BDE48F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		318E33382419AD1D00BDE48F /* Build configuration list for PBXNativeTarget "watchOS Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				318E33392419AD1D00BDE48F /* Debug */,
+				318E333A2419AD1D00BDE48F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 318E33042419AD1B00BDE48F /* Project object */;
+}


### PR DESCRIPTION
### Issue Link :link:
Fixes #3106.

### Goals :soccer:
This PR fixes memory leaks seen on watchOS by working around the fact that watchOS never collects `URLSessionTaskMetrics` for some reason.

### Implementation Details :construction:
This PR conditionalizes the previously added `disassociateIfNecessary` check on watchOS so that metrics are never expected.

### Testing Details :mag:
Still no testing on watchOS, but a watchOS example as been added so we can more easily use Alamofire on watchOS in the future.
