### PR TITLE
Workaround for Xcode 12 beta 1

### DIFF
--- a/Source/HTTPHeaders.swift
+++ b/Source/HTTPHeaders.swift
@@ -368,8 +368,9 @@ extension HTTPHeader {
     /// Example: `iOS Example/1.0 (org.alamofire.iOS-Example; build:1; iOS 13.0.0) Alamofire/5.0.0`
     public static let defaultUserAgent: HTTPHeader = {
         let info = Bundle.main.infoDictionary
+        let firstArgument = ProcessInfo.processInfo.arguments.first?.split(separator: "/").last as String.SubSequence?
         let executable = (info?[kCFBundleExecutableKey as String] as? String) ??
-            (ProcessInfo.processInfo.arguments.first?.split(separator: "/").last.map(String.init)) ??
+            (firstArgument.map(String.init)) ??
             "Unknown"
         let bundle = info?[kCFBundleIdentifierKey as String] as? String ?? "Unknown"
         let appVersion = info?["CFBundleShortVersionString"] as? String ?? "Unknown"


### PR DESCRIPTION
### Issue Link :link:
workaround for https://github.com/Alamofire/Alamofire/issues/3240

### Goals :soccer:
It can be archived by Xcode 12 beta 1

### Implementation Details :construction:
Type inference of String may be broken in Xcode 12 beta 1.
https://developer.apple.com/forums/thread/649918
So I added an explicit type to it.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
Cartfile
```
github "tattn/Alamofire" "hotfix-xcode12"
```
