### PR TITLE
Combine Support!

### DIFF
--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -81,6 +81,10 @@
 		317A6A7620B2207F00A9FEC5 /* DownloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8111E5B19A9674D0040E7D1 /* DownloadTests.swift */; };
 		317A6A7720B2208000A9FEC5 /* DownloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8111E5B19A9674D0040E7D1 /* DownloadTests.swift */; };
 		317A6A7820B2208000A9FEC5 /* DownloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8111E5B19A9674D0040E7D1 /* DownloadTests.swift */; };
+		318DD40F2439780500963291 /* Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318DD40E2439780500963291 /* Combine.swift */; };
+		318DD4102439780500963291 /* Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318DD40E2439780500963291 /* Combine.swift */; };
+		318DD4112439780500963291 /* Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318DD40E2439780500963291 /* Combine.swift */; };
+		318DD4122439780500963291 /* Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318DD40E2439780500963291 /* Combine.swift */; };
 		3191B5751F5F53A6003960A8 /* Protected.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3191B5741F5F53A6003960A8 /* Protected.swift */; };
 		3191B5761F5F53A6003960A8 /* Protected.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3191B5741F5F53A6003960A8 /* Protected.swift */; };
 		3191B5771F5F53A6003960A8 /* Protected.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3191B5741F5F53A6003960A8 /* Protected.swift */; };
@@ -116,6 +120,9 @@
 		31B51E8C2434FECB005356DB /* RequestModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B51E8B2434FECB005356DB /* RequestModifierTests.swift */; };
 		31B51E8D2434FECB005356DB /* RequestModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B51E8B2434FECB005356DB /* RequestModifierTests.swift */; };
 		31B51E8E2434FECB005356DB /* RequestModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B51E8B2434FECB005356DB /* RequestModifierTests.swift */; };
+		31BADE4E2439A8D1007D2AB9 /* CombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BADE4D2439A8D1007D2AB9 /* CombineTests.swift */; };
+		31BADE4F2439A8D1007D2AB9 /* CombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BADE4D2439A8D1007D2AB9 /* CombineTests.swift */; };
+		31BADE502439A8D1007D2AB9 /* CombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BADE4D2439A8D1007D2AB9 /* CombineTests.swift */; };
 		31C2B0EA20B271040089BA7C /* CacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C341BB91B1A865A00C1B34D /* CacheTests.swift */; };
 		31C2B0EB20B271050089BA7C /* CacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C341BB91B1A865A00C1B34D /* CacheTests.swift */; };
 		31C2B0EC20B271060089BA7C /* CacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C341BB91B1A865A00C1B34D /* CacheTests.swift */; };
@@ -377,6 +384,7 @@
 		31727417218BAEC90039FFCC /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		3172741C218BB1790039FFCC /* ParameterEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParameterEncoder.swift; sourceTree = "<group>"; };
 		31727421218BB9A50039FFCC /* HTTPBin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPBin.swift; sourceTree = "<group>"; };
+		318DD40E2439780500963291 /* Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Combine.swift; sourceTree = "<group>"; };
 		3191B5741F5F53A6003960A8 /* Protected.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protected.swift; sourceTree = "<group>"; };
 		31991790209CDA7F00103A19 /* Request.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
 		31991791209CDA7F00103A19 /* Response.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
@@ -387,6 +395,7 @@
 		319917B8209CE53A00103A19 /* OperationQueue+Alamofire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperationQueue+Alamofire.swift"; sourceTree = "<group>"; };
 		31B2CA9521AA25CD005B371A /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		31B51E8B2434FECB005356DB /* RequestModifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestModifierTests.swift; sourceTree = "<group>"; };
+		31BADE4D2439A8D1007D2AB9 /* CombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineTests.swift; sourceTree = "<group>"; };
 		31D83FCD20D5C29300D93E47 /* URLConvertible+URLRequestConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLConvertible+URLRequestConvertible.swift"; sourceTree = "<group>"; };
 		31DADDFA224811ED0051390F /* AlamofireExtended.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireExtended.swift; sourceTree = "<group>"; };
 		31ED52E61D73889D00199085 /* AFError+AlamofireTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AFError+AlamofireTests.swift"; sourceTree = "<group>"; };
@@ -564,6 +573,7 @@
 			children = (
 				4CFD6B132201338E00FFB5E3 /* CachedResponseHandlerTests.swift */,
 				4C341BB91B1A865A00C1B34D /* CacheTests.swift */,
+				31BADE4D2439A8D1007D2AB9 /* CombineTests.swift */,
 				3113D46A21878227001CCD21 /* HTTPHeadersTests.swift */,
 				4C3238E61B3604DB00FE04AE /* MultipartFormDataTests.swift */,
 				4C3D00571C66A8B900D1F709 /* NetworkReachabilityManagerTests.swift */,
@@ -747,6 +757,7 @@
 			children = (
 				31DADDFA224811ED0051390F /* AlamofireExtended.swift */,
 				4C4466EA21F8F5D800AC9703 /* CachedResponseHandler.swift */,
+				318DD40E2439780500963291 /* Combine.swift */,
 				3111CE8720A77843008315E2 /* EventMonitor.swift */,
 				4C23EB421B327C5B0090E0BC /* MultipartFormData.swift */,
 				311B198F20B0D3B40036823B /* MultipartUpload.swift */,
@@ -1312,6 +1323,7 @@
 				4C256A1C21F1449C00AD5D87 /* RetryPolicy.swift in Sources */,
 				31991796209CDA7F00103A19 /* Request.swift in Sources */,
 				4CF627101BA7CBF60011A099 /* ServerTrustEvaluation.swift in Sources */,
+				318DD4112439780500963291 /* Combine.swift in Sources */,
 				3199179E209CDA7F00103A19 /* Session.swift in Sources */,
 				4CF627071BA7CBF60011A099 /* Alamofire.swift in Sources */,
 				3111CE8A20A77945008315E2 /* EventMonitor.swift in Sources */,
@@ -1353,6 +1365,7 @@
 				3107EA4120A1267D00445260 /* SessionDelegateTests.swift in Sources */,
 				31C2B0EC20B271060089BA7C /* CacheTests.swift in Sources */,
 				3111CE9120A7EC27008315E2 /* NetworkReachabilityManagerTests.swift in Sources */,
+				31BADE502439A8D1007D2AB9 /* CombineTests.swift in Sources */,
 				31425AC3241F098000EE3CCC /* InternalRequestTests.swift in Sources */,
 				4CF627171BA7CC240011A099 /* ParameterEncodingTests.swift in Sources */,
 			);
@@ -1391,6 +1404,7 @@
 				4C3D00551C66A63000D1F709 /* NetworkReachabilityManager.swift in Sources */,
 				4C256A1B21F1449C00AD5D87 /* RetryPolicy.swift in Sources */,
 				31991795209CDA7F00103A19 /* Request.swift in Sources */,
+				318DD4102439780500963291 /* Combine.swift in Sources */,
 				4CDE2C441AF89F0900BABAE5 /* Validation.swift in Sources */,
 				3199179D209CDA7F00103A19 /* Session.swift in Sources */,
 				3111CE8920A77944008315E2 /* EventMonitor.swift in Sources */,
@@ -1431,6 +1445,7 @@
 				4C256A1D21F1449C00AD5D87 /* RetryPolicy.swift in Sources */,
 				31991797209CDA7F00103A19 /* Request.swift in Sources */,
 				E4202FD61B667AA100C997FB /* ServerTrustEvaluation.swift in Sources */,
+				318DD4122439780500963291 /* Combine.swift in Sources */,
 				3199179F209CDA7F00103A19 /* Session.swift in Sources */,
 				E4202FD81B667AA100C997FB /* Validation.swift in Sources */,
 				3111CE8B20A77945008315E2 /* EventMonitor.swift in Sources */,
@@ -1471,6 +1486,7 @@
 				4CDE2C431AF89F0900BABAE5 /* Validation.swift in Sources */,
 				4C256A1A21F1449C00AD5D87 /* RetryPolicy.swift in Sources */,
 				31991794209CDA7F00103A19 /* Request.swift in Sources */,
+				318DD40F2439780500963291 /* Combine.swift in Sources */,
 				4CB928291C66BFBC00CE5F08 /* Notifications.swift in Sources */,
 				3199179C209CDA7F00103A19 /* Session.swift in Sources */,
 				3111CE8820A77843008315E2 /* EventMonitor.swift in Sources */,
@@ -1512,6 +1528,7 @@
 				3107EA3F20A1267C00445260 /* SessionDelegateTests.swift in Sources */,
 				31C2B0EA20B271040089BA7C /* CacheTests.swift in Sources */,
 				3111CE8F20A7EC26008315E2 /* NetworkReachabilityManagerTests.swift in Sources */,
+				31BADE4E2439A8D1007D2AB9 /* CombineTests.swift in Sources */,
 				31425AC1241F098000EE3CCC /* InternalRequestTests.swift in Sources */,
 				F8111E6119A9674D0040E7D1 /* ParameterEncodingTests.swift in Sources */,
 			);
@@ -1551,6 +1568,7 @@
 				3107EA4020A1267C00445260 /* SessionDelegateTests.swift in Sources */,
 				31C2B0EB20B271050089BA7C /* CacheTests.swift in Sources */,
 				3111CE9020A7EC27008315E2 /* NetworkReachabilityManagerTests.swift in Sources */,
+				31BADE4F2439A8D1007D2AB9 /* CombineTests.swift in Sources */,
 				31425AC2241F098000EE3CCC /* InternalRequestTests.swift in Sources */,
 				4C256A541B096C770065714F /* BaseTestCase.swift in Sources */,
 			);

--- a/Documentation/AdvancedUsage.md
+++ b/Documentation/AdvancedUsage.md
@@ -991,7 +991,7 @@ On systems supporting the Combine framework, Alamofire offers the ability to pub
 AF.request(...).publishDecodable(type: DecodableType.self)
 ```
 
-This code produces a `DataResponsePublisher<DecodableType>` value which will publish a `DataResponse<DecodableType, AFError>` value. `DataResponsePublisher` is fully lazy, meaning that will only add the response handler and `resume` the request once a downstream `Subscriber` has made demand for values. It only provides one value and cannot be retried. 
+This code produces a `DataResponsePublisher<DecodableType>` value which will publish a `DataResponse<DecodableType, AFError>` value. Like all Alamofire `Publisher`s, `DataResponsePublisher` is fully lazy, meaning that will only add the response handler and `resume` the request once a downstream `Subscriber` has made demand for values. It only provides one value and cannot be retried. 
 
 > To properly handle retry when using Alamofire's `Publisher`s, use Alamofire's built in retry mechanisms, as explained [above](#adapting-and-retrying-requests-with-requestinterceptor).
 
@@ -1033,6 +1033,14 @@ AF.request(...)
 Once subscribed, this chain of transformations will make the first request and then create a publisher for a second, finishing when the second request has finished.
 
 > As with all Combine usage, care must be taken to ensure that subscriptions are cancelled early by maintaining the lifetime of the `AnyCancellable` tokens returned by functions like `sink`. If a request is cancelled prematurely, the response's error will be set to `AFError.explicitlyCancelled`.
+
+#### `DownloadResponsePublisher`
+Alamofire also offers a `Publisher` for `DownloadRequest`s, `DownloadResponsePublisher`. Its behavior and capabilities are the same as `DataResponsePublisher`.
+
+Like most `DownloadRequest`'s response handlers, `DownloadResponsePublisher` reads `Data` from disk to perform serialization, which can impact system performance if reading a large amount of `Data`. It's recommend you use `publishUnserialized()` to receive just the `URL?` that the file was downloaded to and perform your own read from disk for large files.
+
+#### `DataStreamPublisher`
+`DataStreamPublisher` is a `Publisher` for `DataStreamRequest`s. Like `DataStreamRequest` itself, and unlike Alamofire's other `Publisher`s, `DataStreamPublisher` can return multiple values serialized from `Data` received from the network, as well as a final completion event. For more information on how `DataStreamRequest` works, please see our [detailed usage documentation](https://github.com/Alamofire/Alamofire/blob/master/Documentation/Usage.md#streaming-data-from-a-server).
 
 ## Network Reachability
 The `NetworkReachabilityManager` listens for changes in the reachability of hosts and addresses for both Cellular and WiFi network interfaces.

--- a/Documentation/AdvancedUsage.md
+++ b/Documentation/AdvancedUsage.md
@@ -1008,6 +1008,11 @@ let valuePublisher = publisher.value() // Provides an AnyPublisher<DecodableType
 As with any `Publisher`, `DataResponsePublisher` can be used with various Combine APIs, allow Alamofire to support easy simultaneous requests for the first time.
 
 ```swift
+// All usage of cancellable Combine API must have its token stored to maintain the subscription.
+var tokens: Set<AnyCancellable> = []
+
+...
+
 let first = AF.request(...).publishDecodable(type: First.self)
 let second = AF.request(...).publishDecodable(type: Second.self)
 let both = Publishers.CombineLatest(first, second)
@@ -1015,11 +1020,17 @@ both.sink { first, second in // DataResponse<First, AFError>, DataResponse<Secon
     debugPrint(first)
     debugPrint(second)
 }
+.store(in: &tokens)
 ```
 
 Sequential requests are also possible:
 
 ```swift
+// All usage of cancellable Combine API must have its token stored to maintain the subscription.
+var tokens: Set<AnyCancellable> = []
+
+...
+
 AF.request(...)
     .publishDecodable(type: First.self)
     .value()
@@ -1030,6 +1041,7 @@ AF.request(...)
     .sink { second in // DataResponse<Second, AFError>
         debugPrint(second)
     }
+    .store(in: &tokens)
 ```
 
 Once subscribed, this chain of transformations will make the first request and then create a publisher for a second, finishing when the second request has finished.
@@ -1039,7 +1051,7 @@ Once subscribed, this chain of transformations will make the first request and t
 #### `DownloadResponsePublisher`
 Alamofire also offers a `Publisher` for `DownloadRequest`s, `DownloadResponsePublisher`. Its behavior and capabilities are the same as `DataResponsePublisher`.
 
-Like most `DownloadRequest`'s response handlers, `DownloadResponsePublisher` reads `Data` from disk to perform serialization, which can impact system performance if reading a large amount of `Data`. It's recommend you use `publishUnserialized()` to receive just the `URL?` that the file was downloaded to and perform your own read from disk for large files.
+Like most `DownloadRequest`'s response handlers, `DownloadResponsePublisher` reads `Data` from disk to perform serialization, which can impact system performance if reading a large amount of `Data`. It's recommended you use `publishUnserialized()` to receive just the `URL?` that the file was downloaded to and perform your own read from disk for large files.
 
 #### `DataStreamPublisher`
 `DataStreamPublisher` is a `Publisher` for `DataStreamRequest`s. Like `DataStreamRequest` itself, and unlike Alamofire's other `Publisher`s, `DataStreamPublisher` can return multiple values serialized from `Data` received from the network, as well as a final completion event. For more information on how `DataStreamRequest` works, please see our [detailed usage documentation](https://github.com/Alamofire/Alamofire/blob/master/Documentation/Usage.md#streaming-data-from-a-server).

--- a/Documentation/AdvancedUsage.md
+++ b/Documentation/AdvancedUsage.md
@@ -64,6 +64,8 @@
     - [Response Transforms](#response-transforms)
     - [Creating a Custom Response Serializer](#creating-a-custom-response-serializer)
   + [Using Alamofire with Combine](#using-alamofire-with-combine)
+    - [`DownloadResponsePublisher`](#downloadresponsepublisher)
+    - [`DataStreamPublisher`](#datastreampublisher)
 * [Network Reachability](#network-reachability)
 
 # Advanced Usage

--- a/Documentation/AdvancedUsage.md
+++ b/Documentation/AdvancedUsage.md
@@ -987,7 +987,7 @@ AF.streamRequest(...).responseStream(using: DecodableStreamSerializer<DecodableT
 ```
 
 ## Using Alamofire with Combine
-On systems supporting the Combine framework, Alamofire offers the ability to publish responses using a custom `Publisher` type. These publishers would similarly to Alamofire's existing response handlers, in that they are chained onto the various request APIs, such as `validate()`. For example:
+On systems supporting the Combine framework, Alamofire offers the ability to publish responses using a custom `Publisher` type. These publishers work much like Alamofire's response handlers. They are chained onto requests and like response handlers, should come after other API like `validate()`. For example:
 
 ```swift
 AF.request(...).publishDecodable(type: DecodableType.self)
@@ -1034,7 +1034,7 @@ AF.request(...)
 
 Once subscribed, this chain of transformations will make the first request and then create a publisher for a second, finishing when the second request has finished.
 
-> As with all Combine usage, care must be taken to ensure that subscriptions are cancelled early by maintaining the lifetime of the `AnyCancellable` tokens returned by functions like `sink`. If a request is cancelled prematurely, the response's error will be set to `AFError.explicitlyCancelled`.
+> As with all Combine usage, care must be taken to ensure that subscriptions are not cancelled early by maintaining the lifetime of the `AnyCancellable` tokens returned by functions like `sink`. If a request is cancelled prematurely, the response's error will be set to `AFError.explicitlyCancelled`.
 
 #### `DownloadResponsePublisher`
 Alamofire also offers a `Publisher` for `DownloadRequest`s, `DownloadResponsePublisher`. Its behavior and capabilities are the same as `DataResponsePublisher`.

--- a/Source/Combine.swift
+++ b/Source/Combine.swift
@@ -53,6 +53,20 @@ public struct DataResponsePublisher<Value>: Publisher {
         responseHandler = { request.response(queue: queue, responseSerializer: serializer, completionHandler: $0) }
     }
 
+    /// Create an instance which will serialize responses using the provided `DataResponseSerializerProtocol`.
+    ///
+    /// - Parameters:
+    ///   - request:    `DataRequest` for which to publish the response.
+    ///   - queue:      `DispatchQueue` on which the `DataResponse` value will be published. `.main` by default.
+    ///   - serializer: `DataResponseSerializerProtocol` used to produce the published `DataResponse`.
+    public init<Serializer: DataResponseSerializerProtocol>(_ request: DataRequest,
+                                                            queue: DispatchQueue,
+                                                            serializer: Serializer)
+        where Value == Serializer.SerializedObject {
+        self.request = request
+        responseHandler = { request.response(queue: queue, responseSerializer: serializer, completionHandler: $0) }
+    }
+
     /// Publish only the `Result` of the `DataResponse` value.
     ///
     /// - Returns: The `AnyPublisher` publishing the `Result<Value, AFError>` value.
@@ -75,7 +89,6 @@ public struct DataResponsePublisher<Value>: Publisher {
 
     private final class Inner<Downstream: Subscriber>: Subscription, Cancellable
         where Downstream.Input == Output {
-        typealias Input = DataRequest
         typealias Failure = Downstream.Failure
 
         @Protected
@@ -248,13 +261,20 @@ public struct DataStreamPublisher<Value>: Publisher {
         streamHandler = { request.responseStream(using: serializer, on: queue, stream: $0) }
     }
 
-    // TODO: Publishing just the Results means we lose any final errors. Perhaps we need to rebuild the results instead?
-
     /// Publish only the `Result` of the `DataStreamRequest.Stream`'s `Event`s.
     ///
     /// - Returns: The `AnyPublisher` publishing the `Result<Value, AFError>` value.
     public func result() -> AnyPublisher<Result<Value, AFError>, Never> {
-        compactMap { $0.result }.eraseToAnyPublisher()
+        compactMap { stream in
+            switch stream.event {
+            case let .stream(result):
+                return result
+            // If the stream has completed with an error, send the error value downstream as a `.failure`.
+            case let .complete(completion):
+                return completion.error.map(Result.failure)
+            }
+        }
+        .eraseToAnyPublisher()
     }
 
     /// Publish the streamed values of the `DataStreamRequest.Stream` as a sequence of `Value` or fail with the
@@ -273,7 +293,6 @@ public struct DataStreamPublisher<Value>: Publisher {
 
     private final class Inner<Downstream: Subscriber>: Subscription, Cancellable
         where Downstream.Input == Output {
-        typealias Input = DataStreamRequest
         typealias Failure = Downstream.Failure
 
         @Protected
@@ -332,10 +351,25 @@ public struct DownloadResponsePublisher<Value>: Publisher {
     /// Create an instance which will serialize responses using the provided `ResponseSerializer`.
     ///
     /// - Parameters:
-    ///   - request:    `DataRequest` for which to publish the response.
-    ///   - queue:      `DispatchQueue` on which the `DataResponse` value will be published. `.main` by default.
-    ///   - serializer: `ResponseSerializer` used to produce the published `DataResponse`.
+    ///   - request:    `DownloadRequest` for which to publish the response.
+    ///   - queue:      `DispatchQueue` on which the `DownloadResponse` value will be published. `.main` by default.
+    ///   - serializer: `ResponseSerializer` used to produce the published `DownloadResponse`.
     public init<Serializer: ResponseSerializer>(_ request: DownloadRequest, queue: DispatchQueue, serializer: Serializer)
+        where Value == Serializer.SerializedObject {
+        self.request = request
+        responseHandler = { request.response(queue: queue, responseSerializer: serializer, completionHandler: $0) }
+    }
+
+    /// Create an instance which will serialize responses using the provided `DownloadResponseSerializerProtocol` value.
+    ///
+    /// - Parameters:
+    ///   - request:    `DownloadRequest` for which to publish the response.
+    ///   - queue:      `DispatchQueue` on which the `DataResponse` value will be published. `.main` by default.
+    ///   - serializer: `DownloadResponseSerializerProtocol` used to produce the published `DownloadResponse`.
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    public init<Serializer: DownloadResponseSerializerProtocol>(_ request: DownloadRequest,
+                                                                queue: DispatchQueue,
+                                                                serializer: Serializer)
         where Value == Serializer.SerializedObject {
         self.request = request
         responseHandler = { request.response(queue: queue, responseSerializer: serializer, completionHandler: $0) }
@@ -363,7 +397,6 @@ public struct DownloadResponsePublisher<Value>: Publisher {
 
     private final class Inner<Downstream: Subscriber>: Subscription, Cancellable
         where Downstream.Input == Output {
-        typealias Input = DownloadRequest
         typealias Failure = Downstream.Failure
 
         @Protected
@@ -396,6 +429,101 @@ public struct DownloadResponsePublisher<Value>: Publisher {
     }
 }
 
+extension DownloadRequest {
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func publishResponse<Serializer: ResponseSerializer, T>(using serializer: Serializer, on queue: DispatchQueue = .main) -> DownloadResponsePublisher<T>
+        where Serializer.SerializedObject == T {
+        DownloadResponsePublisher(self, queue: queue, serializer: serializer)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func publishResponse<Serializer: DownloadResponseSerializerProtocol, T>(using serializer: Serializer, on queue: DispatchQueue = .main) -> DownloadResponsePublisher<T>
+        where Serializer.SerializedObject == T {
+        DownloadResponsePublisher(self, queue: queue, serializer: serializer)
+    }
+
+    /// Creates a `DataResponsePublisher` for this instance and uses a `DataResponseSerializer` to serialize the
+    /// response.
+    ///
+    /// - Parameters:
+    ///   - queue:               `DispatchQueue` on which the `DataResponse` will be published. `.main` by default.
+    ///   - preprocessor:        `DataPreprocessor` which filters the `Data` before serialization. `PassthroughPreprocessor()`
+    ///                          by default.
+    ///   - emptyResponseCodes:  `Set<Int>` of HTTP status codes for which empty responses are allowed. `[204, 205]` by
+    ///                          default.
+    ///   - emptyRequestMethods: `Set<HTTPMethod>` of `HTTPMethod`s for which empty responses are allowed, regardless of
+    ///                          status code. `[.head]` by default.
+    /// - Returns:               The `DownloadResponsePublisher`.
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    public func publishData(queue: DispatchQueue = .main,
+                            preprocessor: DataPreprocessor = DataResponseSerializer.defaultDataPreprocessor,
+                            emptyResponseCodes: Set<Int> = DataResponseSerializer.defaultEmptyResponseCodes,
+                            emptyRequestMethods: Set<HTTPMethod> = DataResponseSerializer.defaultEmptyRequestMethods) -> DownloadResponsePublisher<Data> {
+        publishResponse(using: DataResponseSerializer(dataPreprocessor: preprocessor,
+                                                      emptyResponseCodes: emptyResponseCodes,
+                                                      emptyRequestMethods: emptyRequestMethods),
+                        on: queue)
+    }
+
+    /// Creates a `DataResponsePublisher` for this instance and uses a `StringResponseSerializer` to serialize the
+    /// response.
+    ///
+    /// - Parameters:
+    ///   - queue:               `DispatchQueue` on which the `DataResponse` will be published. `.main` by default.
+    ///   - preprocessor:        `DataPreprocessor` which filters the `Data` before serialization. `PassthroughPreprocessor()`
+    ///                          by default.
+    ///   - encoding:            `String.Encoding` to parse the response. `nil` by default, in which case the encoding
+    ///                          will be determined by the server response, falling back to the default HTTP character
+    ///                          set, `ISO-8859-1`.
+    ///   - emptyResponseCodes:  `Set<Int>` of HTTP status codes for which empty responses are allowed. `[204, 205]` by
+    ///                          default.
+    ///   - emptyRequestMethods: `Set<HTTPMethod>` of `HTTPMethod`s for which empty responses are allowed, regardless of
+    ///                          status code. `[.head]` by default.
+    ///
+    /// - Returns:               The `DownloadResponsePublisher`.
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    public func publishString(queue: DispatchQueue = .main,
+                              preprocessor: DataPreprocessor = StringResponseSerializer.defaultDataPreprocessor,
+                              encoding: String.Encoding? = nil,
+                              emptyResponseCodes: Set<Int> = StringResponseSerializer.defaultEmptyResponseCodes,
+                              emptyRequestMethods: Set<HTTPMethod> = StringResponseSerializer.defaultEmptyRequestMethods) -> DownloadResponsePublisher<String> {
+        publishResponse(using: StringResponseSerializer(dataPreprocessor: preprocessor,
+                                                        encoding: encoding,
+                                                        emptyResponseCodes: emptyResponseCodes,
+                                                        emptyRequestMethods: emptyRequestMethods),
+                        on: queue)
+    }
+
+    /// Creates a `DataResponsePublisher` for this instance and uses a `DecodableResponseSerializer` to serialize the
+    /// response.
+    ///
+    /// - Parameters:
+    ///   - type:                `Decodable` type to which to decode response `Data`. Inferred from the context by default.
+    ///   - queue:               `DispatchQueue` on which the `DataResponse` will be published. `.main` by default.
+    ///   - preprocessor:        `DataPreprocessor` which filters the `Data` before serialization. `PassthroughPreprocessor()`
+    ///                          by default.
+    ///   - decoder:             `DataDecoder` instance used to decode response `Data`. `JSONDecoder()` by default.
+    ///   - emptyResponseCodes:  `Set<Int>` of HTTP status codes for which empty responses are allowed. `[204, 205]` by
+    ///                          default.
+    ///   - emptyRequestMethods: `Set<HTTPMethod>` of `HTTPMethod`s for which empty responses are allowed, regardless of
+    ///                          status code. `[.head]` by default.
+    ///
+    /// - Returns:               The `DownloadResponsePublisher`.
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    public func publishDecodable<T: Decodable>(type: T.Type = T.self,
+                                               queue: DispatchQueue = .main,
+                                               preprocessor: DataPreprocessor = DecodableResponseSerializer<T>.defaultDataPreprocessor,
+                                               decoder: DataDecoder = JSONDecoder(),
+                                               emptyResponseCodes: Set<Int> = DecodableResponseSerializer<T>.defaultEmptyResponseCodes,
+                                               emptyResponseMethods: Set<HTTPMethod> = DecodableResponseSerializer<T>.defaultEmptyRequestMethods) -> DownloadResponsePublisher<T> {
+        publishResponse(using: DecodableResponseSerializer(dataPreprocessor: preprocessor,
+                                                           decoder: decoder,
+                                                           emptyResponseCodes: emptyResponseCodes,
+                                                           emptyRequestMethods: emptyResponseMethods),
+                        on: queue)
+    }
+}
+
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension DownloadResponsePublisher where Value == URL? {
     /// Create an instance which publishes a `DownloadResponse<URL?, AFError>` value without serialization.
@@ -408,7 +536,7 @@ extension DownloadResponsePublisher where Value == URL? {
 
 extension DownloadRequest {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-    public func publishURL() -> DownloadResponsePublisher<URL?> {
+    public func publishUnserialized() -> DownloadResponsePublisher<URL?> {
         DownloadResponsePublisher(self, queue: .main)
     }
 }

--- a/Source/Combine.swift
+++ b/Source/Combine.swift
@@ -25,6 +25,8 @@
 #if canImport(Combine)
 
 import Combine
+import Dispatch
+import Foundation
 
 // MARK: - DataRequest / UploadRequest
 

--- a/Source/Combine.swift
+++ b/Source/Combine.swift
@@ -65,7 +65,7 @@ public struct DataResponsePublisher<Value>: Publisher {
         setFailureType(to: AFError.self).flatMap { $0.result.publisher }.eraseToAnyPublisher()
     }
 
-    public func receive<S>(subscriber: S) where S: Subscriber, Self.Failure == S.Failure, Self.Output == S.Input {
+    public func receive<S>(subscriber: S) where S: Subscriber, DataResponsePublisher.Failure == S.Failure, DataResponsePublisher.Output == S.Input {
         subscriber.receive(subscription: Inner(request: request,
                                                responseHandler: responseHandler,
                                                downstream: subscriber))

--- a/Source/Combine.swift
+++ b/Source/Combine.swift
@@ -1,0 +1,85 @@
+//
+//  Combine.swift
+//
+//  Copyright (c) 2020 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#if canImport(Combine)
+
+import Combine
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+public struct DataResponsePublisher<Value>: Publisher where Value: Decodable {
+    public typealias Output = DataResponse<Value, AFError>
+    public typealias Failure = Never
+
+    let request: DataRequest
+
+    init(_ request: DataRequest) {
+        self.request = request
+    }
+
+    public func receive<S>(subscriber: S) where S: Subscriber, Self.Failure == S.Failure, Self.Output == S.Input {
+        subscriber.receive(subscription: Inner(request: request, downstream: subscriber))
+    }
+
+    private final class Inner<Downstream: Subscriber>: Subscription, Cancellable
+        where Downstream.Input == Output {
+        typealias Input = DataRequest
+        typealias Failure = Downstream.Failure
+
+        @Protected
+        private var downstream: Downstream?
+        private let request: DataRequest
+
+        init(request: DataRequest, downstream: Downstream) {
+            self.request = request
+            self.downstream = downstream
+        }
+
+        func request(_ demand: Subscribers.Demand) {
+            assert(demand > 0)
+
+            guard let downstream = downstream else { return }
+
+            self.downstream = nil
+
+            request.responseDecodable(of: Value.self) { response in
+                _ = downstream.receive(response)
+                downstream.receive(completion: .finished)
+            }
+        }
+
+        func cancel() {
+            request.cancel()
+            downstream = nil
+        }
+    }
+}
+
+extension DataRequest {
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    public func responsePublisher<T: Decodable>(of: T.Type = T.self) -> DataResponsePublisher<T> {
+        DataResponsePublisher(self)
+    }
+}
+
+#endif

--- a/Source/Combine.swift
+++ b/Source/Combine.swift
@@ -100,7 +100,7 @@ public struct DataResponsePublisher<Value>: Publisher {
 
 extension DataRequest {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-    public func publish<Serializer: ResponseSerializer, T>(serializer: Serializer, queue: DispatchQueue = .main) -> DataResponsePublisher<T>
+    public func publishResponse<Serializer: ResponseSerializer, T>(using serializer: Serializer, queue: DispatchQueue = .main) -> DataResponsePublisher<T>
         where Serializer.SerializedObject == T {
         DataResponsePublisher(self, queue: queue, serializer: serializer)
     }
@@ -110,10 +110,10 @@ extension DataRequest {
                             preprocessor: DataPreprocessor = DataResponseSerializer.defaultDataPreprocessor,
                             emptyResponseCodes: Set<Int> = DataResponseSerializer.defaultEmptyResponseCodes,
                             emptyRequestMethods: Set<HTTPMethod> = DataResponseSerializer.defaultEmptyRequestMethods) -> DataResponsePublisher<Data> {
-        publish(serializer: DataResponseSerializer(dataPreprocessor: preprocessor,
-                                                   emptyResponseCodes: emptyResponseCodes,
-                                                   emptyRequestMethods: emptyRequestMethods),
-                queue: queue)
+        publishResponse(using: DataResponseSerializer(dataPreprocessor: preprocessor,
+                                                      emptyResponseCodes: emptyResponseCodes,
+                                                      emptyRequestMethods: emptyRequestMethods),
+                        queue: queue)
     }
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
@@ -122,11 +122,11 @@ extension DataRequest {
                               encoding: String.Encoding? = nil,
                               emptyResponseCodes: Set<Int> = StringResponseSerializer.defaultEmptyResponseCodes,
                               emptyRequestMethods: Set<HTTPMethod> = StringResponseSerializer.defaultEmptyRequestMethods) -> DataResponsePublisher<String> {
-        publish(serializer: StringResponseSerializer(dataPreprocessor: preprocessor,
-                                                     encoding: encoding,
-                                                     emptyResponseCodes: emptyResponseCodes,
-                                                     emptyRequestMethods: emptyRequestMethods),
-                queue: queue)
+        publishResponse(using: StringResponseSerializer(dataPreprocessor: preprocessor,
+                                                        encoding: encoding,
+                                                        emptyResponseCodes: emptyResponseCodes,
+                                                        emptyRequestMethods: emptyRequestMethods),
+                        queue: queue)
     }
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
@@ -136,11 +136,11 @@ extension DataRequest {
                                                decoder: DataDecoder = JSONDecoder(),
                                                emptyResponseCodes: Set<Int> = DecodableResponseSerializer<T>.defaultEmptyResponseCodes,
                                                emptyResponseMethods: Set<HTTPMethod> = DecodableResponseSerializer<T>.defaultEmptyRequestMethods) -> DataResponsePublisher<T> {
-        publish(serializer: DecodableResponseSerializer(dataPreprocessor: preprocessor,
-                                                        decoder: decoder,
-                                                        emptyResponseCodes: emptyResponseCodes,
-                                                        emptyRequestMethods: emptyResponseMethods),
-                queue: queue)
+        publishResponse(using: DecodableResponseSerializer(dataPreprocessor: preprocessor,
+                                                           decoder: decoder,
+                                                           emptyResponseCodes: emptyResponseCodes,
+                                                           emptyRequestMethods: emptyResponseMethods),
+                        queue: queue)
     }
 }
 

--- a/Source/Combine.swift
+++ b/Source/Combine.swift
@@ -130,7 +130,7 @@ extension DataRequest {
     }
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-    public func publishDecodable<T: Decodable>(of: T.Type = T.self,
+    public func publishDecodable<T: Decodable>(type: T.Type = T.self,
                                                queue: DispatchQueue = .main,
                                                preprocessor: DataPreprocessor = DecodableResponseSerializer<T>.defaultDataPreprocessor,
                                                decoder: DataDecoder = JSONDecoder(),

--- a/Source/Combine.swift
+++ b/Source/Combine.swift
@@ -100,7 +100,7 @@ public struct DataResponsePublisher<Value>: Publisher {
 
 extension DataRequest {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-    public func publishResponse<Serializer: ResponseSerializer, T>(using serializer: Serializer, queue: DispatchQueue = .main) -> DataResponsePublisher<T>
+    public func publishResponse<Serializer: ResponseSerializer, T>(using serializer: Serializer, on queue: DispatchQueue = .main) -> DataResponsePublisher<T>
         where Serializer.SerializedObject == T {
         DataResponsePublisher(self, queue: queue, serializer: serializer)
     }
@@ -113,7 +113,7 @@ extension DataRequest {
         publishResponse(using: DataResponseSerializer(dataPreprocessor: preprocessor,
                                                       emptyResponseCodes: emptyResponseCodes,
                                                       emptyRequestMethods: emptyRequestMethods),
-                        queue: queue)
+                        on: queue)
     }
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
@@ -126,7 +126,7 @@ extension DataRequest {
                                                         encoding: encoding,
                                                         emptyResponseCodes: emptyResponseCodes,
                                                         emptyRequestMethods: emptyRequestMethods),
-                        queue: queue)
+                        on: queue)
     }
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
@@ -140,7 +140,7 @@ extension DataRequest {
                                                            decoder: decoder,
                                                            emptyResponseCodes: emptyResponseCodes,
                                                            emptyRequestMethods: emptyResponseMethods),
-                        queue: queue)
+                        on: queue)
     }
 }
 

--- a/Source/Combine.swift
+++ b/Source/Combine.swift
@@ -41,7 +41,7 @@ public struct DataResponsePublisher<Value>: Publisher {
     private let request: DataRequest
     private let responseHandler: Handler
 
-    /// Create an instance which will serialize responses using the provided `ResponseSerializer`.
+    /// Creates an instance which will serialize responses using the provided `ResponseSerializer`.
     ///
     /// - Parameters:
     ///   - request:    `DataRequest` for which to publish the response.
@@ -53,7 +53,7 @@ public struct DataResponsePublisher<Value>: Publisher {
         responseHandler = { request.response(queue: queue, responseSerializer: serializer, completionHandler: $0) }
     }
 
-    /// Create an instance which will serialize responses using the provided `DataResponseSerializerProtocol`.
+    /// Creates an instance which will serialize responses using the provided `DataResponseSerializerProtocol`.
     ///
     /// - Parameters:
     ///   - request:    `DataRequest` for which to publish the response.
@@ -67,14 +67,14 @@ public struct DataResponsePublisher<Value>: Publisher {
         responseHandler = { request.response(queue: queue, responseSerializer: serializer, completionHandler: $0) }
     }
 
-    /// Publish only the `Result` of the `DataResponse` value.
+    /// Publishes only the `Result` of the `DataResponse` value.
     ///
     /// - Returns: The `AnyPublisher` publishing the `Result<Value, AFError>` value.
     public func result() -> AnyPublisher<Result<Value, AFError>, Never> {
         map { $0.result }.eraseToAnyPublisher()
     }
 
-    /// Publish the `Result` of the `DataResponse` as a single `Value` or fail with the `AFError` instance.
+    /// Publishes the `Result` of the `DataResponse` as a single `Value` or fail with the `AFError` instance.
     ///
     /// - Returns: The `AnyPublisher<Value, AFError>` publishing the stream.
     public func value() -> AnyPublisher<Value, AFError> {
@@ -123,7 +123,7 @@ public struct DataResponsePublisher<Value>: Publisher {
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension DataResponsePublisher where Value == Data? {
-    /// Create an instance which publishes a `DataResponse<Data?, AFError>` value without serialization.
+    /// Creates an instance which publishes a `DataResponse<Data?, AFError>` value without serialization.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     public init(_ request: DataRequest, queue: DispatchQueue) {
         self.request = request
@@ -248,7 +248,7 @@ public struct DataStreamPublisher<Value>: Publisher {
     private let request: DataStreamRequest
     private let streamHandler: Handler
 
-    /// Create an instance which will serialize responses using the provided `ResponseSerializer`.
+    /// Creates an instance which will serialize responses using the provided `DataStreamSerializer`.
     ///
     /// - Parameters:
     ///   - request:    `DataStreamRequest` for which to publish the response.
@@ -261,7 +261,7 @@ public struct DataStreamPublisher<Value>: Publisher {
         streamHandler = { request.responseStream(using: serializer, on: queue, stream: $0) }
     }
 
-    /// Publish only the `Result` of the `DataStreamRequest.Stream`'s `Event`s.
+    /// Publishes only the `Result` of the `DataStreamRequest.Stream`'s `Event`s.
     ///
     /// - Returns: The `AnyPublisher` publishing the `Result<Value, AFError>` value.
     public func result() -> AnyPublisher<Result<Value, AFError>, Never> {
@@ -277,7 +277,7 @@ public struct DataStreamPublisher<Value>: Publisher {
         .eraseToAnyPublisher()
     }
 
-    /// Publish the streamed values of the `DataStreamRequest.Stream` as a sequence of `Value` or fail with the
+    /// Publishes the streamed values of the `DataStreamRequest.Stream` as a sequence of `Value` or fail with the
     /// `AFError` instance.
     ///
     /// - Returns: The `AnyPublisher<Value, AFError>` publishing the stream.
@@ -328,7 +328,7 @@ public struct DataStreamPublisher<Value>: Publisher {
 }
 
 extension DataStreamRequest {
-    /// Crates a `DataStreamPublisher` for this instance using the given `DataStreamSerializer` and `DispatchQueue`.
+    /// Creates a `DataStreamPublisher` for this instance using the given `DataStreamSerializer` and `DispatchQueue`.
     ///
     /// - Parameters:
     ///   - serializer: `DataStreamSerializer` used to serialize the streamed `Data`.
@@ -340,7 +340,7 @@ extension DataStreamRequest {
         DataStreamPublisher(self, queue: queue, serializer: serializer)
     }
 
-    /// Crates a `DataStreamPublisher` for this instance which uses a `PassthroughStreamSerializer` to stream `Data`
+    /// Creates a `DataStreamPublisher` for this instance which uses a `PassthroughStreamSerializer` to stream `Data`
     /// unserialized.
     ///
     /// - Parameters:
@@ -351,7 +351,7 @@ extension DataStreamRequest {
         publishStream(using: PassthroughStreamSerializer(), on: queue)
     }
 
-    /// Crates a `DataStreamPublisher` for this instance which uses a `StringStreamSerializer` to serialize stream
+    /// Creates a `DataStreamPublisher` for this instance which uses a `StringStreamSerializer` to serialize stream
     /// `Data` values into `String` values.
     ///
     /// - Parameters:
@@ -362,7 +362,7 @@ extension DataStreamRequest {
         publishStream(using: StringStreamSerializer(), on: queue)
     }
 
-    /// Crates a `DataStreamPublisher` for this instance which uses a `DecodableStreamSerializer` with the provided
+    /// Creates a `DataStreamPublisher` for this instance which uses a `DecodableStreamSerializer` with the provided
     /// parameters to serialize stream `Data` values into the provided type.
     ///
     /// - Parameters:
@@ -383,7 +383,7 @@ extension DataStreamRequest {
     }
 }
 
-/// A Combine `Publisher` that publishes the `DataResponse<Value, AFError>` of the provided `DataRequest`.
+/// A Combine `Publisher` that publishes the `DownloadResponse<Value, AFError>` of the provided `DownloadRequest`.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public struct DownloadResponsePublisher<Value>: Publisher {
     public typealias Output = DownloadResponse<Value, AFError>
@@ -394,7 +394,7 @@ public struct DownloadResponsePublisher<Value>: Publisher {
     private let request: DownloadRequest
     private let responseHandler: Handler
 
-    /// Create an instance which will serialize responses using the provided `ResponseSerializer`.
+    /// Creates an instance which will serialize responses using the provided `ResponseSerializer`.
     ///
     /// - Parameters:
     ///   - request:    `DownloadRequest` for which to publish the response.
@@ -406,7 +406,7 @@ public struct DownloadResponsePublisher<Value>: Publisher {
         responseHandler = { request.response(queue: queue, responseSerializer: serializer, completionHandler: $0) }
     }
 
-    /// Create an instance which will serialize responses using the provided `DownloadResponseSerializerProtocol` value.
+    /// Creates an instance which will serialize responses using the provided `DownloadResponseSerializerProtocol` value.
     ///
     /// - Parameters:
     ///   - request:    `DownloadRequest` for which to publish the response.
@@ -421,14 +421,14 @@ public struct DownloadResponsePublisher<Value>: Publisher {
         responseHandler = { request.response(queue: queue, responseSerializer: serializer, completionHandler: $0) }
     }
 
-    /// Publish only the `Result` of the `DataResponse` value.
+    /// Publishes only the `Result` of the `DownloadResponse` value.
     ///
     /// - Returns: The `AnyPublisher` publishing the `Result<Value, AFError>` value.
     public func result() -> AnyPublisher<Result<Value, AFError>, Never> {
         map { $0.result }.eraseToAnyPublisher()
     }
 
-    /// Publish the `Result` of the `DataResponse` as a single `Value` or fail with the `AFError` instance.
+    /// Publishes the `Result` of the `DownloadResponse` as a single `Value` or fail with the `AFError` instance.
     ///
     /// - Returns: The `AnyPublisher<Value, AFError>` publishing the stream.
     public func value() -> AnyPublisher<Value, AFError> {
@@ -476,14 +476,29 @@ public struct DownloadResponsePublisher<Value>: Publisher {
 }
 
 extension DownloadRequest {
+    /// Creates a `DownloadResponsePublisher` for this instance using the given `ResponseSerializer` and `DispatchQueue`.
+    ///
+    /// - Parameters:
+    ///   - serializer: `ResponseSerializer` used to serialize the response `Data` from disk.
+    ///   - queue:      `DispatchQueue` on which the `DownloadResponse` will be published.`.main` by default.
+    ///
+    /// - Returns:      The `DownloadResponsePublisher`.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-    func publishResponse<Serializer: ResponseSerializer, T>(using serializer: Serializer, on queue: DispatchQueue = .main) -> DownloadResponsePublisher<T>
+    public func publishResponse<Serializer: ResponseSerializer, T>(using serializer: Serializer, on queue: DispatchQueue = .main) -> DownloadResponsePublisher<T>
         where Serializer.SerializedObject == T {
         DownloadResponsePublisher(self, queue: queue, serializer: serializer)
     }
 
+    /// Creates a `DownloadResponsePublisher` for this instance using the given `DownloadResponseSerializerProtocol` and
+    /// `DispatchQueue`.
+    ///
+    /// - Parameters:
+    ///   - serializer: `DownloadResponseSerializer` used to serialize the response `Data` from disk.
+    ///   - queue:      `DispatchQueue` on which the `DownloadResponse` will be published.`.main` by default.
+    ///
+    /// - Returns:      The `DownloadResponsePublisher`.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-    func publishResponse<Serializer: DownloadResponseSerializerProtocol, T>(using serializer: Serializer, on queue: DispatchQueue = .main) -> DownloadResponsePublisher<T>
+    public func publishResponse<Serializer: DownloadResponseSerializerProtocol, T>(using serializer: Serializer, on queue: DispatchQueue = .main) -> DownloadResponsePublisher<T>
         where Serializer.SerializedObject == T {
         DownloadResponsePublisher(self, queue: queue, serializer: serializer)
     }
@@ -572,7 +587,7 @@ extension DownloadRequest {
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension DownloadResponsePublisher where Value == URL? {
-    /// Create an instance which publishes a `DownloadResponse<URL?, AFError>` value without serialization.
+    /// Creates an instance which publishes a `DownloadResponse<URL?, AFError>` value without serialization.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     public init(_ request: DownloadRequest, queue: DispatchQueue) {
         self.request = request
@@ -581,9 +596,14 @@ extension DownloadResponsePublisher where Value == URL? {
 }
 
 extension DownloadRequest {
+    /// Creates a `DownloadResponsePublisher` for this instance which does not serialize the response before publishing.
+    ///
+    /// - Parameter queue: `DispatchQueue` on which the `DownloadResponse` will be published. `.main` by default.
+    ///
+    /// - Returns:         The `DownloadResponsePublisher`.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-    public func publishUnserialized() -> DownloadResponsePublisher<URL?> {
-        DownloadResponsePublisher(self, queue: .main)
+    public func publishUnserialized(on queue: DispatchQueue = .main) -> DownloadResponsePublisher<URL?> {
+        DownloadResponsePublisher(self, queue: queue)
     }
 }
 

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1300,16 +1300,22 @@ public final class DataStreamRequest: Request {
 }
 
 extension DataStreamRequest.Stream {
+    public var result: Result<Success, Failure>? {
+        guard case let .stream(result) = event else { return nil }
+
+        return result
+    }
+
     /// `Success` value of the instance, if any.
     public var value: Success? {
-        guard case let .stream(result) = event, case let .success(value) = result else { return nil }
+        guard case let .success(value) = result else { return nil }
 
         return value
     }
 
     /// `Failure` value of the instance, if any.
     public var error: Failure? {
-        guard case let .stream(result) = event, case let .failure(error) = result else { return nil }
+        guard case let .failure(error) = result else { return nil }
 
         return error
     }

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1515,7 +1515,7 @@ public class DownloadRequest: Request {
     ///
     /// - Returns: The instance.
     @discardableResult
-    public override func cancel() -> Self {
+    override public func cancel() -> Self {
         cancel(producingResumeData: false)
     }
 
@@ -1732,7 +1732,7 @@ public class UploadRequest: DataRequest {
         return stream
     }
 
-    public override func cleanup() {
+    override public func cleanup() {
         defer { super.cleanup() }
 
         guard

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1300,6 +1300,7 @@ public final class DataStreamRequest: Request {
 }
 
 extension DataStreamRequest.Stream {
+    /// Incoming `Result` values from `Event.stream`.
     public var result: Result<Success, Failure>? {
         guard case let .stream(result) = event else { return nil }
 

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -838,6 +838,18 @@ public struct DecodableStreamSerializer<T: Decodable>: DataStreamSerializer {
     }
 }
 
+/// `DataStreamSerializer` which performs no serialization on incoming `Data`.
+public struct PassthroughStreamSerializer: DataStreamSerializer {
+    public func serialize(_ data: Data) throws -> Data { data }
+}
+
+/// `DataStreamSerializer` which serializes incoming stream `Data` into `UTF8`-decoded `String` values.
+public struct StringStreamSerializer: DataStreamSerializer {
+    public func serialize(_ data: Data) throws -> String {
+        String(decoding: data, as: UTF8.self)
+    }
+}
+
 extension DataStreamRequest {
     /// Adds a stream handler which performs no parsing on incoming `Data`.
     ///

--- a/Tests/CombineTests.swift
+++ b/Tests/CombineTests.swift
@@ -568,7 +568,7 @@ final class DownloadRequestCombineTests: CombineTestCase {
         // When
         store {
             AF.download(URLRequest.makeHTTPBinRequest())
-                .publishURL()
+                .publishUnserialized()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { url = $0.value!; responseReceived.fulfill() })
         }

--- a/Tests/CombineTests.swift
+++ b/Tests/CombineTests.swift
@@ -52,7 +52,7 @@ final class CombineTests: BaseTestCase {
         // When
         store {
             AF.request(URLRequest.makeHTTPBinRequest())
-                .publishDecodable(of: HTTPBinResponse.self)
+                .publishDecodable(type: HTTPBinResponse.self)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { response = $0; responseReceived.fulfill() })
         }
@@ -74,7 +74,7 @@ final class CombineTests: BaseTestCase {
         // When
         store {
             session.request(URLRequest.makeHTTPBinRequest())
-                .publishDecodable(of: HTTPBinResponse.self)
+                .publishDecodable(type: HTTPBinResponse.self)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { response = $0; responseReceived.fulfill() })
         }
@@ -142,7 +142,7 @@ final class CombineTests: BaseTestCase {
         store {
             AF.request(URLRequest.makeHTTPBinRequest())
                 .responseDecodable(of: HTTPBinResponse.self) { handlerResponse = $0; handlerResponseReceived.fulfill() }
-                .publishDecodable(of: HTTPBinResponse.self)
+                .publishDecodable(type: HTTPBinResponse.self)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { publishedResponse = $0; publishedResponseReceived.fulfill() })
         }
@@ -164,7 +164,7 @@ final class CombineTests: BaseTestCase {
         // When
         store {
             AF.request(URLRequest.makeHTTPBinRequest())
-                .publishDecodable(of: HTTPBinResponse.self)
+                .publishDecodable(type: HTTPBinResponse.self)
                 .result()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { result = $0; responseReceived.fulfill() })
@@ -186,7 +186,7 @@ final class CombineTests: BaseTestCase {
         // When
         store {
             AF.request(URLRequest.makeHTTPBinRequest())
-                .publishDecodable(of: HTTPBinResponse.self)
+                .publishDecodable(type: HTTPBinResponse.self)
                 .value()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { value = $0; responseReceived.fulfill() })
@@ -207,7 +207,7 @@ final class CombineTests: BaseTestCase {
         // When
         store {
             AF.request(URLRequest.makeHTTPBinRequest(path: "delay/1", timeout: 0.1))
-                .publishDecodable(of: HTTPBinResponse.self)
+                .publishDecodable(type: HTTPBinResponse.self)
                 .value()
                 .sink(receiveCompletion: { completion in
                     switch completion {
@@ -236,7 +236,7 @@ final class CombineTests: BaseTestCase {
 
         // When
         let request = AF.request(URLRequest.makeHTTPBinRequest())
-        let publisher = request.publishDecodable(of: HTTPBinResponse.self)
+        let publisher = request.publishDecodable(type: HTTPBinResponse.self)
 
         let stateAfterPublisher = request.state
 
@@ -264,7 +264,7 @@ final class CombineTests: BaseTestCase {
         // When
         store {
             AF.request(URLRequest.makeHTTPBinRequest())
-                .publishDecodable(of: HTTPBinResponse.self)
+                .publishDecodable(type: HTTPBinResponse.self)
                 .subscribe(on: queue)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: {
@@ -292,7 +292,7 @@ final class CombineTests: BaseTestCase {
         // When
         store {
             AF.request(URLRequest.makeHTTPBinRequest())
-                .publishDecodable(of: HTTPBinResponse.self, queue: queue)
+                .publishDecodable(type: HTTPBinResponse.self, queue: queue)
                 .sink(receiveCompletion: { _ in
                     dispatchPrecondition(condition: .onQueue(queue))
                     completionReceived.fulfill()
@@ -322,7 +322,7 @@ final class CombineTests: BaseTestCase {
         // When
         store {
             AF.request(URLRequest.makeHTTPBinRequest())
-                .publishDecodable(of: HTTPBinResponse.self, queue: queue)
+                .publishDecodable(type: HTTPBinResponse.self, queue: queue)
                 .receive(on: DispatchQueue.main)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: {
@@ -349,7 +349,7 @@ final class CombineTests: BaseTestCase {
         // When
         let request = AF.request(URLRequest.makeHTTPBinRequest())
         var token: AnyCancellable? = request
-            .publishDecodable(of: HTTPBinResponse.self)
+            .publishDecodable(type: HTTPBinResponse.self)
             .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                   receiveValue: { response = $0; responseReceived.fulfill() })
         token = nil
@@ -372,9 +372,9 @@ final class CombineTests: BaseTestCase {
 
         // When
         let first = AF.request(URLRequest.makeHTTPBinRequest())
-            .publishDecodable(of: HTTPBinResponse.self)
+            .publishDecodable(type: HTTPBinResponse.self)
         let second = AF.request(URLRequest.makeHTTPBinRequest())
-            .publishDecodable(of: HTTPBinResponse.self)
+            .publishDecodable(type: HTTPBinResponse.self)
 
         store {
             Publishers.CombineLatest(first, second)

--- a/Tests/CombineTests.swift
+++ b/Tests/CombineTests.swift
@@ -64,6 +64,191 @@ final class CombineTests: BaseTestCase {
     }
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDataRequestCanPublishResult() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        var result: Result<HTTPBinResponse, AFError>?
+
+        // When
+        store {
+            AF.request(URLRequest.makeHTTPBinRequest())
+                .responsePublisher(of: HTTPBinResponse.self)
+                .result()
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { result = $0; responseReceived.fulfill() })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(result?.isSuccess == true)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDataRequestCanPublishValue() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        var value: HTTPBinResponse?
+
+        // When
+        store {
+            AF.request(URLRequest.makeHTTPBinRequest())
+                .responsePublisher(of: HTTPBinResponse.self)
+                .value()
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { value = $0; responseReceived.fulfill() })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(value)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDataRequestCanPublishValueWithFailure() {
+        // Given
+        let completionReceived = expectation(description: "stream should complete")
+        var error: AFError?
+
+        // When
+        store {
+            AF.request(URLRequest.makeHTTPBinRequest(path: "delay/1", timeout: 0.1))
+                .responsePublisher(of: HTTPBinResponse.self)
+                .value()
+                .sink(receiveCompletion: { completion in
+                    switch completion {
+                    case let .failure(err):
+                        error = err
+                    case .finished:
+                        error = nil
+                    }
+                    completionReceived.fulfill()
+                }, receiveValue: { _ in })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(error)
+        XCTAssertEqual((error?.underlyingError as? URLError)?.code, .timedOut)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatPublishedDataRequestIsNotResumedUnlessSubscribed() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        var response: DataResponse<HTTPBinResponse, AFError>?
+
+        // When
+        let request = AF.request(URLRequest.makeHTTPBinRequest())
+        let publisher = request.responsePublisher(of: HTTPBinResponse.self)
+
+        let stateAfterPublisher = request.state
+
+        store {
+            publisher.sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                           receiveValue: { response = $0; responseReceived.fulfill() })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isSuccess == true)
+        XCTAssertEqual(stateAfterPublisher, .initialized)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDataRequestCanSubscribedFromNonMainQueueButPublishedOnMainQueue() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        let queue = DispatchQueue(label: "org.alamofire.tests.combineEventQueue")
+        var receivedOnMain = false
+        var response: DataResponse<HTTPBinResponse, AFError>?
+
+        // When
+        store {
+            AF.request(URLRequest.makeHTTPBinRequest())
+                .responsePublisher(of: HTTPBinResponse.self)
+                .subscribe(on: queue)
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: {
+                          receivedOnMain = Thread.isMainThread
+                          response = $0
+                          responseReceived.fulfill()
+                })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isSuccess == true)
+        XCTAssertTrue(receivedOnMain)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDataRequestPublishedOnSeparateQueueIsReceivedOnThatQueue() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        let queue = DispatchQueue(label: "org.alamofire.tests.combineEventQueue")
+        var response: DataResponse<HTTPBinResponse, AFError>?
+
+        // When
+        store {
+            AF.request(URLRequest.makeHTTPBinRequest())
+                .responsePublisher(of: HTTPBinResponse.self, queue: queue)
+                .sink(receiveCompletion: { _ in
+                    dispatchPrecondition(condition: .onQueue(queue))
+                    completionReceived.fulfill()
+                },
+                      receiveValue: {
+                    dispatchPrecondition(condition: .onQueue(queue))
+                    response = $0
+                    responseReceived.fulfill()
+                })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isSuccess == true)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDataRequestPublishedOnSeparateQueueCanBeReceivedOntoMainQueue() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        let queue = DispatchQueue(label: "org.alamofire.tests.combineEventQueue")
+        var receivedOnMain = false
+        var response: DataResponse<HTTPBinResponse, AFError>?
+
+        // When
+        store {
+            AF.request(URLRequest.makeHTTPBinRequest())
+                .responsePublisher(of: HTTPBinResponse.self, queue: queue)
+                .receive(on: DispatchQueue.main)
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: {
+                          receivedOnMain = Thread.isMainThread
+                          response = $0
+                          responseReceived.fulfill()
+                })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isSuccess == true)
+        XCTAssertTrue(receivedOnMain)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func testThatPublishedDataRequestCanBeCancelled() {
         // Given
         let responseReceived = expectation(description: "response should be received")
@@ -84,6 +269,36 @@ final class CombineTests: BaseTestCase {
         XCTAssertTrue(response?.result.isFailure == true)
         XCTAssertTrue(request.isCancelled)
         XCTAssertNil(token)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatMultipleDataRequestPublishersCanBeCombined() {
+        // Given
+        let responseReceived = expectation(description: "combined response should be received")
+        let completionReceived = expectation(description: "combined stream should complete")
+        var firstResponse: DataResponse<HTTPBinResponse, AFError>?
+        var secondResponse: DataResponse<HTTPBinResponse, AFError>?
+
+        // When
+        let first = AF.request(URLRequest.makeHTTPBinRequest())
+            .responsePublisher(of: HTTPBinResponse.self)
+        let second = AF.request(URLRequest.makeHTTPBinRequest())
+            .responsePublisher(of: HTTPBinResponse.self)
+
+        store {
+            Publishers.CombineLatest(first, second)
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() }) { first, second in
+                    firstResponse = first
+                    secondResponse = second
+                    responseReceived.fulfill()
+                }
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(firstResponse?.result.isSuccess == true)
+        XCTAssertTrue(secondResponse?.result.isSuccess == true)
     }
 }
 

--- a/Tests/CombineTests.swift
+++ b/Tests/CombineTests.swift
@@ -29,21 +29,6 @@ import Combine
 import XCTest
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-class CombineTestCase: BaseTestCase {
-    var storage: Set<AnyCancellable> = []
-
-    override func tearDown() {
-        storage = []
-
-        super.tearDown()
-    }
-
-    func store(_ toStore: () -> AnyCancellable) {
-        storage.insert(toStore())
-    }
-}
-
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 final class DataRequestCombineTests: CombineTestCase {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func testThatDataRequestCanBePublished() {
@@ -269,11 +254,14 @@ final class DataRequestCombineTests: CombineTestCase {
                            receiveValue: { response = $0; responseReceived.fulfill() })
         }
 
+        let stateAfterSubscription = request.state
+
         waitForExpectations(timeout: timeout)
 
         // Then
         XCTAssertTrue(response?.result.isSuccess == true)
         XCTAssertEqual(stateAfterPublisher, .initialized)
+        XCTAssertEqual(stateAfterSubscription, .resumed)
     }
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
@@ -382,6 +370,7 @@ final class DataRequestCombineTests: CombineTestCase {
 
         // Then
         XCTAssertTrue(response?.result.isFailure == true)
+        XCTAssertTrue(response?.error?.isExplicitlyCancelledError == true)
         XCTAssertTrue(request.isCancelled)
         XCTAssertNil(token)
     }
@@ -407,6 +396,7 @@ final class DataRequestCombineTests: CombineTestCase {
 
         // Then
         XCTAssertTrue(response?.result.isFailure == true)
+        XCTAssertTrue(response?.error?.isExplicitlyCancelledError == true)
         XCTAssertTrue(request.isCancelled)
     }
 
@@ -506,6 +496,130 @@ final class DataStreamRequestCombineTests: CombineTestCase {
     }
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatNonAutomaticDataStreamRequestCanBePublished() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        let session = Session(startRequestsImmediately: false)
+        var result: Result<HTTPBinResponse, AFError>?
+
+        // When
+        store {
+            session.streamRequest(URLRequest.makeHTTPBinRequest())
+                .publishDecodable(type: HTTPBinResponse.self)
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { stream in
+                          switch stream.event {
+                          case let .stream(value):
+                              result = value
+                          case .complete:
+                              responseReceived.fulfill()
+                          }
+                })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(result?.success)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDataStreamRequestCanPublishData() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        var result: Result<Data, AFError>?
+
+        // When
+        store {
+            AF.streamRequest(URLRequest.makeHTTPBinRequest())
+                .publishData()
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { stream in
+                          switch stream.event {
+                          case let .stream(value):
+                              result = value
+                          case .complete:
+                              responseReceived.fulfill()
+                          }
+                })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(result?.success)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDataStreamRequestCanPublishString() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        var result: Result<String, AFError>?
+
+        // When
+        store {
+            AF.streamRequest(URLRequest.makeHTTPBinRequest())
+                .publishString()
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { stream in
+                          switch stream.event {
+                          case let .stream(value):
+                              result = value
+                          case .complete:
+                              responseReceived.fulfill()
+                          }
+                })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(result?.success)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDataStreamRequestCanBePublishedWithMultipleHandlers() {
+        // Given
+        let handlerResponseReceived = expectation(description: "handler response should be received")
+        let publishedResponseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        var handlerResult: Result<HTTPBinResponse, AFError>?
+        var publishedResult: Result<HTTPBinResponse, AFError>?
+
+        // When
+        store {
+            AF.streamRequest(URLRequest.makeHTTPBinRequest())
+                .responseStreamDecodable(of: HTTPBinResponse.self) { stream in
+                    switch stream.event {
+                    case let .stream(value):
+                        handlerResult = value
+                    case .complete:
+                        handlerResponseReceived.fulfill()
+                    }
+                }
+                .publishDecodable(type: HTTPBinResponse.self)
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { stream in
+                          switch stream.event {
+                          case let .stream(value):
+                              publishedResult = value
+                          case .complete:
+                              publishedResponseReceived.fulfill()
+                          }
+                })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(handlerResult?.success)
+        XCTAssertNotNil(publishedResult?.success)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func testThatDataStreamRequestCanPublishResult() {
         // Given
         let responseReceived = expectation(description: "response should be received")
@@ -528,6 +642,32 @@ final class DataStreamRequestCombineTests: CombineTestCase {
 
         // Then
         XCTAssertNotNil(result?.success)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDataStreamRequestCanPublishResultWithResponseFailure() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        var result: Result<HTTPBinResponse, AFError>?
+
+        // When
+        store {
+            AF.streamRequest(URLRequest.makeHTTPBinRequest(path: "delay/1", timeout: 0.1))
+                .publishDecodable(type: HTTPBinResponse.self)
+                .result()
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { received in
+                          result = received
+                          responseReceived.fulfill()
+                })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNil(result?.success)
+        XCTAssertEqual((result?.failure?.underlyingError as? URLError)?.code, .timedOut)
     }
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
@@ -554,6 +694,280 @@ final class DataStreamRequestCombineTests: CombineTestCase {
         // Then
         XCTAssertNotNil(response)
     }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDataStreamRequestCanPublishValueWithFailure() {
+        // Given
+        let completionReceived = expectation(description: "stream should complete")
+        var error: AFError?
+
+        // When
+        store {
+            AF.streamRequest(URLRequest.makeHTTPBinRequest(path: "delay/1", timeout: 0.1))
+                .publishDecodable(type: HTTPBinResponse.self)
+                .value()
+                .sink(receiveCompletion: { completion in
+                    switch completion {
+                    case let .failure(err):
+                        error = err
+                    case .finished:
+                        error = nil
+                    }
+                    completionReceived.fulfill()
+                }, receiveValue: { _ in })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(error)
+        XCTAssertEqual((error?.underlyingError as? URLError)?.code, .timedOut)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatPublishedDataStreamRequestIsNotResumedUnlessSubscribed() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        var result: Result<HTTPBinResponse, AFError>?
+
+        // When
+        let request = AF.streamRequest(URLRequest.makeHTTPBinRequest())
+        let publisher = request.publishDecodable(type: HTTPBinResponse.self)
+
+        let stateAfterPublisher = request.state
+
+        store {
+            publisher.sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                           receiveValue: { stream in
+                               switch stream.event {
+                               case let .stream(value):
+                                   result = value
+                               case .complete:
+                                   responseReceived.fulfill()
+                               }
+                           })
+        }
+
+        let stateAfterSubscription = request.state
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(result?.isSuccess == true)
+        XCTAssertEqual(stateAfterPublisher, .initialized)
+        XCTAssertEqual(stateAfterSubscription, .resumed)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDataStreamRequestCanSubscribedFromNonMainQueueButPublishedOnMainQueue() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        let queue = DispatchQueue(label: "org.alamofire.tests.combineEventQueue")
+        var receivedOnMain = false
+        var result: Result<HTTPBinResponse, AFError>?
+
+        // When
+        store {
+            AF.streamRequest(URLRequest.makeHTTPBinRequest())
+                .publishDecodable(type: HTTPBinResponse.self)
+                .subscribe(on: queue)
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { stream in
+                          receivedOnMain = Thread.isMainThread
+                          switch stream.event {
+                          case let .stream(value):
+                              result = value
+                          case .complete:
+                              responseReceived.fulfill()
+                          }
+                })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(result?.success)
+        XCTAssertTrue(receivedOnMain)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDataStreamRequestPublishedOnSeparateQueueIsReceivedOnThatQueue() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        let queue = DispatchQueue(label: "org.alamofire.tests.combineEventQueue")
+        var result: Result<HTTPBinResponse, AFError>?
+
+        // When
+        store {
+            AF.streamRequest(URLRequest.makeHTTPBinRequest())
+                .publishDecodable(type: HTTPBinResponse.self, queue: queue)
+                .sink(receiveCompletion: { _ in
+                    dispatchPrecondition(condition: .onQueue(queue))
+                    completionReceived.fulfill()
+                },
+                      receiveValue: { stream in
+                    dispatchPrecondition(condition: .onQueue(queue))
+                    switch stream.event {
+                    case let .stream(value):
+                        result = value
+                    case .complete:
+                        responseReceived.fulfill()
+                    }
+                    })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(result?.success)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDataStreamRequestPublishedOnSeparateQueueCanBeReceivedOntoMainQueue() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        let queue = DispatchQueue(label: "org.alamofire.tests.combineEventQueue")
+        var receivedOnMain = false
+        var result: Result<HTTPBinResponse, AFError>?
+
+        // When
+        store {
+            AF.streamRequest(URLRequest.makeHTTPBinRequest())
+                .publishDecodable(type: HTTPBinResponse.self, queue: queue)
+                .receive(on: DispatchQueue.main)
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { stream in
+                          receivedOnMain = Thread.isMainThread
+                          switch stream.event {
+                          case let .stream(value):
+                              result = value
+                          case .complete:
+                              responseReceived.fulfill()
+                          }
+                })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(result?.success)
+        XCTAssertTrue(receivedOnMain)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatPublishedDataStreamRequestCanBeCancelledAutomatically() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        var stream: DataStreamRequest.Stream<HTTPBinResponse, AFError>?
+
+        // When
+        let request = AF.streamRequest(URLRequest.makeHTTPBinRequest())
+        var token: AnyCancellable? = request
+            .publishDecodable(type: HTTPBinResponse.self)
+            .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                  receiveValue: { stream = $0; responseReceived.fulfill() })
+        token = nil
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(stream?.completion?.error)
+        XCTAssertTrue(stream?.completion?.error?.isExplicitlyCancelledError == true)
+        XCTAssertTrue(request.isCancelled)
+        XCTAssertNil(token)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatPublishedDataStreamRequestCanBeCancelledManually() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        var stream: DataStreamRequest.Stream<HTTPBinResponse, AFError>?
+
+        // When
+        let request = AF.streamRequest(URLRequest.makeHTTPBinRequest())
+        store {
+            request
+                .publishDecodable(type: HTTPBinResponse.self)
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { stream = $0; responseReceived.fulfill() })
+        }
+        request.cancel()
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(stream?.completion?.error)
+        XCTAssertTrue(stream?.completion?.error?.isExplicitlyCancelledError == true)
+        XCTAssertTrue(request.isCancelled)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatMultipleDataStreamPublishersCanBeCombined() {
+        // Given
+        let responseReceived = expectation(description: "combined response should be received")
+        let completionReceived = expectation(description: "combined stream should complete")
+        var firstCompletion: DataStreamRequest.Completion?
+        var secondCompletion: DataStreamRequest.Completion?
+
+        // When
+        let first = AF.streamRequest(URLRequest.makeHTTPBinRequest())
+            .publishDecodable(type: HTTPBinResponse.self)
+        let second = AF.streamRequest(URLRequest.makeHTTPBinRequest())
+            .publishDecodable(type: HTTPBinResponse.self)
+
+        store {
+            Publishers.CombineLatest(first.compactMap { $0.completion }, second.compactMap { $0.completion })
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { first, second in
+                          firstCompletion = first
+                          secondCompletion = second
+                          responseReceived.fulfill()
+                      })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(firstCompletion)
+        XCTAssertNotNil(secondCompletion)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatMultipleDataStreamRequestPublishersCanBeChained() {
+        // Given
+        let responseReceived = expectation(description: "combined response should be received")
+        let completionReceived = expectation(description: "combined stream should complete")
+        var firstCompletion: DataStreamRequest.Completion?
+        var secondCompletion: DataStreamRequest.Completion?
+
+        // When
+        store {
+            AF.streamRequest(URLRequest.makeHTTPBinRequest())
+                .publishDecodable(type: HTTPBinResponse.self)
+                .compactMap { $0.completion }
+                .flatMap { completion -> DataStreamPublisher<HTTPBinResponse> in
+                    firstCompletion = completion
+                    let request = URLRequest.makeHTTPBinRequest(headers: ["X-Custom": completion.response?.url?.absoluteString ?? "None"])
+                    return AF.streamRequest(request)
+                        .publishDecodable(type: HTTPBinResponse.self)
+                }
+                .compactMap { $0.completion }
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { secondCompletion = $0; responseReceived.fulfill() })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(firstCompletion)
+        XCTAssertNotNil(secondCompletion)
+    }
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
@@ -563,20 +977,422 @@ final class DownloadRequestCombineTests: CombineTestCase {
         // Given
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "publisher should complete")
-        var url: URL?
+        var response: DownloadResponse<HTTPBinResponse, AFError>?
+
+        // When
+        store {
+            AF.download(URLRequest.makeHTTPBinRequest())
+                .publishDecodable(type: HTTPBinResponse.self)
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { response = $0; responseReceived.fulfill() })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isSuccess == true)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatNonAutomaticDownloadRequestCanBePublished() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "publisher should complete")
+        let session = Session(startRequestsImmediately: false)
+        var response: DownloadResponse<HTTPBinResponse, AFError>?
+
+        // When
+        store {
+            session.download(URLRequest.makeHTTPBinRequest())
+                .publishDecodable(type: HTTPBinResponse.self)
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { response = $0; responseReceived.fulfill() })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isSuccess == true)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDownloadRequestCanPublishData() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "publisher should complete")
+        var response: DownloadResponse<Data, AFError>?
+
+        // When
+        store {
+            AF.download(URLRequest.makeHTTPBinRequest())
+                .publishData()
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { response = $0; responseReceived.fulfill() })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isSuccess == true)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDownloadRequestCanPublishString() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "publisher should complete")
+        var response: DownloadResponse<String, AFError>?
+
+        // When
+        store {
+            AF.download(URLRequest.makeHTTPBinRequest())
+                .publishString()
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { response = $0; responseReceived.fulfill() })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isSuccess == true)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDownloadRequestCanPublishUnserialized() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "publisher should complete")
+        var response: DownloadResponse<URL?, AFError>?
 
         // When
         store {
             AF.download(URLRequest.makeHTTPBinRequest())
                 .publishUnserialized()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
-                      receiveValue: { url = $0.value!; responseReceived.fulfill() })
+                      receiveValue: { response = $0; responseReceived.fulfill() })
         }
 
         waitForExpectations(timeout: timeout)
 
         // Then
-        XCTAssertNotNil(url)
+        XCTAssertTrue(response?.result.isSuccess == true)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDownloadRequestCanPublishWithMultipleHandlers() {
+        // Given
+        let handlerResponseReceived = expectation(description: "handler response should be received")
+        let publishedResponseReceived = expectation(description: "published response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        var handlerResponse: DownloadResponse<HTTPBinResponse, AFError>?
+        var publishedResponse: DownloadResponse<HTTPBinResponse, AFError>?
+
+        // When
+        store {
+            AF.download(URLRequest.makeHTTPBinRequest())
+                .responseDecodable(of: HTTPBinResponse.self) { handlerResponse = $0; handlerResponseReceived.fulfill() }
+                .publishDecodable(type: HTTPBinResponse.self)
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { publishedResponse = $0; publishedResponseReceived.fulfill() })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(handlerResponse?.result.isSuccess == true)
+        XCTAssertTrue(publishedResponse?.result.isSuccess == true)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDownloadRequestCanPublishResult() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "publisher should complete")
+        var result: Result<HTTPBinResponse, AFError>?
+
+        // When
+        store {
+            AF.download(URLRequest.makeHTTPBinRequest())
+                .publishDecodable(type: HTTPBinResponse.self)
+                .result()
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { result = $0; responseReceived.fulfill() })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(result?.isSuccess == true)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDownloadRequestCanPublishValueWithFailure() {
+        // Given
+        let completionReceived = expectation(description: "stream should complete")
+        var error: AFError?
+
+        // When
+        store {
+            AF.download(URLRequest.makeHTTPBinRequest(path: "delay/1", timeout: 0.1))
+                .publishDecodable(type: HTTPBinResponse.self)
+                .value()
+                .sink(receiveCompletion: { completion in
+                    switch completion {
+                    case let .failure(err):
+                        error = err
+                    case .finished:
+                        error = nil
+                    }
+                    completionReceived.fulfill()
+                }, receiveValue: { _ in })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(error)
+        XCTAssertEqual((error?.underlyingError as? URLError)?.code, .timedOut)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatPublishedDownloadRequestIsNotResumedUnlessSubscribed() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        var response: DownloadResponse<HTTPBinResponse, AFError>?
+
+        // When
+        let request = AF.download(URLRequest.makeHTTPBinRequest())
+        let publisher = request.publishDecodable(type: HTTPBinResponse.self)
+
+        let stateAfterPublisher = request.state
+
+        store {
+            publisher.sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                           receiveValue: { response = $0; responseReceived.fulfill() })
+        }
+
+        let stateAfterSubscription = request.state
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isSuccess == true)
+        XCTAssertEqual(stateAfterPublisher, .initialized)
+        XCTAssertEqual(stateAfterSubscription, .resumed)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDownloadRequestCanSubscribedFromNonMainQueueButPublishedOnMainQueue() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        let queue = DispatchQueue(label: "org.alamofire.tests.combineEventQueue")
+        var receivedOnMain = false
+        var response: DownloadResponse<HTTPBinResponse, AFError>?
+
+        // When
+        store {
+            AF.download(URLRequest.makeHTTPBinRequest())
+                .publishDecodable(type: HTTPBinResponse.self)
+                .subscribe(on: queue)
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: {
+                          receivedOnMain = Thread.isMainThread
+                          response = $0
+                          responseReceived.fulfill()
+                })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isSuccess == true)
+        XCTAssertTrue(receivedOnMain)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDownloadRequestPublishedOnSeparateQueueIsReceivedOnThatQueue() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        let queue = DispatchQueue(label: "org.alamofire.tests.combineEventQueue")
+        var response: DownloadResponse<HTTPBinResponse, AFError>?
+
+        // When
+        store {
+            AF.download(URLRequest.makeHTTPBinRequest())
+                .publishDecodable(type: HTTPBinResponse.self, queue: queue)
+                .sink(receiveCompletion: { _ in
+                    dispatchPrecondition(condition: .onQueue(queue))
+                    completionReceived.fulfill()
+                },
+                      receiveValue: {
+                    dispatchPrecondition(condition: .onQueue(queue))
+                    response = $0
+                    responseReceived.fulfill()
+                })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isSuccess == true)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDownloadRequestPublishedOnSeparateQueueCanBeReceivedOntoMainQueue() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        let queue = DispatchQueue(label: "org.alamofire.tests.combineEventQueue")
+        var receivedOnMain = false
+        var response: DownloadResponse<HTTPBinResponse, AFError>?
+
+        // When
+        store {
+            AF.download(URLRequest.makeHTTPBinRequest())
+                .publishDecodable(type: HTTPBinResponse.self, queue: queue)
+                .receive(on: DispatchQueue.main)
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: {
+                          receivedOnMain = Thread.isMainThread
+                          response = $0
+                          responseReceived.fulfill()
+                })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isSuccess == true)
+        XCTAssertTrue(receivedOnMain)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatPublishedDownloadRequestCanBeCancelledAutomatically() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        var response: DownloadResponse<HTTPBinResponse, AFError>?
+
+        // When
+        let request = AF.download(URLRequest.makeHTTPBinRequest())
+        var token: AnyCancellable? = request
+            .publishDecodable(type: HTTPBinResponse.self)
+            .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                  receiveValue: { response = $0; responseReceived.fulfill() })
+        token = nil
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isFailure == true)
+        XCTAssertTrue(response?.error?.isExplicitlyCancelledError == true)
+        XCTAssertTrue(request.isCancelled)
+        XCTAssertNil(token)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatPublishedDownloadRequestCanBeCancelledManually() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        var response: DownloadResponse<HTTPBinResponse, AFError>?
+
+        // When
+        let request = AF.download(URLRequest.makeHTTPBinRequest())
+        store {
+            request
+                .publishDecodable(type: HTTPBinResponse.self)
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { response = $0; responseReceived.fulfill() })
+        }
+        request.cancel()
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isFailure == true)
+        XCTAssertTrue(response?.error?.isExplicitlyCancelledError == true)
+        XCTAssertTrue(request.isCancelled)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatMultipleDownloadRequestPublishersCanBeCombined() {
+        // Given
+        let responseReceived = expectation(description: "combined response should be received")
+        let completionReceived = expectation(description: "combined stream should complete")
+        var firstResponse: DownloadResponse<HTTPBinResponse, AFError>?
+        var secondResponse: DownloadResponse<HTTPBinResponse, AFError>?
+
+        // When
+        let first = AF.download(URLRequest.makeHTTPBinRequest())
+            .publishDecodable(type: HTTPBinResponse.self)
+        let second = AF.download(URLRequest.makeHTTPBinRequest())
+            .publishDecodable(type: HTTPBinResponse.self)
+
+        store {
+            Publishers.CombineLatest(first, second)
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() }) { first, second in
+                    firstResponse = first
+                    secondResponse = second
+                    responseReceived.fulfill()
+                }
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(firstResponse?.result.isSuccess == true)
+        XCTAssertTrue(secondResponse?.result.isSuccess == true)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatMultipleDownloadRequestPublishersCanBeChained() {
+        // Given
+        let responseReceived = expectation(description: "combined response should be received")
+        let completionReceived = expectation(description: "combined stream should complete")
+        var firstResponse: DownloadResponse<HTTPBinResponse, AFError>?
+        var secondResponse: DownloadResponse<HTTPBinResponse, AFError>?
+
+        // When
+        store {
+            AF.download(URLRequest.makeHTTPBinRequest())
+                .publishDecodable(type: HTTPBinResponse.self)
+                .flatMap { response -> DownloadResponsePublisher<HTTPBinResponse> in
+                    firstResponse = response
+                    let request = URLRequest.makeHTTPBinRequest(headers: ["X-Custom": response.value?.url ?? "None"])
+                    return AF.download(request)
+                        .publishDecodable(type: HTTPBinResponse.self)
+                }
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() }) { response in
+                    secondResponse = response
+                    responseReceived.fulfill()
+                }
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(firstResponse?.result.isSuccess == true)
+        XCTAssertTrue(secondResponse?.result.isSuccess == true)
+        XCTAssertEqual(secondResponse?.value?.headers["X-Custom"], "https://httpbin.org/get")
+    }
+}
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+class CombineTestCase: BaseTestCase {
+    var storage: Set<AnyCancellable> = []
+
+    override func tearDown() {
+        storage = []
+
+        super.tearDown()
+    }
+
+    func store(_ toStore: () -> AnyCancellable) {
+        storage.insert(toStore())
     }
 }
 

--- a/Tests/CombineTests.swift
+++ b/Tests/CombineTests.swift
@@ -364,7 +364,7 @@ final class DataRequestCombineTests: CombineTestCase {
     }
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-    func testThatPublishedDataRequestCanBeCancelled() {
+    func testThatPublishedDataRequestCanBeCancelledAutomatically() {
         // Given
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
@@ -384,6 +384,30 @@ final class DataRequestCombineTests: CombineTestCase {
         XCTAssertTrue(response?.result.isFailure == true)
         XCTAssertTrue(request.isCancelled)
         XCTAssertNil(token)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatPublishedDataRequestCanBeCancelledManually() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        var response: DataResponse<HTTPBinResponse, AFError>?
+
+        // When
+        let request = AF.request(URLRequest.makeHTTPBinRequest())
+        store {
+            request
+                .publishDecodable(type: HTTPBinResponse.self)
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { response = $0; responseReceived.fulfill() })
+        }
+        request.cancel()
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isFailure == true)
+        XCTAssertTrue(request.isCancelled)
     }
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)

--- a/Tests/CombineTests.swift
+++ b/Tests/CombineTests.swift
@@ -52,7 +52,7 @@ final class CombineTests: BaseTestCase {
         // When
         store {
             AF.request(URLRequest.makeHTTPBinRequest())
-                .responsePublisher(of: HTTPBinResponse.self)
+                .publishDecodable(of: HTTPBinResponse.self)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { response = $0; responseReceived.fulfill() })
         }
@@ -74,7 +74,51 @@ final class CombineTests: BaseTestCase {
         // When
         store {
             session.request(URLRequest.makeHTTPBinRequest())
-                .responsePublisher(of: HTTPBinResponse.self)
+                .publishDecodable(of: HTTPBinResponse.self)
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { response = $0; responseReceived.fulfill() })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isSuccess == true)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDataRequestCanPublishData() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        let session = Session(startRequestsImmediately: false)
+        var response: DataResponse<Data, AFError>?
+
+        // When
+        store {
+            session.request(URLRequest.makeHTTPBinRequest())
+                .publishData()
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { response = $0; responseReceived.fulfill() })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isSuccess == true)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDataRequestCanPublishString() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        let session = Session(startRequestsImmediately: false)
+        var response: DataResponse<String, AFError>?
+
+        // When
+        store {
+            session.request(URLRequest.makeHTTPBinRequest())
+                .publishString()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { response = $0; responseReceived.fulfill() })
         }
@@ -98,7 +142,7 @@ final class CombineTests: BaseTestCase {
         store {
             AF.request(URLRequest.makeHTTPBinRequest())
                 .responseDecodable(of: HTTPBinResponse.self) { handlerResponse = $0; handlerResponseReceived.fulfill() }
-                .responsePublisher(of: HTTPBinResponse.self)
+                .publishDecodable(of: HTTPBinResponse.self)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { publishedResponse = $0; publishedResponseReceived.fulfill() })
         }
@@ -120,7 +164,7 @@ final class CombineTests: BaseTestCase {
         // When
         store {
             AF.request(URLRequest.makeHTTPBinRequest())
-                .responsePublisher(of: HTTPBinResponse.self)
+                .publishDecodable(of: HTTPBinResponse.self)
                 .result()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { result = $0; responseReceived.fulfill() })
@@ -142,7 +186,7 @@ final class CombineTests: BaseTestCase {
         // When
         store {
             AF.request(URLRequest.makeHTTPBinRequest())
-                .responsePublisher(of: HTTPBinResponse.self)
+                .publishDecodable(of: HTTPBinResponse.self)
                 .value()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { value = $0; responseReceived.fulfill() })
@@ -163,7 +207,7 @@ final class CombineTests: BaseTestCase {
         // When
         store {
             AF.request(URLRequest.makeHTTPBinRequest(path: "delay/1", timeout: 0.1))
-                .responsePublisher(of: HTTPBinResponse.self)
+                .publishDecodable(of: HTTPBinResponse.self)
                 .value()
                 .sink(receiveCompletion: { completion in
                     switch completion {
@@ -192,7 +236,7 @@ final class CombineTests: BaseTestCase {
 
         // When
         let request = AF.request(URLRequest.makeHTTPBinRequest())
-        let publisher = request.responsePublisher(of: HTTPBinResponse.self)
+        let publisher = request.publishDecodable(of: HTTPBinResponse.self)
 
         let stateAfterPublisher = request.state
 
@@ -220,7 +264,7 @@ final class CombineTests: BaseTestCase {
         // When
         store {
             AF.request(URLRequest.makeHTTPBinRequest())
-                .responsePublisher(of: HTTPBinResponse.self)
+                .publishDecodable(of: HTTPBinResponse.self)
                 .subscribe(on: queue)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: {
@@ -248,7 +292,7 @@ final class CombineTests: BaseTestCase {
         // When
         store {
             AF.request(URLRequest.makeHTTPBinRequest())
-                .responsePublisher(of: HTTPBinResponse.self, queue: queue)
+                .publishDecodable(of: HTTPBinResponse.self, queue: queue)
                 .sink(receiveCompletion: { _ in
                     dispatchPrecondition(condition: .onQueue(queue))
                     completionReceived.fulfill()
@@ -278,7 +322,7 @@ final class CombineTests: BaseTestCase {
         // When
         store {
             AF.request(URLRequest.makeHTTPBinRequest())
-                .responsePublisher(of: HTTPBinResponse.self, queue: queue)
+                .publishDecodable(of: HTTPBinResponse.self, queue: queue)
                 .receive(on: DispatchQueue.main)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: {
@@ -305,7 +349,7 @@ final class CombineTests: BaseTestCase {
         // When
         let request = AF.request(URLRequest.makeHTTPBinRequest())
         var token: AnyCancellable? = request
-            .responsePublisher(of: HTTPBinResponse.self)
+            .publishDecodable(of: HTTPBinResponse.self)
             .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                   receiveValue: { response = $0; responseReceived.fulfill() })
         token = nil
@@ -328,9 +372,9 @@ final class CombineTests: BaseTestCase {
 
         // When
         let first = AF.request(URLRequest.makeHTTPBinRequest())
-            .responsePublisher(of: HTTPBinResponse.self)
+            .publishDecodable(of: HTTPBinResponse.self)
         let second = AF.request(URLRequest.makeHTTPBinRequest())
-            .responsePublisher(of: HTTPBinResponse.self)
+            .publishDecodable(of: HTTPBinResponse.self)
 
         store {
             Publishers.CombineLatest(first, second)

--- a/Tests/CombineTests.swift
+++ b/Tests/CombineTests.swift
@@ -62,6 +62,29 @@ final class CombineTests: BaseTestCase {
         // Then
         XCTAssertTrue(response?.result.isSuccess == true)
     }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatPublishedDataRequestCanBeCancelled() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        var response: DataResponse<HTTPBinResponse, AFError>?
+
+        // When
+        let request = AF.request(URLRequest.makeHTTPBinRequest())
+        var token: AnyCancellable? = request
+            .responsePublisher(of: HTTPBinResponse.self)
+            .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                  receiveValue: { response = $0; responseReceived.fulfill() })
+        token = nil
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isFailure == true)
+        XCTAssertTrue(request.isCancelled)
+        XCTAssertNil(token)
+    }
 }
 
 #endif

--- a/Tests/CombineTests.swift
+++ b/Tests/CombineTests.swift
@@ -1,0 +1,67 @@
+//
+//  CombineTests.swift
+//
+//  Copyright (c) 2020 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#if canImport(Combine)
+
+import Alamofire
+import Combine
+import XCTest
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+final class CombineTests: BaseTestCase {
+    var storage: Set<AnyCancellable> = []
+
+    override func tearDown() {
+        storage = []
+
+        super.tearDown()
+    }
+
+    func store(_ toStore: () -> AnyCancellable) {
+        storage.insert(toStore())
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDataRequestCanBePublished() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        var response: DataResponse<HTTPBinResponse, AFError>?
+
+        // When
+        store {
+            AF.request(URLRequest.makeHTTPBinRequest())
+                .responsePublisher(of: HTTPBinResponse.self)
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { response = $0; responseReceived.fulfill() })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isSuccess == true)
+    }
+}
+
+#endif

--- a/Tests/CombineTests.swift
+++ b/Tests/CombineTests.swift
@@ -130,6 +130,27 @@ final class CombineTests: BaseTestCase {
     }
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func testThatDataRequestCanBePublishedUnserialized() {
+        // Given
+        let responseReceived = expectation(description: "response should be received")
+        let completionReceived = expectation(description: "stream should complete")
+        var response: DataResponse<Data?, AFError>?
+
+        // When
+        store {
+            AF.request(URLRequest.makeHTTPBinRequest())
+                .publishUnserialized()
+                .sink(receiveCompletion: { _ in completionReceived.fulfill() },
+                      receiveValue: { response = $0; responseReceived.fulfill() })
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertTrue(response?.result.isSuccess == true)
+    }
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func testThatDataRequestCanBePublishedWithMultipleHandlers() {
         // Given
         let handlerResponseReceived = expectation(description: "handler response should be received")


### PR DESCRIPTION
### Goals :soccer:
This PR adds initial Combine support to Alamofire through the addition of `DataResponsePublisher`, `DownloadResponsePublisher`, and `DataStreamPublisher`.

### Implementation Details :construction:
This PR adds various `Publisher` which lazily add a response handler to the provided request when a demand is made. Extensions are provided to enable the easy creation of publishers using the built in serializers, as well as returning `Result` and generic streams from the publishers.

`DataResponsePublisher` and `DownloadResponsePublisher` are extremely similar. I attempted to make them use the same `Publisher` using more generics, but the type definitions became complex and I couldn't get everything to line up regardless. 

`DataStreamPublisher` is a bit different from the others in that it will publish multiple responses and then a completion event once connected.

### Testing Details :mag:
100 tests have been added for all serialization cases and a variety of Combine use cases.
