### PR TITLE
ServerTrustEvaluating add sessionTask

### DIFF
--- a/Source/ServerTrustEvaluation.swift
+++ b/Source/ServerTrustEvaluation.swift
@@ -69,6 +69,22 @@ open class ServerTrustManager {
 
         return evaluator
     }
+    
+    /// Returns the `ServerTrustEvaluating` value for the given host, if one is set.
+    ///
+    /// By default, this method will return the policy that perfectly matches the given host. Subclasses could override
+    /// this method and implement more complex mapping implementations such as wildcards.
+    ///
+    /// - Parameter host: The host to use when searching for a matching policy.
+    ///
+    /// - Parameter task: The task to use when searching for a matching policy.
+    ///
+    /// - Returns:        The `ServerTrustEvaluating` value for the given host if found, `nil` otherwise.
+    /// - Throws:         `AFError.serverTrustEvaluationFailed` if `allHostsMustBeEvaluated` is `true` and no matching
+    ///                   evaluators are found.
+    open func serverTrustEvaluator(forTask task: URLSessionTask, forHost host: String) throws -> ServerTrustEvaluating? {
+       return try self.serverTrustEvaluator(forHost: host)
+    }
 }
 
 /// A protocol describing the API used to evaluate server trusts.

--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -92,7 +92,7 @@ extension SessionDelegate: URLSessionTaskDelegate {
         let evaluation: ChallengeEvaluation
         switch challenge.protectionSpace.authenticationMethod {
         case NSURLAuthenticationMethodServerTrust:
-            evaluation = attemptServerTrustAuthentication(with: challenge)
+            evaluation = attemptServerTrustAuthentication(forTask: task, with: challenge)
         case NSURLAuthenticationMethodHTTPBasic, NSURLAuthenticationMethodHTTPDigest, NSURLAuthenticationMethodNTLM,
              NSURLAuthenticationMethodNegotiate, NSURLAuthenticationMethodClientCertificate:
             evaluation = attemptCredentialAuthentication(for: challenge, belongingTo: task)
@@ -111,8 +111,10 @@ extension SessionDelegate: URLSessionTaskDelegate {
     ///
     /// - Parameter challenge: The `URLAuthenticationChallenge`.
     ///
+    /// - Parameter task: The `task`.
+    ///
     /// - Returns:             The `ChallengeEvaluation`.
-    func attemptServerTrustAuthentication(with challenge: URLAuthenticationChallenge) -> ChallengeEvaluation {
+    func attemptServerTrustAuthentication(forTask task: URLSessionTask, with challenge: URLAuthenticationChallenge) -> ChallengeEvaluation {
         let host = challenge.protectionSpace.host
 
         guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
@@ -122,7 +124,7 @@ extension SessionDelegate: URLSessionTaskDelegate {
         }
 
         do {
-            guard let evaluator = try stateProvider?.serverTrustManager?.serverTrustEvaluator(forHost: host) else {
+            guard let evaluator = try stateProvider?.serverTrustManager?.serverTrustEvaluator(forTask: task, forHost: host) else {
                 return (.performDefaultHandling, nil, nil)
             }
 


### PR DESCRIPTION
Problem:

 in the same session, there may be many requests at the same time. For the same host service host, there may be different types of services that need to be verified differently. At this time, it is impossible to distinguish which request is issued by the host only,
Solution:

 after task is supplemented, you can obtain URLsessionTask by override func servertrustevaluator (for task: urlsessiontask, for host: String) task.taskIdentifier Attribute matching request.onURLSessionTaskCreation (performance handler: @escaping (urlsessiontask) - > void) identifies which request is specific.