### PR TITLE
Support a Catalyst User-Agent

### DIFF
--- a/Source/HTTPHeaders.swift
+++ b/Source/HTTPHeaders.swift
@@ -380,7 +380,11 @@ extension HTTPHeader {
             let versionString = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
             let osName: String = {
                 #if os(iOS)
+                #if targetEnvironment(macCatalyst)
+                return "macOS(Catalyst)"
+                #else
                 return "iOS"
+                #endif
                 #elseif os(watchOS)
                 return "watchOS"
                 #elseif os(tvOS)

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -275,7 +275,11 @@ final class SessionTestCase: BaseTestCase {
 
             let osName: String = {
                 #if os(iOS)
+                #if targetEnvironment(macCatalyst)
+                return "macOS(Catalyst)"
+                #else
                 return "iOS"
+                #endif
                 #elseif os(watchOS)
                 return "watchOS"
                 #elseif os(tvOS)


### PR DESCRIPTION
### Issue Link :link:
Fixes #3233

### Goals :soccer:
This PR updates our `User-Agent` logic to account for Catalyst and uses "macOS(Catalyst)" for the OS name in that case.

### Implementation Details :construction:
Checking `#targetEnvironment(macCatalyst)` allows us to see when we're compiling for Catalyst.

### Testing Details :mag:
Tests have been updated for this change.
