### PR TITLE
Update GitHub Actions to Xcode 11.4.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   macOS_5_1:
-    name: Test macOS 
+    name: Test macOS (5.1)
     runs-on: macOS-latest
     env: 
       DEVELOPER_DIR: /Applications/Xcode_11.3.1.app/Contents/Developer
@@ -20,7 +20,7 @@ jobs:
       - name: macOS
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire macOS" -destination "platform=macOS" clean test | xcpretty
   macOS_5_2:
-    name: Test macOS 
+    name: Test macOS (5.2)
     runs-on: macOS-latest
     env: 
       DEVELOPER_DIR: /Applications/Xcode_11.4.0.app/Contents/Developer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - '*'
 
 jobs:
-  macOS(5.1):
+  macOS(5_1):
     name: Test macOS 
     runs-on: macOS-latest
     env: 
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: macOS
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire macOS" -destination "platform=macOS" clean test | xcpretty
-  macOS(5.2):
+  macOS(5_2):
     name: Test macOS 
     runs-on: macOS-latest
     env: 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - '*'
 
 jobs:
-  macOS(5_1):
+  macOS_5_1:
     name: Test macOS 
     runs-on: macOS-latest
     env: 
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: macOS
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire macOS" -destination "platform=macOS" clean test | xcpretty
-  macOS(5_2):
+  macOS_5_2:
     name: Test macOS 
     runs-on: macOS-latest
     env: 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: Test macOS (5.2)
     runs-on: macOS-latest
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.4.0.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
       - name: macOS
@@ -32,7 +32,7 @@ jobs:
     name: Test Catalyst 
     runs-on: macOS-latest
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.4.0.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
       - name: Catalyst
@@ -41,7 +41,7 @@ jobs:
     name: Test iOS 
     runs-on: macOS-latest
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.4.0.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
     strategy:
       matrix:
         destination: ["OS=13.4,name=iPhone 11 Pro"] #, "OS=12.4,name=iPhone XS", "OS=11.4,name=iPhone X", "OS=10.3.1,name=iPhone SE"]
@@ -53,7 +53,7 @@ jobs:
     name: Test tvOS 
     runs-on: macOS-latest
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.4.0.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
     strategy:
       matrix:
         destination: ["OS=13.4,name=Apple TV 4K"] #, "OS=11.4,name=Apple TV 4K", "OS=10.2,name=Apple TV 1080p"]
@@ -65,7 +65,7 @@ jobs:
     name: Build watchOS
     runs-on: macOS-latest
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.4.0.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
     strategy:
       matrix:
         destination: ["OS=6.2,name=Apple Watch Series 5 - 44mm"] #, "OS=4.2,name=Apple Watch Series 3 - 42mm", "OS=3.2,name=Apple Watch Series 2 - 42mm"]
@@ -77,7 +77,7 @@ jobs:
     name: Test with SPM
     runs-on: macOS-latest    
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.4.0.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
       - name: SPM Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - '*'
 
 jobs:
-  macOS:
+  macOS(5.1):
     name: Test macOS 
     runs-on: macOS-latest
     env: 
@@ -19,14 +19,23 @@ jobs:
       - uses: actions/checkout@v2
       - name: macOS
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire macOS" -destination "platform=macOS" clean test | xcpretty
+  macOS(5.2):
+    name: Test macOS 
+    runs-on: macOS-latest
+    env: 
+      DEVELOPER_DIR: /Applications/Xcode_11.4.0.app/Contents/Developer
+    steps:
+      - uses: actions/checkout@v2
+      - name: macOS
+        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire macOS" -destination "platform=macOS" clean test | xcpretty
   iOS:
     name: Test iOS 
     runs-on: macOS-latest
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.3.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.4.0.app/Contents/Developer
     strategy:
       matrix:
-        destination: ["OS=13.3,name=iPhone 11 Pro"] #, "OS=12.4,name=iPhone XS", "OS=11.4,name=iPhone X", "OS=10.3.1,name=iPhone SE"]
+        destination: ["OS=13.4,name=iPhone 11 Pro"] #, "OS=12.4,name=iPhone XS", "OS=11.4,name=iPhone X", "OS=10.3.1,name=iPhone SE"]
     steps:
       - uses: actions/checkout@v2
       - name: iOS - ${{ matrix.destination }}
@@ -35,10 +44,10 @@ jobs:
     name: Test tvOS 
     runs-on: macOS-latest
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.3.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.4.0.app/Contents/Developer
     strategy:
       matrix:
-        destination: ["OS=13.3,name=Apple TV 4K"] #, "OS=11.4,name=Apple TV 4K", "OS=10.2,name=Apple TV 1080p"]
+        destination: ["OS=13.4,name=Apple TV 4K"] #, "OS=11.4,name=Apple TV 4K", "OS=10.2,name=Apple TV 1080p"]
     steps:
       - uses: actions/checkout@v2
       - name: tvOS - ${{ matrix.destination }}
@@ -47,10 +56,10 @@ jobs:
     name: Build watchOS
     runs-on: macOS-latest
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.3.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.4.0.app/Contents/Developer
     strategy:
       matrix:
-        destination: ["OS=6.1.1,name=Apple Watch Series 5 - 44mm"] #, "OS=4.2,name=Apple Watch Series 3 - 42mm", "OS=3.2,name=Apple Watch Series 2 - 42mm"]
+        destination: ["OS=6.2,name=Apple Watch Series 5 - 44mm"] #, "OS=4.2,name=Apple Watch Series 3 - 42mm", "OS=3.2,name=Apple Watch Series 2 - 42mm"]
     steps:
       - uses: actions/checkout@v2
       - name: watchOS - ${{ matrix.destination }}
@@ -59,7 +68,7 @@ jobs:
     name: Test with SPM
     runs-on: macOS-latest    
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.3.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.4.0.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
       - name: SPM Test


### PR DESCRIPTION
### Goals :soccer:
This PR updates our GitHub Action configuration to use Xcode 11.4 for most actions, leaving one 11.3 action to verify Swift 5.1 compatibility.

