### PR TITLE
Fixes for parameters in doc comments throughout the project

### DIFF
--- a/Source/Combine.swift
+++ b/Source/Combine.swift
@@ -201,17 +201,17 @@ extension DataRequest {
     /// response.
     ///
     /// - Parameters:
-    ///   - type:                `Decodable` type to which to decode response `Data`. Inferred from the context by default.
-    ///   - queue:               `DispatchQueue` on which the `DataResponse` will be published. `.main` by default.
-    ///   - preprocessor:        `DataPreprocessor` which filters the `Data` before serialization. `PassthroughPreprocessor()`
-    ///                          by default.
-    ///   - decoder:             `DataDecoder` instance used to decode response `Data`. `JSONDecoder()` by default.
-    ///   - emptyResponseCodes:  `Set<Int>` of HTTP status codes for which empty responses are allowed. `[204, 205]` by
-    ///                          default.
-    ///   - emptyRequestMethods: `Set<HTTPMethod>` of `HTTPMethod`s for which empty responses are allowed, regardless of
-    ///                          status code. `[.head]` by default.
+    ///   - type:                 `Decodable` type to which to decode response `Data`. Inferred from the context by default.
+    ///   - queue:                `DispatchQueue` on which the `DataResponse` will be published. `.main` by default.
+    ///   - preprocessor:         `DataPreprocessor` which filters the `Data` before serialization.
+    ///                           `PassthroughPreprocessor()` by default.
+    ///   - decoder:              `DataDecoder` instance used to decode response `Data`. `JSONDecoder()` by default.
+    ///   - emptyResponseCodes:   `Set<Int>` of HTTP status codes for which empty responses are allowed. `[204, 205]` by
+    ///                           default.
+    ///   - emptyResponseMethods: `Set<HTTPMethod>` of `HTTPMethod`s for which empty responses are allowed, regardless
+    ///                           of status code. `[.head]` by default.
     ///
-    /// - Returns:               The `DataResponsePublisher`.
+    /// - Returns:                The `DataResponsePublisher`.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     public func publishDecodable<T: Decodable>(type: T.Type = T.self,
                                                queue: DispatchQueue = .main,
@@ -571,17 +571,17 @@ extension DownloadRequest {
     /// response.
     ///
     /// - Parameters:
-    ///   - type:                `Decodable` type to which to decode response `Data`. Inferred from the context by default.
-    ///   - queue:               `DispatchQueue` on which the `DataResponse` will be published. `.main` by default.
-    ///   - preprocessor:        `DataPreprocessor` which filters the `Data` before serialization. `PassthroughPreprocessor()`
-    ///                          by default.
-    ///   - decoder:             `DataDecoder` instance used to decode response `Data`. `JSONDecoder()` by default.
-    ///   - emptyResponseCodes:  `Set<Int>` of HTTP status codes for which empty responses are allowed. `[204, 205]` by
-    ///                          default.
-    ///   - emptyRequestMethods: `Set<HTTPMethod>` of `HTTPMethod`s for which empty responses are allowed, regardless of
-    ///                          status code. `[.head]` by default.
+    ///   - type:                 `Decodable` type to which to decode response `Data`. Inferred from the context by default.
+    ///   - queue:                `DispatchQueue` on which the `DataResponse` will be published. `.main` by default.
+    ///   - preprocessor:         `DataPreprocessor` which filters the `Data` before serialization.
+    ///                           `PassthroughPreprocessor()` by default.
+    ///   - decoder:              `DataDecoder` instance used to decode response `Data`. `JSONDecoder()` by default.
+    ///   - emptyResponseCodes:   `Set<Int>` of HTTP status codes for which empty responses are allowed. `[204, 205]` by
+    ///                           default.
+    ///   - emptyResponseMethods: `Set<HTTPMethod>` of `HTTPMethod`s for which empty responses are allowed, regardless
+    ///                           of status code. `[.head]` by default.
     ///
-    /// - Returns:               The `DownloadResponsePublisher`.
+    /// - Returns:                The `DownloadResponsePublisher`.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     public func publishDecodable<T: Decodable>(type: T.Type = T.self,
                                                queue: DispatchQueue = .main,

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1782,6 +1782,8 @@ public class UploadRequest: DataRequest {
     ///                         `underlyingQueue`, but can be passed another queue from a `Session`.
     ///   - eventMonitor:       `EventMonitor` called for event callbacks from internal `Request` actions.
     ///   - interceptor:        `RequestInterceptor` used throughout the request lifecycle.
+    ///   - fileManager:        `FileManager` used to perform cleanup tasks, including the removal of multipart form
+    ///                         encoded payloads written to disk.
     ///   - delegate:           `RequestDelegate` that provides an interface to actions not performed by the `Request`.
     init(id: UUID = UUID(),
          convertible: UploadConvertible,

--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -248,8 +248,7 @@ public struct DownloadResponse<Success, Failure: Error> {
     /// - Parameters:
     ///   - request:               The `URLRequest` sent to the server.
     ///   - response:              The `HTTPURLResponse` from the server.
-    ///   - temporaryURL:          The temporary destination `URL` of the data returned from the server.
-    ///   - destinationURL:        The final destination `URL` of the data returned from the server, if it was moved.
+    ///   - fileURL:               The final destination URL of the data returned from the server after it is moved.
     ///   - resumeData:            The resume `Data` generated if the request was cancelled.
     ///   - metrics:               The `URLSessionTaskMetrics` of the `DownloadRequest`.
     ///   - serializationDuration: The duration taken by serialization.

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -312,15 +312,17 @@ open class Session {
     /// `RequestInterceptor`.
     ///
     /// - Parameters:
-    ///   - convertible: `URLConvertible` value to be used as the `URLRequest`'s `URL`.
-    ///   - method:      `HTTPMethod` for the `URLRequest`. `.get` by default.
-    ///   - parameters:  `Encodable` value to be encoded into the `URLRequest`. `nil` by default.
-    ///   - encoder:     `ParameterEncoder` to be used to encode the `parameters` value into the `URLRequest`.
-    ///                  `URLEncodedFormParameterEncoder.default` by default.
-    ///   - headers:     `HTTPHeaders` value to be added to the `URLRequest`. `nil` by default.
-    ///   - interceptor: `RequestInterceptor` value to be used by the returned `DataRequest`. `nil` by default.
+    ///   - convertible:     `URLConvertible` value to be used as the `URLRequest`'s `URL`.
+    ///   - method:          `HTTPMethod` for the `URLRequest`. `.get` by default.
+    ///   - parameters:      `Encodable` value to be encoded into the `URLRequest`. `nil` by default.
+    ///   - encoder:         `ParameterEncoder` to be used to encode the `parameters` value into the `URLRequest`.
+    ///                      `URLEncodedFormParameterEncoder.default` by default.
+    ///   - headers:         `HTTPHeaders` value to be added to the `URLRequest`. `nil` by default.
+    ///   - interceptor:     `RequestInterceptor` value to be used by the returned `DataRequest`. `nil` by default.
+    ///   - requestModifier: `RequestModifier` which will be applied to the `URLRequest` created from
+    ///                      the provided parameters. `nil` by default.
     ///
-    /// - Returns:       The created `DataRequest`.
+    /// - Returns:           The created `DataRequest`.
     open func request<Parameters: Encodable>(_ convertible: URLConvertible,
                                              method: HTTPMethod = .get,
                                              parameters: Parameters? = nil,
@@ -784,8 +786,8 @@ open class Session {
     /// technique was used.
     ///
     /// - Parameters:
-    ///   - multipartFormData:       `MultipartFormData` building closure.
-    ///   - convertible:             `URLConvertible` value to be used as the `URLRequest`'s `URL`.
+    ///   - multipartFormData:      `MultipartFormData` building closure.
+    ///   - url:                    `URLConvertible` value to be used as the `URLRequest`'s `URL`.
     ///   - encodingMemoryThreshold: Byte threshold used to determine whether the form data is encoded into memory or
     ///                              onto disk before being uploaded. `MultipartFormData.encodingMemoryThreshold` by
     ///                              default.

--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -152,9 +152,9 @@ extension DataRequest {
     ///
     /// If validation fails, subsequent calls to response handlers will have an associated error.
     ///
-    /// - Parameter statusCode: `Sequence` of acceptable response status codes.
+    /// - Parameter acceptableStatusCodes: `Sequence` of acceptable response status codes.
     ///
-    /// - Returns:              The instance.
+    /// - Returns:                         The instance.
     @discardableResult
     public func validate<S: Sequence>(statusCode acceptableStatusCodes: S) -> Self where S.Iterator.Element == Int {
         validate { [unowned self] _, response, _ in
@@ -200,9 +200,9 @@ extension DataStreamRequest {
     ///
     /// If validation fails, subsequent calls to response handlers will have an associated error.
     ///
-    /// - Parameter statusCode: `Sequence` of acceptable response status codes.
+    /// - Parameter acceptableStatusCodes: `Sequence` of acceptable response status codes.
     ///
-    /// - Returns:              The instance.
+    /// - Returns:                         The instance.
     @discardableResult
     public func validate<S: Sequence>(statusCode acceptableStatusCodes: S) -> Self where S.Iterator.Element == Int {
         validate { [unowned self] _, response in
@@ -253,9 +253,9 @@ extension DownloadRequest {
     ///
     /// If validation fails, subsequent calls to response handlers will have an associated error.
     ///
-    /// - Parameter statusCode: `Sequence` of acceptable response status codes.
+    /// - Parameter acceptableStatusCodes: `Sequence` of acceptable response status codes.
     ///
-    /// - Returns:              The instance.
+    /// - Returns:                         The instance.
     @discardableResult
     public func validate<S: Sequence>(statusCode acceptableStatusCodes: S) -> Self where S.Iterator.Element == Int {
         validate { [unowned self] _, response, _ in


### PR DESCRIPTION
Noticed several warnings for "Mismatched doc comments and function signature"  inspection displayed by AppCode, so I run the inspection with "Whole project" scope and fixed all of the issues.