### PR TITLE
Encode array of objects correctly

### DIFF
--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -94,6 +94,15 @@ public struct URLEncoding: ParameterEncoding {
                 return key
             }
         }
+        
+        func encode(key: String, index: Int) -> String {
+            switch self {
+            case .brackets:
+                return "\(key)[\(index)]"
+            case .noBrackets:
+                return key
+            }
+        }
     }
 
     /// Configures how `Bool` parameters are encoded.
@@ -193,8 +202,8 @@ public struct URLEncoding: ParameterEncoding {
                 components += queryComponents(fromKey: "\(key)[\(nestedKey)]", value: value)
             }
         } else if let array = value as? [Any] {
-            for value in array {
-                components += queryComponents(fromKey: arrayEncoding.encode(key: key), value: value)
+            for (index, value) in array.enumerated() {
+                components += queryComponents(fromKey: arrayEncoding.encode(key: key, index: index), value: value)
             }
         } else if let value = value as? NSNumber {
             if value.isBool {


### PR DESCRIPTION
### Goals :soccer:
From an array of objects:
```
"test": [{
   "key1": "val1",
   "key2": "val2"
},{
   "key3": "val3",
   "key4": "val4"
}]
```

It will be transformed to
```
test[0][key1]=val1
&test[0][key2]=val2
&test[1][key3]=val3
&test[1][key4]=val4
```

