### PR TITLE
Changed DisabledEvaluator to DisabledTrustEvaluator

### DIFF
--- a/Documentation/AdvancedUsage.md
+++ b/Documentation/AdvancedUsage.md
@@ -541,7 +541,7 @@ Alamofire includes many different types of trust evaluators, providing composabl
 * `PinnedCertificatesTrustEvaluator`: Uses the provided certificates to validate the server trust. The server trust is considered valid if one of the pinned certificates match one of the server certificates. This evaluator can also accept self-signed certificates.
 * `PublicKeysTrustEvaluator`: Uses the provided public keys to validate the server trust. The server trust is considered valid if one of the pinned public keys match one of the server certificate public keys.
 * `CompositeTrustEvaluator`: Evaluates an array of `ServerTrustEvaluating` values, only succeeding if all of them are successful. This type can be used to combine, for example, the `RevocationTrustEvaluator` and the `PinnedCertificatesTrustEvaluator`.
-* `DisabledEvaluator`: This evaluator should only be used in debug scenarios as it disables all evaluation which in turn will always consider any server trust as valid. This evaluator should **never** be used in production environments!
+* `DisabledTrustEvaluator`: This evaluator should only be used in debug scenarios as it disables all evaluation which in turn will always consider any server trust as valid. This evaluator should **never** be used in production environments!
 
 #### `ServerTrustManager`
 The `ServerTrustManager` is responsible for storing an internal mapping of `ServerTrustEvaluating` values to a particular host. This allows Alamofire to evaluate each host with different evaluators. 

--- a/Documentation/Alamofire 5.0 Migration Guide.md
+++ b/Documentation/Alamofire 5.0 Migration Guide.md
@@ -33,7 +33,7 @@ Most APIs have changed in Alamofire 5, so this list is not complete. While most 
 	- `.performRevokedEvaluation	` is replaced by `RevocationTrustEvaluator`.
 	- `.pinCertificates` is replaced by `PinnedCertificatesTrustEvaluator`.
 	- `.pinPublicKeys` is replaced by `PublicKeysTrustEvaluator`.
-	- `.disableEvalution` is replaced by `DisabledTrustEvalutor`.
+	- `.disableEvaluation` is replaced by `DisabledTrustEvaluator`.
 	- `.customEvaluation` is replaced by either using `CompositeTrustEvalutor` to combine existing `ServerTrustEvaluating` types or by creating a new type that conforms to `ServerTrustEvaluating`.
 - `DataResponse` and `DownloadResponse` are now both doubly generic to both the response type as well as the error type. By default all Alamofire APIs return a `AF` prefixed response type, which defaults the `Error` type to `AFError`.
 - Alamofire now returns `AFError` for all of its APIs, wrapping any underlying system or custom APIs in `AFError` instances.

--- a/Source/ServerTrustEvaluation.swift
+++ b/Source/ServerTrustEvaluation.swift
@@ -335,7 +335,10 @@ public final class CompositeTrustEvaluator: ServerTrustEvaluating {
 /// Disables all evaluation which in turn will always consider any server trust as valid.
 ///
 /// **THIS EVALUATOR SHOULD NEVER BE USED IN PRODUCTION!**
-public final class DisabledEvaluator: ServerTrustEvaluating {
+@available(*, deprecated, message: "DisabledEvaluator will be renamed, please use DisabledTrustEvaluator instead")
+public typealias DisabledEvaluator = DisabledTrustEvaluator
+
+public final class DisabledTrustEvaluator: ServerTrustEvaluating {
     /// Creates an instance.
     public init() {}
 

--- a/Source/ServerTrustEvaluation.swift
+++ b/Source/ServerTrustEvaluation.swift
@@ -335,7 +335,7 @@ public final class CompositeTrustEvaluator: ServerTrustEvaluating {
 /// Disables all evaluation which in turn will always consider any server trust as valid.
 ///
 /// **THIS EVALUATOR SHOULD NEVER BE USED IN PRODUCTION!**
-@available(*, deprecated, message: "DisabledEvaluator will be renamed, please use DisabledTrustEvaluator instead")
+@available(*, deprecated, renamed: "DisabledTrustEvaluator", message: "DisabledEvaluator has been renamed DisabledTrustEvaluator.")
 public typealias DisabledEvaluator = DisabledTrustEvaluator
 
 public final class DisabledTrustEvaluator: ServerTrustEvaluating {

--- a/Source/ServerTrustEvaluation.swift
+++ b/Source/ServerTrustEvaluation.swift
@@ -338,6 +338,9 @@ public final class CompositeTrustEvaluator: ServerTrustEvaluating {
 @available(*, deprecated, renamed: "DisabledTrustEvaluator", message: "DisabledEvaluator has been renamed DisabledTrustEvaluator.")
 public typealias DisabledEvaluator = DisabledTrustEvaluator
 
+/// Disables all evaluation which in turn will always consider any server trust as valid.
+///
+/// **THIS EVALUATOR SHOULD NEVER BE USED IN PRODUCTION!**
 public final class DisabledTrustEvaluator: ServerTrustEvaluating {
     /// Creates an instance.
     public init() {}

--- a/Tests/ServerTrustEvaluatorTests.swift
+++ b/Tests/ServerTrustEvaluatorTests.swift
@@ -1309,7 +1309,7 @@ class ServerTrustPolicyDisableEvaluationTestCase: ServerTrustPolicyTestCase {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafValidDNSNameMissingIntermediate.trust
-        let serverTrustPolicy = DisabledEvaluator()
+        let serverTrustPolicy = DisabledTrustEvaluator()
 
         // When
         let result = Result { try serverTrustPolicy.evaluate(serverTrust, forHost: host) }
@@ -1322,7 +1322,7 @@ class ServerTrustPolicyDisableEvaluationTestCase: ServerTrustPolicyTestCase {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafExpired.trust
-        let serverTrustPolicy = DisabledEvaluator()
+        let serverTrustPolicy = DisabledTrustEvaluator()
 
         // When
         let result = Result { try serverTrustPolicy.evaluate(serverTrust, forHost: host) }

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -534,7 +534,7 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
     func testThatExpiredCertificateRequestSucceedsWhenDisablingEvaluation() {
         // Given
-        let evaluators = [expiredHost: DisabledEvaluator()]
+        let evaluators = [expiredHost: DisabledTrustEvaluator()]
         let manager = Session(configuration: configuration,
                               serverTrustManager: ServerTrustManager(evaluators: evaluators))
 


### PR DESCRIPTION
### Goals :soccer:
Trust evaluators have changed in 5.0 and while migrating it is difficult to discover the evaluator that previously was used as `.disableEvaluation` due to semantic inconsistency and typos in the [migration guide](https://github.com/alamofire/Alamofire/blame/master/Documentation/Alamofire%205.0%20Migration%20Guide.md#L36)

### Implementation Details :construction:
Nothing new, I renamed `DisabledEvaluator` to `DisabledTrustEvaluator` and updated documentation and migration guide accordingly
