### PR TITLE
Use .utility QoS instead of .background

### DIFF
--- a/Source/EventMonitor.swift
+++ b/Source/EventMonitor.swift
@@ -310,7 +310,7 @@ extension EventMonitor {
 
 /// An `EventMonitor` which can contain multiple `EventMonitor`s and calls their methods on their queues.
 public final class CompositeEventMonitor: EventMonitor {
-    public let queue = DispatchQueue(label: "org.alamofire.compositeEventMonitor", qos: .background)
+    public let queue = DispatchQueue(label: "org.alamofire.compositeEventMonitor", qos: .utility)
 
     let monitors: [EventMonitor]
 

--- a/Tests/NSLoggingEventMonitor.swift
+++ b/Tests/NSLoggingEventMonitor.swift
@@ -26,7 +26,7 @@ import Alamofire
 import Foundation
 
 public final class NSLoggingEventMonitor: EventMonitor {
-    public let queue = DispatchQueue(label: "org.alamofire.nsLoggingEventMonitorQueue", qos: .background)
+    public let queue = DispatchQueue(label: "org.alamofire.nsLoggingEventMonitorQueue", qos: .utility)
 
     public init() {}
 


### PR DESCRIPTION
### Issue Link :link:
[AFNetworking #4223](https://github.com/AFNetworking/AFNetworking/issues/4223) and attendant [tweet](https://twitter.com/gregheo/status/1001501337907970048) indicate that `.background` queues may stop execution altogether in low power mode, so utility mode is recommended.

### Goals :soccer:
This PR updates our uses of `.background` QoS to `.utility`.

### Implementation Details :construction:
`.background` -> `.utility`.

### Testing Details :mag:
None, there's no way to test this behavior.
