### PR TITLE
fix: reques URLEncoding bug and add test case

### DIFF
--- a/Source/ParameterEncoder.swift
+++ b/Source/ParameterEncoder.swift
@@ -162,7 +162,7 @@ open class URLEncodedFormParameterEncoder: ParameterEncoder {
             var components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
             let query: String = try Result<String, Error> { try encoder.encode(parameters) }
                 .mapError { AFError.parameterEncoderFailed(reason: .encoderFailed(error: $0)) }.get()
-            let newQueryString = [components.percentEncodedQuery, query].compactMap { $0 }.joinedWithAmpersands()
+            let newQueryString = (components.percentEncodedQuery.map { $0.isEmpty ? $0 : $0 + "&" } ?? "") + query
             components.percentEncodedQuery = newQueryString.isEmpty ? nil : newQueryString
 
             guard let newURL = components.url else {

--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -163,7 +163,7 @@ public struct URLEncoding: ParameterEncoding {
             }
 
             if var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false), !parameters.isEmpty {
-                let percentEncodedQuery = (urlComponents.percentEncodedQuery.map { $0 + "&" } ?? "") + query(parameters)
+                let percentEncodedQuery = (urlComponents.percentEncodedQuery.map { $0.isEmpty ? $0 : $0 + "&" } ?? "") + query(parameters)
                 urlComponents.percentEncodedQuery = percentEncodedQuery
                 urlRequest.url = urlComponents.url
             }

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -1122,3 +1122,54 @@ final class RequestCURLDescriptionTestCase: BaseTestCase {
             .filter { $0 != "" && $0 != "\\" }
     }
 }
+
+final class RequestURLTestCase: BaseTestCase {
+    
+    func testRequestParametersURL()  {
+        // Given
+        let urlString = "https://httpbin.org/get?"
+        let parameters = ["key": "value"]
+        
+        let manager = Session(startRequestsImmediately: false)
+        let request = manager.request(urlString, parameters: parameters, encoder:URLEncodedFormParameterEncoder.default)
+        
+        let expectation = self.expectation(description: "Request URL should splice done")
+        
+        var response: HTTPURLResponse?
+        
+        // When
+        request.response { resp in
+            response = resp.response
+            
+            expectation.fulfill()
+        }.resume()
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        // Then
+        XCTAssertEqual(request.request?.url?.absoluteString, "https://httpbin.org/get?key=value")
+        XCTAssertEqual(response?.url?.absoluteString, "https://httpbin.org/get?key=value")
+    }
+    func testDefaultRequestParametersURL()  {
+        // Given
+        let urlString = "https://httpbin.org/get?"
+        let parameters = ["key": "value"]
+        
+        let request = AF.request(urlString, parameters: parameters, encoding: URLEncoding.default)
+        
+        let expectation = self.expectation(description: "Request URL should splice done")
+        
+        var response: HTTPURLResponse?
+        
+        // When
+        request.response { resp in
+            response = resp.response
+            
+            expectation.fulfill()
+        }.resume()
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        // Then
+        XCTAssertEqual(request.request?.url?.absoluteString, "https://httpbin.org/get?key=value")
+        XCTAssertEqual(response?.url?.absoluteString, "https://httpbin.org/get?key=value")
+    }
+}


### PR DESCRIPTION

### Implementation Details :construction:
let newQueryString = (components.percentEncodedQuery.map { $0.isEmpty ? $0 : $0 + "&" } ?? "") + query
let percentEncodedQuery = (urlComponents.percentEncodedQuery.map { $0.isEmpty ? $0 : $0 + "&" } ?? "") + query(parameters)

### Testing Details :mag:
add RequestURLTestCase
