### PR TITLE
Fix the screen title for each request in the sample app

### DIFF
--- a/Example/Source/DetailViewController.swift
+++ b/Example/Source/DetailViewController.swift
@@ -35,6 +35,10 @@ class DetailViewController: UITableViewController {
             oldValue?.cancel()
 
             title = request?.description
+            request?.onURLRequestCreation { [weak self] _ in
+                self?.title = self?.request?.description
+            }
+            
             refreshControl?.endRefreshing()
             headers.removeAll()
             body = nil


### PR DESCRIPTION
### Goals :soccer:
Fix the title of the `DetailViewController`, in the iOS sample app. It permanently displays the following title:  **No request created yet.**, even after the test request is performed (more context in the gif files).

This happens because the `title` is changed too early, before the internal `URLRequest` gets configured (which is used in the `description` property).

To fix this issue, the controller now assigns a closure to the `onURLRequestCreation` method on the `Request` type. Inside this closure, it updates its title.

#### Before the change:

<img src="https://user-images.githubusercontent.com/6910889/132962038-81b107c0-9c25-4ae2-b3f6-545d087b0c36.gif" width=250px />

#### After the change:

<img src="https://user-images.githubusercontent.com/6910889/132962064-7451faea-f1dc-4edf-912f-8f0cd29b9f11.gif" width=250px />
