### PR TITLE
Use serveral URLCredentials for different protection spaces

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -106,6 +106,8 @@ public class Request {
         var responseSerializerProcessingFinished = false
         /// `URLCredential` used for authentication challenges.
         var credential: URLCredential?
+        /// All `URLCredential` added by a authenticationMethod of the protection space used for authentication challenges.
+        var credentialsByAuthenticationMethod: [String: URLCredential] = [:]
         /// All `URLRequest`s created by Alamofire on behalf of the `Request`.
         var requests: [URLRequest] = []
         /// All `URLSessionTask`s created by Alamofire on behalf of the `Request`.
@@ -183,7 +185,12 @@ public class Request {
         get { mutableState.credential }
         set { mutableState.credential = newValue }
     }
-
+    
+    public private(set) var credentialsByAuthenticationMethod: [String:URLCredential] {
+        get { mutableState.credentialsByAuthenticationMethod }
+        set { mutableState.credentialsByAuthenticationMethod = newValue }
+    }
+    
     // MARK: Validators
 
     /// `Validator` callback closures that store the validation calls enqueued.
@@ -753,6 +760,19 @@ public class Request {
     @discardableResult
     public func authenticate(with credential: URLCredential) -> Self {
         mutableState.credential = credential
+
+        return self
+    }
+
+    /// Associates the provided credential for a specific authenticationMethod with the instance.
+    ///
+    /// - Parameter credential: The `URLCredential`.
+    /// - Parameter authenticationMethod: The authenticationMethod as `String`. See Foundation.NSURLProtectionSpace for possible values.
+    ///
+    /// - Returns:              The instance.
+    @discardableResult
+    public func authenticate(with credential: URLCredential, for authenticationMethod: String) -> Self {
+        mutableState.credentialsByAuthenticationMethod[authenticationMethod] = credential
 
         return self
     }

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1005,6 +1005,11 @@ extension Request {
             } else {
                 if let credential = credential, let user = credential.user, let password = credential.password {
                     components.append("-u \(user):\(password)")
+                } else {
+                    for credential in credentialsByAuthenticationMethod.values {
+                        guard let user = credential.user, let password = credential.password else { continue }
+                        components.append("-u \(user):\(password)")
+                    }
                 }
             }
         }

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -1240,8 +1240,9 @@ extension Session: SessionStateProvider {
 
     func credential(for task: URLSessionTask, in protectionSpace: URLProtectionSpace) -> URLCredential? {
         dispatchPrecondition(condition: .onQueue(rootQueue))
-
-        return requestTaskMap[task]?.credential ??
+        
+        return requestTaskMap[task]?.credentialsByAuthenticationMethod[protectionSpace.authenticationMethod] ??
+            requestTaskMap[task]?.credential ??
             session.configuration.urlCredentialStorage?.defaultCredential(for: protectionSpace)
     }
 


### PR DESCRIPTION
### Goals :soccer:
I have some calls that are protected by more than one authentication challenge. At my example I have a client certificate and a http basic auth. The goal is to add the possibility to add several URLCredential objects depending on the authenticationMethod of the protectionSpace.

### Implementation Details :construction:
I added the dictionary credentialsByAuthenticationMethod to the mutableState of a Request. This can hold a URLCredential for each authenticationMethod. In Session.credential I look first if a specific URLCredential is available in credentialsByAuthenticationMethod. If not, I fallback to the existing behaviour. 

### Testing Details :mag:
None.