### PR TITLE
Fix memory leak in NetworkReachabilityManager.

### DIFF
--- a/Source/NetworkReachabilityManager.swift
+++ b/Source/NetworkReachabilityManager.swift
@@ -174,7 +174,7 @@ open class NetworkReachabilityManager {
         }
 
         var context = SCNetworkReachabilityContext(version: 0,
-                                                   info: Unmanaged.passRetained(self).toOpaque(),
+                                                   info: Unmanaged.passUnretained(self).toOpaque(),
                                                    retain: nil,
                                                    release: nil,
                                                    copyDescription: nil)

--- a/Tests/NetworkReachabilityManagerTests.swift
+++ b/Tests/NetworkReachabilityManagerTests.swift
@@ -127,28 +127,40 @@ final class NetworkReachabilityManagerTestCase: BaseTestCase {
 
     func testThatHostManagerCanBeDeinitialized() {
         // Given
+        let expect = expectation(description: "reachability queue should clear")
         var manager: NetworkReachabilityManager? = NetworkReachabilityManager(host: "localhost")
+        weak var weakManager = manager
 
         // When
+        manager?.startListening(onUpdatePerforming: { _ in })
+        manager?.stopListening()
+        manager?.reachabilityQueue.async { expect.fulfill() }
         manager = nil
 
+        waitForExpectations(timeout: timeout)
+
         // Then
-        XCTAssertNil(manager)
+        XCTAssertNil(manager, "strong reference should be nil")
+        XCTAssertNil(weakManager, "weak reference should be nil")
     }
 
     func testThatAddressManagerCanBeDeinitialized() {
         // Given
+        let expect = expectation(description: "reachability queue should clear")
         var manager: NetworkReachabilityManager? = NetworkReachabilityManager()
         weak var weakManager = manager
-        
+
         // When
         manager?.startListening(onUpdatePerforming: { _ in })
         manager?.stopListening()
+        manager?.reachabilityQueue.async { expect.fulfill() }
         manager = nil
 
+        waitForExpectations(timeout: timeout)
+
         // Then
-        XCTAssertNil(manager)
-        XCTAssertNil(weakManager)
+        XCTAssertNil(manager, "strong reference should be nil")
+        XCTAssertNil(weakManager, "weak reference should be nil")
     }
 
     // MARK: - Listener

--- a/Tests/NetworkReachabilityManagerTests.swift
+++ b/Tests/NetworkReachabilityManagerTests.swift
@@ -139,12 +139,16 @@ final class NetworkReachabilityManagerTestCase: BaseTestCase {
     func testThatAddressManagerCanBeDeinitialized() {
         // Given
         var manager: NetworkReachabilityManager? = NetworkReachabilityManager()
-
+        weak var weakManager = manager
+        
         // When
+        manager?.startListening(onUpdatePerforming: { _ in
+        })
+        manager?.stopListening()
         manager = nil
-
+        
         // Then
-        XCTAssertNil(manager)
+        XCTAssertNil(weakManager)
     }
 
     // MARK: - Listener

--- a/Tests/NetworkReachabilityManagerTests.swift
+++ b/Tests/NetworkReachabilityManagerTests.swift
@@ -142,12 +142,12 @@ final class NetworkReachabilityManagerTestCase: BaseTestCase {
         weak var weakManager = manager
         
         // When
-        manager?.startListening(onUpdatePerforming: { _ in
-        })
+        manager?.startListening(onUpdatePerforming: { _ in })
         manager?.stopListening()
         manager = nil
-        
+
         // Then
+        XCTAssertNil(manager)
         XCTAssertNil(weakManager)
     }
 


### PR DESCRIPTION
### Goals :soccer:
- Fix a memory leak in `NetworkReachabilityManager`

### Implementation Details :construction:
As [passRetained(_:)](https://developer.apple.com/documentation/swift/unmanaged/1541288-passretained) described, it creates an unmanaged reference with an unbalanced retain.The instance passed as value will leak if nothing eventually balances the retain.
In this case, we don't need to perform a retain, if the `NetworkReachabilityManager` deinit, we will call `stopListening` to set the context of callback nil.

