### PR TITLE
Deprecate responseJSON

### DIFF
--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -764,6 +764,7 @@ extension DownloadRequest {
 /// A `ResponseSerializer` that decodes the response data using `JSONSerialization`. By default, a request returning
 /// `nil` or no data is considered an error. However, if the request has an `HTTPMethod` or the response has an
 /// HTTP status code valid for empty responses, then an `NSNull` value is returned.
+@available(*, deprecated, message: "JSONResponseSerializer deprecated and will be removed in Alamofire 6. Use DecodableResponseSerializer instead.")
 public final class JSONResponseSerializer: ResponseSerializer {
     public let dataPreprocessor: DataPreprocessor
     public let emptyResponseCodes: Set<Int>
@@ -825,6 +826,7 @@ extension DataRequest {
     ///   - completionHandler:   A closure to be executed once the request has finished.
     ///
     /// - Returns:               The request.
+    @available(*, deprecated, message: "responseJSON deprecated and will be removed in Alamofire 6. Use responseDecodable instead.")
     @discardableResult
     public func responseJSON(queue: DispatchQueue = .main,
                              dataPreprocessor: DataPreprocessor = JSONResponseSerializer.defaultDataPreprocessor,
@@ -857,6 +859,7 @@ extension DownloadRequest {
     ///   - completionHandler:   A closure to be executed once the request has finished.
     ///
     /// - Returns:               The request.
+    @available(*, deprecated, message: "responseJSON deprecated and will be removed in Alamofire 6. Use responseDecodable instead.")
     @discardableResult
     public func responseJSON(queue: DispatchQueue = .main,
                              dataPreprocessor: DataPreprocessor = JSONResponseSerializer.defaultDataPreprocessor,

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -600,12 +600,12 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         XCTAssertEqual(response?.resumeData, download.resumeData)
     }
 
-    func testThatCancelledDownloadResumeDataIsAvailableWithJSONResponseSerializer() {
+    func testThatCancelledDownloadResumeDataIsAvailableWithDecodableResponseSerializer() {
         // Given
         let expectation = self.expectation(description: "Download should be cancelled")
         var cancelled = false
 
-        var response: DownloadResponse<Any, AFError>?
+        var response: DownloadResponse<TestResponse, AFError>?
 
         // When
         let download = AF.download(.download())
@@ -617,7 +617,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
                 cancelled = true
             }
         }
-        download.responseJSON { resp in
+        download.responseDecodable(of: TestResponse.self) { resp in
             response = resp
             expectation.fulfill()
         }
@@ -746,10 +746,9 @@ final class DownloadResponseMapTestCase: BaseTestCase {
         var response: DownloadResponse<String, AFError>?
 
         // When
-        AF.download(.get, parameters: ["foo": "bar"]).responseJSON { resp in
-            response = resp.map { json in
-                // json["args"]["foo"] is "bar": use this invariant to test the map function
-                ((json as? [String: Any])?["args"] as? [String: Any])?["foo"] as? String ?? "invalid"
+        AF.download(.get, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
+            response = resp.map { response in
+                response.args?["foo"] ?? "invalid"
             }
 
             expectation.fulfill()
@@ -775,7 +774,7 @@ final class DownloadResponseMapTestCase: BaseTestCase {
         var response: DownloadResponse<String, AFError>?
 
         // When
-        AF.download(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
+        AF.download(urlString, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
             response = resp.map { _ in "ignored" }
             expectation.fulfill()
         }
@@ -803,10 +802,9 @@ final class DownloadResponseTryMapTestCase: BaseTestCase {
         var response: DownloadResponse<String, Error>?
 
         // When
-        AF.download(.get, parameters: ["foo": "bar"]).responseJSON { resp in
-            response = resp.tryMap { json in
-                // json["args"]["foo"] is "bar": use this invariant to test the map function
-                ((json as? [String: Any])?["args"] as? [String: Any])?["foo"] as? String ?? "invalid"
+        AF.download(.get, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
+            response = resp.tryMap { response in
+                response.args?["foo"] ?? "invalid"
             }
 
             expectation.fulfill()
@@ -833,7 +831,7 @@ final class DownloadResponseTryMapTestCase: BaseTestCase {
         var response: DownloadResponse<String, Error>?
 
         // When
-        AF.download(.get, parameters: ["foo": "bar"]).responseJSON { resp in
+        AF.download(.get, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
             response = resp.tryMap { _ in
                 throw TransformError()
             }
@@ -865,7 +863,7 @@ final class DownloadResponseTryMapTestCase: BaseTestCase {
         var response: DownloadResponse<String, Error>?
 
         // When
-        AF.download(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
+        AF.download(urlString, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
             response = resp.tryMap { _ in "ignored" }
             expectation.fulfill()
         }
@@ -889,10 +887,10 @@ final class DownloadResponseMapErrorTestCase: BaseTestCase {
         let urlString = String.nonexistentDomain
         let expectation = self.expectation(description: "request should not succeed")
 
-        var response: DownloadResponse<Any, TestError>?
+        var response: DownloadResponse<TestResponse, TestError>?
 
         // When
-        AF.download(urlString).responseJSON { resp in
+        AF.download(urlString).responseDecodable(of: TestResponse.self) { resp in
             response = resp.mapError { error in
                 TestError.error(error: error)
             }

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -100,11 +100,11 @@ final class RequestResponseTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Any, AFError>?
+        var response: DataResponse<TestResponse, AFError>?
 
         // When
         AF.request(.method(.post), parameters: parameters)
-            .responseJSON { closureResponse in
+            .responseDecodable(of: TestResponse.self) { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
             }
@@ -116,7 +116,7 @@ final class RequestResponseTestCase: BaseTestCase {
         XCTAssertNotNil(response?.response)
         XCTAssertNotNil(response?.data)
 
-        if let json = response?.result.success as? [String: Any], let form = json["form"] as? [String: String] {
+        if let form = response?.result.success?.form {
             XCTAssertEqual(form["french"], parameters["french"])
             XCTAssertEqual(form["japanese"], parameters["japanese"])
             XCTAssertEqual(form["arabic"], parameters["arabic"])
@@ -149,11 +149,11 @@ final class RequestResponseTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "request should succeed")
 
-        var response: DataResponse<Any, AFError>?
+        var response: DataResponse<TestResponse, AFError>?
 
         // When
         AF.request(Endpoint.method(.post), method: .post, parameters: parameters)
-            .responseJSON { closureResponse in
+            .responseDecodable(of: TestResponse.self) { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
             }
@@ -166,7 +166,7 @@ final class RequestResponseTestCase: BaseTestCase {
         XCTAssertNotNil(response?.data)
         XCTAssertEqual(response?.result.isSuccess, true)
 
-        if let json = response?.result.success as? [String: Any], let form = json["form"] as? [String: String] {
+        if let form = response?.result.success?.form {
             XCTAssertEqual(form["email"], parameters["email"])
             XCTAssertEqual(form["png_image"], parameters["png_image"])
             XCTAssertEqual(form["jpeg_image"], parameters["jpeg_image"])
@@ -183,10 +183,10 @@ final class RequestResponseTestCase: BaseTestCase {
         let queue = DispatchQueue(label: "org.alamofire.testSerializationQueue")
         let manager = Session(serializationQueue: queue)
         let expectation = self.expectation(description: "request should complete")
-        var response: DataResponse<Any, AFError>?
+        var response: DataResponse<TestResponse, AFError>?
 
         // When
-        manager.request(Endpoint.get).responseJSON { resp in
+        manager.request(.get).responseDecodable(of: TestResponse.self) { resp in
             response = resp
             expectation.fulfill()
         }
@@ -203,10 +203,10 @@ final class RequestResponseTestCase: BaseTestCase {
         let serializationQueue = DispatchQueue(label: "org.alamofire.testSerializationQueue")
         let manager = Session(requestQueue: requestQueue, serializationQueue: serializationQueue)
         let expectation = self.expectation(description: "request should complete")
-        var response: DataResponse<Any, AFError>?
+        var response: DataResponse<TestResponse, AFError>?
 
         // When
-        manager.request(Endpoint.get).responseJSON { resp in
+        manager.request(.get).responseDecodable(of: TestResponse.self) { resp in
             response = resp
             expectation.fulfill()
         }
@@ -225,11 +225,11 @@ final class RequestResponseTestCase: BaseTestCase {
         let count = 10
         let expectation = self.expectation(description: "request should complete")
         expectation.expectedFulfillmentCount = count
-        var responses: [DataResponse<Any, AFError>] = []
+        var responses: [DataResponse<TestResponse, AFError>] = []
 
         // When
         DispatchQueue.concurrentPerform(iterations: count) { _ in
-            session.request(.default).responseJSON { resp in
+            session.request(.default).responseDecodable(of: TestResponse.self) { resp in
                 responses.append(resp)
                 expectation.fulfill()
             }
@@ -666,8 +666,8 @@ final class RequestResponseTestCase: BaseTestCase {
         // Given
         let session = Session()
 
-        var response1: DataResponse<Any, AFError>?
-        var response2: DataResponse<Any, AFError>?
+        var response1: DataResponse<TestResponse, AFError>?
+        var response2: DataResponse<TestResponse, AFError>?
 
         let expect = expectation(description: "both response serializer completions should be called")
         expect.expectedFulfillmentCount = 2
@@ -675,11 +675,11 @@ final class RequestResponseTestCase: BaseTestCase {
         // When
         let request = session.request(.default)
 
-        request.responseJSON { resp in
+        request.responseDecodable(of: TestResponse.self) { resp in
             response1 = resp
             expect.fulfill()
 
-            request.responseJSON { resp in
+            request.responseDecodable(of: TestResponse.self) { resp in
                 response2 = resp
                 expect.fulfill()
             }
@@ -698,9 +698,9 @@ final class RequestResponseTestCase: BaseTestCase {
         // Given
         let session = Session()
 
-        var response1: DataResponse<Any, AFError>?
-        var response2: DataResponse<Any, AFError>?
-        var response3: DataResponse<Any, AFError>?
+        var response1: DataResponse<TestResponse, AFError>?
+        var response2: DataResponse<TestResponse, AFError>?
+        var response3: DataResponse<TestResponse, AFError>?
 
         let expect = expectation(description: "all response serializer completions should be called")
         expect.expectedFulfillmentCount = 3
@@ -708,15 +708,15 @@ final class RequestResponseTestCase: BaseTestCase {
         // When
         let request = session.request(.default)
 
-        request.responseJSON { resp in
+        request.responseDecodable(of: TestResponse.self) { resp in
             response1 = resp
             expect.fulfill()
 
-            request.responseJSON { resp in
+            request.responseDecodable(of: TestResponse.self) { resp in
                 response2 = resp
                 expect.fulfill()
 
-                request.responseJSON { resp in
+                request.responseDecodable(of: TestResponse.self) { resp in
                     response3 = resp
                     expect.fulfill()
                 }
@@ -736,21 +736,21 @@ final class RequestResponseTestCase: BaseTestCase {
         let session = Session()
         let request = session.request(.default)
 
-        var response1: DataResponse<Any, AFError>?
-        var response2: DataResponse<Any, AFError>?
-        var response3: DataResponse<Any, AFError>?
+        var response1: DataResponse<TestResponse, AFError>?
+        var response2: DataResponse<TestResponse, AFError>?
+        var response3: DataResponse<TestResponse, AFError>?
 
         // When
         let expect1 = expectation(description: "response serializer 1 completion should be called")
-        request.responseJSON { response1 = $0; expect1.fulfill() }
+        request.responseDecodable(of: TestResponse.self) { response1 = $0; expect1.fulfill() }
         waitForExpectations(timeout: timeout)
 
         let expect2 = expectation(description: "response serializer 2 completion should be called")
-        request.responseJSON { response2 = $0; expect2.fulfill() }
+        request.responseDecodable(of: TestResponse.self) { response2 = $0; expect2.fulfill() }
         waitForExpectations(timeout: timeout)
 
         let expect3 = expectation(description: "response serializer 3 completion should be called")
-        request.responseJSON { response3 = $0; expect3.fulfill() }
+        request.responseDecodable(of: TestResponse.self) { response3 = $0; expect3.fulfill() }
         waitForExpectations(timeout: timeout)
 
         // Then
@@ -762,7 +762,7 @@ final class RequestResponseTestCase: BaseTestCase {
 
 // MARK: -
 
-class RequestDescriptionTestCase: BaseTestCase {
+final class RequestDescriptionTestCase: BaseTestCase {
     func testRequestDescription() {
         // Given
         let url = Endpoint().url

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -320,6 +320,7 @@ final class DataResponseSerializationTestCase: BaseTestCase {
 
     // MARK: JSONResponseSerializer
 
+    @available(*, deprecated)
     func testThatJSONResponseSerializerFailsWhenDataIsNil() {
         // Given
         let serializer = JSONResponseSerializer()
@@ -334,6 +335,7 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
+    @available(*, deprecated)
     func testThatJSONResponseSerializerFailsWhenDataIsEmpty() {
         // Given
         let serializer = JSONResponseSerializer()
@@ -348,6 +350,7 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
+    @available(*, deprecated)
     func testThatJSONResponseSerializerSucceedsWhenDataIsValidJSON() {
         // Given
         let serializer = JSONResponseSerializer()
@@ -362,6 +365,7 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertNil(result.failure)
     }
 
+    @available(*, deprecated)
     func testThatJSONResponseSerializerFailsWhenDataIsInvalidJSON() {
         // Given
         let serializer = JSONResponseSerializer()
@@ -378,6 +382,7 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertEqual((result.failure?.asAFError?.underlyingError as? CocoaError)?.code, .propertyListReadCorrupt)
     }
 
+    @available(*, deprecated)
     func testThatJSONResponseSerializerFailsWhenErrorIsNotNil() {
         // Given
         let serializer = JSONResponseSerializer()
@@ -392,6 +397,7 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
+    @available(*, deprecated)
     func testThatJSONResponseSerializerFailsWhenDataIsNilWithNonEmptyResponseStatusCode() {
         // Given
         let serializer = JSONResponseSerializer()
@@ -407,6 +413,7 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
+    @available(*, deprecated)
     func testThatJSONResponseSerializerSucceedsWhenDataIsNilWithGETRequestAnd204ResponseStatusCode() {
         // Given
         let serializer = JSONResponseSerializer()
@@ -423,6 +430,7 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertEqual(result.success as? NSNull, NSNull())
     }
 
+    @available(*, deprecated)
     func testThatJSONResponseSerializerSucceedsWhenDataIsNilWithGETRequestAnd205ResponseStatusCode() {
         // Given
         let serializer = JSONResponseSerializer()
@@ -439,6 +447,7 @@ final class DataResponseSerializationTestCase: BaseTestCase {
         XCTAssertEqual(result.success as? NSNull, NSNull())
     }
 
+    @available(*, deprecated)
     func testThatJSONResponseSerializerSucceedsWhenDataIsNilWithHEADRequestAnd200ResponseStatusCode() {
         // Given
         let serializer = JSONResponseSerializer()
@@ -1050,6 +1059,7 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
 
     // MARK: Tests - JSON Response Serializer
 
+    @available(*, deprecated)
     func testThatJSONResponseSerializerFailsWhenFileURLIsNil() {
         // Given
         let serializer = JSONResponseSerializer()
@@ -1064,6 +1074,7 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
         XCTAssertEqual(result.failure?.asAFError?.isInputFileNil, true)
     }
 
+    @available(*, deprecated)
     func testThatJSONResponseSerializerFailsWhenFileURLIsInvalid() {
         // Given
         let serializer = JSONResponseSerializer()
@@ -1078,6 +1089,7 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
         XCTAssertEqual(result.failure?.asAFError?.isInputFileReadFailed, true)
     }
 
+    @available(*, deprecated)
     func testThatJSONResponseSerializerFailsWhenFileDataIsEmpty() {
         // Given
         let serializer = JSONResponseSerializer()
@@ -1092,6 +1104,7 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
         XCTAssertEqual(result.failure?.asAFError?.isInputDataNilOrZeroLength, true)
     }
 
+    @available(*, deprecated)
     func testThatJSONResponseSerializerSucceedsWhenDataIsValidJSON() {
         // Given
         let serializer = JSONResponseSerializer()
@@ -1105,6 +1118,7 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
         XCTAssertNil(result.failure)
     }
 
+    @available(*, deprecated)
     func testThatJSONResponseSerializerFailsWhenDataIsInvalidJSON() {
         // Given
         let serializer = JSONResponseSerializer()
@@ -1120,6 +1134,7 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
         XCTAssertEqual((result.failure?.asAFError?.underlyingError as? CocoaError)?.code, .propertyListReadCorrupt)
     }
 
+    @available(*, deprecated)
     func testThatJSONResponseSerializerFailsWhenErrorIsNotNil() {
         // Given
         let serializer = JSONResponseSerializer()
@@ -1134,6 +1149,7 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
         XCTAssertEqual(result.failure?.asAFError?.isInputFileNil, true)
     }
 
+    @available(*, deprecated)
     func testThatJSONResponseSerializerFailsWhenDataIsNilWithNonEmptyResponseStatusCode() {
         // Given
         let serializer = JSONResponseSerializer()
@@ -1149,6 +1165,7 @@ final class DownloadResponseSerializationTestCase: BaseTestCase {
         XCTAssertEqual(result.failure?.asAFError?.isInputFileNil, true)
     }
 
+    @available(*, deprecated)
     func testThatJSONResponseSerializerSucceedsWhenDataIsNilWithEmptyResponseStatusCode() {
         // Given
         let serializer = JSONResponseSerializer()
@@ -1267,6 +1284,7 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
         XCTAssertNotNil(result.failure)
     }
 
+    @available(*, deprecated)
     func testThatJSONResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
         // Given
         let preprocessor = DropFirst()
@@ -1282,6 +1300,7 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
         XCTAssertNil(result.failure)
     }
 
+    @available(*, deprecated)
     func testThatJSONResponseSerializerProperlyReceivesErrorFromFailingDataPreprocessor() {
         // Given
         let preprocessor = Throwing()

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -181,6 +181,7 @@ final class ResponseStringTestCase: BaseTestCase {
 
 // MARK: -
 
+@available(*, deprecated)
 final class ResponseJSONTestCase: BaseTestCase {
     func testThatResponseJSONReturnsSuccessResultWithValidJSON() {
         // Given
@@ -378,10 +379,9 @@ final class ResponseMapTestCase: BaseTestCase {
         var response: DataResponse<String, AFError>?
 
         // When
-        AF.request(.default, parameters: ["foo": "bar"]).responseJSON { resp in
-            response = resp.map { json in
-                // json["args"]["foo"] is "bar": use this invariant to test the map function
-                ((json as? [String: Any])?["args"] as? [String: Any])?["foo"] as? String ?? "invalid"
+        AF.request(.default, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
+            response = resp.map { response in
+                response.args?["foo"] ?? "invalid"
             }
 
             expectation.fulfill()
@@ -434,10 +434,9 @@ final class ResponseTryMapTestCase: BaseTestCase {
         var response: DataResponse<String, Error>?
 
         // When
-        AF.request(.default, parameters: ["foo": "bar"]).responseJSON { resp in
-            response = resp.tryMap { json in
-                // json["args"]["foo"] is "bar": use this invariant to test the tryMap function
-                ((json as? [String: Any])?["args"] as? [String: Any])?["foo"] as? String ?? "invalid"
+        AF.request(.default, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
+            response = resp.tryMap { response in
+                response.args?["foo"] ?? "invalid"
             }
 
             expectation.fulfill()
@@ -534,10 +533,10 @@ final class ResponseMapErrorTestCase: BaseTestCase {
         let urlString = String.nonexistentDomain
         let expectation = self.expectation(description: "request should not succeed")
 
-        var response: DataResponse<Any, TestError>?
+        var response: DataResponse<TestResponse, TestError>?
 
         // When
-        AF.request(urlString).responseJSON { resp in
+        AF.request(urlString).responseDecodable(of: TestResponse.self) { resp in
             response = resp.mapError { error in
                 TestError.error(error: error)
             }

--- a/Tests/ServerTrustEvaluatorTests.swift
+++ b/Tests/ServerTrustEvaluatorTests.swift
@@ -1424,7 +1424,7 @@ final class StaticServerTrustAccessorTests: ServerTrustPolicyTestCase {
 
     func testThatRevocationEvaluatorCanBeCreatedStaticallyFromProtocol() {
         // Given, When, Then
-        consumeServerTrustEvaluator(.revocation())
+        consumeServerTrustEvaluator(.revocationChecking())
     }
 
     func testThatPinnedCertificatesEvaluatorCanBeCreatedStaticallyFromProtocol() {

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -1163,7 +1163,7 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(request.retryCount, 0)
         XCTAssertEqual(response?.result.isSuccess, false)
         XCTAssertEqual(response?.error?.isResponseSerializationError, true)
-        XCTAssertEqual((response?.error?.underlyingError as? CocoaError)?.code, .propertyListReadCorrupt)
+        XCTAssertNotNil(response?.error?.underlyingError as? DecodingError)
         assert(on: session.rootQueue) {
             XCTAssertTrue(session.requestTaskMap.isEmpty)
             XCTAssertTrue(session.activeRequests.isEmpty)
@@ -1218,7 +1218,7 @@ final class SessionTestCase: BaseTestCase {
             XCTAssertTrue(error.isRequestRetryError)
             if case let .requestRetryFailed(retryError, originalError) = error {
                 XCTAssertEqual(retryError.asAFError?.urlConvertible as? String, "/invalid/url/\(index + 1)")
-                XCTAssertEqual((originalError.asAFError?.underlyingError as? CocoaError)?.code, .propertyListReadCorrupt)
+                XCTAssertNotNil(originalError.asAFError?.underlyingError as? DecodingError)
             } else {
                 XCTFail("Error failure reason should be response serialization failure")
             }

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -825,12 +825,12 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any, AFError>?
+        var response: DataResponse<TestResponse, AFError>?
 
         // When
         session.request(.basicAuth(), interceptor: handler)
             .validate()
-            .responseJSON { jsonResponse in
+            .responseDecodable(of: TestResponse.self) { jsonResponse in
                 response = jsonResponse
                 expectation.fulfill()
             }
@@ -859,7 +859,7 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DownloadResponse<Any, AFError>?
+        var response: DownloadResponse<TestResponse, AFError>?
 
         let destination: DownloadRequest.Destination = { _, _ in
             let fileURL = self.testDirectoryURL.appendingPathComponent("test-output.json")
@@ -869,7 +869,7 @@ final class SessionTestCase: BaseTestCase {
         // When
         session.download(.basicAuth(), interceptor: handler, to: destination)
             .validate()
-            .responseJSON { jsonResponse in
+            .responseDecodable(of: TestResponse.self) { jsonResponse in
                 response = jsonResponse
                 expectation.fulfill()
             }
@@ -894,14 +894,14 @@ final class SessionTestCase: BaseTestCase {
         let session = Session(interceptor: handler)
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any, AFError>?
+        var response: DataResponse<TestResponse, AFError>?
 
         let uploadData = Data("upload data".utf8)
 
         // When
         session.upload(uploadData, to: .method(.post))
             .validate()
-            .responseJSON { jsonResponse in
+            .responseDecodable(of: TestResponse.self) { jsonResponse in
                 response = jsonResponse
                 expectation.fulfill()
             }
@@ -927,12 +927,12 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any, AFError>?
+        var response: DataResponse<TestResponse, AFError>?
 
         // When
         let request = session.request(.basicAuth(), interceptor: handler)
             .validate()
-            .responseJSON { jsonResponse in
+            .responseDecodable(of: TestResponse.self) { jsonResponse in
                 response = jsonResponse
                 expectation.fulfill()
             }
@@ -960,12 +960,12 @@ final class SessionTestCase: BaseTestCase {
         let session = Session(interceptor: sessionHandler)
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any, AFError>?
+        var response: DataResponse<TestResponse, AFError>?
 
         // When
         let request = session.request(.basicAuth(), interceptor: requestHandler)
             .validate()
-            .responseJSON { jsonResponse in
+            .responseDecodable(of: TestResponse.self) { jsonResponse in
                 response = jsonResponse
                 expectation.fulfill()
             }
@@ -997,12 +997,12 @@ final class SessionTestCase: BaseTestCase {
         let session = Session(interceptor: handler)
 
         let expectation = self.expectation(description: "request should eventually succeed")
-        var response: DataResponse<Any, AFError>?
+        var response: DataResponse<TestResponse, AFError>?
 
         // When
         let request = session.request(.basicAuth())
             .validate()
-            .responseJSON { jsonResponse in
+            .responseDecodable(of: TestResponse.self) { jsonResponse in
                 response = jsonResponse
                 expectation.fulfill()
             }
@@ -1030,12 +1030,12 @@ final class SessionTestCase: BaseTestCase {
         let session = Session(interceptor: handler)
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any, AFError>?
+        var response: DataResponse<TestResponse, AFError>?
 
         // When
         let request = session.request(.basicAuth())
             .validate()
-            .responseJSON { jsonResponse in
+            .responseDecodable(of: TestResponse.self) { jsonResponse in
                 response = jsonResponse
                 expectation.fulfill()
             }
@@ -1066,12 +1066,12 @@ final class SessionTestCase: BaseTestCase {
         let session = Session(interceptor: handler)
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any, AFError>?
+        var response: DataResponse<TestResponse, AFError>?
 
         // When
         let request = session.request(.basicAuth())
             .validate()
-            .responseJSON { jsonResponse in
+            .responseDecodable(of: TestResponse.self) { jsonResponse in
                 response = jsonResponse
                 expectation.fulfill()
             }
@@ -1101,12 +1101,12 @@ final class SessionTestCase: BaseTestCase {
         let session = Session(interceptor: handler)
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any, AFError>?
+        var response: DataResponse<TestResponse, AFError>?
 
         // When
         let request = session.request(.basicAuth())
             .validate()
-            .responseJSON { jsonResponse in
+            .responseDecodable(of: TestResponse.self) { jsonResponse in
                 response = jsonResponse
                 expectation.fulfill()
             }
@@ -1143,12 +1143,12 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let expectation = self.expectation(description: "request should eventually fail")
-        var response: DataResponse<Any, AFError>?
+        var response: DataResponse<TestResponse, AFError>?
 
         // When
         let request = session.request(.image(.jpeg), interceptor: handler)
             .validate()
-            .responseJSON { jsonResponse in
+            .responseDecodable(of: TestResponse.self) { jsonResponse in
                 response = jsonResponse
                 expectation.fulfill()
             }
@@ -1178,19 +1178,19 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let json1Expectation = expectation(description: "request should eventually fail")
-        var json1Response: DataResponse<Any, AFError>?
+        var json1Response: DataResponse<TestResponse, AFError>?
 
         let json2Expectation = expectation(description: "request should eventually fail")
-        var json2Response: DataResponse<Any, AFError>?
+        var json2Response: DataResponse<TestResponse, AFError>?
 
         // When
         let request = session.request(.image(.jpeg), interceptor: handler)
             .validate()
-            .responseJSON { response in
+            .responseDecodable(of: TestResponse.self) { response in
                 json1Response = response
                 json1Expectation.fulfill()
             }
-            .responseJSON { response in
+            .responseDecodable(of: TestResponse.self) { response in
                 json2Response = response
                 json2Expectation.fulfill()
             }
@@ -1231,24 +1231,24 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let json1Expectation = expectation(description: "request should eventually fail")
-        var json1Response: DataResponse<Any, AFError>?
+        var json1Response: DataResponse<TestResponse, AFError>?
 
         let json2Expectation = expectation(description: "request should eventually fail")
-        var json2Response: DataResponse<Any, AFError>?
+        var json2Response: DataResponse<TestResponse, AFError>?
 
         // When
         let request = session.request(.image(.jpeg), interceptor: handler)
             .validate()
-            .responseJSON { response in
+            .responseDecodable(of: TestResponse.self) { response in
                 json1Response = response
                 json1Expectation.fulfill()
             }
-            .responseJSON { response in
+            .responseDecodable(of: TestResponse.self) { response in
                 json2Response = response
                 json2Expectation.fulfill()
             }
 
-        waitForExpectations(timeout: 10, handler: nil)
+        waitForExpectations(timeout: timeout)
 
         // Then
         XCTAssertEqual(handler.adaptCalledCount, 2)
@@ -1268,7 +1268,7 @@ final class SessionTestCase: BaseTestCase {
 
         for error in errors {
             XCTAssertTrue(error.isResponseSerializationError)
-            XCTAssertEqual((error.underlyingError as? CocoaError)?.code, .propertyListReadCorrupt)
+            XCTAssertNotNil(error.underlyingError as? DecodingError)
         }
     }
 
@@ -1286,24 +1286,24 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let json1Expectation = expectation(description: "request should eventually fail")
-        var json1Response: DataResponse<Any, AFError>?
+        var json1Response: DataResponse<TestResponse, AFError>?
 
         let json2Expectation = expectation(description: "request should eventually fail")
-        var json2Response: DataResponse<Any, AFError>?
+        var json2Response: DataResponse<TestResponse, AFError>?
 
         // When
         let request = session.request(.image(.jpeg), interceptor: handler)
             .validate()
-            .responseJSON { response in
+            .responseDecodable(of: TestResponse.self) { response in
                 json1Response = response
                 json1Expectation.fulfill()
             }
-            .responseJSON { response in
+            .responseDecodable(of: TestResponse.self) { response in
                 json2Response = response
                 json2Expectation.fulfill()
             }
 
-        waitForExpectations(timeout: 10, handler: nil)
+        waitForExpectations(timeout: timeout)
 
         // Then
         XCTAssertEqual(handler.adaptCalledCount, 2)
@@ -1341,24 +1341,24 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let json1Expectation = expectation(description: "request should eventually fail")
-        var json1Response: DownloadResponse<Any, AFError>?
+        var json1Response: DownloadResponse<TestResponse, AFError>?
 
         let json2Expectation = expectation(description: "request should eventually fail")
-        var json2Response: DownloadResponse<Any, AFError>?
+        var json2Response: DownloadResponse<TestResponse, AFError>?
 
         // When
         let request = session.download(.image(.jpeg), interceptor: handler)
             .validate()
-            .responseJSON { response in
+            .responseDecodable(of: TestResponse.self) { response in
                 json1Response = response
                 json1Expectation.fulfill()
             }
-            .responseJSON { response in
+            .responseDecodable(of: TestResponse.self) { response in
                 json2Response = response
                 json2Expectation.fulfill()
             }
 
-        waitForExpectations(timeout: 10, handler: nil)
+        waitForExpectations(timeout: timeout)
 
         // Then
         XCTAssertEqual(handler.adaptCalledCount, 2)
@@ -1416,14 +1416,14 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let expectation = self.expectation(description: "request should complete")
-        var response: DataResponse<Any, AFError>?
+        var response: DataResponse<TestResponse, AFError>?
         var completionCallCount = 0
 
         // When
         let request = session.request(.default, interceptor: handler)
         request.validate()
 
-        request.responseJSON { resp in
+        request.responseDecodable(of: TestResponse.self) { resp in
             request.cancel()
 
             response = resp
@@ -1455,10 +1455,10 @@ final class SessionTestCase: BaseTestCase {
         let session = Session()
 
         let expectation = self.expectation(description: "request should complete")
-        var response: DataResponse<Any, AFError>?
+        var response: DataResponse<TestResponse, AFError>?
 
         // When
-        let request = session.request(.default).responseJSON { resp in
+        let request = session.request(.default).responseDecodable(of: TestResponse.self) { resp in
             response = resp
             expectation.fulfill()
         }

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -204,7 +204,7 @@ final class UploadDataTestCase: BaseTestCase {
     func testUploadDataRequestWithProgress() {
         // Given
         let url = Endpoint.method(.post).url
-        let string = String(repeating: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. ", count: 300)
+        let string = String(repeating: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. ", count: 1000)
         let data = Data(string.utf8)
 
         let expectation = self.expectation(description: "Bytes upload progress should be reported: \(url)")

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -683,9 +683,9 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
     private func executeMultipartFormDataUploadRequestWithProgress(streamFromDisk: Bool) {
         // Given
         let loremData1 = Data(String(repeating: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-                                     count: 100).utf8)
+                                     count: 500).utf8)
         let loremData2 = Data(String(repeating: "Lorem ipsum dolor sit amet, nam no graeco recusabo appellantur.",
-                                     count: 100).utf8)
+                                     count: 500).utf8)
 
         let expectation = self.expectation(description: "multipart form data upload should succeed")
 


### PR DESCRIPTION
### Goals :soccer:
Despite the extensive documentation, `responseJSON` seems to be greatly misunderstood. As I've observed in many code samples on StackOverflow and elsewhere, people seem to think you need to call it for every response that returns JSON, even if you then want to use `JSONDecoder` on the `Data` returned. Since this convenience is largely unneeded nowadays, it seems like a good idea to deprecate and point everyone to the much superior `responseDecodable`.

### Implementation Details :construction:
This PR simply deprecates the `responseJSON` methods and `JSONResponseSerializer`.

### Testing Details :mag:
This PR updates our tests to replace `responseJSON` with `responseDecodable`, except for tests which exercised `responseJSON` specifically, which have themselves been deprecated as well.