### PR TITLE
A Better debugDescription

### DIFF
--- a/Source/HTTPHeaders.swift
+++ b/Source/HTTPHeaders.swift
@@ -93,16 +93,19 @@ public struct HTTPHeaders {
         headers.remove(at: index)
     }
 
-    /// Sort the current instance by header name.
+    /// Sort the current instance by header name, case insensitively.
     public mutating func sort() {
-        headers.sort { $0.name < $1.name }
+        headers.sort { $0.name.lowercased() < $1.name.lowercased() }
     }
 
     /// Returns an instance sorted by header name.
     ///
     /// - Returns: A copy of the current instance sorted by name.
     public func sorted() -> HTTPHeaders {
-        HTTPHeaders(headers.sorted { $0.name < $1.name })
+        var headers = self
+        headers.sort()
+
+        return headers
     }
 
     /// Case-insensitively find a header's value by name.

--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -91,31 +91,30 @@ extension DataResponse: CustomStringConvertible, CustomDebugStringConvertible {
         "\(result)"
     }
 
-    /// The debug textual representation used when written to an output stream, which includes the URL request, the URL
-    /// response, the server data, the duration of the network and serialization actions, and the response serialization
-    /// result.
+    /// The debug textual representation used when written to an output stream, which includes (if available) a summary
+    /// of the `URLRequest`, the request's headers and body (if decodable as a `String` below 100KB); the
+    /// `HTTPURLResponse`'s status code, headers, and body; the duration of the network and serialization actions; and
+    /// the `Result` of serialization.
     public var debugDescription: String {
-        let requestDescription = request.map { "\($0.httpMethod!) \($0)" } ?? "nil"
-        let requestBody = request?.httpBody.map { String(decoding: $0, as: UTF8.self) } ?? "None"
+        guard let urlRequest = request else { return "[Request]: None\n[Result]: \(result)" }
+
+        let requestDescription = DebugDescription.description(of: urlRequest)
+
         let responseDescription = response.map { response in
-            let sortedHeaders = response.headers.sorted()
+            let responseBodyDescription = DebugDescription.description(for: data, headers: response.headers)
 
             return """
-            [Status Code]: \(response.statusCode)
-            [Headers]:
-            \(sortedHeaders)
+            \(DebugDescription.description(of: response))
+                \(responseBodyDescription.indentingNewlines())
             """
-        } ?? "nil"
-        let responseBody = data.map { String(decoding: $0, as: UTF8.self) } ?? "None"
-        let metricsDescription = metrics.map { "\($0.taskInterval.duration)s" } ?? "None"
+        } ?? "[Response]: None"
+
+        let networkDuration = metrics.map { "\($0.taskInterval.duration)s" } ?? "None"
 
         return """
-        [Request]: \(requestDescription)
-        [Request Body]: \n\(requestBody)
-        [Response]: \n\(responseDescription)
-        [Response Body]: \n\(responseBody)
-        [Data]: \(data?.description ?? "None")
-        [Network Duration]: \(metricsDescription)
+        \(requestDescription)
+        \(responseDescription)
+        [Network Duration]: \(networkDuration)
         [Serialization Duration]: \(serializationDuration)s
         [Result]: \(result)
         """
@@ -285,27 +284,19 @@ extension DownloadResponse: CustomStringConvertible, CustomDebugStringConvertibl
     /// response, the temporary and destination URLs, the resume data, the durations of the network and serialization
     /// actions, and the response serialization result.
     public var debugDescription: String {
-        let requestDescription = request.map { "\($0.httpMethod!) \($0)" } ?? "nil"
-        let requestBody = request?.httpBody.map { String(decoding: $0, as: UTF8.self) } ?? "None"
-        let responseDescription = response.map { response in
-            let sortedHeaders = response.headers.sorted()
+        guard let urlRequest = request else { return "[Request]: None\n[Result]: \(result)" }
 
-            return """
-            [Status Code]: \(response.statusCode)
-            [Headers]:
-            \(sortedHeaders)
-            """
-        } ?? "nil"
-        let metricsDescription = metrics.map { "\($0.taskInterval.duration)s" } ?? "None"
+        let requestDescription = DebugDescription.description(of: urlRequest)
+        let responseDescription = response.map(DebugDescription.description(of:)) ?? "[Response]: None"
+        let networkDuration = metrics.map { "\($0.taskInterval.duration)s" } ?? "None"
         let resumeDataDescription = resumeData.map { "\($0)" } ?? "None"
 
         return """
-        [Request]: \(requestDescription)
-        [Request Body]: \n\(requestBody)
-        [Response]: \n\(responseDescription)
-        [File URL]: \(fileURL?.path ?? "nil")
-        [ResumeData]: \(resumeDataDescription)
-        [Network Duration]: \(metricsDescription)
+        \(requestDescription)
+        \(responseDescription)
+        [File URL]: \(fileURL?.path ?? "None")
+        [Resume Data]: \(resumeDataDescription)
+        [Network Duration]: \(networkDuration)
         [Serialization Duration]: \(serializationDuration)s
         [Result]: \(result)
         """
@@ -401,5 +392,63 @@ extension DownloadResponse {
                                          metrics: metrics,
                                          serializationDuration: serializationDuration,
                                          result: result.tryMapError(transform))
+    }
+}
+
+private enum DebugDescription {
+    static func description(of request: URLRequest) -> String {
+        let requestSummary = "\(request.httpMethod!) \(request)"
+        let requestHeadersDescription = DebugDescription.description(for: request.headers)
+        let requestBodyDescription = DebugDescription.description(for: request.httpBody, headers: request.headers)
+
+        return """
+        [Request]: \(requestSummary)
+            \(requestHeadersDescription.indentingNewlines())
+            \(requestBodyDescription.indentingNewlines())
+        """
+    }
+
+    static func description(of response: HTTPURLResponse) -> String {
+        """
+        [Response]:
+            [Status Code]: \(response.statusCode)
+            \(DebugDescription.description(for: response.headers).indentingNewlines())
+        """
+    }
+
+    static func description(for headers: HTTPHeaders) -> String {
+        guard !headers.isEmpty else { return "[Headers]: None" }
+
+        let headerDescription = "\(headers.sorted())".indentingNewlines()
+        return """
+        [Headers]:
+            \(headerDescription)
+        """
+    }
+
+    static func description(for data: Data?,
+                            headers: HTTPHeaders,
+                            allowingPrintableTypes printableTypes: [String] = ["json", "xml", "text"],
+                            maximumLength: Int = 100_000) -> String {
+        guard let data = data, !data.isEmpty else { return "[Body]: None" }
+
+        guard
+            data.count <= maximumLength,
+            printableTypes.compactMap({ headers["Content-Type"]?.contains($0) }).contains(true)
+        else { return "[Body]: \(data.count) bytes" }
+
+        return """
+        [Body]:
+            \(String(decoding: data, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .indentingNewlines())
+        """
+    }
+}
+
+extension String {
+    fileprivate func indentingNewlines(by spaceCount: Int = 4) -> String {
+        let spaces = String(repeating: " ", count: spaceCount)
+        return replacingOccurrences(of: "\n", with: "\n\(spaces)")
     }
 }

--- a/Tests/CombineTests.swift
+++ b/Tests/CombineTests.swift
@@ -612,7 +612,7 @@ final class DataStreamRequestCombineTests: CombineTestCase {
                           case .complete:
                               publishedResponseReceived.fulfill()
                           }
-            })
+                })
         }
 
         waitForExpectations(timeout: timeout)

--- a/Tests/DataStreamTests.swift
+++ b/Tests/DataStreamTests.swift
@@ -614,7 +614,7 @@ final class DataStreamIntegrationTests: BaseTestCase {
         let redirector = Redirector(behavior: .modify { _, _, _ in
             didRedirect.fulfill()
             return URLRequest.makeHTTPBinRequest(path: "stream/1")
-            })
+        })
         let didReceive = expectation(description: "stream should receive")
         let didComplete = expectation(description: "stream should complete")
 
@@ -660,7 +660,7 @@ final class DataStreamIntegrationTests: BaseTestCase {
         let cacher = ResponseCacher(behavior: .modify { _, _ in
             cached.fulfill()
             return nil
-            })
+        })
         let didReceive = expectation(description: "stream did receive")
         let didComplete = expectation(description: "stream complete")
 


### PR DESCRIPTION
### Goals :soccer:
This PR enhances the `debugDescription` for `DataResponse` and `DownloadResponse` to include more detail. It also stops decoding body `Data` as a `String` if the `Content-Type` doesn't contain `xml`, `json`, or `text`, with more possible. Additionally, it won't print bodies over 100K in length.

For example, here's the new `DataRequest.debugDescription`:

```
[Request]: GET https://httpbin.org/get
    [Headers]: None
    [Body]: None
[Response]:
    [Status Code]: 200
    [Headers]:
        access-control-allow-credentials: true
        Access-Control-Allow-Origin: *
        Content-Length: 423
        Content-Type: application/json
        Date: Fri, 10 Jul 2020 00:39:58 GMT
        Server: gunicorn/19.9.0
    [Body]:
        {
          "args": {}, 
          "headers": {
            "Accept": "*/*", 
            "Accept-Encoding": "br;q=1.0, gzip;q=0.9, deflate;q=0.8", 
            "Accept-Language": "en;q=1.0", 
            "Host": "httpbin.org", 
            "User-Agent": "iOS Example/1.0 (org.alamofire.iOS-Example; build:1; iOS 13.5.0) Alamofire/5.2.1", 
            "X-Amzn-Trace-Id": "Root=1-5f07b8de-edf7f22e7f43625565fa8675"
          }, 
          "origin": "108.64.179.78", 
          "url": "https://httpbin.org/get"
        }
[Network Duration]: 0.770063042640686s
[Serialization Duration]: 9.56639414653182e-05s
[Result]: success("{\n  \"args\": {}, \n  \"headers\": {\n    \"Accept\": \"*/*\", \n    \"Accept-Encoding\": \"br;q=1.0, gzip;q=0.9, deflate;q=0.8\", \n    \"Accept-Language\": \"en;q=1.0\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"iOS Example/1.0 (org.alamofire.iOS-Example; build:1; iOS 13.5.0) Alamofire/5.2.1\", \n    \"X-Amzn-Trace-Id\": \"Root=1-5f07b8de-edf7f22e7f43625565fa8675\"\n  }, \n  \"origin\": \"108.64.179.78\", \n  \"url\": \"https://httpbin.org/get\"\n}\n")
```

And here's `DownloadResponse.debugDescription`:

```
[Request]: GET https://httpbin.org/stream/1
    [Headers]: None
    [Body]: None
[Response]:
    [Status Code]: 200
    [Headers]:
        access-control-allow-credentials: true
        Access-Control-Allow-Origin: *
        Content-Type: application/json
        Date: Fri, 10 Jul 2020 00:40:05 GMT
        Server: gunicorn/19.9.0
[File URL]: /Users/user/Library/Developer/CoreSimulator/Devices/49B4BC9B-316F-4507-91A6-D8DC6A3AD9D0/data/Containers/Data/Application/BE3A5ACD-DFF1-4032-ACD1-F21E9300C1C8/Library/Caches/1
[Resume Data]: None
[Network Duration]: 0.6685709953308105s
[Serialization Duration]: 0.0017910009482875466s
[Result]: success("{\"url\": \"https://httpbin.org/stream/1\", \"args\": {}, \"headers\": {\"Host\": \"httpbin.org\", \"X-Amzn-Trace-Id\": \"Root=1-5f07b8e5-514f02a7552d252ba40edc00\", \"User-Agent\": \"iOS Example/1.0 (org.alamofire.iOS-Example; build:1; iOS 13.5.0) Alamofire/5.2.1\", \"Accept-Language\": \"en;q=1.0\", \"Accept\": \"*/*\", \"Accept-Encoding\": \"br;q=1.0, gzip;q=0.9, deflate;q=0.8\"}, \"origin\": \"108.64.179.78\", \"id\": 0}\n")
```

### Implementation Details :construction:
A `fileprivate` namespace, `DebugDescription` has been added which contains the various logic used between both responses to generate the description. It's all private unless we want to expose it for some reason.

This PR also makes the `sort()` and `sorted()` on `HTTPHeaders` case-insensitive by comparing the `lowercased()` names.

### Testing Details :mag:
No tests added, unless we want to do some simple sanity checks or something. I chose not to for now.
