### PR TITLE
Perhaps an unnecessary check?

### DIFF
--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -181,7 +181,6 @@ open class Session {
                             redirectHandler: RedirectHandler? = nil,
                             cachedResponseHandler: CachedResponseHandler? = nil,
                             eventMonitors: [EventMonitor] = []) {
-        precondition(configuration.identifier == nil, "Alamofire does not support background URLSessionConfigurations.")
 
         let delegateQueue = OperationQueue(maxConcurrentOperationCount: 1, underlyingQueue: rootQueue, name: "org.alamofire.session.sessionDelegateQueue")
         let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: delegateQueue)


### PR DESCRIPTION
Goals ⚽️:
Because in the later init will go according to the session to determine, whether the early detection here is unnecessary? I don't know much about it, so if I'm wrong, I'm sorry : ) .

Implementation :
Delete a precondition

