### PR TITLE
fix:(ParameterEncoding.swift)reques URLEncoding bug

### DIFF
--- a/Source/ParameterEncoder.swift
+++ b/Source/ParameterEncoder.swift
@@ -162,7 +162,7 @@ open class URLEncodedFormParameterEncoder: ParameterEncoder {
             var components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
             let query: String = try Result<String, Error> { try encoder.encode(parameters) }
                 .mapError { AFError.parameterEncoderFailed(reason: .encoderFailed(error: $0)) }.get()
-            let newQueryString = [components.percentEncodedQuery, query].compactMap { $0 }.joinedWithAmpersands()
+            let newQueryString = (components.percentEncodedQuery.map { $0.isEmpty ? $0 : $0 + "&" } ?? "") + query
             components.percentEncodedQuery = newQueryString.isEmpty ? nil : newQueryString
 
             guard let newURL = components.url else {

--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -163,7 +163,7 @@ public struct URLEncoding: ParameterEncoding {
             }
 
             if var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false), !parameters.isEmpty {
-                let percentEncodedQuery = (urlComponents.percentEncodedQuery.map { $0 + "&" } ?? "") + query(parameters)
+                let percentEncodedQuery = (urlComponents.percentEncodedQuery.map { $0.isEmpty ? $0 : $0 + "&" } ?? "") + query(parameters)
                 urlComponents.percentEncodedQuery = percentEncodedQuery
                 urlRequest.url = urlComponents.url
             }

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -786,6 +786,52 @@ class RequestDescriptionTestCase: BaseTestCase {
         // Then
         XCTAssertEqual(request.description, "GET https://httpbin.org/get (\(response?.statusCode ?? -1))")
     }
+    func testRequestParametersDescruotion()  {
+        // Given
+        let urlString = "https://httpbin.org/get?"
+        let parameters = ["key": "value"]
+        
+        let manager = Session(startRequestsImmediately: false)
+        let request = manager.request(urlString, parameters: parameters)
+        
+        let expectation = self.expectation(description: "Request description should update: \(urlString)")
+        
+        var response: HTTPURLResponse?
+        
+        // When
+        request.response { resp in
+            response = resp.response
+            
+            expectation.fulfill()
+        }.resume()
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        // Then
+        XCTAssertEqual(request.description, "GET https://httpbin.org/get?key=value (\(response?.statusCode ?? -1))")
+    }
+    func testDefaultRequestParametersDescruotion()  {
+        // Given
+        let urlString = "https://httpbin.org/get?"
+        let parameters = ["key": "value"]
+        
+        
+        let request = AF.request(urlString, parameters: parameters)
+        
+        let expectation = self.expectation(description: "Request description should update: \(urlString)")
+        
+        var response: HTTPURLResponse?
+        
+        // When
+        request.response { resp in
+            response = resp.response
+            
+            expectation.fulfill()
+        }.resume()
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        // Then
+        XCTAssertEqual(request.description, "GET https://httpbin.org/get?key=value (\(response?.statusCode ?? -1))")
+    }
 }
 
 // MARK: -


### PR DESCRIPTION
  AF.request("https://httpbin.org/get?" parameters:["key":"value"]) 
expect "https://httpbin.org/get?key=value" 
result "https://httpbin.org/get?&key=value"

### Implementation Details :construction:
let percentEncodedQuery = (urlComponents.percentEncodedQuery.map { $0.isEmpty ? $0 : $0 + "&" } ?? "") + query(parameters)

