### PR TITLE
Multipart Form Data Encoding Fix

### DIFF
--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -420,7 +420,7 @@ open class Session {
                             requestModifier: RequestModifier? = nil) -> DataStreamRequest {
         let convertible = RequestEncodableConvertible(url: convertible,
                                                       method: method,
-                                                      parameters: Optional<Empty>.none,
+                                                      parameters: Empty?.none,
                                                       encoder: URLEncodedFormParameterEncoder.default,
                                                       headers: headers,
                                                       requestModifier: requestModifier)

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -1019,13 +1019,15 @@ open class Session {
     func performUploadRequest(_ request: UploadRequest) {
         dispatchPrecondition(condition: .onQueue(requestQueue))
 
-        do {
-            let uploadable = try request.upload.createUploadable()
-            rootQueue.async { request.didCreateUploadable(uploadable) }
-
-            performSetupOperations(for: request, convertible: request.convertible)
-        } catch {
-            rootQueue.async { request.didFailToCreateUploadable(with: error.asAFError(or: .createUploadableFailed(error: error))) }
+        performSetupOperations(for: request, convertible: request.convertible) {
+            do {
+                let uploadable = try request.upload.createUploadable()
+                self.rootQueue.async { request.didCreateUploadable(uploadable) }
+                return true
+            } catch {
+                self.rootQueue.async { request.didFailToCreateUploadable(with: error.asAFError(or: .createUploadableFailed(error: error))) }
+                return false
+            }
         }
     }
 
@@ -1040,7 +1042,10 @@ open class Session {
         }
     }
 
-    func performSetupOperations(for request: Request, convertible: URLRequestConvertible) {
+    func performSetupOperations(for request: Request,
+                                convertible: URLRequestConvertible,
+                                shouldCreateTask: @escaping () -> Bool = { true })
+    {
         dispatchPrecondition(condition: .onQueue(requestQueue))
 
         let initialRequest: URLRequest
@@ -1058,6 +1063,7 @@ open class Session {
         guard !request.isCancelled else { return }
 
         guard let adapter = adapter(for: request) else {
+            guard shouldCreateTask() else { return }
             rootQueue.async { self.didCreateURLRequest(initialRequest, for: request) }
             return
         }
@@ -1067,10 +1073,11 @@ open class Session {
                 let adaptedRequest = try result.get()
                 try adaptedRequest.validate()
 
-                self.rootQueue.async {
-                    request.didAdaptInitialRequest(initialRequest, to: adaptedRequest)
-                    self.didCreateURLRequest(adaptedRequest, for: request)
-                }
+                self.rootQueue.async { request.didAdaptInitialRequest(initialRequest, to: adaptedRequest) }
+
+                guard shouldCreateTask() else { return }
+
+                self.rootQueue.async { self.didCreateURLRequest(adaptedRequest, for: request) }
             } catch {
                 self.rootQueue.async { request.didFailToAdaptURLRequest(initialRequest, withError: .requestAdaptationFailed(error: error)) }
             }

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -620,7 +620,7 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
         XCTAssertNil(response?.error)
 
         switch uploadRequest.uploadable {
-        case .data(let data):
+        case let .data(data):
             XCTAssertEqual(data.count, 241)
 
         default:

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -580,6 +580,54 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
         XCTAssertTrue(response?.result.isSuccess == false)
     }
 
+    func testThatUploadingMultipartFormDataWorksWhenAppendingBodyPartsInURLRequestConvertible() {
+        // Given
+        struct MultipartFormDataRequest: URLRequestConvertible {
+            let multipartFormData = MultipartFormData()
+
+            func asURLRequest() throws -> URLRequest {
+                appendBodyParts()
+                return try Endpoint.method(.post).asURLRequest()
+            }
+
+            func appendBodyParts() {
+                let frenchData = Data("français".utf8)
+                multipartFormData.append(frenchData, withName: "french")
+
+                let japaneseData = Data("日本語".utf8)
+                multipartFormData.append(japaneseData, withName: "japanese")
+            }
+        }
+
+        let request = MultipartFormDataRequest()
+
+        let expectation = self.expectation(description: "multipart form data upload should succeed")
+        var response: DataResponse<Data?, AFError>?
+
+        // When
+        let uploadRequest = AF.upload(multipartFormData: request.multipartFormData, with: request)
+            .response { resp in
+                response = resp
+                expectation.fulfill()
+            }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(response?.request)
+        XCTAssertNotNil(response?.response)
+        XCTAssertNotNil(response?.data)
+        XCTAssertNil(response?.error)
+
+        switch uploadRequest.uploadable {
+        case .data(let data):
+            XCTAssertEqual(data.count, 241)
+
+        default:
+            XCTFail("Uploadable should be of type data and not be empty")
+        }
+    }
+
     #if os(macOS)
     func disabled_testThatUploadingMultipartFormDataOnBackgroundSessionWritesDataToFileToAvoidCrash() {
         // Given


### PR DESCRIPTION
This PR fixes up a regression introduced by PR #3421 where clients relying on the `URLRequest` creation process to append body parts to `MultipartFormData` objects were no longer doing so. The body parts would no longer be appended since the `Uploadable` creation was happening before the `URLRequest` creation took place.

As @jshier and I looked into the issue further, it became apparent that we needed to redesign the logic to instead operate as follows:

1. Create the initial `URLRequest` (this is where I'm appending the body parts)
2. Adapt the `URLRequest` with any appended interceptors
3. Create the `Uploadable` which will encode the `MultipartFormData`
4. Create the`URLSessionUploadTask` which will actually upload the data

This approach will ensure we not only allow clients to append body parts as part of the `URLRequestConvertible` conformance prior to encoding, but it also allows us to avoid encoding the `MultipartFormData` if the `URLRequest` creation or adaptation fails. Win win!

### Issue Link :link:
No original issue filed.

### Goals :soccer:
- To allow clients to continue to append body parts to `MultipartFormData` as part of the `URLRequest` creation process
- To streamline the `MultipartFormData` upload process to only encode the data if the `URLRequest` creation and adaptation process succeeds

### Implementation Details :construction:
Minor change internally where we're just re-ordering the operations for uploads.

### Testing Details :mag:
Added a test which ensures the body parts are appended to the `MultipartFormData` as part of the `URLRequest` creation process and also verifies the size of the data being uploaded.
