### PR TITLE
Fix crash when request download with fileURL

### DIFF
--- a/Source/URLRequest+Alamofire.swift
+++ b/Source/URLRequest+Alamofire.swift
@@ -32,6 +32,11 @@ public extension URLRequest {
     }
 
     func validate() throws {
+        if let url = url, url.isFileURL {
+            // This should become another urlRequestValidationFailed error in Alamofire 6.
+            throw AFError.invalidURL(url: url)
+        }
+
         if method == .get, let bodyData = httpBody {
             throw AFError.urlRequestValidationFailed(reason: .bodyDataInGETRequest(bodyData))
         }

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -1181,3 +1181,84 @@ final class RequestLifetimeTests: BaseTestCase {
         XCTAssertNotNil(task)
     }
 }
+
+// MARK: -
+
+class RequestInvalidURLTestCase: BaseTestCase {
+    #if !SWIFT_PACKAGE
+    func testThatDataRequestWithFileURLThrowsError() {
+        // Given
+        let fileUrlString = url(forResource: "valid_data", withExtension: "json").absoluteString
+        
+        let expectation = self.expectation(description: "Request should fail with error")
+        var response: DataResponse<Data?, AFError>?
+
+        // When
+        AF.request(fileUrlString)
+            .response { resp in
+                response = resp
+                expectation.fulfill()
+            }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNil(response?.request)
+        XCTAssertNil(response?.response)
+        XCTAssertNil(response?.data)
+        XCTAssertNotNil(response?.error)
+        XCTAssertEqual(response?.error?.isInvalidURLError, true)
+        XCTAssertEqual(response?.result.isFailure, true)
+    }
+    
+    func testThatDownloadRequestWithFileURLThrowsError() {
+        // Given
+        let fileUrlString = url(forResource: "unicorn", withExtension: "png").absoluteString
+
+        let expectation = self.expectation(description: "Request should fail with error")
+        var response: DownloadResponse<URL?, AFError>?
+
+        // When
+        AF.download(fileUrlString)
+            .response { resp in
+                response = resp
+                expectation.fulfill()
+            }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNil(response?.request)
+        XCTAssertNil(response?.response)
+        XCTAssertNil(response?.fileURL)
+        XCTAssertNotNil(response?.error)
+        XCTAssertEqual(response?.error?.isInvalidURLError, true)
+        XCTAssertEqual(response?.result.isFailure, true)
+    }
+    
+    func testThatDataStreamRequestWithFileURLThrowsError() {
+        // Given
+        let fileURL = url(forResource: "unicorn", withExtension: "png").absoluteString
+
+        let expectation = self.expectation(description: "Request should fail with error")
+        var response: DataStreamRequest.Completion?
+
+        // When
+        AF.streamRequest(fileURL)
+            .responseStream { stream in
+                guard case let .complete(completion) = stream.event else { return }
+                
+                response = completion
+                expectation.fulfill()
+            }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNil(response?.request)
+        XCTAssertNil(response?.response)
+        XCTAssertNotNil(response?.error)
+        XCTAssertEqual(response?.error?.isInvalidURLError, true)
+    }
+    #endif
+}

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -1188,13 +1188,12 @@ class RequestInvalidURLTestCase: BaseTestCase {
     #if !SWIFT_PACKAGE
     func testThatDataRequestWithFileURLThrowsError() {
         // Given
-        let fileUrlString = url(forResource: "valid_data", withExtension: "json").absoluteString
-        
-        let expectation = self.expectation(description: "Request should fail with error")
+        let fileURL = url(forResource: "valid_data", withExtension: "json")
+        let expectation = self.expectation(description: "Request should fail with invalid URL error.")
         var response: DataResponse<Data?, AFError>?
 
         // When
-        AF.request(fileUrlString)
+        AF.request(fileURL)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -1203,23 +1202,17 @@ class RequestInvalidURLTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout)
 
         // Then
-        XCTAssertNil(response?.request)
-        XCTAssertNil(response?.response)
-        XCTAssertNil(response?.data)
-        XCTAssertNotNil(response?.error)
         XCTAssertEqual(response?.error?.isInvalidURLError, true)
-        XCTAssertEqual(response?.result.isFailure, true)
     }
     
     func testThatDownloadRequestWithFileURLThrowsError() {
         // Given
-        let fileUrlString = url(forResource: "unicorn", withExtension: "png").absoluteString
-
-        let expectation = self.expectation(description: "Request should fail with error")
+        let fileURL = url(forResource: "valid_data", withExtension: "json")
+        let expectation = self.expectation(description: "Request should fail with invalid URL error.")
         var response: DownloadResponse<URL?, AFError>?
 
         // When
-        AF.download(fileUrlString)
+        AF.download(fileURL)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -1228,19 +1221,13 @@ class RequestInvalidURLTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout)
 
         // Then
-        XCTAssertNil(response?.request)
-        XCTAssertNil(response?.response)
-        XCTAssertNil(response?.fileURL)
-        XCTAssertNotNil(response?.error)
         XCTAssertEqual(response?.error?.isInvalidURLError, true)
-        XCTAssertEqual(response?.result.isFailure, true)
     }
     
     func testThatDataStreamRequestWithFileURLThrowsError() {
         // Given
-        let fileURL = url(forResource: "unicorn", withExtension: "png").absoluteString
-
-        let expectation = self.expectation(description: "Request should fail with error")
+        let fileURL = url(forResource: "valid_data", withExtension: "json")
+        let expectation = self.expectation(description: "Request should fail with invalid URL error.")
         var response: DataStreamRequest.Completion?
 
         // When
@@ -1255,9 +1242,6 @@ class RequestInvalidURLTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout)
 
         // Then
-        XCTAssertNil(response?.request)
-        XCTAssertNil(response?.response)
-        XCTAssertNotNil(response?.error)
         XCTAssertEqual(response?.error?.isInvalidURLError, true)
     }
     #endif


### PR DESCRIPTION
### Issue Link :link:
https://github.com/Alamofire/Alamofire/issues/3293

### Goals :soccer:
Crash occurs when request download with fileURL (AF.download)
- modified to throw an error without causing a crash.

### Implementation Details :construction:
If URL is fileURL, throw AFError.invalidURL
```swift
switch request {
    case is DownloadRequest:
        if let url = initialRequest.url, url.isFileURL {
            throw AFError.invalidURL(url: url)
        }
    default:
        break
}
```
### Testing Details :mag:
add downloadTestCase (testDownloadRequestWithLocalFileURLStringThrowsAnError)
