### PR TITLE
Fixed a memory leak issue in iOS 14.

### DIFF
--- a/Source/URLEncodedFormEncoder.swift
+++ b/Source/URLEncodedFormEncoder.swift
@@ -966,11 +966,11 @@ extension CharacterSet {
     /// In RFC 3986 - Section 3.4, it states that the "?" and "/" characters should not be escaped to allow
     /// query strings to include a URL. Therefore, all "reserved" characters with the exception of "?" and "/"
     /// should be percent-escaped in the query string.
-    public static let afURLQueryAllowed: CharacterSet = {
+    public static var afURLQueryAllowed: CharacterSet {
         let generalDelimitersToEncode = ":#[]@" // does not include "?" or "/" due to RFC 3986 - Section 3.4
         let subDelimitersToEncode = "!$&'()*+,;="
         let encodableDelimiters = CharacterSet(charactersIn: "\(generalDelimitersToEncode)\(subDelimitersToEncode)")
 
         return CharacterSet.urlQueryAllowed.subtracting(encodableDelimiters)
-    }()
+    }
 }


### PR DESCRIPTION
### Issue Link :link:
#3374

### Goals :soccer:
Allocating a closure to afURLQueryAllowed results in a memory leak in the NSCFCharacterSet.
This issue occurs since iOS 14.

If don't necessarily need to create afURLQueryAllowed as a closure,
I think it's a better to get rid of the memory issue using the get-only property.

### Implementation Details :construction:
```
public static var afURLQueryAllowed: CharacterSet {
        let generalDelimitersToEncode = ":#[]@" // does not include "?" or "/" due to RFC 3986 - Section 3.4
        let subDelimitersToEncode = "!$&'()*+,;="
        let encodableDelimiters = CharacterSet(charactersIn: "\(generalDelimitersToEncode)\(subDelimitersToEncode)")

        return CharacterSet.urlQueryAllowed.subtracting(encodableDelimiters)
    }
```

### Testing Details :mag:
testThatEscapedCharactersCanBeCustomized case passed, and it runs well in the Example project.

Thanks for Alamofire.
