### PR TITLE
Add originalError to AFError and all its nested enums

### DIFF
--- a/Source/AFError+OriginalError.swift
+++ b/Source/AFError+OriginalError.swift
@@ -1,0 +1,152 @@
+//
+//  AFError+OriginalError.swift
+//
+//  Copyright (c) 2014-2020 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+public extension AFError {
+    
+    var originalError: Error? {
+        switch self {
+        case .createUploadableFailed(let error): return error
+        case .createURLRequestFailed(let error): return error
+        case .downloadedFileMoveFailed(let error, _, _): return error
+        case .explicitlyCancelled: return nil
+        case .invalidURL: return nil
+        case .multipartEncodingFailed(let reason): return reason.originalError
+        case .parameterEncoderFailed(let reason): return reason.originalError
+        case .parameterEncodingFailed(let reason): return reason.originalError
+        case .requestAdaptationFailed(let error): return error
+        case .requestRetryFailed(_, let originalError): return originalError
+        case .responseValidationFailed(let reason): return reason.originalError
+        case .responseSerializationFailed(let reason): return reason.originalError
+        case .serverTrustEvaluationFailed(let reason): return reason.originalError
+        case .sessionDeinitialized: return nil
+        case .sessionInvalidated(let error): return error
+        case .sessionTaskFailed(let error): return error
+        case .urlRequestValidationFailed(let reason): return reason.originalError
+        }
+    }
+}
+
+public extension AFError.MultipartEncodingFailureReason {
+    
+    var originalError: Error? {
+        switch self {
+        case .bodyPartURLInvalid: return nil
+        case .bodyPartFilenameInvalid: return nil
+        case .bodyPartFileNotReachable: return nil
+        case .bodyPartFileNotReachableWithError(_, let error): return error
+        case .bodyPartFileIsDirectory: return nil
+        case .bodyPartFileSizeNotAvailable: return nil
+        case .bodyPartFileSizeQueryFailedWithError(_, let error): return error
+        case .bodyPartInputStreamCreationFailed: return nil
+        case .outputStreamCreationFailed: return nil
+        case .outputStreamFileAlreadyExists: return nil
+        case .outputStreamURLInvalid: return nil
+        case .outputStreamWriteFailed(let error): return error
+        case .inputStreamReadFailed(let error): return error
+        }
+    }
+}
+
+public extension AFError.ParameterEncoderFailureReason {
+    
+    var originalError: Error? {
+        switch self {
+        case .missingRequiredComponent: return nil
+        case .encoderFailed(let error): return error
+        }
+    }
+}
+
+public extension AFError.ParameterEncodingFailureReason {
+    
+    var originalError: Error? {
+        switch self {
+        case .missingURL: return nil
+        case .jsonEncodingFailed(let error): return error
+        case .customEncodingFailed(let error): return error
+        }
+    }
+}
+
+public extension AFError.ResponseValidationFailureReason {
+    
+    var originalError: Error? {
+        switch self {
+        case .dataFileNil: return nil
+        case .dataFileReadFailed: return nil
+        case .missingContentType: return nil
+        case .unacceptableContentType: return nil
+        case .unacceptableStatusCode: return nil
+        case .customValidationFailed(let error): return error
+        }
+    }
+}
+
+public extension AFError.ResponseSerializationFailureReason {
+    
+    var originalError: Error? {
+        switch self {
+        case .inputDataNilOrZeroLength: return nil
+        case .inputFileNil: return nil
+        case .inputFileReadFailed: return nil
+        case .stringSerializationFailed: return nil
+        case .jsonSerializationFailed(let error): return error
+        case .decodingFailed(let error): return error
+        case .customSerializationFailed(let error): return error
+        case .invalidEmptyResponse: return nil
+        }
+    }
+}
+
+public extension AFError.ServerTrustFailureReason {
+    
+    var originalError: Error? {
+        switch self {
+        case .noRequiredEvaluator: return nil
+        case .noCertificatesFound: return nil
+        case .noPublicKeysFound: return nil
+        case .policyApplicationFailed: return nil
+        case .settingAnchorCertificatesFailed: return nil
+        case .revocationPolicyCreationFailed: return nil
+        case .trustEvaluationFailed(let error): return error
+        case .defaultEvaluationFailed: return nil
+        case .hostValidationFailed: return nil
+        case .revocationCheckFailed: return nil
+        case .certificatePinningFailed: return nil
+        case .publicKeyPinningFailed: return nil
+        case .customEvaluationFailed(let error): return error
+        }
+    }
+}
+
+public extension AFError.URLRequestValidationFailureReason {
+    
+    var originalError: Error? {
+        switch self {
+        case .bodyDataInGETRequest: return nil
+        }
+    }
+}

--- a/Tests/AFError+OriginalErrorTests.swift
+++ b/Tests/AFError+OriginalErrorTests.swift
@@ -1,0 +1,134 @@
+//
+//  AFError+OriginalErrorTests.swift
+//
+//  Copyright (c) 2014-2018 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+import XCTest
+@testable import Alamofire
+
+class AFErrorOriginalErrorTestCase: BaseTestCase {
+    
+    let testError = NSError(domain: "com.alamofire.test.error", code: -123456789, userInfo: nil)
+    let retryError = NSError(domain: "com.alamofire.test.retryError", code: -1, userInfo: nil)
+    let testUrl = URL(string: "http://alamofire.com")!
+    
+    func testAFErrorOriginalErrorForNonNestedCases() {
+        XCTAssertOriginalError(for: .createUploadableFailed(error: testError))
+        XCTAssertOriginalError(for: .createURLRequestFailed(error: testError))
+        XCTAssertOriginalError(for: .downloadedFileMoveFailed(error: testError, source: testUrl, destination: testUrl))
+        XCTAssertNoOriginalError(for: .explicitlyCancelled)
+        XCTAssertNoOriginalError(for: .invalidURL(url: testUrl))
+        XCTAssertOriginalError(for: .requestAdaptationFailed(error: testError))
+        XCTAssertOriginalError(for: .requestRetryFailed(retryError: retryError, originalError: testError))
+        XCTAssertNoOriginalError(for: .sessionDeinitialized)
+        XCTAssertOriginalError(for: .sessionInvalidated(error: testError))
+        XCTAssertOriginalError(for: .sessionTaskFailed(error: testError))
+    }
+    
+    func testAFErrorOriginalErrorForMultipartEncodingFailed() {
+        XCTAssertNoOriginalError(for: .multipartEncodingFailed(reason: .bodyPartURLInvalid(url: testUrl)))
+        XCTAssertNoOriginalError(for: .multipartEncodingFailed(reason: .bodyPartFilenameInvalid(in: testUrl)))
+        XCTAssertNoOriginalError(for: .multipartEncodingFailed(reason: .bodyPartFileNotReachable(at: testUrl)))
+        XCTAssertOriginalError(for: .multipartEncodingFailed(reason: .bodyPartFileNotReachableWithError(atURL: testUrl, error: testError)))
+        XCTAssertNoOriginalError(for: .multipartEncodingFailed(reason: .bodyPartFileIsDirectory(at: testUrl)))
+        XCTAssertNoOriginalError(for: .multipartEncodingFailed(reason: .bodyPartFileSizeNotAvailable(at: testUrl)))
+        XCTAssertOriginalError(for: .multipartEncodingFailed(reason: .bodyPartFileSizeQueryFailedWithError(forURL: testUrl, error: testError)))
+        XCTAssertNoOriginalError(for: .multipartEncodingFailed(reason: .bodyPartInputStreamCreationFailed(for: testUrl)))
+        XCTAssertNoOriginalError(for: .multipartEncodingFailed(reason: .outputStreamCreationFailed(for: testUrl)))
+        XCTAssertNoOriginalError(for: .multipartEncodingFailed(reason: .outputStreamFileAlreadyExists(at: testUrl)))
+        XCTAssertNoOriginalError(for: .multipartEncodingFailed(reason: .outputStreamURLInvalid(url: testUrl)))
+        XCTAssertOriginalError(for: .multipartEncodingFailed(reason: .outputStreamWriteFailed(error: testError)))
+        XCTAssertOriginalError(for: .multipartEncodingFailed(reason: .inputStreamReadFailed(error: testError)))
+    }
+    
+    func testAFErrorOriginalErrorForParameterEncoderFailed() {
+        XCTAssertNoOriginalError(for: .parameterEncoderFailed(reason: .missingRequiredComponent(.url)))
+        XCTAssertOriginalError(for: .parameterEncoderFailed(reason: .encoderFailed(error: testError)))
+    }
+    
+    func testAFErrorOriginalErrorForParameterEncodingFailed() {
+        XCTAssertNoOriginalError(for: .parameterEncodingFailed(reason: .missingURL))
+        XCTAssertOriginalError(for: .parameterEncodingFailed(reason: .jsonEncodingFailed(error: testError)))
+        XCTAssertOriginalError(for: .parameterEncodingFailed(reason: .customEncodingFailed(error: testError)))
+    }
+    
+    func testAFErrorOriginalErrorForResponseValidationFailed() {
+        XCTAssertNoOriginalError(for: .responseValidationFailed(reason: .dataFileNil))
+        XCTAssertNoOriginalError(for: .responseValidationFailed(reason: .dataFileReadFailed(at: testUrl)))
+        XCTAssertNoOriginalError(for: .responseValidationFailed(reason: .missingContentType(acceptableContentTypes: [])))
+        XCTAssertNoOriginalError(for: .responseValidationFailed(reason: .unacceptableContentType(acceptableContentTypes: [], responseContentType: "")))
+        XCTAssertNoOriginalError(for: .responseValidationFailed(reason: .unacceptableStatusCode(code: 123)))
+        XCTAssertOriginalError(for: .responseValidationFailed(reason: .customValidationFailed(error: testError)))
+    }
+    
+    func testAFErrorOriginalErrorForResponseSerializationFailed() {
+        XCTAssertNoOriginalError(for: .responseSerializationFailed(reason: .inputDataNilOrZeroLength))
+        XCTAssertNoOriginalError(for: .responseSerializationFailed(reason: .inputFileNil))
+        XCTAssertNoOriginalError(for: .responseSerializationFailed(reason: .inputFileReadFailed(at: testUrl)))
+        XCTAssertNoOriginalError(for: .responseSerializationFailed(reason: .stringSerializationFailed(encoding: .ascii)))
+        XCTAssertOriginalError(for: .responseSerializationFailed(reason: .jsonSerializationFailed(error: testError)))
+        XCTAssertOriginalError(for: .responseSerializationFailed(reason: .decodingFailed(error: testError)))
+        XCTAssertOriginalError(for: .responseSerializationFailed(reason: .customSerializationFailed(error: testError)))
+        XCTAssertNoOriginalError(for: .responseSerializationFailed(reason: .invalidEmptyResponse(type: "")))
+    }
+    
+    /**
+     This test suite doesn't test trust-based logic, since I
+     couldn't figure out how to create a trust object.
+     */
+    func testAFErrorOriginalErrorForServerTrustEvaluationFailed() {
+        let policy = SecPolicyCreateBasicX509()
+        let status = OSStatus()
+        var trust: SecTrust?
+        _ = SecTrustCreateWithCertificates([] as AnyObject, policy, &trust)
+        // let output = AFError.ServerTrustFailureReason.Output("", trust, status, .deny)
+        XCTAssertNoOriginalError(for: .serverTrustEvaluationFailed(reason: .noRequiredEvaluator(host: "")))
+        XCTAssertNoOriginalError(for: .serverTrustEvaluationFailed(reason: .noCertificatesFound))
+        XCTAssertNoOriginalError(for: .serverTrustEvaluationFailed(reason: .noPublicKeysFound))
+        // XCTAssertNoOriginalError(for: .serverTrustEvaluationFailed(reason: .policyApplicationFailed(trust: trust, policy: policy, status: status)))
+        XCTAssertNoOriginalError(for: .serverTrustEvaluationFailed(reason: .settingAnchorCertificatesFailed(status: status, certificates: [])))
+        XCTAssertNoOriginalError(for: .serverTrustEvaluationFailed(reason: .revocationPolicyCreationFailed))
+        XCTAssertOriginalError(for: .serverTrustEvaluationFailed(reason: .trustEvaluationFailed(error: testError)))
+        // XCTAssertNoOriginalError(for: .serverTrustEvaluationFailed(reason: .defaultEvaluationFailed(output: output)))
+        // XCTAssertNoOriginalError(for: .serverTrustEvaluationFailed(reason: .hostValidationFailed(output: output)))
+        // XCTAssertNoOriginalError(for: .serverTrustEvaluationFailed(reason: .revocationCheckFailed(output: output, options: .crl)))
+        // XCTAssertNoOriginalError(for: .serverTrustEvaluationFailed(reason: .certificatePinningFailed(host: "", trust: trust, pinnedCertificates: [], serverCertificates: [])))
+        // XCTAssertNoOriginalError(for: .serverTrustEvaluationFailed(reason: .publicKeyPinningFailed(host: "", trust: trust, pinnedKeys: [], serverKeys: [])))
+        XCTAssertOriginalError(for: .serverTrustEvaluationFailed(reason: .customEvaluationFailed(error: testError)))
+    }
+    
+    func testAFErrorOriginalErrorForUrlRequestValidationFailed() {
+        let data = "".data(using: .ascii)!
+        XCTAssertNoOriginalError(for: .urlRequestValidationFailed(reason: .bodyDataInGETRequest(data)))
+    }
+}
+
+private func XCTAssertOriginalError(for error: AFError) {
+    guard let nsError = error.originalError as NSError? else { return XCTFail("originalError should exist for \(error)") }
+    XCTAssertEqual(nsError.domain, "com.alamofire.test.error")
+    XCTAssertEqual(nsError.code, -123456789)
+}
+
+private func XCTAssertNoOriginalError(for error: AFError) {
+    XCTAssertNil(error.originalError, "originalError should be nil for \(error)")
+}


### PR DESCRIPTION
### Issue Link :link:
https://github.com/Alamofire/Alamofire/issues/3271

### Goals :soccer:
To simplify accessing the original error of an `AFError` instance.

### Implementation Details :construction:
I have placed the implementation and unit tests in separate files to simplify review and merge. Feel free to move this if it's something that you want to include in the library.

### Testing Details :mag:
I have added tests for all enums. You can find them in `AFError+OriginalErrorTests`.

The only tests that I had to disable were SecTrust-related ones, since I couldn't construct a trust instance.
