### PR TITLE
Removes customization of URLError localized error messages

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "self:">
-   </FileRef>
-</Workspace>

--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -673,7 +673,7 @@ extension AFError: LocalizedError {
         case let .downloadedFileMoveFailed(error, source, destination):
             return "Moving downloaded file from: \(source) to: \(destination) failed with error: \(error.localizedDescription)"
         case let .sessionTaskFailed(error):
-            return "URLSessionTask failed with error: \(error.localizedDescription)"
+            return error.localizedDescription
         }
     }
 }


### PR DESCRIPTION
### Issue Link :link:

Fixes #3194

### Goals :soccer:

Remove localized error message overriding by Alamofire when a URLSessionTask error occurs

### Implementation Details :construction:

Opts to remove the custom value from `localizedString` and relay the underlying localized error message instead.
