### PR TITLE
Add try-with-ipad badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Twitter](https://img.shields.io/badge/twitter-@AlamofireSF-blue.svg?style=flat)](https://twitter.com/AlamofireSF)
 [![Gitter](https://badges.gitter.im/Alamofire/Alamofire.svg)](https://gitter.im/Alamofire/Alamofire?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Open Source Helpers](https://www.codetriage.com/alamofire/alamofire/badges/users.svg)](https://www.codetriage.com/alamofire/alamofire)
+[![Try it with iPad](https://raw.githubusercontent.com/bow-swift/bow-art/master/badges/nef-playgrounds-badge.svg)](https://badge.bow-swift.io/recipe?name=Alamofire&description=Elegant%20HTTP%20Networking%20in%20Swift&url=https://github.com/Alamofire/Alamofire&owner=Alamofire&avatar=https://avatars3.githubusercontent.com/u/7774181?v=4&tag=5.2.2)
 
 Alamofire is an HTTP networking library written in Swift.
 


### PR DESCRIPTION
### Goals :soccer:
We have launched [nef Playgrounds](https://apps.apple.com/us/app/nef-playgrounds/id1511012848), an [OSS project](https://github.com/bow-swift/nef-editor-client), that let you play with pure Swift libraries (like this one) in your iPad. I think it is so interesting let users test Alamofire in their iPads with just-one-click.

---

<a href="https://badge.bow-swift.io/recipe?name=Alamofire&description=Elegant%20HTTP%20Networking%20in%20Swift&url=https://github.com/Alamofire/Alamofire&owner=Alamofire&avatar=https://avatars3.githubusercontent.com/u/7774181?v=4&tag=5.2.2"><img src="https://raw.githubusercontent.com/bow-swift/bow-art/master/badges/nef-playgrounds-badge.svg" alt="Alamofire Playground" style="height:20px"></a>

- **Author** Alamofire
- **Project** Alamofire
- **Tag** 5.2.2

## Preview
![Screen Shot 2020-08-05 at 20 57 16](https://user-images.githubusercontent.com/25568562/89452635-44d61580-d75e-11ea-8529-16f4dbd5366a.png)


![alamofire-nef](https://user-images.githubusercontent.com/25568562/89520418-1c8dfb80-d7de-11ea-9fab-db6335311946.gif)


## References
- [Badge Generator](https://badge.bow-swift.io/): lets you create nef badges easily.
- [nef](https://github.com/bow-swift/nef#-creating-a-playground-book): lets you build a Playground Book with external dependencies from a Swift Package specification.
- [nef Playgrounds (App)](https://github.com/bow-swift/nef-editor-client)
- [nef Playgrounds (Server)](https://github.com/bow-swift/nef-editor-server)
