### PR TITLE
Fix #3416

### DIFF
--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -433,6 +433,13 @@ extension AFError {
         guard case let .downloadedFileMoveFailed(_, _, destination) = self else { return nil }
         return destination
     }
+   
+    /// The resumeData of a `.sessionTaskFailed` error.
+    /// Only works for `DownloadRequest`
+    public var resumeData: Data? {
+        guard case let .sessionTaskFailed(error) = self else { return nil }
+        return (error as NSError).userInfo[NSURLSessionDownloadTaskResumeData] as? Data
+    }
 }
 
 extension AFError.ParameterEncodingFailureReason {

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1613,6 +1613,14 @@ public class DownloadRequest: Request {
         session.downloadTask(with: request)
     }
 
+    override func didCompleteTask(_ task: URLSessionTask, with error: AFError?) {
+        super.didCompleteTask(task, with: error)
+        
+        $mutableDownloadState.write {
+            $0.resumeData = self.error?.resumeData
+        }
+    }
+
     /// Creates a `URLSessionTask` from the provided resume data.
     ///
     /// - Parameters:


### PR DESCRIPTION
### Issue Link :link:
#3416 

### Implementation Details :construction:
update the resume data from the `error.user[NSURLSessionDownloadTaskResumeData]` when the download request was interrupted.
