### PR TITLE
Fix to throw an error in MultipartUpload when copying a file to a temporary path fails.

### DIFF
--- a/Source/MultipartUpload.swift
+++ b/Source/MultipartUpload.swift
@@ -67,6 +67,7 @@ final class MultipartUpload {
             } catch {
                 // Cleanup after attempted write if it fails.
                 try? fileManager.removeItem(at: fileURL)
+                throw error
             }
 
             uploadable = .file(fileURL, shouldRemove: true)

--- a/Tests/CombineTests.swift
+++ b/Tests/CombineTests.swift
@@ -306,14 +306,14 @@ final class DataRequestCombineTests: CombineTestCase {
             AF.request(URLRequest.makeHTTPBinRequest())
                 .publishDecodable(type: HTTPBinResponse.self, queue: queue)
                 .sink(receiveCompletion: { _ in
-                    dispatchPrecondition(condition: .onQueue(queue))
-                    completionReceived.fulfill()
-                },
+                          dispatchPrecondition(condition: .onQueue(queue))
+                          completionReceived.fulfill()
+                      },
                       receiveValue: {
-                    dispatchPrecondition(condition: .onQueue(queue))
-                    response = $0
-                    responseReceived.fulfill()
-                })
+                          dispatchPrecondition(condition: .onQueue(queue))
+                          response = $0
+                          responseReceived.fulfill()
+                      })
         }
 
         waitForExpectations(timeout: timeout)
@@ -812,18 +812,18 @@ final class DataStreamRequestCombineTests: CombineTestCase {
             AF.streamRequest(URLRequest.makeHTTPBinRequest())
                 .publishDecodable(type: HTTPBinResponse.self, queue: queue)
                 .sink(receiveCompletion: { _ in
-                    dispatchPrecondition(condition: .onQueue(queue))
-                    completionReceived.fulfill()
-                },
+                          dispatchPrecondition(condition: .onQueue(queue))
+                          completionReceived.fulfill()
+                      },
                       receiveValue: { stream in
-                    dispatchPrecondition(condition: .onQueue(queue))
-                    switch stream.event {
-                    case let .stream(value):
-                        result = value
-                    case .complete:
-                        responseReceived.fulfill()
-                    }
-                })
+                          dispatchPrecondition(condition: .onQueue(queue))
+                          switch stream.event {
+                          case let .stream(value):
+                              result = value
+                          case .complete:
+                              responseReceived.fulfill()
+                          }
+                      })
         }
 
         waitForExpectations(timeout: timeout)
@@ -1236,14 +1236,14 @@ final class DownloadRequestCombineTests: CombineTestCase {
             AF.download(URLRequest.makeHTTPBinRequest())
                 .publishDecodable(type: HTTPBinResponse.self, queue: queue)
                 .sink(receiveCompletion: { _ in
-                    dispatchPrecondition(condition: .onQueue(queue))
-                    completionReceived.fulfill()
-                },
+                          dispatchPrecondition(condition: .onQueue(queue))
+                          completionReceived.fulfill()
+                      },
                       receiveValue: {
-                    dispatchPrecondition(condition: .onQueue(queue))
-                    response = $0
-                    responseReceived.fulfill()
-                })
+                          dispatchPrecondition(condition: .onQueue(queue))
+                          response = $0
+                          responseReceived.fulfill()
+                      })
         }
 
         waitForExpectations(timeout: timeout)

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -280,9 +280,9 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
 
         // When
         AF.upload(multipartFormData: { multipartFormData in
-            multipartFormData.append(uploadData, withName: "upload_data")
-            formData = multipartFormData
-        },
+                      multipartFormData.append(uploadData, withName: "upload_data")
+                      formData = multipartFormData
+                  },
                   to: urlString)
             .response { resp in
                 response = resp
@@ -351,9 +351,9 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
 
         // When
         AF.upload(multipartFormData: { multipartFormData in
-            multipartFormData.append(frenchData, withName: "french")
-            multipartFormData.append(japaneseData, withName: "japanese")
-        },
+                      multipartFormData.append(frenchData, withName: "french")
+                      multipartFormData.append(japaneseData, withName: "japanese")
+                  },
                   to: urlString)
             .response { resp in
                 response = resp
@@ -388,9 +388,9 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
 
         // When
         let request = AF.upload(multipartFormData: { multipartFormData in
-            multipartFormData.append(frenchData, withName: "french")
-            multipartFormData.append(japaneseData, withName: "japanese")
-        },
+                                    multipartFormData.append(frenchData, withName: "french")
+                                    multipartFormData.append(japaneseData, withName: "japanese")
+                                },
                                 to: urlString)
             .response { resp in
                 response = resp
@@ -420,9 +420,9 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
 
         // When
         let request = AF.upload(multipartFormData: { multipartFormData in
-            multipartFormData.append(uploadData, withName: "upload_data")
-            formData = multipartFormData
-        },
+                                    multipartFormData.append(uploadData, withName: "upload_data")
+                                    formData = multipartFormData
+                                },
                                 to: urlString)
             .response { resp in
                 response = resp
@@ -458,9 +458,9 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
 
         // When
         let request = AF.upload(multipartFormData: { multipartFormData in
-            multipartFormData.append(frenchData, withName: "french")
-            multipartFormData.append(japaneseData, withName: "japanese")
-        },
+                                    multipartFormData.append(frenchData, withName: "french")
+                                    multipartFormData.append(japaneseData, withName: "japanese")
+                                },
                                 to: urlString,
                                 usingThreshold: 0).response { resp in
             response = resp
@@ -490,9 +490,9 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
 
         // When
         let request = AF.upload(multipartFormData: { multipartFormData in
-            multipartFormData.append(uploadData, withName: "upload_data")
-            formData = multipartFormData
-        },
+                                    multipartFormData.append(uploadData, withName: "upload_data")
+                                    formData = multipartFormData
+                                },
                                 to: urlString,
                                 usingThreshold: 0).response { resp in
             response = resp
@@ -518,30 +518,29 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
             XCTFail("Content-Type header value should not be nil")
         }
     }
-    
-    func testThatUploadingMultipartFormDataWithNotExistFileShouldFail() {
-        // Given
-        let urlString = "https://httpbin.org/post"
-        let imageURL = URL(string: "file://not_exists_file.jpg")!
 
-        let expectation = self.expectation(description: "multipart form data upload with wrong file should fail")
+    func testThatUploadingMultipartFormDataWithNonexistentFileThrowsAnError() {
+        // Given
+        let urlString = URL.makeHTTPBinURL(path: "post")
+        let imageURL = URL(fileURLWithPath: "does_not_exist.jpg")
+
+        let expectation = self.expectation(description: "multipart form data upload from nonexistent file should fail")
         var response: DataResponse<Data?, AFError>?
 
         // When
         let request = AF.upload(multipartFormData: { multipartFormData in
-            multipartFormData.append(imageURL, withName: "upload_file")
-        },
+                                    multipartFormData.append(imageURL, withName: "upload_file")
+                                },
                                 to: urlString,
                                 usingThreshold: 0).response { resp in
             response = resp
             expectation.fulfill()
         }
 
-        waitForExpectations(timeout: timeout, handler: nil)
+        waitForExpectations(timeout: timeout)
 
         // Then
-        let uploadable = request.uploadable
-        XCTAssertNil(uploadable)
+        XCTAssertNil(request.uploadable)
         XCTAssertTrue(response?.result.isSuccess == false)
     }
 
@@ -568,9 +567,9 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
 
         // When
         let upload = manager.upload(multipartFormData: { multipartFormData in
-            multipartFormData.append(french, withName: "french")
-            multipartFormData.append(japanese, withName: "japanese")
-        },
+                                        multipartFormData.append(french, withName: "french")
+                                        multipartFormData.append(japanese, withName: "japanese")
+                                    },
                                     to: urlString)
             .response { defaultResponse in
                 request = defaultResponse.request
@@ -615,9 +614,9 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
 
         // When
         AF.upload(multipartFormData: { multipartFormData in
-            multipartFormData.append(loremData1, withName: "lorem1")
-            multipartFormData.append(loremData2, withName: "lorem2")
-        },
+                      multipartFormData.append(loremData1, withName: "lorem1")
+                      multipartFormData.append(loremData2, withName: "lorem2")
+                  },
                   to: urlString,
                   usingThreshold: streamFromDisk ? 0 : 100_000_000)
             .uploadProgress { progress in

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -518,6 +518,32 @@ class UploadMultipartFormDataTestCase: BaseTestCase {
             XCTFail("Content-Type header value should not be nil")
         }
     }
+    
+    func testThatUploadingMultipartFormDataWithNotExistFileShouldFail() {
+        // Given
+        let urlString = "https://httpbin.org/post"
+        let imageURL = URL(string: "file://not_exists_file.jpg")!
+
+        let expectation = self.expectation(description: "multipart form data upload with wrong file should fail")
+        var response: DataResponse<Data?, AFError>?
+
+        // When
+        let request = AF.upload(multipartFormData: { multipartFormData in
+            multipartFormData.append(imageURL, withName: "upload_file")
+        },
+                                to: urlString,
+                                usingThreshold: 0).response { resp in
+            response = resp
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        let uploadable = request.uploadable
+        XCTAssertNil(uploadable)
+        XCTAssertTrue(response?.result.isSuccess == false)
+    }
 
     #if os(macOS)
     func disabled_testThatUploadingMultipartFormDataOnBackgroundSessionWritesDataToFileToAvoidCrash() {


### PR DESCRIPTION

### Goals :soccer:
When uploading a file with MultipartFormData, if the file copy to the temporary path fails, the entire upload process also fails.

### Implementation Details :construction:
I'm using Alamofire very well in my project. Thank you👍👍. Recently, I found the following errors when uploading files with MultipartFormData.

_Cannot read file at file:///private/var/mobile/Containers/Data/Application/041F8DB7-8C7D-4DC8-A976-4F3B9EACE686/tmp/org.alamofire.manager/multipart.form.data/D80342DA-28F4-40A9-913E-CC42161AE546_

The error above occurred when the uploadTask (with: fromFile:) of URLSsession was called to the nonexistent file. To correct the above problem, I modified the build() of MultipartUpload as follows.

```swift
do {
    try multipartFormData.writeEncodedData(to: fileURL)
} catch {
    // Cleanup after attempted write if it fails.
    try? fileManager.removeItem(at: fileURL)

    // WriteEncodedData(to:) can fail for several reasons, such as when a non-existent file url is entered.
    // In this case, I propose a way to throw through errors to ensure that the build step and all upload processes fail.
    throw error
}

```

### Testing Details :mag:
I have added a test to determine if the upload failed when the actual nonexistent file URL was entered.
