### PR TITLE
Use switch to replace if else expression

### DIFF
--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -187,27 +187,26 @@ public struct URLEncoding: ParameterEncoding {
     /// - Returns: The percent-escaped, URL encoded query string components.
     public func queryComponents(fromKey key: String, value: Any) -> [(String, String)] {
         var components: [(String, String)] = []
-
-        if let dictionary = value as? [String: Any] {
+        switch value {
+        case let dictionary as [String: Any]:
             for (nestedKey, value) in dictionary {
                 components += queryComponents(fromKey: "\(key)[\(nestedKey)]", value: value)
             }
-        } else if let array = value as? [Any] {
+        case let array as [Any]:
             for value in array {
                 components += queryComponents(fromKey: arrayEncoding.encode(key: key), value: value)
             }
-        } else if let value = value as? NSNumber {
-            if value.isBool {
-                components.append((escape(key), escape(boolEncoding.encode(value: value.boolValue))))
+        case let number as NSNumber:
+            if number.isBool {
+                components.append((escape(key), escape(boolEncoding.encode(value: number.boolValue))))
             } else {
-                components.append((escape(key), escape("\(value)")))
+                components.append((escape(key), escape("\(number)")))
             }
-        } else if let bool = value as? Bool {
+        case let bool as Bool:
             components.append((escape(key), escape(boolEncoding.encode(value: bool))))
-        } else {
+        default:
             components.append((escape(key), escape("\(value)")))
         }
-
         return components
     }
 


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
Makes `queryComponents(fromKey:value:)` more readable.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
Use switch to replace if else expression, we can use switch to attempt casting into different types.

### Testing Details :mag:
No new tests.
