### PR TITLE
Must cast to UploadRequest before DataRequest

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1409,6 +1409,13 @@ public class UploadRequest: DataRequest {
         }
     }
 
+    override func reset() {
+        // Uploadable must be recreated on every retry.
+        uploadable = nil
+
+        super.reset()
+    }
+
     /// Produces the `InputStream` from `uploadable`, if it can.
     ///
     /// - Note: Calling this method with a non-`.stream` `Uploadable` is a logic error and will crash.

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -813,9 +813,10 @@ open class Session {
     ///
     /// - Parameter request: The `Request` to perform.
     func perform(_ request: Request) {
+        // Leaf types must come first, otherwise they will cast as their superclass.
         switch request {
+        case let r as UploadRequest: perform(r) // UploadRequest must come before DataRequest due to subtype relationship.
         case let r as DataRequest: perform(r)
-        case let r as UploadRequest: perform(r)
         case let r as DownloadRequest: perform(r)
         default: fatalError("Attempted to perform unsupported Request subclass: \(type(of: request))")
         }


### PR DESCRIPTION
### Issue Link :link:
Fixes #3126.

### Goals :soccer:
This PR fixes an issue where `UploadRequest` retry wouldn't accurately recreate the `Uploadable` value. Requests would likely still succeed as long as it wasn't the creation of the uploadable that needed to be retried.

### Implementation Details :construction:
The fix is straightforward: try to cast to `UploadRequest` before `DataRequest`. It was triggering a visible test failure to fix that was more difficult. Instead I realized that the `Uploadable` is supposed to be recreated for every retry, so resetting that state produced the failure.

### Testing Details :mag:
An upload specific retry test was added that triggers failure if the `Uploadable` is reset on each retry but is not then recreated.
