### PR TITLE
Fix Usage.md to reflect the change in URLSessionConfiguration

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -421,7 +421,7 @@ The default Alamofire `Session` provides a default set of headers for every `Req
 - `Accept-Language`, which defaults to up to the top 6 preferred languages on the system, formatted like `en;q=1.0`, per [RFC 7231 §5.3.5](https://tools.ietf.org/html/rfc7231#section-5.3.5).
 - `User-Agent`, which contains versioning information about the current app. For example: `iOS Example/1.0 (com.alamofire.iOS-Example; build:1; iOS 13.0.0) Alamofire/5.0.0`, per [RFC 7231 §5.5.3](https://tools.ietf.org/html/rfc7231#section-5.5.3).
 
-If you need to customize these headers, a custom `URLSessionConfiguration` should be created, the `defaultHTTPHeaders` property updated, and the configuration applied to a new `Session` instance. Use `URLSessionConfiguration.af.default` to customize your configuration while keeping Alamofire's default headers.
+If you need to customize these headers, a custom `URLSessionConfiguration` should be created, the `headers` property updated, and the configuration applied to a new `Session` instance. Use `URLSessionConfiguration.af.default` to customize your configuration while keeping Alamofire's default headers.
 
 ### Response Validation
 


### PR DESCRIPTION
## Issue Link :link:
Fixes #3266.

### Goals :soccer:
Fix documentation about customizing HTTP headers.
`defaultHTTPHeaders` is no longer present in `URLSessionConfiguration` and `headers` must be used instead to customize the headers. 

### Implementation Details :construction:
Simple doc change.

### Testing Details :mag:
Just simple doc change
