### PR TITLE
doc: fix CachedResponseHandler ResponseCacher documentation

### DIFF
--- a/Source/CachedResponseHandler.swift
+++ b/Source/CachedResponseHandler.swift
@@ -58,9 +58,9 @@ public struct ResponseCacher {
         case modify((URLSessionDataTask, CachedURLResponse) -> CachedURLResponse?)
     }
 
-    /// Returns a `ResponseCacher` with a follow `Behavior`.
+    /// Returns a `ResponseCacher` with a `.cache` `Behavior`.
     public static let cache = ResponseCacher(behavior: .cache)
-    /// Returns a `ResponseCacher` with a do not follow `Behavior`.
+    /// Returns a `ResponseCacher` with a `.doNotCache` `Behavior`.
     public static let doNotCache = ResponseCacher(behavior: .doNotCache)
 
     /// The `Behavior` of the `ResponseCacher`.


### PR DESCRIPTION
Hello!

### Goals :soccer:
This PR updates the documentation of the ResponseCacher in CachedResponseHandler.
It changes the notion of Follow by the notion of Cache. It tries to follow the convention used in Redirector from RedirectHandler.swift.

The documentation is also generated in a second commit, which is dedicated to the jazzy run.

Thanks!
