### PR TITLE
Disable Resume Test Until Replacement Found

### DIFF
--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -585,7 +585,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         XCTAssertEqual(response?.resumeData, download.resumeData)
     }
 
-    func testThatCancelledDownloadCanBeResumedWithResumeData() {
+    func _testThatCancelledDownloadCanBeResumedWithResumeData() {
         // Given
         let expectation1 = expectation(description: "Download should be cancelled")
         var cancelled = false


### PR DESCRIPTION
### Goals :soccer:
This PR fixes a recent test failure by disabling a resume data test, as it appears wikimedia no longer supports resume ranges.

### Testing Details :mag:
Disabled `testThatCancelledDownloadCanBeResumedWithResumeData()` until another resumable source can be found.
