### PR TITLE
More Flexible Response Handlers

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -485,22 +485,34 @@ func response<Serializer: DataResponseSerializerProtocol>(queue: DispatchQueue =
 
 // Response Data Handler - Serialized into Data
 func responseData(queue: DispatchQueue = .main,
+                  dataPreprocessor: DataPreprocessor = DataResponseSerializer.defaultDataPreprocessor,
+                  emptyResponseCodes: Set<Int> = DataResponseSerializer.defaultEmptyResponseCodes,
+                  emptyRequestMethods: Set<HTTPMethod> = DataResponseSerializer.defaultEmptyRequestMethods,
                   completionHandler: @escaping (AFDataResponse<Data>) -> Void) -> Self
 
 // Response String Handler - Serialized into String
 func responseString(queue: DispatchQueue = .main,
+                    dataPreprocessor: DataPreprocessor = StringResponseSerializer.defaultDataPreprocessor,
                     encoding: String.Encoding? = nil,
+                    emptyResponseCodes: Set<Int> = StringResponseSerializer.defaultEmptyResponseCodes,
+                    emptyRequestMethods: Set<HTTPMethod> = StringResponseSerializer.defaultEmptyRequestMethods,
                     completionHandler: @escaping (AFDataResponse<String>) -> Void) -> Self
 
 // Response JSON Handler - Serialized into Any Using JSONSerialization
 func responseJSON(queue: DispatchQueue = .main,
+                  dataPreprocessor: DataPreprocessor = JSONResponseSerializer.defaultDataPreprocessor,
+                  emptyResponseCodes: Set<Int> = JSONResponseSerializer.defaultEmptyResponseCodes,
+                  emptyRequestMethods: Set<HTTPMethod> = JSONResponseSerializer.defaultEmptyRequestMethods,
                   options: JSONSerialization.ReadingOptions = .allowFragments,
                   completionHandler: @escaping (AFDataResponse<Any>) -> Void) -> Self
 
 // Response Decodable Handler - Serialized into Decodable Type
 func responseDecodable<T: Decodable>(of type: T.Type = T.self,
                                      queue: DispatchQueue = .main,
+                                     dataPreprocessor: DataPreprocessor = DecodableResponseSerializer<T>.defaultDataPreprocessor,
                                      decoder: DataDecoder = JSONDecoder(),
+                                     emptyResponseCodes: Set<Int> = DecodableResponseSerializer<T>.defaultEmptyResponseCodes,
+                                     emptyRequestMethods: Set<HTTPMethod> = DecodableResponseSerializer<T>.defaultEmptyRequestMethods,
                                      completionHandler: @escaping (AFDataResponse<T>) -> Void) -> Self
 ```
 

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -396,27 +396,9 @@ extension DownloadRequest {
 
 // MARK: - Data
 
-extension DataRequest {
-    /// Adds a handler to be called once the request has finished.
-    ///
-    /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. `.main` by default.
-    ///   - completionHandler: The code to be executed once the request has finished.
-    ///
-    /// - Returns:             The request.
-    @discardableResult
-    public func responseData(queue: DispatchQueue = .main,
-                             completionHandler: @escaping (AFDataResponse<Data>) -> Void)
-        -> Self {
-        response(queue: queue,
-                 responseSerializer: DataResponseSerializer(),
-                 completionHandler: completionHandler)
-    }
-}
-
-/// A `ResponseSerializer` that performs minimal response checking and returns any response data as-is. By default, a
-/// request returning `nil` or no data is considered an error. However, if the response is has a status code valid for
-/// empty responses (`204`, `205`), then an empty `Data` value is returned.
+/// A `ResponseSerializer` that performs minimal response checking and returns any response `Data` as-is. By default, a
+/// request returning `nil` or no data is considered an error. However, if the request has an `HTTPMethod` or the
+/// response has an  HTTP status code valid for empty responses, then an empty `Data` value is returned.
 public final class DataResponseSerializer: ResponseSerializer {
     public let dataPreprocessor: DataPreprocessor
     public let emptyResponseCodes: Set<Int>
@@ -453,20 +435,54 @@ public final class DataResponseSerializer: ResponseSerializer {
     }
 }
 
-extension DownloadRequest {
-    /// Adds a handler to be called once the request has finished.
+extension DataRequest {
+    /// Adds a handler using a `DataResponseSerializer` to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. `.main` by default.
-    ///   - completionHandler: The code to be executed once the request has finished.
+    ///   - queue:               The queue on which the completion handler is called. `.main` by default.
+    ///   - dataPreprocessor:    `DataPreprocessor` which processes the received `Data` before calling the
+    ///                          `completionHandler`. `PassthroughPreprocessor()` by default.
+    ///   - emptyResponseCodes:  HTTP status codes for which empty responses are always valid. `[204, 205]` by default.
+    ///   - emptyRequestMethods: `HTTPMethod`s for which empty responses are always valid. `[.head]` by default.
+    ///   - completionHandler:   A closure to be executed once the request has finished.
     ///
-    /// - Returns:             The request.
+    /// - Returns:               The request.
     @discardableResult
     public func responseData(queue: DispatchQueue = .main,
-                             completionHandler: @escaping (AFDownloadResponse<Data>) -> Void)
-        -> Self {
+                             dataPreprocessor: DataPreprocessor = DataResponseSerializer.defaultDataPreprocessor,
+                             emptyResponseCodes: Set<Int> = DataResponseSerializer.defaultEmptyResponseCodes,
+                             emptyRequestMethods: Set<HTTPMethod> = DataResponseSerializer.defaultEmptyRequestMethods,
+                             completionHandler: @escaping (AFDataResponse<Data>) -> Void) -> Self {
         response(queue: queue,
-                 responseSerializer: DataResponseSerializer(),
+                 responseSerializer: DataResponseSerializer(dataPreprocessor: dataPreprocessor,
+                                                            emptyResponseCodes: emptyResponseCodes,
+                                                            emptyRequestMethods: emptyRequestMethods),
+                 completionHandler: completionHandler)
+    }
+}
+
+extension DownloadRequest {
+    /// Adds a handler using a `DataResponseSerializer` to be called once the request has finished.
+    ///
+    /// - Parameters:
+    ///   - queue:               The queue on which the completion handler is called. `.main` by default.
+    ///   - dataPreprocessor:    `DataPreprocessor` which processes the received `Data` before calling the
+    ///                          `completionHandler`. `PassthroughPreprocessor()` by default.
+    ///   - emptyResponseCodes:  HTTP status codes for which empty responses are always valid. `[204, 205]` by default.
+    ///   - emptyRequestMethods: `HTTPMethod`s for which empty responses are always valid. `[.head]` by default.
+    ///   - completionHandler:   A closure to be executed once the request has finished.
+    ///
+    /// - Returns:               The request.
+    @discardableResult
+    public func responseData(queue: DispatchQueue = .main,
+                             dataPreprocessor: DataPreprocessor = DataResponseSerializer.defaultDataPreprocessor,
+                             emptyResponseCodes: Set<Int> = DataResponseSerializer.defaultEmptyResponseCodes,
+                             emptyRequestMethods: Set<HTTPMethod> = DataResponseSerializer.defaultEmptyRequestMethods,
+                             completionHandler: @escaping (AFDownloadResponse<Data>) -> Void) -> Self {
+        response(queue: queue,
+                 responseSerializer: DataResponseSerializer(dataPreprocessor: dataPreprocessor,
+                                                            emptyResponseCodes: emptyResponseCodes,
+                                                            emptyRequestMethods: emptyRequestMethods),
                  completionHandler: completionHandler)
     }
 }
@@ -474,8 +490,8 @@ extension DownloadRequest {
 // MARK: - String
 
 /// A `ResponseSerializer` that decodes the response data as a `String`. By default, a request returning `nil` or no
-/// data is considered an error. However, if the response is has a status code valid for empty responses (`204`, `205`),
-/// then an empty `String` is returned.
+/// data is considered an error. However, if the request has an `HTTPMethod` or the response has an  HTTP status code
+/// valid for empty responses, then an empty `String` is returned.
 public final class StringResponseSerializer: ResponseSerializer {
     public let dataPreprocessor: DataPreprocessor
     /// Optional string encoding used to validate the response.
@@ -531,42 +547,61 @@ public final class StringResponseSerializer: ResponseSerializer {
 }
 
 extension DataRequest {
-    /// Adds a handler to be called once the request has finished.
+    /// Adds a handler using a `StringResponseSerializer` to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. `.main` by default.
-    ///   - encoding:          The string encoding. Defaults to `nil`, in which case the encoding will be determined from
-    ///                        the server response, falling back to the default HTTP character set, `ISO-8859-1`.
-    ///   - completionHandler: A closure to be executed once the request has finished.
+    ///   - queue:               The queue on which the completion handler is dispatched. `.main` by default.
+    ///   - dataPreprocessor:    `DataPreprocessor` which processes the received `Data` before calling the
+    ///                          `completionHandler`. `PassthroughPreprocessor()` by default.
+    ///   - encoding:            The string encoding. Defaults to `nil`, in which case the encoding will be determined
+    ///                          from the server response, falling back to the default HTTP character set, `ISO-8859-1`.
+    ///   - emptyResponseCodes:  HTTP status codes for which empty responses are always valid. `[204, 205]` by default.
+    ///   - emptyRequestMethods: `HTTPMethod`s for which empty responses are always valid. `[.head]` by default.
+    ///   - completionHandler:   A closure to be executed once the request has finished.
     ///
-    /// - Returns:             The request.
+    /// - Returns:               The request.
     @discardableResult
     public func responseString(queue: DispatchQueue = .main,
+                               dataPreprocessor: DataPreprocessor = StringResponseSerializer.defaultDataPreprocessor,
                                encoding: String.Encoding? = nil,
+                               emptyResponseCodes: Set<Int> = StringResponseSerializer.defaultEmptyResponseCodes,
+                               emptyRequestMethods: Set<HTTPMethod> = StringResponseSerializer.defaultEmptyRequestMethods,
                                completionHandler: @escaping (AFDataResponse<String>) -> Void) -> Self {
         response(queue: queue,
-                 responseSerializer: StringResponseSerializer(encoding: encoding),
+                 responseSerializer: StringResponseSerializer(dataPreprocessor: dataPreprocessor,
+                                                              encoding: encoding,
+                                                              emptyResponseCodes: emptyResponseCodes,
+                                                              emptyRequestMethods: emptyRequestMethods),
                  completionHandler: completionHandler)
     }
 }
 
 extension DownloadRequest {
-    /// Adds a handler to be called once the request has finished.
+    /// Adds a handler using a `StringResponseSerializer` to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. `.main` by default.
-    ///   - encoding:          The string encoding. Defaults to `nil`, in which case the encoding will be determined from
-    ///                        the server response, falling back to the default HTTP character set, `ISO-8859-1`.
-    ///   - completionHandler: A closure to be executed once the request has finished.
+    ///   - queue:               The queue on which the completion handler is dispatched. `.main` by default.
+    ///   - dataPreprocessor:    `DataPreprocessor` which processes the received `Data` before calling the
+    ///                          `completionHandler`. `PassthroughPreprocessor()` by default.
+    ///   - encoding:            The string encoding. Defaults to `nil`, in which case the encoding will be determined
+    ///                          from the server response, falling back to the default HTTP character set, `ISO-8859-1`.
+    ///   - emptyResponseCodes:  HTTP status codes for which empty responses are always valid. `[204, 205]` by default.
+    ///   - emptyRequestMethods: `HTTPMethod`s for which empty responses are always valid. `[.head]` by default.
+    ///   - completionHandler:   A closure to be executed once the request has finished.
     ///
-    /// - Returns:             The request.
+    /// - Returns:               The request.
     @discardableResult
     public func responseString(queue: DispatchQueue = .main,
+                               dataPreprocessor: DataPreprocessor = StringResponseSerializer.defaultDataPreprocessor,
                                encoding: String.Encoding? = nil,
-                               completionHandler: @escaping (AFDownloadResponse<String>) -> Void)
-        -> Self {
+                               emptyResponseCodes: Set<Int> = StringResponseSerializer.defaultEmptyResponseCodes,
+                               emptyRequestMethods: Set<HTTPMethod> = StringResponseSerializer.defaultEmptyRequestMethods,
+                               completionHandler: @escaping (AFDownloadResponse<String>) -> Void) -> Self {
         response(queue: queue,
-                 responseSerializer: StringResponseSerializer(encoding: encoding),
+                 responseSerializer: StringResponseSerializer(dataPreprocessor: dataPreprocessor,
+                                                              encoding: encoding,
+                                                              emptyResponseCodes: emptyResponseCodes,
+                                                              emptyRequestMethods: emptyRequestMethods),
                  completionHandler: completionHandler)
     }
 }
@@ -574,8 +609,8 @@ extension DownloadRequest {
 // MARK: - JSON
 
 /// A `ResponseSerializer` that decodes the response data using `JSONSerialization`. By default, a request returning
-/// `nil` or no data is considered an error. However, if the response is has a status code valid for empty responses
-/// (`204`, `205`), then an `NSNull`  value is returned.
+/// `nil` or no data is considered an error. However, if the request has an `HTTPMethod` or the response has an
+/// HTTP status code valid for empty responses, then an `NSNull` value is returned.
 public final class JSONResponseSerializer: ResponseSerializer {
     public let dataPreprocessor: DataPreprocessor
     public let emptyResponseCodes: Set<Int>
@@ -622,40 +657,65 @@ public final class JSONResponseSerializer: ResponseSerializer {
 }
 
 extension DataRequest {
-    /// Adds a handler to be called once the request has finished.
+    /// Adds a handler using a `JSONResponseSerializer` to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. `.main` by default.
-    ///   - options:           The JSON serialization reading options. `.allowFragments` by default.
-    ///   - completionHandler: A closure to be executed once the request has finished.
+    ///   - queue:               The queue on which the completion handler is dispatched. `.main` by default.
+    ///   - dataPreprocessor:    `DataPreprocessor` which processes the received `Data` before calling the
+    ///                          `completionHandler`. `PassthroughPreprocessor()` by default.
+    ///   - encoding:            The string encoding. Defaults to `nil`, in which case the encoding will be determined
+    ///                          from the server response, falling back to the default HTTP character set, `ISO-8859-1`.
+    ///   - emptyResponseCodes:  HTTP status codes for which empty responses are always valid. `[204, 205]` by default.
+    ///   - emptyRequestMethods: `HTTPMethod`s for which empty responses are always valid. `[.head]` by default.
+    ///   - options:             `JSONSerialization.ReadingOptions` used when parsing the response. `.allowFragments`
+    ///                          by default.
+    ///   - completionHandler:   A closure to be executed once the request has finished.
     ///
-    /// - Returns:             The request.
+    /// - Returns:               The request.
     @discardableResult
     public func responseJSON(queue: DispatchQueue = .main,
+                             dataPreprocessor: DataPreprocessor = JSONResponseSerializer.defaultDataPreprocessor,
+                             emptyResponseCodes: Set<Int> = JSONResponseSerializer.defaultEmptyResponseCodes,
+                             emptyRequestMethods: Set<HTTPMethod> = JSONResponseSerializer.defaultEmptyRequestMethods,
                              options: JSONSerialization.ReadingOptions = .allowFragments,
                              completionHandler: @escaping (AFDataResponse<Any>) -> Void) -> Self {
         response(queue: queue,
-                 responseSerializer: JSONResponseSerializer(options: options),
+                 responseSerializer: JSONResponseSerializer(dataPreprocessor: dataPreprocessor,
+                                                            emptyResponseCodes: emptyResponseCodes,
+                                                            emptyRequestMethods: emptyRequestMethods,
+                                                            options: options),
                  completionHandler: completionHandler)
     }
 }
 
 extension DownloadRequest {
-    /// Adds a handler to be called once the request has finished.
+    /// Adds a handler using a `JSONResponseSerializer` to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - queue:             The queue on which the completion handler is dispatched. `.main` by default.
-    ///   - options:           The JSON serialization reading options. `.allowFragments` by default.
-    ///   - completionHandler: A closure to be executed once the request has finished.
+    ///   - queue:               The queue on which the completion handler is dispatched. `.main` by default.
+    ///   - dataPreprocessor:    `DataPreprocessor` which processes the received `Data` before calling the
+    ///                          `completionHandler`. `PassthroughPreprocessor()` by default.
+    ///   - encoding:            The string encoding. Defaults to `nil`, in which case the encoding will be determined
+    ///                          from the server response, falling back to the default HTTP character set, `ISO-8859-1`.
+    ///   - emptyResponseCodes:  HTTP status codes for which empty responses are always valid. `[204, 205]` by default.
+    ///   - emptyRequestMethods: `HTTPMethod`s for which empty responses are always valid. `[.head]` by default.
+    ///   - options:             `JSONSerialization.ReadingOptions` used when parsing the response. `.allowFragments`
+    ///                          by default.
+    ///   - completionHandler:   A closure to be executed once the request has finished.
     ///
-    /// - Returns:             The request.
+    /// - Returns:               The request.
     @discardableResult
     public func responseJSON(queue: DispatchQueue = .main,
+                             dataPreprocessor: DataPreprocessor = JSONResponseSerializer.defaultDataPreprocessor,
+                             emptyResponseCodes: Set<Int> = JSONResponseSerializer.defaultEmptyResponseCodes,
+                             emptyRequestMethods: Set<HTTPMethod> = JSONResponseSerializer.defaultEmptyRequestMethods,
                              options: JSONSerialization.ReadingOptions = .allowFragments,
-                             completionHandler: @escaping (AFDownloadResponse<Any>) -> Void)
-        -> Self {
+                             completionHandler: @escaping (AFDownloadResponse<Any>) -> Void) -> Self {
         response(queue: queue,
-                 responseSerializer: JSONResponseSerializer(options: options),
+                 responseSerializer: JSONResponseSerializer(dataPreprocessor: dataPreprocessor,
+                                                            emptyResponseCodes: emptyResponseCodes,
+                                                            emptyRequestMethods: emptyRequestMethods,
+                                                            options: options),
                  completionHandler: completionHandler)
     }
 }
@@ -699,13 +759,17 @@ public protocol DataDecoder {
 
 /// `JSONDecoder` automatically conforms to `DataDecoder`.
 extension JSONDecoder: DataDecoder {}
+/// `PropertyListDecoder` automatically conforms to `DataDecoder`.
+extension PropertyListDecoder: DataDecoder {}
 
 // MARK: - Decodable
 
 /// A `ResponseSerializer` that decodes the response data as a generic value using any type that conforms to
 /// `DataDecoder`. By default, this is an instance of `JSONDecoder`. Additionally, a request returning `nil` or no data
-/// is considered an error. However, if the response is has a status code valid for empty responses (`204`, `205`), then
-/// the `Empty.value` value is returned.
+/// is considered an error. However, if the request has an `HTTPMethod` or the response has an HTTP status code valid
+/// for empty responses then an empty value will be returned. If the decoded type conforms to `EmptyResponse`, the
+/// type's `emptyValue()` will be returned. If the decoded type is `Empty`, the `.value` instance is returned. If the
+/// decoded type *does not* conform to `EmptyResponse` and isn't `Empty`, an error will be produced.
 public final class DecodableResponseSerializer<T: Decodable>: ResponseSerializer {
     public let dataPreprocessor: DataPreprocessor
     /// The `DataDecoder` instance used to decode responses.
@@ -756,43 +820,71 @@ public final class DecodableResponseSerializer<T: Decodable>: ResponseSerializer
 }
 
 extension DataRequest {
-    /// Adds a handler to be called once the request has finished.
+    /// Adds a handler using a `DecodableResponseSerializer` to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - type:              `Decodable` type to decode from response data.
-    ///   - queue:             The queue on which the completion handler is dispatched. `.main` by default.
-    ///   - decoder:           `DataDecoder` to use to decode the response. `JSONDecoder()` by default.
-    ///   - completionHandler: A closure to be executed once the request has finished.
+    ///   - type:                `Decodable` type to decode from response data.
+    ///   - queue:               The queue on which the completion handler is dispatched. `.main` by default.
+    ///   - dataPreprocessor:    `DataPreprocessor` which processes the received `Data` before calling the
+    ///                          `completionHandler`. `PassthroughPreprocessor()` by default.
+    ///   - decoder:             `DataDecoder` to use to decode the response. `JSONDecoder()` by default.
+    ///   - encoding:            The string encoding. Defaults to `nil`, in which case the encoding will be determined
+    ///                          from the server response, falling back to the default HTTP character set, `ISO-8859-1`.
+    ///   - emptyResponseCodes:  HTTP status codes for which empty responses are always valid. `[204, 205]` by default.
+    ///   - emptyRequestMethods: `HTTPMethod`s for which empty responses are always valid. `[.head]` by default.
+    ///   - options:             `JSONSerialization.ReadingOptions` used when parsing the response. `.allowFragments`
+    ///                          by default.
+    ///   - completionHandler:   A closure to be executed once the request has finished.
     ///
-    /// - Returns:             The request.
+    /// - Returns:               The request.
     @discardableResult
     public func responseDecodable<T: Decodable>(of type: T.Type = T.self,
                                                 queue: DispatchQueue = .main,
+                                                dataPreprocessor: DataPreprocessor = DecodableResponseSerializer<T>.defaultDataPreprocessor,
                                                 decoder: DataDecoder = JSONDecoder(),
+                                                emptyResponseCodes: Set<Int> = DecodableResponseSerializer<T>.defaultEmptyResponseCodes,
+                                                emptyRequestMethods: Set<HTTPMethod> = DecodableResponseSerializer<T>.defaultEmptyRequestMethods,
                                                 completionHandler: @escaping (AFDataResponse<T>) -> Void) -> Self {
         response(queue: queue,
-                 responseSerializer: DecodableResponseSerializer(decoder: decoder),
+                 responseSerializer: DecodableResponseSerializer(dataPreprocessor: dataPreprocessor,
+                                                                 decoder: decoder,
+                                                                 emptyResponseCodes: emptyResponseCodes,
+                                                                 emptyRequestMethods: emptyRequestMethods),
                  completionHandler: completionHandler)
     }
 }
 
 extension DownloadRequest {
-    /// Adds a handler to be called once the request has finished.
+    /// Adds a handler using a `DecodableResponseSerializer` to be called once the request has finished.
     ///
     /// - Parameters:
-    ///   - type:              `Decodable` type to decode from response data.
-    ///   - queue:             The queue on which the completion handler is dispatched. `.main` by default.
-    ///   - decoder:           `DataDecoder` to use to decode the response. `JSONDecoder()` by default.
-    ///   - completionHandler: A closure to be executed once the request has finished.
+    ///   - type:                `Decodable` type to decode from response data.
+    ///   - queue:               The queue on which the completion handler is dispatched. `.main` by default.
+    ///   - dataPreprocessor:    `DataPreprocessor` which processes the received `Data` before calling the
+    ///                          `completionHandler`. `PassthroughPreprocessor()` by default.
+    ///   - decoder:             `DataDecoder` to use to decode the response. `JSONDecoder()` by default.
+    ///   - encoding:            The string encoding. Defaults to `nil`, in which case the encoding will be determined
+    ///                          from the server response, falling back to the default HTTP character set, `ISO-8859-1`.
+    ///   - emptyResponseCodes:  HTTP status codes for which empty responses are always valid. `[204, 205]` by default.
+    ///   - emptyRequestMethods: `HTTPMethod`s for which empty responses are always valid. `[.head]` by default.
+    ///   - options:             `JSONSerialization.ReadingOptions` used when parsing the response. `.allowFragments`
+    ///                          by default.
+    ///   - completionHandler:   A closure to be executed once the request has finished.
     ///
-    /// - Returns:             The request.
+    /// - Returns:               The request.
     @discardableResult
     public func responseDecodable<T: Decodable>(of type: T.Type = T.self,
                                                 queue: DispatchQueue = .main,
+                                                dataPreprocessor: DataPreprocessor = DecodableResponseSerializer<T>.defaultDataPreprocessor,
                                                 decoder: DataDecoder = JSONDecoder(),
+                                                emptyResponseCodes: Set<Int> = DecodableResponseSerializer<T>.defaultEmptyResponseCodes,
+                                                emptyRequestMethods: Set<HTTPMethod> = DecodableResponseSerializer<T>.defaultEmptyRequestMethods,
                                                 completionHandler: @escaping (AFDownloadResponse<T>) -> Void) -> Self {
         response(queue: queue,
-                 responseSerializer: DecodableResponseSerializer(decoder: decoder),
+                 responseSerializer: DecodableResponseSerializer(dataPreprocessor: dataPreprocessor,
+                                                                 decoder: decoder,
+                                                                 emptyResponseCodes: emptyResponseCodes,
+                                                                 emptyRequestMethods: emptyRequestMethods),
                  completionHandler: completionHandler)
     }
 }
@@ -839,7 +931,7 @@ public struct DecodableStreamSerializer<T: Decodable>: DataStreamSerializer {
 }
 
 extension DataStreamRequest {
-    /// Adds a stream handler which performs no parsing on incoming `Data`.
+    /// Adds a `StreamHandler` which performs no parsing on incoming `Data`.
     ///
     /// - Parameters:
     ///   - queue:  `DispatchQueue` on which to perform `StreamHandler` closure.


### PR DESCRIPTION
### Goals :soccer:
This PR adds support for passing additional parameters to response handlers to customize the underlying serializer. This allows full customization of the serializer without having to create a separate instance and using a different response handler. This is a fairly common need, especially for empty response code or method handling.

### Implementation Details :construction:
This PR just adds additional defaulted parameters to the response handler methods, and updates the inline docs.

### Testing Details :mag:
No tests were added, as I couldn't see a good way to add useful tests. If tests are required, waiting until after the testing update when we have more flexibility for custom test cases.
