### PR TITLE
Remove file URL error, add support for downloads

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1459,8 +1459,11 @@ public class DownloadRequest: Request {
 
     /// A closure executed once a `DownloadRequest` has successfully completed in order to determine where to move the
     /// temporary file written to during the download process. The closure takes two arguments: the temporary file URL
-    /// and the URL response, and returns a two arguments: the file URL where the temporary file should be moved and
+    /// and the `HTTPURLResponse`, and returns two values: the file URL where the temporary file should be moved and
     /// the options defining how the file should be moved.
+    ///
+    /// - Note: Downloads from a local `file://` `URL`s do not use the `Destination` closure, as those downloads do not
+    ///         return an `HTTPURLResponse`. Instead the file is merely moved within the temporary directory.
     public typealias Destination = (_ temporaryURL: URL,
                                     _ response: HTTPURLResponse) -> (destinationURL: URL, options: Options)
 

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1489,10 +1489,16 @@ public class DownloadRequest: Request {
     /// with this destination must be additionally moved if they should survive the system reclamation of temporary
     /// space.
     static let defaultDestination: Destination = { url, _ in
+        (defaultDestinationURL(url), [])
+    }
+
+    /// Default `URL` creation closure. Creates a `URL` in the temporary directory with `Alamofire_` prepended to the
+    /// provided file name.
+    static let defaultDestinationURL: (URL) -> URL = { url in
         let filename = "Alamofire_\(url.lastPathComponent)"
         let destination = url.deletingLastPathComponent().appendingPathComponent(filename)
 
-        return (destination, [])
+        return destination
     }
 
     // MARK: Downloadable

--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -298,11 +298,13 @@ extension SessionDelegate: URLSessionDownloadDelegate {
             return
         }
 
-        guard let response = request.response else {
-            fatalError("URLSessionDownloadTask finished downloading with no response.")
+        let (destination, options): (URL, DownloadRequest.Options)
+        if let response = request.response {
+            (destination, options) = request.destination(location, response)
+        } else {
+            // If there's no response this is likely a local file download, so generate the temporary URL directly.
+            (destination, options) = (DownloadRequest.defaultDestinationURL(location), [])
         }
-
-        let (destination, options) = (request.destination)(location, response)
 
         eventMonitor?.request(request, didCreateDestinationURL: destination)
 

--- a/Source/URLRequest+Alamofire.swift
+++ b/Source/URLRequest+Alamofire.swift
@@ -32,11 +32,6 @@ extension URLRequest {
     }
 
     public func validate() throws {
-        if let url = url, url.isFileURL {
-            // This should become another urlRequestValidationFailed error in Alamofire 6.
-            throw AFError.invalidURL(url: url)
-        }
-
         if method == .get, let bodyData = httpBody {
             throw AFError.urlRequestValidationFailed(reason: .bodyDataInGETRequest(bodyData))
         }

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -1184,12 +1184,12 @@ final class RequestLifetimeTests: BaseTestCase {
 
 // MARK: -
 
-class RequestInvalidURLTestCase: BaseTestCase {
-    #if !SWIFT_PACKAGE
+#if !SWIFT_PACKAGE
+final class RequestInvalidURLTestCase: BaseTestCase {
     func testThatDataRequestWithFileURLThrowsError() {
         // Given
         let fileURL = url(forResource: "valid_data", withExtension: "json")
-        let expectation = self.expectation(description: "Request should fail with invalid URL error.")
+        let expectation = self.expectation(description: "Request should succeed.")
         var response: DataResponse<Data?, AFError>?
 
         // When
@@ -1202,13 +1202,13 @@ class RequestInvalidURLTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout)
 
         // Then
-        XCTAssertEqual(response?.error?.isInvalidURLError, true)
+        XCTAssertEqual(response?.result.isSuccess, true)
     }
 
     func testThatDownloadRequestWithFileURLThrowsError() {
         // Given
         let fileURL = url(forResource: "valid_data", withExtension: "json")
-        let expectation = self.expectation(description: "Request should fail with invalid URL error.")
+        let expectation = self.expectation(description: "Request should succeed.")
         var response: DownloadResponse<URL?, AFError>?
 
         // When
@@ -1221,13 +1221,13 @@ class RequestInvalidURLTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout)
 
         // Then
-        XCTAssertEqual(response?.error?.isInvalidURLError, true)
+        XCTAssertEqual(response?.result.isSuccess, true)
     }
 
     func testThatDataStreamRequestWithFileURLThrowsError() {
         // Given
         let fileURL = url(forResource: "valid_data", withExtension: "json")
-        let expectation = self.expectation(description: "Request should fail with invalid URL error.")
+        let expectation = self.expectation(description: "Request should succeed.")
         var response: DataStreamRequest.Completion?
 
         // When
@@ -1242,7 +1242,7 @@ class RequestInvalidURLTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout)
 
         // Then
-        XCTAssertEqual(response?.error?.isInvalidURLError, true)
+        XCTAssertNil(response?.response)
     }
-    #endif
 }
+#endif


### PR DESCRIPTION
### Issue Link :link:
#3332

### Goals :soccer:
Turns out some people do use local file URLs for testing and such, so this PR removes the previous error and fixes `DownloadRequest` to properly support downloaded files.

### Implementation Details :construction:
The only code changes are in `DownloadRequest` since it previously required an `HTTPURLResponse` to generate the file location on disk. Unfortunately `URLSessionDownloadTask` doesn't treat a file `URL` download in any special way, so it just copies the file to the temp directory. Alamofire then moves that file to a new name so it survives the `URLSession` cleanup.

### Testing Details :mag:
Previously added tests have been updated to now succeed with file `URL`s.
