### PR TITLE
Fix Decimal encoding in URLEncodedFormEncoder

### DIFF
--- a/Source/URLEncodedFormEncoder.swift
+++ b/Source/URLEncodedFormEncoder.swift
@@ -778,6 +778,9 @@ extension _URLEncodedFormEncoder.SingleValueContainer: SingleValueEncodingContai
             }
 
             try encode(value, as: string)
+        case let decimal as Decimal:
+            // Decimal's `Encodable` implementation returns an object, not a single value, so override it.
+            try encode(value, as: String(describing: decimal))
         default:
             try attemptToEncode(value)
         }

--- a/Tests/ParameterEncoderTests.swift
+++ b/Tests/ParameterEncoderTests.swift
@@ -229,6 +229,32 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         XCTAssertEqual(result.success, "a=a")
     }
 
+    func testEncoderCanEncodeDecimal() {
+        // Given
+        let encoder = URLEncodedFormEncoder()
+        let decimal: Decimal = 1.0
+        let parameters = ["a": decimal]
+
+        // When
+        let result = Result<String, Error> { try encoder.encode(parameters) }
+
+        // Then
+        XCTAssertEqual(result.success, "a=1")
+    }
+
+    func testEncoderCanEncodeDecimalWithHighPrecision() {
+        // Given
+        let encoder = URLEncodedFormEncoder()
+        let decimal: Decimal = 1.123456
+        let parameters = ["a": decimal]
+
+        // When
+        let result = Result<String, Error> { try encoder.encode(parameters) }
+
+        // Then
+        XCTAssertEqual(result.success, "a=1.123456")
+    }
+
     func testEncoderCanEncodeDouble() {
         // Given
         let encoder = URLEncodedFormEncoder()


### PR DESCRIPTION
### Issue Link :link:
Fixes #3184

### Goals :soccer:
This PR fixes the encoding of `Decimal` values using `URLEncodedFormEncoder`.

### Implementation Details :construction:
`Decimal`'s native `Encodable` implementation encodes the full description of the value as an object with all the decimal values broken out. `JSONEncoder` cheats by using `JSONSerialization`'s existing special handling to get around this fact. Instead, we just use `String(describing:)` to build the output `String`, rather than letting the value encode itself. This *should* produce a stable value, but better approaches are appreciated.

### Testing Details :mag:
Tests added for `Decimal` encoding.
