### PR TITLE
Refactor Multipart Upload URL Access

### DIFF
--- a/Source/MultipartUpload.swift
+++ b/Source/MultipartUpload.swift
@@ -28,29 +28,24 @@ import Foundation
 final class MultipartUpload {
     lazy var result = Result { try build() }
 
-    let isInBackgroundSession: Bool
-    let multipartFormData: MultipartFormData
+    @Protected
+    private(set) var multipartFormData: MultipartFormData
     let encodingMemoryThreshold: UInt64
     let request: URLRequestConvertible
     let fileManager: FileManager
 
-    init(isInBackgroundSession: Bool,
-         encodingMemoryThreshold: UInt64,
+    init(encodingMemoryThreshold: UInt64,
          request: URLRequestConvertible,
          multipartFormData: MultipartFormData) {
-        self.isInBackgroundSession = isInBackgroundSession
         self.encodingMemoryThreshold = encodingMemoryThreshold
         self.request = request
         fileManager = multipartFormData.fileManager
         self.multipartFormData = multipartFormData
     }
 
-    func build() throws -> (request: URLRequest, uploadable: UploadRequest.Uploadable) {
-        var urlRequest = try request.asURLRequest()
-        urlRequest.setValue(multipartFormData.contentType, forHTTPHeaderField: "Content-Type")
-
+    func build() throws -> UploadRequest.Uploadable {
         let uploadable: UploadRequest.Uploadable
-        if multipartFormData.contentLength < encodingMemoryThreshold && !isInBackgroundSession {
+        if multipartFormData.contentLength < encodingMemoryThreshold {
             let data = try multipartFormData.encode()
 
             uploadable = .data(data)
@@ -73,16 +68,22 @@ final class MultipartUpload {
             uploadable = .file(fileURL, shouldRemove: true)
         }
 
-        return (request: urlRequest, uploadable: uploadable)
+        return uploadable
     }
 }
 
 extension MultipartUpload: UploadConvertible {
     func asURLRequest() throws -> URLRequest {
-        try result.get().request
+        var urlRequest = try request.asURLRequest()
+
+        $multipartFormData.read { multipartFormData in
+            urlRequest.headers.add(.contentType(multipartFormData.contentType))
+        }
+
+        return urlRequest
     }
 
     func createUploadable() throws -> UploadRequest.Uploadable {
-        try result.get().uploadable
+        try result.get()
     }
 }

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -907,8 +907,7 @@ open class Session {
                                                           headers: headers,
                                                           requestModifier: requestModifier)
 
-        let multipartUpload = MultipartUpload(isInBackgroundSession: session.configuration.identifier != nil,
-                                              encodingMemoryThreshold: encodingMemoryThreshold,
+        let multipartUpload = MultipartUpload(encodingMemoryThreshold: encodingMemoryThreshold,
                                               request: convertible,
                                               multipartFormData: multipartFormData)
 
@@ -947,8 +946,7 @@ open class Session {
                      usingThreshold encodingMemoryThreshold: UInt64 = MultipartFormData.encodingMemoryThreshold,
                      interceptor: RequestInterceptor? = nil,
                      fileManager: FileManager = .default) -> UploadRequest {
-        let multipartUpload = MultipartUpload(isInBackgroundSession: session.configuration.identifier != nil,
-                                              encodingMemoryThreshold: encodingMemoryThreshold,
+        let multipartUpload = MultipartUpload(encodingMemoryThreshold: encodingMemoryThreshold,
                                               request: request,
                                               multipartFormData: multipartFormData)
 


### PR DESCRIPTION
### Issue Link :link:
Fixes #3403

### Goals :soccer:
This PR refactors how multipart uploads create their `URLRequest`s so that it doesn't require the full result calculation.

### Implementation Details :construction:
Rather than create the `URLRequest` in the `build()` method, it's now generated as part of the `URLRequestConvertible` conformance.

### Testing Details :mag:
Added a test that directly accesses the generated `URLRequest`, which triggers the thread sanitizer if the access is unsafe.
