### PR TITLE
Temporarily disable redirect tests due to HTTPBin issue

### DIFF
--- a/Source/RetryPolicy.swift
+++ b/Source/RetryPolicy.swift
@@ -325,7 +325,7 @@ open class RetryPolicy: RequestInterceptor {
     /// - Returns:     `Bool` determining whether or not to retry the `Request`.
     open func shouldRetry(request: Request, dueTo error: Error) -> Bool {
         guard let httpMethod = request.request?.method, retryableHTTPMethods.contains(httpMethod) else { return false }
-        
+
         if let statusCode = request.response?.statusCode, retryableHTTPStatusCodes.contains(statusCode) {
             return true
         } else {

--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -157,7 +157,7 @@ extension DataRequest {
     /// - Returns:              The instance.
     @discardableResult
     public func validate<S: Sequence>(statusCode acceptableStatusCodes: S) -> Self where S.Iterator.Element == Int {
-        return validate { [unowned self] _, response, _ in
+        validate { [unowned self] _, response, _ in
             self.validate(statusCode: acceptableStatusCodes, response: response)
         }
     }
@@ -171,7 +171,7 @@ extension DataRequest {
     /// - returns: The request.
     @discardableResult
     public func validate<S: Sequence>(contentType acceptableContentTypes: @escaping @autoclosure () -> S) -> Self where S.Iterator.Element == String {
-        return validate { [unowned self] _, response, data in
+        validate { [unowned self] _, response, data in
             self.validate(contentType: acceptableContentTypes(), response: response, data: data)
         }
     }
@@ -205,7 +205,7 @@ extension DataStreamRequest {
     /// - Returns:              The instance.
     @discardableResult
     public func validate<S: Sequence>(statusCode acceptableStatusCodes: S) -> Self where S.Iterator.Element == Int {
-        return validate { [unowned self] _, response in
+        validate { [unowned self] _, response in
             self.validate(statusCode: acceptableStatusCodes, response: response)
         }
     }
@@ -219,7 +219,7 @@ extension DataStreamRequest {
     /// - returns: The request.
     @discardableResult
     public func validate<S: Sequence>(contentType acceptableContentTypes: @escaping @autoclosure () -> S) -> Self where S.Iterator.Element == String {
-        return validate { [unowned self] _, response in
+        validate { [unowned self] _, response in
             self.validate(contentType: acceptableContentTypes(), response: response)
         }
     }
@@ -258,7 +258,7 @@ extension DownloadRequest {
     /// - Returns:              The instance.
     @discardableResult
     public func validate<S: Sequence>(statusCode acceptableStatusCodes: S) -> Self where S.Iterator.Element == Int {
-        return validate { [unowned self] _, response, _ in
+        validate { [unowned self] _, response, _ in
             self.validate(statusCode: acceptableStatusCodes, response: response)
         }
     }
@@ -272,7 +272,7 @@ extension DownloadRequest {
     /// - returns: The request.
     @discardableResult
     public func validate<S: Sequence>(contentType acceptableContentTypes: @escaping @autoclosure () -> S) -> Self where S.Iterator.Element == String {
-        return validate { [unowned self] _, response, fileURL in
+        validate { [unowned self] _, response, fileURL in
             guard let validFileURL = fileURL else {
                 return .failure(AFError.responseValidationFailed(reason: .dataFileNil))
             }

--- a/Tests/SessionDelegateTests.swift
+++ b/Tests/SessionDelegateTests.swift
@@ -38,7 +38,8 @@ class SessionDelegateTestCase: BaseTestCase {
 
     // MARK: - Tests - Redirects
 
-    func testThatRequestWillPerformHTTPRedirectionByDefault() {
+    // Disabled due to HTTPBin issue: https://github.com/postmanlabs/httpbin/issues/617
+    func _testThatRequestWillPerformHTTPRedirectionByDefault() {
         // Given
         let redirectURLString = "https://www.apple.com/"
         let urlString = "https://httpbin.org/redirect-to?url=\(redirectURLString)"
@@ -66,7 +67,8 @@ class SessionDelegateTestCase: BaseTestCase {
         XCTAssertEqual(response?.response?.statusCode, 200)
     }
 
-    func testThatRequestWillPerformRedirectionMultipleTimesByDefault() {
+    // Disabled due to HTTPBin issue: https://github.com/postmanlabs/httpbin/issues/617
+    func _testThatRequestWillPerformRedirectionMultipleTimesByDefault() {
         // Given
         let redirectURLString = "https://httpbin.org/get"
         let urlString = "https://httpbin.org/redirect/5"


### PR DESCRIPTION
### Issue Link :link:
https://github.com/postmanlabs/httpbin/issues/617

### Goals :soccer:
This PR disables our redirect tests while HTTPBin is returning a 404. This will also be fixed once we move to Firewalk for testing.

### Implementation Details :construction:
Commented out all of the `RedirectHandler` tests, underbarred the general `Session` tests.

### Testing Details :mag:
Tests should now pass.
