### PR TITLE
Fix threading issue: activeRequests could be accessed off of the rootQueue.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: Test macOS (5.2)
     runs-on: macOS-latest
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.4.1.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
       - name: macOS
@@ -32,7 +32,7 @@ jobs:
     name: Test Catalyst 
     runs-on: macOS-latest
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.4.1.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
       - name: Catalyst
@@ -41,10 +41,10 @@ jobs:
     name: Test iOS 
     runs-on: macOS-latest
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.4.1.app/Contents/Developer
     strategy:
       matrix:
-        destination: ["OS=13.4,name=iPhone 11 Pro"] #, "OS=12.4,name=iPhone XS", "OS=11.4,name=iPhone X", "OS=10.3.1,name=iPhone SE"]
+        destination: ["OS=13.4.1,name=iPhone 11 Pro"] #, "OS=12.4,name=iPhone XS", "OS=11.4,name=iPhone X", "OS=10.3.1,name=iPhone SE"]
     steps:
       - uses: actions/checkout@v2
       - name: iOS - ${{ matrix.destination }}
@@ -53,7 +53,7 @@ jobs:
     name: Test tvOS 
     runs-on: macOS-latest
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.4.1.app/Contents/Developer
     strategy:
       matrix:
         destination: ["OS=13.4,name=Apple TV 4K"] #, "OS=11.4,name=Apple TV 4K", "OS=10.2,name=Apple TV 1080p"]
@@ -65,7 +65,7 @@ jobs:
     name: Build watchOS
     runs-on: macOS-latest
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.4.1.app/Contents/Developer
     strategy:
       matrix:
         destination: ["OS=6.2,name=Apple Watch Series 5 - 44mm"] #, "OS=4.2,name=Apple Watch Series 3 - 42mm", "OS=3.2,name=Apple Watch Series 2 - 42mm"]
@@ -77,7 +77,7 @@ jobs:
     name: Test with SPM
     runs-on: macOS-latest    
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.4.1.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
       - name: SPM Test

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1508,7 +1508,7 @@ public class DownloadRequest: Request {
     ///
     /// - Returns: The instance.
     @discardableResult
-    public override func cancel() -> Self {
+    override public func cancel() -> Self {
         cancel(producingResumeData: false)
     }
 
@@ -1725,7 +1725,7 @@ public class UploadRequest: DataRequest {
         return stream
     }
 
-    public override func cleanup() {
+    override public func cleanup() {
         defer { super.cleanup() }
 
         guard

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -963,9 +963,7 @@ open class Session {
 
     // MARK: Perform
 
-    /// Perform `Request`.
-    ///
-    /// - Note: Called during retry.
+    /// Starts performing the provided `Request`.
     ///
     /// - Parameter request: The `Request` to perform.
     func perform(_ request: Request) {

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -969,69 +969,63 @@ open class Session {
     ///
     /// - Parameter request: The `Request` to perform.
     func perform(_ request: Request) {
-        // Leaf types must come first, otherwise they will cast as their superclass.
-        switch request {
-        case let r as UploadRequest: perform(r) // UploadRequest must come before DataRequest due to subtype relationship.
-        case let r as DataRequest: perform(r)
-        case let r as DownloadRequest: perform(r)
-        case let r as DataStreamRequest: perform(r)
-        default: fatalError("Attempted to perform unsupported Request subclass: \(type(of: request))")
-        }
-    }
-
-    func perform(_ request: DataRequest) {
-        requestQueue.async {
+        rootQueue.async {
             guard !request.isCancelled else { return }
 
             self.activeRequests.insert(request)
 
-            self.performSetupOperations(for: request, convertible: request.convertible)
-        }
-    }
-
-    func perform(_ request: DataStreamRequest) {
-        requestQueue.async {
-            guard !request.isCancelled else { return }
-
-            self.activeRequests.insert(request)
-
-            self.performSetupOperations(for: request, convertible: request.convertible)
-        }
-    }
-
-    func perform(_ request: UploadRequest) {
-        requestQueue.async {
-            guard !request.isCancelled else { return }
-
-            self.activeRequests.insert(request)
-
-            do {
-                let uploadable = try request.upload.createUploadable()
-                self.rootQueue.async { request.didCreateUploadable(uploadable) }
-
-                self.performSetupOperations(for: request, convertible: request.convertible)
-            } catch {
-                self.rootQueue.async { request.didFailToCreateUploadable(with: error.asAFError(or: .createUploadableFailed(error: error))) }
+            self.requestQueue.async {
+                // Leaf types must come first, otherwise they will cast as their superclass.
+                switch request {
+                case let r as UploadRequest: self.performUploadRequest(r) // UploadRequest must come before DataRequest due to subtype relationship.
+                case let r as DataRequest: self.performDataRequest(r)
+                case let r as DownloadRequest: self.performDownloadRequest(r)
+                case let r as DataStreamRequest: self.performDataStreamRequest(r)
+                default: fatalError("Attempted to perform unsupported Request subclass: \(type(of: request))")
+                }
             }
         }
     }
 
-    func perform(_ request: DownloadRequest) {
-        requestQueue.async {
-            guard !request.isCancelled else { return }
+    func performDataRequest(_ request: DataRequest) {
+        dispatchPrecondition(condition: .onQueue(requestQueue))
 
-            self.activeRequests.insert(request)
+        performSetupOperations(for: request, convertible: request.convertible)
+    }
 
-            switch request.downloadable {
-            case let .request(convertible):
-                self.performSetupOperations(for: request, convertible: convertible)
-            case let .resumeData(resumeData):
-                self.rootQueue.async { self.didReceiveResumeData(resumeData, for: request) }
-            }
+    func performDataStreamRequest(_ request: DataStreamRequest) {
+        dispatchPrecondition(condition: .onQueue(requestQueue))
+
+        performSetupOperations(for: request, convertible: request.convertible)
+    }
+
+    func performUploadRequest(_ request: UploadRequest) {
+        dispatchPrecondition(condition: .onQueue(requestQueue))
+
+        do {
+            let uploadable = try request.upload.createUploadable()
+            rootQueue.async { request.didCreateUploadable(uploadable) }
+
+            performSetupOperations(for: request, convertible: request.convertible)
+        } catch {
+            rootQueue.async { request.didFailToCreateUploadable(with: error.asAFError(or: .createUploadableFailed(error: error))) }
+        }
+    }
+
+    func performDownloadRequest(_ request: DownloadRequest) {
+        dispatchPrecondition(condition: .onQueue(requestQueue))
+
+        switch request.downloadable {
+        case let .request(convertible):
+            performSetupOperations(for: request, convertible: convertible)
+        case let .resumeData(resumeData):
+            rootQueue.async { self.didReceiveResumeData(resumeData, for: request) }
         }
     }
 
     func performSetupOperations(for request: Request, convertible: URLRequestConvertible) {
+        dispatchPrecondition(condition: .onQueue(requestQueue))
+
         let initialRequest: URLRequest
 
         do {
@@ -1069,6 +1063,8 @@ open class Session {
     // MARK: - Task Handling
 
     func didCreateURLRequest(_ urlRequest: URLRequest, for request: Request) {
+        dispatchPrecondition(condition: .onQueue(rootQueue))
+
         request.didCreateURLRequest(urlRequest)
 
         guard !request.isCancelled else { return }
@@ -1081,6 +1077,8 @@ open class Session {
     }
 
     func didReceiveResumeData(_ data: Data, for request: DownloadRequest) {
+        dispatchPrecondition(condition: .onQueue(rootQueue))
+
         guard !request.isCancelled else { return }
 
         let task = request.task(forResumeData: data, using: session)
@@ -1091,6 +1089,8 @@ open class Session {
     }
 
     func updateStatesForTask(_ task: URLSessionTask, request: Request) {
+        dispatchPrecondition(condition: .onQueue(rootQueue))
+
         request.withState { state in
             switch state {
             case .initialized, .finished:

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -200,7 +200,7 @@ final class RequestResponseTestCase: BaseTestCase {
         XCTAssertEqual(response?.result.isSuccess, true)
     }
 
-    func testThatRequestsWorksWithRequestAndSerializationQueue() {
+    func testThatRequestsWorksWithRequestAndSerializationQueues() {
         // Given
         let requestQueue = DispatchQueue(label: "org.alamofire.testRequestQueue")
         let serializationQueue = DispatchQueue(label: "org.alamofire.testSerializationQueue")
@@ -218,6 +218,31 @@ final class RequestResponseTestCase: BaseTestCase {
 
         // Then
         XCTAssertEqual(response?.result.isSuccess, true)
+    }
+
+    func testThatRequestsWorksWithConcurrentRequestAndSerializationQueues() {
+        // Given
+        let requestQueue = DispatchQueue(label: "org.alamofire.testRequestQueue", attributes: .concurrent)
+        let serializationQueue = DispatchQueue(label: "org.alamofire.testSerializationQueue", attributes: .concurrent)
+        let session = Session(requestQueue: requestQueue, serializationQueue: serializationQueue)
+        let count = 10
+        let expectation = self.expectation(description: "request should complete")
+        expectation.expectedFulfillmentCount = count
+        var responses: [DataResponse<Any, AFError>] = []
+
+        // When
+        DispatchQueue.concurrentPerform(iterations: count) { _ in
+            session.request("https://httpbin.org/get").responseJSON { resp in
+                responses.append(resp)
+                expectation.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertEqual(responses.count, count)
+        XCTAssertTrue(responses.allSatisfy(\.result.isSuccess))
     }
 
     // MARK: Encodable Parameters

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -242,7 +242,7 @@ final class RequestResponseTestCase: BaseTestCase {
 
         // Then
         XCTAssertEqual(responses.count, count)
-        XCTAssertTrue(responses.allSatisfy(\.result.isSuccess))
+        XCTAssertTrue(responses.allSatisfy { $0.result.isSuccess })
     }
 
     // MARK: Encodable Parameters


### PR DESCRIPTION
### Issue Link :link:
Could be related to #3128, #3148, #3174, might not.

### Goals :soccer:
During investigation of the existing crash reports, threading issues were [suggested as a possible cause](https://forums.swift.org/t/spike-in-alamofire-runtime-crashes-in-swift-5-2/36138/2). In stress testing using `DispatchQueue.concurrentPerform` and `.concurrent` `requestQueue` and `serializationQueue`s, a sanitizer issue was found on access to `Session`'s `activeRequests` property:

```
WARNING: ThreadSanitizer: Swift access race (pid=57537)
  Modifying access of Swift variable at 0x7b40000310e8 by thread T12:
    #0 Alamofire.Session.activeRequests.modify : Swift.Set<Alamofire.Request> <compiler-generated> (Alamofire:x86_64+0x1739b6)
    #1 closure #1 () -> () in Alamofire.Session.perform(Alamofire.DataRequest) -> () Session.swift:986 (Alamofire:x86_64+0x181942)
    #2 partial apply forwarder for closure #1 () -> () in Alamofire.Session.perform(Alamofire.DataRequest) -> () <compiler-generated> (Alamofire:x86_64+0x181b05)
    #3 reabstraction thunk helper from @escaping @callee_guaranteed () -> () to @escaping @callee_unowned @convention(block) () -> () <compiler-generated> (Alamofire:x86_64+0x2a523)
    #4 __tsan::invoke_and_release_block(void*) <null>:10721552 (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x6f53b)
    #5 _dispatch_client_callout <null>:10721552 (libdispatch.dylib:x86_64+0x2e8d)

  Previous modifying access of Swift variable at 0x7b40000310e8 by thread T10:
    #0 Alamofire.Session.activeRequests.modify : Swift.Set<Alamofire.Request> <compiler-generated> (Alamofire:x86_64+0x1739b6)
    #1 closure #1 () -> () in Alamofire.Session.perform(Alamofire.DataRequest) -> () Session.swift:986 (Alamofire:x86_64+0x181942)
    #2 partial apply forwarder for closure #1 () -> () in Alamofire.Session.perform(Alamofire.DataRequest) -> () <compiler-generated> (Alamofire:x86_64+0x181b05)
    #3 reabstraction thunk helper from @escaping @callee_guaranteed () -> () to @escaping @callee_unowned @convention(block) () -> () <compiler-generated> (Alamofire:x86_64+0x2a523)
    #4 __tsan::invoke_and_release_block(void*) <null>:10721552 (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x6f53b)
    #5 _dispatch_client_callout <null>:10721552 (libdispatch.dylib:x86_64+0x2e8d)

  Location is heap block of size 248 at 0x7b4000031000 allocated by main thread:
    #0 malloc <null>:10721568 (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x4dbea)
    #1 swift_slowAlloc <null>:10721568 (libswiftCore.dylib:x86_64+0x2f8c58)
    #2 Alamofire.Session.__allocating_init(configuration: __C.NSURLSessionConfiguration, delegate: Alamofire.SessionDelegate, rootQueue: __C.OS_dispatch_queue, startRequestsImmediately: Swift.Bool, requestQueue: __C.OS_dispatch_queue?, serializationQueue: __C.OS_dispatch_queue?, interceptor: Alamofire.RequestInterceptor?, serverTrustManager: Alamofire.ServerTrustManager?, redirectHandler: Alamofire.RedirectHandler?, cachedResponseHandler: Alamofire.CachedResponseHandler?, eventMonitors: [Alamofire.EventMonitor]) -> Alamofire.Session Session.swift:185 (Alamofire:x86_64+0x17288a)
    #3 AlamofireTest.ContentView.testMany() -> () ContentView.swift:28 (AlamofireTest:x86_64+0x10000649d)
    #4 partial apply forwarder for AlamofireTest.ContentView.testMany() -> () <compiler-generated> (AlamofireTest:x86_64+0x1000097f9)
    #5 SwiftUI.PrimitiveButtonStyleConfiguration.trigger() -> () <null>:10721568 (SwiftUI:x86_64+0x79baf)
    #6 start <null>:10721568 (libdyld.dylib:x86_64+0x11fc)

  Thread T12 (tid=1385961, running) is a GCD worker thread

  Thread T10 (tid=1385959, running) is a GCD worker thread

SUMMARY: ThreadSanitizer: Swift access race <compiler-generated> in Alamofire.Session.activeRequests.modify : Swift.Set<Alamofire.Request>
``` 

### Implementation Details :construction:
This PR fixes the access race by ensuring a single path when starting all types of `Request` by refactoring all paths through `perform(_ request: Request)`. The overloaded, type specific versions have been renamed. This ensures that the `activeRequests` property is always accessed on the `rootQueue` while dispatching the request performance onto the `requestQueue`. Additional `dispatchPrecondition`s were added to ensure `Session` methods are called on the right queue.

### Testing Details :mag:
An additional test was added that uses a `Session` with `.concurrent` `requestQueue` and `serializationQueue`s to perform 10 requests using `DispatchQueue.concurrentPerform`. Further stress testing is recommended for the future, but only once we move to a local test server.
