### PR TITLE
Enable task gathering on watchOS 7+

### DIFF
--- a/Source/RequestTaskMap.swift
+++ b/Source/RequestTaskMap.swift
@@ -131,11 +131,18 @@ struct RequestTaskMap {
 
         switch (events.completed, events.metricsGathered) {
         case (true, _): fatalError("RequestTaskMap consistency error: duplicate completionReceivedForTask call.")
-        #if os(watchOS) // watchOS doesn't gather metrics, so unconditionally remove the reference and return true.
+        #if os(Linux) // Linux doesn't gather metrics, so unconditionally remove the reference and return true.
         default: self[task] = nil; return true
         #else
-        case (false, false): taskEvents[task] = (completed: true, metricsGathered: false); return false
-        case (false, true): self[task] = nil; return true
+        case (false, false):
+            if #available(macOS 10.12, iOS 10, watchOS 7, tvOS 10, *) {
+                taskEvents[task] = (completed: true, metricsGathered: false); return false
+            } else {
+                // watchOS < 7 doesn't gather metrics, so unconditionally remove the reference and return true.
+                self[task] = nil; return true
+            }
+        case (false, true):
+            self[task] = nil; return true
         #endif
         }
     }


### PR DESCRIPTION
### Goals :soccer:
This PR enables the gathering of `URLSessionTaskMetrics` on watchOS 7+. Previous versions of watchOS never gathered metrics.

### Implementation Details :construction:
This PR turns the previous compile time `os(watchOS)` check into a runtime check for supported OS versions. The compile time check is left in place for Linux support.

### Testing Details :mag:
No test, as there is **still** no testing on watchOS.
