### PR TITLE
Ensure encoded multipart body stream has appropriate length.

### DIFF
--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -57,6 +57,15 @@ public enum AFError: Error {
         case inputStreamReadFailed(error: Error)
     }
 
+    /// Represents unexpected input stream length that occur when encoding the `MultipartFormData`. Instances will be
+    /// embedded within an `AFError.multipartEncodingFailed` `.inputStreamReadFailed` case.
+    public struct UnexpectedInputStreamLength: Error {
+        /// The expected byte count to read.
+        public var bytesExpected: UInt64
+        /// The actual byte count read.
+        public var bytesRead: UInt64
+    }
+
     /// The underlying reason the `.parameterEncodingFailed` error occurred.
     public enum ParameterEncodingFailureReason {
         /// The `URLRequest` did not have a `URL` to encode.

--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -418,9 +418,11 @@ open class MultipartFormData {
                 break
             }
         }
-        
+
         guard UInt64(encoded.count) == bodyPart.bodyContentLength else {
-            throw AFError.multipartEncodingFailed(reason: .inputStreamReadFailed(error: UnexpectedInputStreamLengthError(bytesExpected: bodyPart.bodyContentLength, bytesRead: UInt64(encoded.count))))
+            let error = AFError.UnexpectedInputStreamLength(bytesExpected: bodyPart.bodyContentLength,
+                                                            bytesRead: UInt64(encoded.count))
+            throw AFError.multipartEncodingFailed(reason: .inputStreamReadFailed(error: error))
         }
 
         return encoded
@@ -548,15 +550,4 @@ open class MultipartFormData {
         guard bodyPartError == nil else { return }
         bodyPartError = AFError.multipartEncodingFailed(reason: reason)
     }
-}
-
-/// Represents unexpected input stream length that occur when encoding the `MultipartFormData`. All errors are
-/// still vended from Alamofire as `AFError` types. The `UnexpectedInputStreamLengthError` instances will be
-/// embedded within the `AFError` `.multipartEncodingFailed` `.inputStreamReadFailed` case.
-public struct UnexpectedInputStreamLengthError: Error {
-    /// The expected byte count to read.
-    public var bytesExpected: UInt64
-    
-    /// The actual byte count read.
-    public var bytesRead: UInt64
 }

--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -418,6 +418,10 @@ open class MultipartFormData {
                 break
             }
         }
+        
+        guard UInt64(encoded.count) == bodyPart.bodyContentLength else {
+            throw AFError.multipartEncodingFailed(reason: .inputStreamReadFailed(error: UnexpectedInputStreamLengthError(bytesExpected: bodyPart.bodyContentLength, bytesRead: UInt64(encoded.count))))
+        }
 
         return encoded
     }
@@ -544,4 +548,15 @@ open class MultipartFormData {
         guard bodyPartError == nil else { return }
         bodyPartError = AFError.multipartEncodingFailed(reason: reason)
     }
+}
+
+/// Represents unexpected input stream length that occur when encoding the `MultipartFormData`. All errors are
+/// still vended from Alamofire as `AFError` types. The `UnexpectedInputStreamLengthError` instances will be
+/// embedded within the `AFError` `.multipartEncodingFailed` `.inputStreamReadFailed` case.
+public struct UnexpectedInputStreamLengthError: Error {
+    /// The expected byte count to read.
+    public var bytesExpected: UInt64
+    
+    /// The actual byte count read.
+    public var bytesRead: UInt64
 }

--- a/Tests/MultipartFormDataTests.swift
+++ b/Tests/MultipartFormDataTests.swift
@@ -918,33 +918,31 @@ class MultipartFormDataFailureTestCase: BaseTestCase {
         XCTAssertNotNil(encodingError, "encoding error should not be nil")
         XCTAssertEqual(encodingError?.asAFError?.isOutputStreamURLInvalid, true)
     }
-    
+
     func testThatStreamBodyPartHasUnexpectedLength() {
         // Given
         let multipartFormData = MultipartFormData()
         let data = Data("Lorem ipsum dolor sit amet.".utf8)
         multipartFormData.append(data, withName: "data")
-        var encodingError: Error?
-        
-        // When
-        do {
-            _ = try multipartFormData.encode()
-        } catch {
-            encodingError = error
-        }
-        
-        XCTAssertNil(encodingError, "encoding error should be nil")
-        
-        // When
-        do {
-            _ = try multipartFormData.encode()
-        } catch {
-            encodingError = error
-        }
-        
-        XCTAssertNotNil(encodingError, "encoding error should not be nil")
-        XCTAssertEqual(encodingError?.asAFError?.isInputStreamReadFailed, true)
-        XCTAssert(encodingError?.asAFError?.underlyingError is UnexpectedInputStreamLengthError)
-    }
+        var firstError: Error?
+        var secondError: Error?
 
+        // When
+        do {
+            _ = try multipartFormData.encode()
+        } catch {
+            firstError = error
+        }
+
+        do {
+            _ = try multipartFormData.encode()
+        } catch {
+            secondError = error
+        }
+
+        XCTAssertNil(firstError, "firstError should be nil")
+        XCTAssertNotNil(secondError, "secondError should not be nil")
+        XCTAssertEqual(secondError?.asAFError?.isInputStreamReadFailed, true)
+        XCTAssert(secondError?.asAFError?.underlyingError is AFError.UnexpectedInputStreamLength)
+    }
 }

--- a/Tests/MultipartFormDataTests.swift
+++ b/Tests/MultipartFormDataTests.swift
@@ -918,4 +918,33 @@ class MultipartFormDataFailureTestCase: BaseTestCase {
         XCTAssertNotNil(encodingError, "encoding error should not be nil")
         XCTAssertEqual(encodingError?.asAFError?.isOutputStreamURLInvalid, true)
     }
+    
+    func testThatStreamBodyPartHasUnexpectedLength() {
+        // Given
+        let multipartFormData = MultipartFormData()
+        let data = Data("Lorem ipsum dolor sit amet.".utf8)
+        multipartFormData.append(data, withName: "data")
+        var encodingError: Error?
+        
+        // When
+        do {
+            _ = try multipartFormData.encode()
+        } catch {
+            encodingError = error
+        }
+        
+        XCTAssertNil(encodingError, "encoding error should be nil")
+        
+        // When
+        do {
+            _ = try multipartFormData.encode()
+        } catch {
+            encodingError = error
+        }
+        
+        XCTAssertNotNil(encodingError, "encoding error should not be nil")
+        XCTAssertEqual(encodingError?.asAFError?.isInputStreamReadFailed, true)
+        XCTAssert(encodingError?.asAFError?.underlyingError is UnexpectedInputStreamLengthError)
+    }
+
 }


### PR DESCRIPTION
### Issue Link :link:
#3380

### Goals :soccer:
This PR cleans up #3380 for merge.
