### PR TITLE
Exclude NetworkReachabilityManager from Windows

### DIFF
--- a/Source/NetworkReachabilityManager.swift
+++ b/Source/NetworkReachabilityManager.swift
@@ -22,7 +22,7 @@
 //  THE SOFTWARE.
 //
 
-#if !(os(watchOS) || os(Linux))
+#if !(os(watchOS) || os(Linux) || os(Windows))
 
 import Foundation
 import SystemConfiguration


### PR DESCRIPTION
### Issue Link :link:
#3459

### Goals :soccer:
Support Windows compilation

### Implementation Details :construction:
Just adds `os(Windows)` to the exclusion

### Testing Details :mag:
Existing tests work
