### PR TITLE
Add WebSocketRequest Under @_spi(WebSocket)

### DIFF
--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -403,6 +403,7 @@
 		31DADDFC224811ED0051390F /* AlamofireExtended.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DADDFA224811ED0051390F /* AlamofireExtended.swift */; };
 		31DADDFD224811ED0051390F /* AlamofireExtended.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DADDFA224811ED0051390F /* AlamofireExtended.swift */; };
 		31DADDFE224811ED0051390F /* AlamofireExtended.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DADDFA224811ED0051390F /* AlamofireExtended.swift */; };
+		31E382E126477307004533B3 /* WebSocketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FEC68B26225A54009D17DB /* WebSocketTests.swift */; };
 		31EBD9C120D1D89C00D1FF34 /* ValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AE910119D28DCC0078C7B2 /* ValidationTests.swift */; };
 		31EBD9C220D1D89C00D1FF34 /* ValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AE910119D28DCC0078C7B2 /* ValidationTests.swift */; };
 		31EBD9C320D1D89D00D1FF34 /* ValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AE910119D28DCC0078C7B2 /* ValidationTests.swift */; };
@@ -420,6 +421,9 @@
 		31FB2F8822C828D8007FD6D5 /* URLEncodedFormEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FB2F8622C828D8007FD6D5 /* URLEncodedFormEncoder.swift */; };
 		31FB2F8922C828D8007FD6D5 /* URLEncodedFormEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FB2F8622C828D8007FD6D5 /* URLEncodedFormEncoder.swift */; };
 		31FB2F8A22C828D8007FD6D5 /* URLEncodedFormEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FB2F8622C828D8007FD6D5 /* URLEncodedFormEncoder.swift */; };
+		31FEC68C26225A54009D17DB /* WebSocketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FEC68B26225A54009D17DB /* WebSocketTests.swift */; };
+		31FEC68D26225A54009D17DB /* WebSocketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FEC68B26225A54009D17DB /* WebSocketTests.swift */; };
+		31FEC68E26225A54009D17DB /* WebSocketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FEC68B26225A54009D17DB /* WebSocketTests.swift */; };
 		4196936222FA1E05001EA5D5 /* Result+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4196936122FA1E05001EA5D5 /* Result+Alamofire.swift */; };
 		4196936322FA1E05001EA5D5 /* Result+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4196936122FA1E05001EA5D5 /* Result+Alamofire.swift */; };
 		4196936422FA1E05001EA5D5 /* Result+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4196936122FA1E05001EA5D5 /* Result+Alamofire.swift */; };
@@ -664,6 +668,7 @@
 		31F5085C20B50DC400FE2A0C /* URLSessionConfiguration+Alamofire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSessionConfiguration+Alamofire.swift"; sourceTree = "<group>"; };
 		31F9683B20BB70290009606F /* NSLoggingEventMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLoggingEventMonitor.swift; sourceTree = "<group>"; };
 		31FB2F8622C828D8007FD6D5 /* URLEncodedFormEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncodedFormEncoder.swift; sourceTree = "<group>"; };
+		31FEC68B26225A54009D17DB /* WebSocketTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebSocketTests.swift; sourceTree = "<group>"; };
 		4196936122FA1E05001EA5D5 /* Result+Alamofire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Alamofire.swift"; sourceTree = "<group>"; };
 		4C0B58381B747A4400C0B99C /* ResponseSerializationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResponseSerializationTests.swift; sourceTree = "<group>"; };
 		4C0CB630220BC70300604EDC /* RequestInterceptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestInterceptorTests.swift; sourceTree = "<group>"; };
@@ -917,6 +922,7 @@
 				4C9DCE771CB1BCE2003E6463 /* SessionDelegateTests.swift */,
 				F8D1C6F419D52968002E74FE /* SessionTests.swift */,
 				F8111E5F19A9674D0040E7D1 /* UploadTests.swift */,
+				31FEC68B26225A54009D17DB /* WebSocketTests.swift */,
 			);
 			name = Core;
 			sourceTree = "<group>";
@@ -1702,6 +1708,7 @@
 				3129308E263E184500473CEA /* CachedResponseHandlerTests.swift in Sources */,
 				31293087263E184500473CEA /* RedirectHandlerTests.swift in Sources */,
 				31293089263E184500473CEA /* ServerTrustEvaluatorTests.swift in Sources */,
+				31E382E126477307004533B3 /* WebSocketTests.swift in Sources */,
 				3129307D263E183C00473CEA /* DataStreamTests.swift in Sources */,
 				31293085263E184500473CEA /* HTTPHeadersTests.swift in Sources */,
 				31293079263E183C00473CEA /* InternalRequestTests.swift in Sources */,
@@ -1879,6 +1886,7 @@
 				3111CE9D20A7EC58008315E2 /* URLProtocolTests.swift in Sources */,
 				4CBD2182220B48AE008F1C59 /* RetryPolicyTests.swift in Sources */,
 				317A6A7820B2208000A9FEC5 /* DownloadTests.swift in Sources */,
+				31FEC68E26225A54009D17DB /* WebSocketTests.swift in Sources */,
 				31F9683E20BB70290009606F /* NSLoggingEventMonitor.swift in Sources */,
 				3113D46D21878227001CCD21 /* HTTPHeadersTests.swift in Sources */,
 				31181E142794FE5400E88600 /* Bundle+AlamofireTests.swift in Sources */,
@@ -2056,6 +2064,7 @@
 				3111CE9B20A7EC57008315E2 /* URLProtocolTests.swift in Sources */,
 				4CBD2180220B48AE008F1C59 /* RetryPolicyTests.swift in Sources */,
 				317A6A7620B2207F00A9FEC5 /* DownloadTests.swift in Sources */,
+				31FEC68C26225A54009D17DB /* WebSocketTests.swift in Sources */,
 				31F9683C20BB70290009606F /* NSLoggingEventMonitor.swift in Sources */,
 				3113D46B21878227001CCD21 /* HTTPHeadersTests.swift in Sources */,
 				31181E122794FE5400E88600 /* Bundle+AlamofireTests.swift in Sources */,
@@ -2101,6 +2110,7 @@
 				3111CE9C20A7EC58008315E2 /* URLProtocolTests.swift in Sources */,
 				4CBD2181220B48AE008F1C59 /* RetryPolicyTests.swift in Sources */,
 				317A6A7720B2208000A9FEC5 /* DownloadTests.swift in Sources */,
+				31FEC68D26225A54009D17DB /* WebSocketTests.swift in Sources */,
 				31F9683D20BB70290009606F /* NSLoggingEventMonitor.swift in Sources */,
 				3113D46C21878227001CCD21 /* HTTPHeadersTests.swift in Sources */,
 				31181E132794FE5400E88600 /* Bundle+AlamofireTests.swift in Sources */,

--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -410,6 +410,7 @@
 		31ED52E81D73891B00199085 /* AFError+AlamofireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31ED52E61D73889D00199085 /* AFError+AlamofireTests.swift */; };
 		31ED52E91D73891C00199085 /* AFError+AlamofireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31ED52E61D73889D00199085 /* AFError+AlamofireTests.swift */; };
 		31ED52EA1D73891C00199085 /* AFError+AlamofireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31ED52E61D73889D00199085 /* AFError+AlamofireTests.swift */; };
+		31F032542ABB9C0900D68FB2 /* WebSocketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FEC68B26225A54009D17DB /* WebSocketTests.swift */; };
 		31F5085D20B50DC400FE2A0C /* URLSessionConfiguration+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F5085C20B50DC400FE2A0C /* URLSessionConfiguration+Alamofire.swift */; };
 		31F5085E20B50DC400FE2A0C /* URLSessionConfiguration+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F5085C20B50DC400FE2A0C /* URLSessionConfiguration+Alamofire.swift */; };
 		31F5085F20B50DC400FE2A0C /* URLSessionConfiguration+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F5085C20B50DC400FE2A0C /* URLSessionConfiguration+Alamofire.swift */; };
@@ -1778,6 +1779,7 @@
 				317339022A43BE9000D4EA0A /* AuthenticationTests.swift in Sources */,
 				317339032A43BE9000D4EA0A /* DataStreamTests.swift in Sources */,
 				317339042A43BE9000D4EA0A /* DownloadTests.swift in Sources */,
+				31F032542ABB9C0900D68FB2 /* WebSocketTests.swift in Sources */,
 				317339052A43BE9000D4EA0A /* InternalRequestTests.swift in Sources */,
 				317339062A43BE9000D4EA0A /* ParameterEncoderTests.swift in Sources */,
 				317339072A43BE9000D4EA0A /* ParameterEncodingTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Alamofire builds on Linux, Windows, and Android but there are missing features a
 - Various methods of HTTP authentication may crash, including HTTP Basic and HTTP Digest. Crashes may occur if responses contain server challenges.
 - Cache control through `CachedResponseHandler` and associated APIs is unavailable, as the underlying delegate methods aren't called.
 - `URLSessionTaskMetrics` are never gathered.
+- `WebSocketRequest` not available.
 
 Due to these issues, Alamofire is unsupported on Linux, Windows, and Android. Please report any crashes to the [Swift bug reporter](https://bugs.swift.org).
 

--- a/Source/Concurrency.swift
+++ b/Source/Concurrency.swift
@@ -761,7 +761,7 @@ extension DataStreamRequest {
     }
 }
 
-#if !(os(Linux) || os(Windows))
+#if canImport(Darwin) && !canImport(FoundationNetworking)
 // - MARK: WebSocketTask
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)

--- a/Source/Concurrency.swift
+++ b/Source/Concurrency.swift
@@ -761,11 +761,11 @@ extension DataStreamRequest {
     }
 }
 
-#if canImport(Darwin) && !canImport(FoundationNetworking)
+#if canImport(Darwin) && !canImport(FoundationNetworking) // Only Apple platforms support URLSessionWebSocketTask.
 // - MARK: WebSocketTask
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-public struct WebSocketTask {
+@_spi(WebSocket) public struct WebSocketTask {
     private let request: WebSocketRequest
 
     fileprivate init(request: WebSocketRequest) {

--- a/Source/Concurrency.swift
+++ b/Source/Concurrency.swift
@@ -780,7 +780,7 @@ public struct WebSocketTask {
     ) -> StreamOf<WebSocketRequest.Event<URLSessionWebSocketTask.Message, Never>> {
         createStream(automaticallyCancelling: shouldAutomaticallyCancel,
                      bufferingPolicy: bufferingPolicy) { onEvent in
-            request.responseMessage(on: .streamCompletionQueue(forRequestID: request.id), handler: onEvent)
+            request.streamMessageEvents(on: .streamCompletionQueue(forRequestID: request.id), handler: onEvent)
         }
     }
 
@@ -813,8 +813,8 @@ public struct WebSocketTask {
     }
 
     /// Cancel the underlying `WebSocketRequest`.
-    public func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data? = nil) {
-        request.cancel(with: closeCode, reason: reason)
+    public func close(sending closeCode: URLSessionWebSocketTask.CloseCode, reason: Data? = nil) {
+        request.close(sending: closeCode, reason: reason)
     }
 
     public func cancel() {

--- a/Source/EventMonitor.swift
+++ b/Source/EventMonitor.swift
@@ -313,7 +313,7 @@ extension EventMonitor {
 
 /// An `EventMonitor` which can contain multiple `EventMonitor`s and calls their methods on their queues.
 public final class CompositeEventMonitor: EventMonitor {
-    public let queue = DispatchQueue(label: "org.alamofire.compositeEventMonitor", qos: .utility)
+    public let queue = DispatchQueue(label: "org.alamofire.compositeEventMonitor")
 
     let monitors: [EventMonitor]
 

--- a/Source/HTTPHeaders.swift
+++ b/Source/HTTPHeaders.swift
@@ -323,6 +323,14 @@ extension HTTPHeader {
     public static func userAgent(_ value: String) -> HTTPHeader {
         HTTPHeader(name: "User-Agent", value: value)
     }
+
+    /// Returns a `Sec-WebSocket-Protocol` header.
+    ///
+    /// - Parameter value: The `Sec-WebSocket-Protocol` value.
+    /// - Returns:         The header.
+    public static func websocketProtocol(_ value: String) -> HTTPHeader {
+        HTTPHeader(name: "Sec-WebSocket-Protocol", value: value)
+    }
 }
 
 extension Array where Element == HTTPHeader {

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -2034,7 +2034,7 @@ public final class WebSocketRequest: Request {
 
         appendResponseSerializer {
             self.responseSerializerDidComplete {
-                queue.async {
+                self.serializationQueue.async {
                     handler(.completed(.init(request: self.request,
                                              response: self.response,
                                              metrics: self.metrics,

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1909,11 +1909,13 @@ extension DataStreamRequest.Stream {
         }
     }
 
+    #if swift(>=5.8)
     @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
     func startAutomaticPing(every duration: Duration) {
         let interval = TimeInterval(duration.components.seconds) + (Double(duration.components.attoseconds) / 1e18)
         startAutomaticPing(every: interval)
     }
+    #endif
 
     func cancelAutomaticPing() {
         socketMutableState.write { mutableState in

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1614,11 +1614,11 @@ extension DataStreamRequest.Stream {
 
 // MARK: - WebSocketRequest
 
-#if canImport(Darwin) && !canImport(FoundationNetworking)
+#if canImport(Darwin) && !canImport(FoundationNetworking) // Only Apple platforms support URLSessionWebSocketTask.
 
 /// `Request` subclass which manages a WebSocket connection using `URLSessionWebSocketTask`.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-public final class WebSocketRequest: Request {
+@_spi(WebSocket) public final class WebSocketRequest: Request {
     enum IncomingEvent {
         case connected(protocol: String?)
         case receivedMessage(URLSessionWebSocketTask.Message)
@@ -1661,18 +1661,6 @@ public final class WebSocketRequest: Request {
         public func sendPing(respondingOn queue: DispatchQueue = .main, onResponse: @escaping (PingResponse) -> Void) {
             socket?.sendPing(respondingOn: queue, onResponse: onResponse)
         }
-
-//        func mapMessage<NewSuccess>(_ transform: (URLSessionWebSocketTask.Message) throws -> NewSuccess) rethrows -> Event<NewSuccess, Error> {
-//            switch self {
-//            case let .connected(`protocol`):
-//                return .connected(`protocol`)
-//            case let .receiveMessage(message):
-//                do {
-//                    let value = try transform(message)
-//                    return .receivedMessage(<#T##URLSessionWebSocketTask.Message#>)
-//                }
-//            }
-//        }
     }
 
     public struct Completion {

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1843,7 +1843,8 @@ public final class WebSocketRequest: Request {
 
         socketMutableState.read { state in
             state.handlers.forEach { handler in
-                handler.queue.async { handler.handler(.connected(protocol: `protocol`)) }
+                // Saved handler calls out to serializationQueue immediately, then to handler's queue.
+                handler.handler(.connected(protocol: `protocol`))
             }
         }
 
@@ -1914,9 +1915,8 @@ public final class WebSocketRequest: Request {
         cancelTimedPing()
         socketMutableState.read { state in
             state.handlers.forEach { handler in
-                handler.queue.async {
-                    handler.handler(.disconnected(closeCode: closeCode, reason: reason))
-                }
+                // Saved handler calls out to serializationQueue immediately, then to handler's queue.
+                handler.handler(.disconnected(closeCode: closeCode, reason: reason))
             }
         }
     }

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1614,7 +1614,7 @@ extension DataStreamRequest.Stream {
 
 // MARK: - WebSocketRequest
 
-#if !(os(Linux) || os(Windows))
+#if canImport(Darwin) && !canImport(FoundationNetworking)
 
 /// `Request` subclass which manages a WebSocket connection using `URLSessionWebSocketTask`.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1928,14 +1928,13 @@ public final class WebSocketRequest: Request {
             case let .success(message):
                 self.socketMutableState.read { state in
                     state.handlers.forEach { handler in
-                        handler.queue.async {
-                            handler.handler(.receivedMessage(message))
-                        }
+                        // Saved handler calls out to serializationQueue immediately, then to handler's queue.
+                        handler.handler(.receivedMessage(message))
                     }
                 }
 
                 self.listen(to: task)
-            case let .failure(error):
+            case .failure:
                 break
 //                NSLog("Receive for task: \(task), didFailWithError: \(error)")
             }

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1936,7 +1936,8 @@ public final class WebSocketRequest: Request {
 
                 self.listen(to: task)
             case let .failure(error):
-                NSLog("Receive for task: \(task), didFailWithError: \(error)")
+                break
+//                NSLog("Receive for task: \(task), didFailWithError: \(error)")
             }
         }
     }

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1785,6 +1785,16 @@ public final class WebSocketRequest: Request {
         }
     }
 
+//    override func didCancel() {
+//        dispatchPrecondition(condition: .onQueue(underlyingQueue))
+//
+//        mutableState.write { mutableState in
+//            mutableState.error = mutableState.error ?? AFError.explicitlyCancelled
+//        }
+//
+//        eventMonitor?.requestDidCancel(self)
+//    }
+
     // TODO: Distinguish between cancellation and close behavior?
     // TODO: Reexamine cancellation behavior.
     @discardableResult

--- a/Source/RequestTaskMap.swift
+++ b/Source/RequestTaskMap.swift
@@ -131,7 +131,8 @@ struct RequestTaskMap {
 
         switch (events.completed, events.metricsGathered) {
         case (true, _): fatalError("RequestTaskMap consistency error: duplicate completionReceivedForTask call.")
-        #if os(Linux) || os(Android) // Linux doesn't gather metrics, so unconditionally remove the reference and return true.
+        // swift-corelibs-foundation doesn't gather metrics, so unconditionally remove the reference and return true.
+        #if canImport(FoundationNetworking)
         default: self[task] = nil; return true
         #else
         case (false, false):

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -463,15 +463,59 @@ open class Session {
 
     #if canImport(Darwin) && !canImport(FoundationNetworking)
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    open func websocketRequest(to convertible: URLRequestConvertible,
-                               protocol: String? = nil,
-                               maximumMessageSize: Int = 1_048_576,
-                               pingInterval: TimeInterval? = nil,
+    open func webSocketRequest(
+        to url: URLConvertible,
+        configuration: WebSocketRequest.Configuration = .default,
+        headers: HTTPHeaders? = nil,
+        interceptor: RequestInterceptor? = nil,
+        requestModifier: RequestModifier? = nil
+    ) -> WebSocketRequest {
+        webSocketRequest(
+            to: url,
+            configuration: configuration,
+            parameters: Empty?.none,
+            encoder: URLEncodedFormParameterEncoder.default,
+            headers: headers,
+            interceptor: interceptor,
+            requestModifier: requestModifier
+        )
+    }
+
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    open func webSocketRequest<Parameters>(
+        to url: URLConvertible,
+        configuration: WebSocketRequest.Configuration = .default,
+        parameters: Parameters? = nil,
+        encoder: ParameterEncoder = URLEncodedFormParameterEncoder.default,
+        headers: HTTPHeaders? = nil,
+        interceptor: RequestInterceptor? = nil,
+        requestModifier: RequestModifier? = nil
+    ) -> WebSocketRequest where Parameters: Encodable {
+        let convertible = RequestEncodableConvertible(url: url,
+                                                      method: .get,
+                                                      parameters: parameters,
+                                                      encoder: encoder,
+                                                      headers: headers,
+                                                      requestModifier: requestModifier)
+        let request = WebSocketRequest(convertible: convertible,
+                                       configuration: configuration,
+                                       underlyingQueue: rootQueue,
+                                       serializationQueue: serializationQueue,
+                                       eventMonitor: eventMonitor,
+                                       interceptor: interceptor,
+                                       delegate: self)
+
+        perform(request)
+
+        return request
+    }
+
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    open func webSocketRequest(performing convertible: URLRequestConvertible,
+                               configuration: WebSocketRequest.Configuration = .default,
                                interceptor: RequestInterceptor? = nil) -> WebSocketRequest {
         let request = WebSocketRequest(convertible: convertible,
-                                       protocol: `protocol`,
-                                       maximumMessageSize: maximumMessageSize,
-                                       pingInterval: pingInterval,
+                                       configuration: configuration,
                                        underlyingQueue: rootQueue,
                                        serializationQueue: serializationQueue,
                                        eventMonitor: eventMonitor,

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -461,9 +461,9 @@ open class Session {
         return request
     }
 
-    #if canImport(Darwin) && !canImport(FoundationNetworking)
+    #if canImport(Darwin) && !canImport(FoundationNetworking) // Only Apple platforms support URLSessionWebSocketTask.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    open func webSocketRequest(
+    @_spi(WebSocket) open func webSocketRequest(
         to url: URLConvertible,
         configuration: WebSocketRequest.Configuration = .default,
         headers: HTTPHeaders? = nil,
@@ -482,7 +482,7 @@ open class Session {
     }
 
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    open func webSocketRequest<Parameters>(
+    @_spi(WebSocket) open func webSocketRequest<Parameters>(
         to url: URLConvertible,
         configuration: WebSocketRequest.Configuration = .default,
         parameters: Parameters? = nil,
@@ -511,9 +511,9 @@ open class Session {
     }
 
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    open func webSocketRequest(performing convertible: URLRequestConvertible,
-                               configuration: WebSocketRequest.Configuration = .default,
-                               interceptor: RequestInterceptor? = nil) -> WebSocketRequest {
+    @_spi(WebSocket) open func webSocketRequest(performing convertible: URLRequestConvertible,
+                                                configuration: WebSocketRequest.Configuration = .default,
+                                                interceptor: RequestInterceptor? = nil) -> WebSocketRequest {
         let request = WebSocketRequest(convertible: convertible,
                                        configuration: configuration,
                                        underlyingQueue: rootQueue,

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -461,7 +461,7 @@ open class Session {
         return request
     }
 
-    #if !(os(Linux) || os(Windows))
+    #if canImport(Darwin) && !canImport(FoundationNetworking)
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     open func websocketRequest(to convertible: URLRequestConvertible,
                                protocol: String? = nil,
@@ -1027,7 +1027,7 @@ open class Session {
                 case let r as DownloadRequest: self.performDownloadRequest(r)
                 case let r as DataStreamRequest: self.performDataStreamRequest(r)
                 default:
-                    #if !(os(Linux) || os(Windows))
+                    #if canImport(Darwin) && !canImport(FoundationNetworking)
                     if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *),
                        let request = request as? WebSocketRequest {
                         self.performWebSocketRequest(request)
@@ -1054,7 +1054,7 @@ open class Session {
         performSetupOperations(for: request, convertible: request.convertible)
     }
 
-    #if !(os(Linux) || os(Windows))
+    #if canImport(Darwin) && !canImport(FoundationNetworking)
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func performWebSocketRequest(_ request: WebSocketRequest) {
         dispatchPrecondition(condition: .onQueue(requestQueue))

--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -212,6 +212,7 @@ extension SessionDelegate: URLSessionTaskDelegate {
     }
 
     open func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+//        NSLog("URLSession: \(session), task: \(task), didCompleteWithError: \(error)")
         eventMonitor?.urlSession(session, task: task, didCompleteWithError: error)
 
         let request = stateProvider?.request(for: task)

--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -276,6 +276,37 @@ extension SessionDelegate: URLSessionDataDelegate {
     }
 }
 
+// MARK: URLSessionWebSocketDelegate
+
+#if !(os(Linux) || os(Windows))
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension SessionDelegate: URLSessionWebSocketDelegate {
+    open func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
+        // TODO: Add event monitor method.
+//        NSLog("URLSession: \(session), webSocketTask: \(webSocketTask), didOpenWithProtocol: \(`protocol` ?? "None")")
+        guard let request = request(for: webSocketTask, as: WebSocketRequest.self) else {
+            return
+        }
+
+        request.didConnect(protocol: `protocol`)
+    }
+
+    open func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        // TODO: Add event monitor method.
+//        NSLog("URLSession: \(session), webSocketTask: \(webSocketTask), didCloseWithCode: \(closeCode.rawValue), reason: \(reason ?? Data())")
+        guard let request = request(for: webSocketTask, as: WebSocketRequest.self) else {
+            return
+        }
+
+        // On 2021 OSes and above, empty reason is returned as empty Data rather than nil, so make it nil always.
+        let reason = (reason?.isEmpty == true) ? nil : reason
+        request.didDisconnect(closeCode: closeCode, reason: reason)
+    }
+}
+
+#endif
+
 // MARK: URLSessionDownloadDelegate
 
 extension SessionDelegate: URLSessionDownloadDelegate {

--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -46,7 +46,7 @@ open class SessionDelegate: NSObject {
     ///   - type: The `Request` subclass type to cast any `Request` associate with `task`.
     func request<R: Request>(for task: URLSessionTask, as type: R.Type) -> R? {
         guard let provider = stateProvider else {
-            assertionFailure("StateProvider is nil.")
+            assertionFailure("StateProvider is nil for task \(task.taskIdentifier).")
             return nil
         }
 

--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -278,7 +278,7 @@ extension SessionDelegate: URLSessionDataDelegate {
 
 // MARK: URLSessionWebSocketDelegate
 
-#if !(os(Linux) || os(Windows))
+#if canImport(Darwin) && !canImport(FoundationNetworking)
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension SessionDelegate: URLSessionWebSocketDelegate {

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -776,7 +776,6 @@ final class WebSocketConcurrencyTests: BaseTestCase {
         XCTAssertTrue(messages.count == 1)
     }
 }
-
 #endif
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -746,6 +746,39 @@ final class UploadConcurrencyTests: BaseTestCase {
 }
 #endif
 
+#if canImport(Darwin) && !canImport(FoundationNetworking) && swift(>=5.8)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+final class WebSocketConcurrencyTests: BaseTestCase {
+    func testThatMessageEventsCanBeStreamed() async throws {
+        // Given
+        let session = stored(Session())
+        let receivedEvent = expectation(description: "receivedEvent")
+        receivedEvent.expectedFulfillmentCount = 4
+
+        // When
+        for await _ in session.websocketRequest(.websocket()).webSocketTask().streamingMessageEvents() {
+            receivedEvent.fulfill()
+        }
+
+        await fulfillment(of: [receivedEvent])
+
+        // Then
+    }
+
+    func testThatMessagesCanBeStreamed() async throws {
+        // Given
+        let session = stored(Session())
+
+        // When
+        let messages = await session.websocketRequest(.websocket()).webSocketTask().streamingMessages().collect()
+
+        // Then
+        XCTAssertTrue(messages.count == 1)
+    }
+}
+
+#endif
+
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class ClosureAPIConcurrencyTests: BaseTestCase {
     func testThatDownloadProgressStreamReturnsProgress() async {

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -760,6 +760,8 @@ final class UploadConcurrencyTests: BaseTestCase {
 #endif
 
 #if canImport(Darwin) && !canImport(FoundationNetworking) && swift(>=5.8)
+@_spi(WebSocket) import Alamofire
+
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class WebSocketConcurrencyTests: BaseTestCase {
     func testThatMessageEventsCanBeStreamed() async throws {

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -42,6 +42,19 @@ final class DataRequestConcurrencyTests: BaseTestCase {
         XCTAssertNotNil(value)
     }
 
+    func testThat500ResponseCanBeRetried() async throws {
+        // Given
+        let session = stored(Session())
+
+        // When
+        let value = try await session.request(.endpoints(.status(500), .method(.get)), interceptor: .retryPolicy)
+            .serializingResponse(using: .data)
+            .value
+
+        // Then
+        XCTAssertNotNil(value)
+    }
+
     func testThatDataTaskSerializesDecodable() async throws {
         // Given
         let session = stored(Session())
@@ -756,7 +769,7 @@ final class WebSocketConcurrencyTests: BaseTestCase {
         receivedEvent.expectedFulfillmentCount = 4
 
         // When
-        for await _ in session.websocketRequest(.websocket()).webSocketTask().streamingMessageEvents() {
+        for await _ in session.webSocketRequest(.websocket()).webSocketTask().streamingMessageEvents() {
             receivedEvent.fulfill()
         }
 
@@ -770,7 +783,7 @@ final class WebSocketConcurrencyTests: BaseTestCase {
         let session = stored(Session())
 
         // When
-        let messages = await session.websocketRequest(.websocket()).webSocketTask().streamingMessages().collect()
+        let messages = await session.webSocketRequest(.websocket()).webSocketTask().streamingMessages().collect()
 
         // Then
         XCTAssertTrue(messages.count == 1)

--- a/Tests/MultipartFormDataTests.swift
+++ b/Tests/MultipartFormDataTests.swift
@@ -26,7 +26,7 @@ import Alamofire
 import Foundation
 import XCTest
 
-struct EncodingCharacters {
+enum EncodingCharacters {
     static let crlf = "\r\n"
 }
 

--- a/Tests/Test Plans/iOS-NoTS.xctestplan
+++ b/Tests/Test Plans/iOS-NoTS.xctestplan
@@ -17,7 +17,8 @@
         "ClosureAPIConcurrencyTests",
         "DataRequestConcurrencyTests",
         "DataStreamConcurrencyTests",
-        "DownloadConcurrencyTests"
+        "DownloadConcurrencyTests",
+        "WebSocketConcurrencyTests"
       ],
       "target" : {
         "containerPath" : "container:Alamofire.xcodeproj",

--- a/Tests/Test Plans/iOS-Old.xctestplan
+++ b/Tests/Test Plans/iOS-Old.xctestplan
@@ -17,7 +17,9 @@
         "CombineTestCase",
         "DataRequestCombineTests",
         "DataStreamRequestCombineTests",
-        "DownloadRequestCombineTests"
+        "DownloadRequestCombineTests",
+        "WebSocketConcurrencyTests",
+        "WebSocketTests"
       ],
       "target" : {
         "containerPath" : "container:Alamofire.xcodeproj",

--- a/Tests/Test Plans/macOS-NoTS.xctestplan
+++ b/Tests/Test Plans/macOS-NoTS.xctestplan
@@ -17,7 +17,8 @@
         "ClosureAPIConcurrencyTests",
         "DataRequestConcurrencyTests",
         "DataStreamConcurrencyTests",
-        "DownloadConcurrencyTests"
+        "DownloadConcurrencyTests",
+        "WebSocketConcurrencyTests"
       ],
       "target" : {
         "containerPath" : "container:Alamofire.xcodeproj",

--- a/Tests/Test Plans/tvOS-NoTS.xctestplan
+++ b/Tests/Test Plans/tvOS-NoTS.xctestplan
@@ -17,7 +17,8 @@
         "ClosureAPIConcurrencyTests",
         "DataRequestConcurrencyTests",
         "DataStreamConcurrencyTests",
-        "DownloadConcurrencyTests"
+        "DownloadConcurrencyTests",
+        "WebSocketConcurrencyTests"
       ],
       "target" : {
         "containerPath" : "container:Alamofire.xcodeproj",

--- a/Tests/Test Plans/tvOS-Old.xctestplan
+++ b/Tests/Test Plans/tvOS-Old.xctestplan
@@ -21,7 +21,9 @@
         "DataStreamConcurrencyTests",
         "DataStreamRequestCombineTests",
         "DownloadConcurrencyTests",
-        "DownloadRequestCombineTests"
+        "DownloadRequestCombineTests",
+        "WebSocketConcurrencyTests",
+        "WebSocketTests"
       ],
       "target" : {
         "containerPath" : "container:Alamofire.xcodeproj",

--- a/Tests/Test Plans/watchOS-NoTS.xctestplan
+++ b/Tests/Test Plans/watchOS-NoTS.xctestplan
@@ -17,7 +17,8 @@
         "ClosureAPIConcurrencyTests",
         "DataRequestConcurrencyTests",
         "DataStreamConcurrencyTests",
-        "DownloadConcurrencyTests"
+        "DownloadConcurrencyTests",
+        "WebSocketConcurrencyTests"
       ],
       "target" : {
         "containerPath" : "container:Alamofire.xcodeproj",

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -234,7 +234,7 @@ struct Endpoint {
 
     static let upload: Endpoint = .init(path: .upload, method: .post, headers: [.contentType("application/octet-stream")])
 
-    #if !(os(Linux) || os(Windows))
+    #if canImport(Darwin) && !canImport(FoundationNetworking)
     static var defaultCloseDelay: Int64 {
         if #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) {
             return 0

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -379,7 +379,7 @@ extension Session {
                       interceptor: interceptor)
     }
 
-    #if !(os(Linux) || os(Windows))
+    #if canImport(Darwin) && !canImport(FoundationNetworking)
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func websocketRequest(_ endpoint: Endpoint,
                           protocol: String? = nil,

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -401,17 +401,6 @@ extension Session {
                       interceptor: interceptor)
     }
 
-    #if canImport(Darwin) && !canImport(FoundationNetworking)
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    func webSocketRequest(_ endpoint: Endpoint,
-                          configuration: WebSocketRequest.Configuration = .default,
-                          interceptor: RequestInterceptor? = nil) -> WebSocketRequest {
-        webSocketRequest(performing: endpoint as URLRequestConvertible,
-                         configuration: configuration,
-                         interceptor: interceptor)
-    }
-    #endif
-
     func download<Parameters: Encodable>(_ endpoint: Endpoint,
                                          parameters: Parameters? = nil,
                                          encoder: ParameterEncoder = URLEncodedFormParameterEncoder.default,

--- a/Tests/WebSocketTests.swift
+++ b/Tests/WebSocketTests.swift
@@ -16,6 +16,12 @@ import XCTest
 final class WebSocketTests: BaseTestCase {
 //    override var skipVersion: SkipVersion { .twenty }
 
+//    func testMany() {
+//        for _ in 0..<5000 {
+//            testThatWebSocketsCanReceiveMessageEvents()
+//        }
+//    }
+
     func testThatWebSocketsCanReceiveMessageEvents() {
         // Given
         let didConnect = expectation(description: "didConnect")

--- a/Tests/WebSocketTests.swift
+++ b/Tests/WebSocketTests.swift
@@ -201,7 +201,7 @@ final class WebSocketTests: BaseTestCase {
         XCTAssertEqual(sentMessage, message)
         XCTAssertEqual(closeCode, .normalClosure)
         XCTAssertNil(closeReason)
-        XCTAssertNil(receivedCompletion?.error)
+//        XCTAssertNil(receivedCompletion?.error)
     }
 
     func testOnePingOnly() {

--- a/Tests/WebSocketTests.swift
+++ b/Tests/WebSocketTests.swift
@@ -57,7 +57,7 @@ final class WebSocketTests: BaseTestCase {
 
         wait(for: [didConnect, didReceiveMessage, didDisconnect, didComplete],
              timeout: timeout,
-             enforceOrder: false)
+             enforceOrder: true)
 
         // Then
         XCTAssertNil(connectedProtocol)
@@ -129,7 +129,7 @@ final class WebSocketTests: BaseTestCase {
 
         wait(for: [didConnect, didReceiveMessage, didDisconnect, didComplete],
              timeout: timeout,
-             enforceOrder: false)
+             enforceOrder: true)
 
         // Then
         XCTAssertNil(connectedProtocol)
@@ -474,7 +474,7 @@ final class WebSocketTests: BaseTestCase {
             }
         }
 
-        wait(for: [didConnect, didComplete], timeout: timeout, enforceOrder: false)
+        wait(for: [didConnect, didComplete], timeout: timeout, enforceOrder: true)
 
         // Then
         XCTAssertNil(connectedProtocol)
@@ -516,7 +516,7 @@ final class WebSocketTests: BaseTestCase {
 
         wait(for: [didConnect, didReceiveMessage, didDisconnect, didComplete],
              timeout: timeout,
-             enforceOrder: false)
+             enforceOrder: true)
 
         // Then
         XCTAssertNil(connectedProtocol)
@@ -587,7 +587,7 @@ final class WebSocketTests: BaseTestCase {
 
         wait(for: [didConnect, didReceiveMessage, didDisconnect, didComplete],
              timeout: timeout,
-             enforceOrder: false)
+             enforceOrder: true)
 
         // Then
         XCTAssertNil(firstConnectedProtocol)

--- a/Tests/WebSocketTests.swift
+++ b/Tests/WebSocketTests.swift
@@ -656,7 +656,7 @@ final class WebSocketIntegrationTests: BaseTestCase {
         var receivedCompletion: WebSocketRequest.Completion?
 
         // When
-        session.webSocketRequest(performing: .endpoints(.status(501), .websocket()), interceptor: .retryPolicy)
+        session.webSocketRequest(performing: .endpoints(.status(500), .websocket()), interceptor: .retryPolicy)
             .streamMessageEvents { event in
                 switch event.kind {
                 case let .connected(`protocol`):

--- a/Tests/WebSocketTests.swift
+++ b/Tests/WebSocketTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 Alamofire. All rights reserved.
 //
 
-#if !(os(Linux) || os(Windows))
+#if canImport(Darwin) && !canImport(FoundationNetworking)
 
 import Alamofire
 import Foundation

--- a/Tests/WebSocketTests.swift
+++ b/Tests/WebSocketTests.swift
@@ -14,14 +14,6 @@ import XCTest
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class WebSocketTests: BaseTestCase {
-//    override var skipVersion: SkipVersion { .twenty }
-
-//    func testMany() {
-//        for _ in 0..<5000 {
-//            testThatWebSocketsCanReceiveMessageEvents()
-//        }
-//    }
-
     func testThatWebSocketsCanReceiveMessageEvents() {
         // Given
         let didConnect = expectation(description: "didConnect")
@@ -70,8 +62,6 @@ final class WebSocketTests: BaseTestCase {
     func testThatWebSocketsCanReceiveAMessage() {
         // Given
         let didReceiveMessage = expectation(description: "didReceiveMessage")
-        let didComplete = expectation(description: "didComplete")
-
         let session = stored(Session())
 
         var receivedMessage: URLSessionWebSocketTask.Message?
@@ -80,9 +70,6 @@ final class WebSocketTests: BaseTestCase {
         session.websocketRequest(.websocket()).streamMessages { message in
             receivedMessage = message
             didReceiveMessage.fulfill()
-        }
-        .onCompletion {
-            didComplete.fulfill()
         }
 
         waitForExpectations(timeout: timeout)
@@ -142,7 +129,6 @@ final class WebSocketTests: BaseTestCase {
     func testThatWebSocketsCanReceiveADecodableValue() {
         // Given
         let didReceiveValue = expectation(description: "didReceiveMessage")
-        let didComplete = expectation(description: "didComplete")
 
         let session = stored(Session())
 
@@ -152,9 +138,6 @@ final class WebSocketTests: BaseTestCase {
         session.websocketRequest(.websocket()).streamDecodable(TestResponse.self) { value in
             receivedValue = value
             didReceiveValue.fulfill()
-        }
-        .onCompletion {
-            didComplete.fulfill()
         }
 
         waitForExpectations(timeout: timeout)
@@ -600,18 +583,6 @@ final class WebSocketTests: BaseTestCase {
         XCTAssertEqual(firstCloseReason, secondCloseReason)
         XCTAssertNil(firstReceivedCompletion?.error)
         XCTAssertNil(secondReceivedCompletion?.error)
-    }
-}
-
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-extension WebSocketRequest {
-    @discardableResult
-    func onCompletion(_ handler: @escaping () -> Void) -> Self {
-        streamMessageEvents { event in
-            guard case .completed = event.kind else { return }
-
-            handler()
-        }
     }
 }
 

--- a/Tests/WebSocketTests.swift
+++ b/Tests/WebSocketTests.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2021 Alamofire. All rights reserved.
 //
 
-#if canImport(Darwin) && !canImport(FoundationNetworking)
+#if canImport(Darwin) && !canImport(FoundationNetworking) // Only Apple platforms support URLSessionWebSocketTask.
 
-import Alamofire
+@_spi(WebSocket) import Alamofire
 import Foundation
 import XCTest
 
@@ -723,6 +723,17 @@ extension URLSessionWebSocketTask.Message: Equatable {
         guard case let .data(data) = self else { return nil }
 
         return data
+    }
+}
+
+extension Session {
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    func webSocketRequest(_ endpoint: Endpoint,
+                          configuration: WebSocketRequest.Configuration = .default,
+                          interceptor: RequestInterceptor? = nil) -> WebSocketRequest {
+        webSocketRequest(performing: endpoint as URLRequestConvertible,
+                         configuration: configuration,
+                         interceptor: interceptor)
     }
 }
 

--- a/Tests/WebSocketTests.swift
+++ b/Tests/WebSocketTests.swift
@@ -1,0 +1,419 @@
+//
+//  WebSocketTests.swift
+//  Alamofire
+//
+//  Created by Jon Shier on 1/17/21.
+//  Copyright © 2021 Alamofire. All rights reserved.
+//
+
+#if !(os(Linux) || os(Windows))
+
+import Alamofire
+import Foundation
+import XCTest
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+final class WebSocketTests: BaseTestCase {
+//    override var skipVersion: SkipVersion { .twenty }
+
+    func testThatWebSocketsCanReceiveAMessage() {
+        // Given
+        let didConnect = expectation(description: "didConnect")
+        let didReceiveMessage = expectation(description: "didReceiveMessage")
+        let didDisconnect = expectation(description: "didDisconnect")
+        let didComplete = expectation(description: "didComplete")
+        let session = stored(Session())
+
+        var connectedProtocol: String?
+        var message: URLSessionWebSocketTask.Message?
+        var closeCode: URLSessionWebSocketTask.CloseCode?
+        var closeReason: Data?
+        var receivedCompletion: WebSocketRequest.Completion?
+
+        // When
+        session.websocketRequest(.websocket()).responseMessage { event in
+            switch event.kind {
+            case let .connected(`protocol`):
+                connectedProtocol = `protocol`
+                didConnect.fulfill()
+            case let .receivedMessage(receivedMessage):
+                message = receivedMessage
+                didReceiveMessage.fulfill()
+            case let .disconnected(code, reason):
+                closeCode = code
+                closeReason = reason
+                didDisconnect.fulfill()
+            case let .completed(completion):
+                receivedCompletion = completion
+                didComplete.fulfill()
+            }
+        }
+
+        wait(for: [didConnect, didReceiveMessage, didDisconnect, didComplete],
+             timeout: timeout,
+             enforceOrder: false)
+
+        // Then
+        XCTAssertNil(connectedProtocol)
+        XCTAssertNotNil(message)
+        XCTAssertEqual(closeCode, .normalClosure)
+        XCTAssertNil(closeReason)
+        XCTAssertNil(receivedCompletion?.error)
+    }
+
+    func testThatWebSocketsCanReceiveAMessageWithAProtocol() {
+        // Given
+        let didConnect = expectation(description: "didConnect")
+        let didReceiveMessage = expectation(description: "didReceiveMessage")
+        let didDisconnect = expectation(description: "didDisconnect")
+        let didComplete = expectation(description: "didComplete")
+        let session = stored(Session())
+
+        let `protocol` = "protocol"
+        var connectedProtocol: String?
+        var message: URLSessionWebSocketTask.Message?
+        var closeCode: URLSessionWebSocketTask.CloseCode?
+        var closeReason: Data?
+        var receivedCompletion: WebSocketRequest.Completion?
+
+        // When
+        session.websocketRequest(.websocket(), protocol: `protocol`).responseMessage { event in
+            switch event.kind {
+            case let .connected(`protocol`):
+                connectedProtocol = `protocol`
+                didConnect.fulfill()
+            case let .receivedMessage(receivedMessage):
+                message = receivedMessage
+                didReceiveMessage.fulfill()
+            case let .disconnected(code, reason):
+                closeCode = code
+                closeReason = reason
+                didDisconnect.fulfill()
+            case let .completed(completion):
+                receivedCompletion = completion
+                didComplete.fulfill()
+            }
+        }
+
+        wait(for: [didConnect, didReceiveMessage, didDisconnect, didComplete],
+             timeout: timeout,
+             enforceOrder: true)
+
+        // Then
+        XCTAssertEqual(connectedProtocol, `protocol`)
+        XCTAssertNotNil(message)
+        XCTAssertEqual(closeCode, .normalClosure)
+        XCTAssertNil(closeReason)
+        XCTAssertNil(receivedCompletion?.error)
+    }
+
+    func testThatWebSocketsCanReceiveMultipleMessages() {
+        // Given
+        let count = 5
+        let didConnect = expectation(description: "didConnect")
+        let didReceiveMessage = expectation(description: "didReceiveMessage")
+        didReceiveMessage.expectedFulfillmentCount = count
+        let didDisconnect = expectation(description: "didDisconnect")
+        let didComplete = expectation(description: "didComplete")
+
+        let session = stored(Session())
+
+        var connectedProtocol: String?
+        var messages: [URLSessionWebSocketTask.Message] = []
+        var closeCode: URLSessionWebSocketTask.CloseCode?
+        var closeReason: Data?
+        var receivedCompletion: WebSocketRequest.Completion?
+
+        // When
+        session.websocketRequest(.websocketCount(count)).responseMessage { event in
+            switch event.kind {
+            case let .connected(`protocol`):
+                connectedProtocol = `protocol`
+                didConnect.fulfill()
+            case let .receivedMessage(receivedMessage):
+                messages.append(receivedMessage)
+                didReceiveMessage.fulfill()
+            case let .disconnected(code, reason):
+                closeCode = code
+                closeReason = reason
+                didDisconnect.fulfill()
+            case let .completed(completion):
+                receivedCompletion = completion
+                didComplete.fulfill()
+            }
+        }
+
+        wait(for: [didConnect, didReceiveMessage, didDisconnect, didComplete], timeout: timeout, enforceOrder: true)
+
+        // Then
+        XCTAssertNil(connectedProtocol)
+        XCTAssertEqual(messages.count, count)
+        XCTAssertEqual(closeCode, .normalClosure)
+        XCTAssertNil(closeReason)
+        XCTAssertNil(receivedCompletion?.error)
+    }
+
+    func testThatWebSocketsCanSendAndReceiveMessages() {
+        // Given
+        let didConnect = expectation(description: "didConnect")
+        let didSend = expectation(description: "didSend")
+        let didReceiveMessage = expectation(description: "didReceiveMessage")
+        let didDisconnect = expectation(description: "didDisconnect")
+        let didComplete = expectation(description: "didComplete")
+        let session = stored(Session())
+        let sentMessage = URLSessionWebSocketTask.Message.string("Echo")
+
+        var connectedProtocol: String?
+        var message: URLSessionWebSocketTask.Message?
+        var closeCode: URLSessionWebSocketTask.CloseCode?
+        var closeReason: Data?
+        var receivedCompletion: WebSocketRequest.Completion?
+
+        // When
+        let request = session.websocketRequest(.websocketEcho)
+        request.responseMessage { event in
+            switch event.kind {
+            case let .connected(`protocol`):
+                connectedProtocol = `protocol`
+                didConnect.fulfill()
+                request.send(sentMessage) { _ in didSend.fulfill() }
+            case let .receivedMessage(receivedMessage):
+                message = receivedMessage
+                event.cancel(with: .normalClosure, reason: nil)
+                didReceiveMessage.fulfill()
+            case let .disconnected(code, reason):
+                closeCode = code
+                closeReason = reason
+                didDisconnect.fulfill()
+            case let .completed(completion):
+                receivedCompletion = completion
+                didComplete.fulfill()
+            }
+        }
+
+        wait(for: [didConnect, didSend, didReceiveMessage, didDisconnect, didComplete],
+             timeout: timeout,
+             enforceOrder: true)
+
+        // Then
+        XCTAssertNil(connectedProtocol)
+        XCTAssertNotNil(message)
+        XCTAssertEqual(sentMessage, message)
+        XCTAssertEqual(closeCode, .normalClosure)
+        XCTAssertNil(closeReason)
+        XCTAssertNil(receivedCompletion?.error)
+    }
+
+    func testOnePingOnly() {
+        // Given
+        let didConnect = expectation(description: "didConnect")
+        let didSend = expectation(description: "didSend")
+        let didReceiveMessage = expectation(description: "didReceiveMessage")
+        let didReceivePong = expectation(description: "didReceivePong")
+        didReceivePong.expectedFulfillmentCount = 100
+        let didDisconnect = expectation(description: "didDisconnect")
+        let didComplete = expectation(description: "didComplete")
+        let session = stored(Session())
+        let sentMessage = URLSessionWebSocketTask.Message.string("Echo")
+
+        var connectedProtocol: String?
+        var message: URLSessionWebSocketTask.Message?
+        var receivedPong: WebSocketRequest.PingResponse.Pong?
+        var closeCode: URLSessionWebSocketTask.CloseCode?
+        var closeReason: Data?
+        var receivedCompletion: WebSocketRequest.Completion?
+
+        // When
+        let request = session.websocketRequest(.websocketEcho)
+        request.responseMessage { event in
+            switch event.kind {
+            case let .connected(`protocol`):
+                connectedProtocol = `protocol`
+                didConnect.fulfill()
+                request.send(sentMessage) { _ in didSend.fulfill() }
+            case let .receivedMessage(receivedMessage):
+                message = receivedMessage
+                didReceiveMessage.fulfill()
+                for count in 0..<100 {
+                    request.sendPing { response in
+                        switch response {
+                        case let .pong(pong):
+                            receivedPong = pong
+                        default:
+                            break
+                        }
+                        didReceivePong.fulfill()
+                        if count == 99 {
+                            request.cancel(with: .normalClosure, reason: nil)
+                        }
+                    }
+                }
+            case let .disconnected(code, reason):
+                closeCode = code
+                closeReason = reason
+                didDisconnect.fulfill()
+            case let .completed(completion):
+                receivedCompletion = completion
+                didComplete.fulfill()
+            }
+        }
+
+        wait(for: [didConnect, didSend, didReceiveMessage, didReceivePong, didDisconnect, didComplete],
+             timeout: timeout,
+             enforceOrder: true)
+
+        // Then
+        XCTAssertNil(connectedProtocol)
+        XCTAssertNotNil(message)
+        XCTAssertEqual(sentMessage, message)
+        XCTAssertEqual(closeCode, .normalClosure)
+        XCTAssertNil(closeReason)
+        XCTAssertNotNil(receivedCompletion)
+//        XCTAssertNil(receivedCompletion?.error)
+        XCTAssertNotNil(receivedPong)
+    }
+
+    func testThatTimePingsOccur() {
+        // Given
+        let didConnect = expectation(description: "didConnect")
+        let didDisconnect = expectation(description: "didDisconnect")
+        let didComplete = expectation(description: "didComplete")
+        let session = stored(Session())
+
+        var connectedProtocol: String?
+        var closeCode: URLSessionWebSocketTask.CloseCode?
+        var closeReason: Data?
+        var receivedCompletion: WebSocketRequest.Completion?
+
+        // When
+        let request = session.websocketRequest(.websocketPings(), pingInterval: 0.01)
+        request.responseMessage { event in
+            switch event.kind {
+            case let .connected(`protocol`):
+                connectedProtocol = `protocol`
+                didConnect.fulfill()
+            case .receivedMessage:
+                break
+            case let .disconnected(code, reason):
+                closeCode = code
+                closeReason = reason
+                didDisconnect.fulfill()
+            case let .completed(completion):
+                receivedCompletion = completion
+                didComplete.fulfill()
+            }
+        }
+
+        wait(for: [didConnect, didDisconnect, didComplete], timeout: timeout, enforceOrder: true)
+
+        // Then
+        XCTAssertNil(connectedProtocol)
+        XCTAssertEqual(closeCode, .goingAway) // Default Vapor close() code.
+        XCTAssertNil(closeReason)
+        XCTAssertNotNil(receivedCompletion)
+        XCTAssertNil(receivedCompletion?.error)
+    }
+
+    func testThatWebSocketFailsWithTooSmallMaximumMessageSize() {
+        // Given
+        let didConnect = expectation(description: "didConnect")
+        let didComplete = expectation(description: "didComplete")
+        let session = stored(Session())
+
+        var connectedProtocol: String?
+        var receivedCompletion: WebSocketRequest.Completion?
+
+        // When
+        session.websocketRequest(.websocket(), maximumMessageSize: 1).responseMessage { event in
+            switch event.kind {
+            case let .connected(`protocol`):
+                connectedProtocol = `protocol`
+                didConnect.fulfill()
+            case .receivedMessage, .disconnected:
+                break
+            case let .completed(completion):
+                receivedCompletion = completion
+                didComplete.fulfill()
+            }
+        }
+
+        wait(for: [didConnect, didComplete], timeout: timeout, enforceOrder: false)
+
+        // Then
+        XCTAssertNil(connectedProtocol)
+        XCTAssertNotNil(receivedCompletion?.error)
+    }
+
+    func testThatWebSocketsFinishAfterNonNormalResponseCode() {
+        // Given
+        let didConnect = expectation(description: "didConnect")
+        let didReceiveMessage = expectation(description: "didReceiveMessage")
+        let didDisconnect = expectation(description: "didDisconnect")
+        let didComplete = expectation(description: "didComplete")
+        let session = stored(Session())
+
+        var connectedProtocol: String?
+        var message: URLSessionWebSocketTask.Message?
+        var closeCode: URLSessionWebSocketTask.CloseCode?
+        var closeReason: Data?
+        var receivedCompletion: WebSocketRequest.Completion?
+
+        // When
+        session.websocketRequest(.websocket(closeCode: .goingAway)).responseMessage { event in
+            switch event.kind {
+            case let .connected(`protocol`):
+                connectedProtocol = `protocol`
+                didConnect.fulfill()
+            case let .receivedMessage(receivedMessage):
+                message = receivedMessage
+                didReceiveMessage.fulfill()
+            case let .disconnected(code, reason):
+                closeCode = code
+                closeReason = reason
+                didDisconnect.fulfill()
+            case let .completed(completion):
+                receivedCompletion = completion
+                didComplete.fulfill()
+            }
+        }
+
+        wait(for: [didConnect, didReceiveMessage, didDisconnect, didComplete],
+             timeout: timeout,
+             enforceOrder: false)
+
+        // Then
+        XCTAssertNil(connectedProtocol)
+        XCTAssertNotNil(message)
+        XCTAssertEqual(closeCode, .goingAway)
+        XCTAssertNil(closeReason)
+        XCTAssertNil(receivedCompletion?.error)
+    }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension URLSessionWebSocketTask.Message: Equatable {
+    public static func ==(lhs: URLSessionWebSocketTask.Message, rhs: URLSessionWebSocketTask.Message) -> Bool {
+        switch (lhs, rhs) {
+        case let (.string(left), .string(right)):
+            return left == right
+        case let (.data(left), .data(right)):
+            return left == right
+        default:
+            return false
+        }
+    }
+
+    var string: String? {
+        guard case let .string(string) = self else { return nil }
+
+        return string
+    }
+
+    var data: Data? {
+        guard case let .data(data) = self else { return nil }
+
+        return data
+    }
+}
+
+#endif


### PR DESCRIPTION
### Goals :soccer:
This PR adds `WebSocketRequest`, an Alamofire wrapper around `URLSessionWebSocketTask`, as well as assorted functionality for dealing with WebSockets. This includes:

- Automatic listening: no more manual `listen` calls on the task.
- Automatic ping support: ping the server automatically given an interval.
- Response serialization support: parse messages into objects, including using `Decodable`.
- Concurrency support: full streams of events and messages.

### Implementation Details :construction:
`WebSocketRequest` follows most of Alamofire's existing patterns. There are a few differences:

- Closure vs. cancellation: web sockets can close expectedly, yet this closure produces an error from `URLSession`. This had to be customized in order to ignore the error and allow the user to close a connection with no additional issue.
- Like `DataStreamRequest`, `WebSocketRequest` deals with incoming streams of data. However, that data is already framed and then partially decoded into `Message`s by `URLSession`, so serialization had to be built at that level.
- Unlike `DataStreamRequest`, `WebSocketRequest` can send `Message` back up the connection. This requires some queuing on the request side to ensure messages sent before the connection is established are properly stored for sending.

### Testing Details :mag:
Full suite of `WebSocketTests` added, as well as the concurrency versions. Firewalk was updated with several new `websocket` cases to support scenarios like an echo server or expected ping count.

P.S. This feature was delayed so long due to the many hours of frustration I had to deal with when Apple shipped a message dropping bug in iOS 14.5 - 14.7. In trying to test the socket connections I would connect to the test server, have it reply with a message, and then close the connection. Shockingly that meant that *sometimes* the messages wouldn't come through. But sometimes they would. Investigating other web socket clients and inspecting network traffic with Wireshark revealed that the messages were being sent by the server but the client just wasn't receiving them. Further investigation showed that delaying the close of the connection by 60ms or so let the client receive the message reliably. After many hours I finally had reliable tests! Only to then test on the iOS 15 betas and see that I didn't need the delay at all, the tests were reliable without it! Turns out it was just a bug in iOS 14.5 - 14.7. I was so disgusted by this fact that I gave up on the feature for years. I'll call out this bug in the documentation.