### PR TITLE
Require Swift 5.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire macOS" -destination "platform=macOS" clean test | xcpretty
   macOS_5_5:
     name: Test macOS 11 (5.5)
-    runs-on: firewalk
+    runs-on: firebreak
     env:
       DEVELOPER_DIR: /Applications/Xcode_13.1.app/Contents/Developer
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,30 +21,8 @@ concurrency:
   group: ci
   cancel-in-progress: true
 jobs:
-  macOS_5_1:
-    name: Build macOS (5.1)
-    runs-on: macOS-10.15
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_11.3.1.app/Contents/Developer
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v2
-      - name: macOS (5.1)
-        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire macOS" -destination "platform=macOS" clean build | xcpretty
-  macOS_5_2:
-    name: Test macOS (5.2)
-    runs-on: macOS-10.15
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Firewalk
-        run: brew install alamofire/alamofire/firewalk && firewalk &
-      - name: macOS (5.2)
-        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire macOS" -destination "platform=macOS" clean test | xcpretty
   macOS_5_3:
-    name: Test macOS (5.3)
+    name: Test macOS 10.15 (5.3)
     runs-on: macOS-10.15
     env:
       DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
@@ -53,25 +31,37 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Firewalk
         run: brew install alamofire/alamofire/firewalk && firewalk &
-      - name: macOS (5.3)
+      - name: macOS 10.15 (5.3)
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire macOS" -destination "platform=macOS" clean test | xcpretty
   macOS_5_4:
-    name: Test macOS (5.4)
-    runs-on: firebreak
+    name: Test macOS 11 (5.4)
+    runs-on: macOS-11
     env:
-      DEVELOPER_DIR: /Applications/Xcode_12.5.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_12.5.1.app/Contents/Developer
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Firewalk
+        run: brew install alamofire/alamofire/firewalk && firewalk &
+      - name: macOS 11 (5.4)
+        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire macOS" -destination "platform=macOS" clean test | xcpretty
+  macOS_5_5:
+    name: Test macOS 11 (5.5)
+    runs-on: firewalk
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_13.1.app/Contents/Developer
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
       - name: Install Firewalk
         run: arch -arch arm64e brew install alamofire/alamofire/firewalk || arch -arch arm64e brew upgrade alamofire/alamofire/firewalk && arch -arch x86_64 firewalk &
-      - name: macOS (5.4)
+      - name: macOS 11 (5.5)
         run: set -o pipefail && arch -arch arm64e env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire macOS" -destination "platform=macOS" clean test | xcpretty
   Catalyst:
     name: Test Catalyst
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     env:
-      DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.1.app/Contents/Developer
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
@@ -80,25 +70,10 @@ jobs:
       - name: Catalyst
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "platform=macOS" clean test | xcpretty
   iOS:
-    name: Test iOS
-    runs-on: firebreak
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_12.5.app/Contents/Developer
-    timeout-minutes: 10
-    strategy:
-      matrix:
-        destination: ["OS=14.5,name=iPhone 12 Pro"]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Firewalk
-        run: arch -arch arm64e brew install alamofire/alamofire/firewalk || arch -arch arm64e brew upgrade alamofire/alamofire/firewalk && arch -arch x86_64 firewalk &
-      - name: iOS - ${{ matrix.destination }}
-        run: set -o pipefail && arch -arch arm64e env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "${{ matrix.destination }}" clean test | xcpretty
-  iOS_15:
     name: Test iOS 15
     runs-on: firebreak
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.0.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.1.app/Contents/Developer
     timeout-minutes: 10
     strategy:
       matrix:
@@ -113,11 +88,11 @@ jobs:
     name: Test tvOS
     runs-on: firebreak
     env:
-      DEVELOPER_DIR: /Applications/Xcode_12.5.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.1.app/Contents/Developer
     timeout-minutes: 10
     strategy:
       matrix:
-        destination: ["OS=14.5,name=Apple TV"]
+        destination: ["OS=15.0,name=Apple TV"]
     steps:
       - uses: actions/checkout@v2
       - name: Install Firewalk
@@ -128,11 +103,11 @@ jobs:
     name: Test watchOS
     runs-on: firebreak
     env:
-      DEVELOPER_DIR: /Applications/Xcode_12.5.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.1.app/Contents/Developer
     timeout-minutes: 10
     strategy:
       matrix:
-        destination: ["OS=7.4,name=Apple Watch Series 6 - 44mm"]
+        destination: ["OS=8.0,name=Apple Watch Series 7 - 45mm"]
     steps:
       - uses: actions/checkout@v2
       - name: Install Firewalk
@@ -143,7 +118,7 @@ jobs:
     name: Test with SPM
     runs-on: firebreak
     env:
-      DEVELOPER_DIR: /Applications/Xcode_12.5.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.1.app/Contents/Developer
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
@@ -155,7 +130,7 @@ jobs:
     name: Linux
     runs-on: ubuntu-20.04
     container:
-      image: swift:5.4.1-focal
+      image: swift:5.5.1-focal
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
@@ -181,7 +156,7 @@ jobs:
     - uses: seanmiddleditch/gha-setup-vsdevenv@master
     - name: Install Swift
       run: |
-        Install-Binary -Url "https://swift.org/builds/swift-5.4.1-release/windows10/swift-5.4.1-RELEASE/swift-5.4.1-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+        Install-Binary -Url "https://swift.org/builds/swift-5.5.1-release/windows10/swift-5.5.1-RELEASE/swift-5.5.1-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
     - name: Set Environment Variables
       run: |
         echo "SDKROOT=C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,7 +1,7 @@
 # file options
 
 --symlinks ignore
---swiftversion 5.1
+--swiftversion 5.3
 
 # rules
 --enable isEmpty

--- a/Alamofire.podspec
+++ b/Alamofire.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '3.0'
 
-  s.swift_versions = ['5.1', '5.2', '5.3', '5.4', '5.5']
+  s.swift_versions = ['5.3', '5.4', '5.5']
 
   s.source_files = 'Source/*.swift'
 

--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -1224,7 +1224,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1250;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1320;
 				ORGANIZATIONNAME = Alamofire;
 				TargetAttributes = {
 					31293064263E17D600473CEA = {

--- a/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire iOS.xcscheme
+++ b/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire macOS.xcscheme
+++ b/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire tvOS.xcscheme
+++ b/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire watchOS.xcscheme
+++ b/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/iOS Example.xcodeproj/xcshareddata/xcschemes/iOS Example.xcscheme
+++ b/Example/iOS Example.xcodeproj/xcshareddata/xcschemes/iOS Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Package@5.3.swift
+++ b/Package@5.3.swift
@@ -1,8 +1,8 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.3
 //
-//  Package.swift
+//  Package@5.3.swift
 //
-//  Copyright (c) 2014-2020 Alamofire Software Foundation (http://alamofire.org/)
+//  Copyright (c) 2021 Alamofire Software Foundation (http://alamofire.org/)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Package@5.4.swift
+++ b/Package@5.4.swift
@@ -1,8 +1,8 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.4
 //
-//  Package.swift
+//  Package@5.4.swift
 //
-//  Copyright (c) 2014-2020 Alamofire Software Foundation (http://alamofire.org/)
+//  Copyright (c) 2021 Alamofire Software Foundation (http://alamofire.org/)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Alamofire: Elegant Networking in Swift](https://raw.githubusercontent.com/Alamofire/Alamofire/master/Resources/AlamofireLogo.png)
 
-[![Swift](https://img.shields.io/badge/Swift-5.1_5.2_5.3_5.4-orange?style=flat-square)](https://img.shields.io/badge/Swift-5.1_5.2_5.3_5.4-Orange?style=flat-square)
+[![Swift](https://img.shields.io/badge/Swift-5.3_5.4_5.5-orange?style=flat-square)](https://img.shields.io/badge/Swift-5.3_5.4_5.5-Orange?style=flat-square)
 [![Platforms](https://img.shields.io/badge/Platforms-macOS_iOS_tvOS_watchOS_Linux_Windows-yellowgreen?style=flat-square)](https://img.shields.io/badge/Platforms-macOS_iOS_tvOS_watchOS_Linux_Windows-Green?style=flat-square)
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/Alamofire.svg?style=flat-square)](https://img.shields.io/cocoapods/v/Alamofire.svg)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat-square)](https://github.com/Carthage/Carthage)
@@ -61,7 +61,7 @@ In order to keep Alamofire focused specifically on core networking implementatio
 
 | Platform | Minimum Swift Version | Installation | Status |
 | --- | --- | --- | --- |
-| iOS 10.0+ / macOS 10.12+ / tvOS 10.0+ / watchOS 3.0+ | 5.1 | [CocoaPods](#cocoapods), [Carthage](#carthage), [Swift Package Manager](#swift-package-manager), [Manual](#manually) | Fully Tested |
+| iOS 10.0+ / macOS 10.12+ / tvOS 10.0+ / watchOS 3.0+ | 5.3 | [CocoaPods](#cocoapods), [Carthage](#carthage), [Swift Package Manager](#swift-package-manager), [Manual](#manually) | Fully Tested |
 | Linux | Latest Only | [Swift Package Manager](#swift-package-manager) | Building But Unsupported |
 | Windows | Latest Only | [Swift Package Manager](#swift-package-manager) | Building But Unsupported |
 

--- a/Source/Combine.swift
+++ b/Source/Combine.swift
@@ -71,14 +71,14 @@ public struct DataResponsePublisher<Value>: Publisher {
     ///
     /// - Returns: The `AnyPublisher` publishing the `Result<Value, AFError>` value.
     public func result() -> AnyPublisher<Result<Value, AFError>, Never> {
-        map { $0.result }.eraseToAnyPublisher()
+        map(\.result).eraseToAnyPublisher()
     }
 
     /// Publishes the `Result` of the `DataResponse` as a single `Value` or fail with the `AFError` instance.
     ///
     /// - Returns: The `AnyPublisher<Value, AFError>` publishing the stream.
     public func value() -> AnyPublisher<Value, AFError> {
-        setFailureType(to: AFError.self).flatMap { $0.result.publisher }.eraseToAnyPublisher()
+        setFailureType(to: AFError.self).flatMap(\.result.publisher).eraseToAnyPublisher()
     }
 
     public func receive<S>(subscriber: S) where S: Subscriber, DataResponsePublisher.Failure == S.Failure, DataResponsePublisher.Output == S.Input {
@@ -282,7 +282,7 @@ public struct DataStreamPublisher<Value>: Publisher {
     ///
     /// - Returns: The `AnyPublisher<Value, AFError>` publishing the stream.
     public func value() -> AnyPublisher<Value, AFError> {
-        result().setFailureType(to: AFError.self).flatMap { $0.publisher }.eraseToAnyPublisher()
+        result().setFailureType(to: AFError.self).flatMap(\.publisher).eraseToAnyPublisher()
     }
 
     public func receive<S>(subscriber: S) where S: Subscriber, DataStreamPublisher.Failure == S.Failure, DataStreamPublisher.Output == S.Input {
@@ -425,14 +425,14 @@ public struct DownloadResponsePublisher<Value>: Publisher {
     ///
     /// - Returns: The `AnyPublisher` publishing the `Result<Value, AFError>` value.
     public func result() -> AnyPublisher<Result<Value, AFError>, Never> {
-        map { $0.result }.eraseToAnyPublisher()
+        map(\.result).eraseToAnyPublisher()
     }
 
     /// Publishes the `Result` of the `DownloadResponse` as a single `Value` or fail with the `AFError` instance.
     ///
     /// - Returns: The `AnyPublisher<Value, AFError>` publishing the stream.
     public func value() -> AnyPublisher<Value, AFError> {
-        setFailureType(to: AFError.self).flatMap { $0.result.publisher }.eraseToAnyPublisher()
+        setFailureType(to: AFError.self).flatMap(\.result.publisher).eraseToAnyPublisher()
     }
 
     public func receive<S>(subscriber: S) where S: Subscriber, DownloadResponsePublisher.Failure == S.Failure, DownloadResponsePublisher.Output == S.Input {

--- a/Source/HTTPHeaders.swift
+++ b/Source/HTTPHeaders.swift
@@ -183,7 +183,7 @@ extension HTTPHeaders: Collection {
 
 extension HTTPHeaders: CustomStringConvertible {
     public var description: String {
-        headers.map { $0.description }
+        headers.map(\.description)
             .joined(separator: "\n")
     }
 }

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -203,7 +203,7 @@ public class Request {
 
     /// `URLRequest`s from all of the `URLSessionTask`s executed on behalf of the `Request`. May be different from
     /// `requests` due to `URLSession` manipulation.
-    public var performedRequests: [URLRequest] { $mutableState.read { $0.tasks.compactMap { $0.currentRequest } } }
+    public var performedRequests: [URLRequest] { $mutableState.read { $0.tasks.compactMap(\.currentRequest) } }
 
     // MARK: HTTPURLResponse
 

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -125,7 +125,7 @@ extension ResponseSerializer {
     ///
     /// - Returns:           `Bool` representing the outcome of the evaluation, or `nil` if `request` was `nil`.
     public func requestAllowsEmptyResponseData(_ request: URLRequest?) -> Bool? {
-        request.flatMap { $0.httpMethod }
+        request.flatMap(\.httpMethod)
             .flatMap(HTTPMethod.init)
             .map { emptyRequestMethods.contains($0) }
     }
@@ -136,7 +136,7 @@ extension ResponseSerializer {
     ///
     /// - Returns:            `Bool` representing the outcome of the evaluation, or `nil` if `response` was `nil`.
     public func responseAllowsEmptyResponseData(_ response: HTTPURLResponse?) -> Bool? {
-        response.flatMap { $0.statusCode }
+        response.map(\.statusCode)
             .map { emptyResponseCodes.contains($0) }
     }
 

--- a/Source/ServerTrustEvaluation.swift
+++ b/Source/ServerTrustEvaluation.swift
@@ -685,7 +685,7 @@ extension AlamofireExtension where ExtendedType == [SecCertificate] {
 
     /// All public `SecKey` values for the contained `SecCertificate`s.
     public var publicKeys: [SecKey] {
-        type.compactMap { $0.af.publicKey }
+        type.compactMap(\.af.publicKey)
     }
 }
 

--- a/Tests/CombineTests.swift
+++ b/Tests/CombineTests.swift
@@ -935,7 +935,7 @@ final class DataStreamRequestCombineTests: CombineTestCase {
             .publishDecodable(type: TestResponse.self)
 
         store {
-            Publishers.CombineLatest(first.compactMap { $0.completion }, second.compactMap { $0.completion })
+            Publishers.CombineLatest(first.compactMap(\.completion), second.compactMap(\.completion))
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { first, second in
                           firstCompletion = first
@@ -963,13 +963,13 @@ final class DataStreamRequestCombineTests: CombineTestCase {
         store {
             AF.streamRequest(.default)
                 .publishDecodable(type: TestResponse.self)
-                .compactMap { $0.completion }
+                .compactMap(\.completion)
                 .flatMap { completion -> DataStreamPublisher<TestResponse> in
                     firstCompletion = completion
                     return AF.streamRequest(.default)
                         .publishDecodable(type: TestResponse.self)
                 }
-                .compactMap { $0.completion }
+                .compactMap(\.completion)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { secondCompletion = $0; responseReceived.fulfill() })
         }

--- a/Tests/HTTPHeadersTests.swift
+++ b/Tests/HTTPHeadersTests.swift
@@ -65,10 +65,10 @@ class HTTPHeadersTests: BaseTestCase {
         headersCreatedManually.update(name: "a", value: "")
 
         // When
-        let dictionaryLiteralNames = headersFromDictionaryLiteral.map { $0.name }
-        let arrayLiteralNames = headersFromArrayLiteral.map { $0.name }
-        let arrayNames = headersFromArray.map { $0.name }
-        let manualNames = headersCreatedManually.map { $0.name }
+        let dictionaryLiteralNames = headersFromDictionaryLiteral.map(\.name)
+        let arrayLiteralNames = headersFromArrayLiteral.map(\.name)
+        let arrayNames = headersFromArray.map(\.name)
+        let manualNames = headersCreatedManually.map(\.name)
 
         // Then
         XCTAssertEqual(dictionaryLiteralNames, ["c", "a", "b"])
@@ -85,8 +85,8 @@ class HTTPHeadersTests: BaseTestCase {
         let sortedHeaders = headers.sorted()
 
         // Then
-        XCTAssertEqual(headers.map { $0.name }, ["c", "a", "b"])
-        XCTAssertEqual(sortedHeaders.map { $0.name }, ["a", "b", "c"])
+        XCTAssertEqual(headers.map(\.name), ["c", "a", "b"])
+        XCTAssertEqual(sortedHeaders.map(\.name), ["a", "b", "c"])
     }
 
     func testHeadersCanInsensitivelyGetAndSetThroughSubscript() {
@@ -100,7 +100,7 @@ class HTTPHeadersTests: BaseTestCase {
 
         // Then
         XCTAssertEqual(headers["c"], "c")
-        XCTAssertEqual(headers.map { $0.value }, ["c", "a", "b"])
+        XCTAssertEqual(headers.map(\.value), ["c", "a", "b"])
         XCTAssertEqual(headers.count, 3)
     }
 

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -239,7 +239,7 @@ final class RequestResponseTestCase: BaseTestCase {
 
         // Then
         XCTAssertEqual(responses.count, count)
-        XCTAssertTrue(responses.allSatisfy { $0.result.isSuccess })
+        XCTAssertTrue(responses.allSatisfy(\.result.isSuccess))
     }
 
     // MARK: Encodable Parameters

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -101,10 +101,9 @@ final class SessionTestCase: BaseTestCase {
         var shouldRetry = true
         var retryDelay: TimeInterval?
 
-        func adapt(
-            _ urlRequest: URLRequest,
-            using state: RequestAdapterState,
-            completion: @escaping (Result<URLRequest, Error>) -> Void) {
+        func adapt(_ urlRequest: URLRequest,
+                   using state: RequestAdapterState,
+                   completion: @escaping (Result<URLRequest, Error>) -> Void) {
             adaptCalledCount += 1
 
             let result: Result<URLRequest, Error> = Result {
@@ -1554,7 +1553,7 @@ final class SessionMassActionTestCase: BaseTestCase {
         wait(for: [massActions], timeout: timeout)
 
         // Then
-        XCTAssertTrue(requests.allSatisfy { $0.isSuspended })
+        XCTAssertTrue(requests.allSatisfy(\.isSuspended))
     }
 
     func testThatAutomaticallyResumedRequestsCanBeMassCancelled() {

--- a/watchOS Example/watchOS Example.xcodeproj/xcshareddata/xcschemes/watchOS Example WatchKit App.xcscheme
+++ b/watchOS Example/watchOS Example.xcodeproj/xcshareddata/xcschemes/watchOS Example WatchKit App.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
### Goals :soccer:
This PR bumps Alamofire's required Swift version to 5.3 / Xcode 12 now that Xcode 13 is imminent. Since no one can release software on iOS with older Xcode versions, it seems safe to drop this. Older macOS users can keep using older Alamofire versions.

This also follows [SwiftNIO's Swift version support](https://forums.swift.org/t/swiftnio-swift-version-support/53232) which they recently updated. However, instead of tracking Swift prerelease - 2, we'll track Swift current - 2. So with 5.5 out we'll go back to 5.3 and with 5.6 we may update to 5.4, but that isn't necessarily guaranteed.

### Implementation Details :construction:
SwiftFormat has been set to 5.3 mode and run. Updates are entirely closure to key path conversion.
