### PR TITLE
Sample app: display the initial loading state for each Request

### DIFF
--- a/Example/Source/DetailViewController.swift
+++ b/Example/Source/DetailViewController.swift
@@ -76,6 +76,7 @@ class DetailViewController: UITableViewController {
             return
         }
 
+        refreshControl?.isHidden = false
         refreshControl?.beginRefreshing()
 
         let start = CACurrentMediaTime()


### PR DESCRIPTION
### Goal :soccer:
To display the initial loading state for each `Request` object in the `DetailViewController` of the sample application.

#### Before the change
<img src="https://user-images.githubusercontent.com/6910889/139678587-aed9fea9-6671-4f78-a9f0-215815e403fe.gif" width=300px />

#### After the change
<img src="https://user-images.githubusercontent.com/6910889/139678652-f48f6f8e-7446-483b-ac9f-2dcd41e5c715.gif" width=300px />

### Implementation Details :construction:
This change simply displays the `refreshIndicator` of the `UITableView`. For some reason the tint color isn't applied.
As an alternative, a `backgroundView` with an `UIActivityIndicator` can be added to the `UITableView` in order to display this initial loading state, with the proper color and layout position (centered).