### PR TITLE
Fix the tests target build 

### DIFF
--- a/Tests/ServerTrustEvaluatorTests.swift
+++ b/Tests/ServerTrustEvaluatorTests.swift
@@ -1424,7 +1424,7 @@ final class StaticServerTrustAccessorTests: ServerTrustPolicyTestCase {
 
     func testThatRevocationEvaluatorCanBeCreatedStaticallyFromProtocol() {
         // Given, When, Then
-        consumeServerTrustEvaluator(.revocation())
+        consumeServerTrustEvaluator(.revocationChecking())
     }
 
     func testThatPinnedCertificatesEvaluatorCanBeCreatedStaticallyFromProtocol() {


### PR DESCRIPTION
### Goals :soccer:
Fix the build of the tests target. The code in the `ServerTrustEvaluatorTests.swift` isn't compiling due to the usage of  the `.revocation()` static accessor, which was renamed to `.revocationChecking()`.

### Testing Details :mag:
No tests were added.
