### PR TITLE
Add .indexInBrackets array serialization option for URL parameters

### DIFF
--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -85,13 +85,17 @@ public struct URLEncoding: ParameterEncoding {
         case brackets
         /// No brackets are appended. The key is encoded as is.
         case noBrackets
+        /// Brackets containing the item index appended. This matches the jQuery and Node.js behavior.
+        case indexInBrackets
 
-        func encode(key: String) -> String {
+        func encode(key: String, index: Int) -> String {
             switch self {
             case .brackets:
                 return "\(key)[]"
             case .noBrackets:
                 return key
+            case .indexInBrackets:
+                return "\(key)[\(index)]"
             }
         }
     }
@@ -193,8 +197,8 @@ public struct URLEncoding: ParameterEncoding {
                 components += queryComponents(fromKey: "\(key)[\(nestedKey)]", value: value)
             }
         case let array as [Any]:
-            for value in array {
-                components += queryComponents(fromKey: arrayEncoding.encode(key: key), value: value)
+            for (index, value) in array.enumerated() {
+                components += queryComponents(fromKey: arrayEncoding.encode(key: key, index: index), value: value)
             }
         case let number as NSNumber:
             if number.isBool {

--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -85,10 +85,10 @@ public struct URLEncoding: ParameterEncoding {
         case brackets
         /// No brackets are appended. The key is encoded as is.
         case noBrackets
-        /// Brackets containing the item index appended. This matches the jQuery and Node.js behavior.
+        /// Brackets containing the item index are appended. This matches the jQuery and Node.js behavior.
         case indexInBrackets
 
-        func encode(key: String, index: Int) -> String {
+        func encode(key: String, atIndex index: Int) -> String {
             switch self {
             case .brackets:
                 return "\(key)[]"
@@ -198,7 +198,7 @@ public struct URLEncoding: ParameterEncoding {
             }
         case let array as [Any]:
             for (index, value) in array.enumerated() {
-                components += queryComponents(fromKey: arrayEncoding.encode(key: key, index: index), value: value)
+                components += queryComponents(fromKey: arrayEncoding.encode(key: key, atIndex: index), value: value)
             }
         case let number as NSNumber:
             if number.isBool {

--- a/Source/URLEncodedFormEncoder.swift
+++ b/Source/URLEncodedFormEncoder.swift
@@ -48,15 +48,19 @@ public final class URLEncodedFormEncoder {
         case brackets
         /// No brackets are appended to the key and the key is encoded as is.
         case noBrackets
+        /// Brackets containing the item index appended. This matches the jQuery and Node.js behavior.
+        case indexInBrackets
 
         /// Encodes the key according to the encoding.
         ///
-        /// - Parameter key: The `key` to encode.
-        /// - Returns:       The encoded key.
-        func encode(_ key: String) -> String {
+        /// - Parameter key:    The `key` to encode.
+        /// - Parameter index:  When this enum instance is `.indexInBrackets`, the `index` to encode.
+        /// - Returns:          The encoded key.
+        func encode(_ key: String, index: Int) -> String {
             switch self {
             case .brackets: return "\(key)[]"
             case .noBrackets: return key
+            case .indexInBrackets: return "\(key)[\(index)]"
             }
         }
     }
@@ -930,8 +934,8 @@ final class URLEncodedFormSerializer {
     }
 
     func serialize(_ array: [URLEncodedFormComponent], forKey key: String) -> String {
-        var segments: [String] = array.map { component in
-            let keyPath = arrayEncoding.encode(key)
+        var segments: [String] = array.enumerated().map { index, component in
+            let keyPath = arrayEncoding.encode(key, index: index)
             return serialize(component, forKey: keyPath)
         }
         segments = alphabetizeKeyValuePairs ? segments.sorted() : segments

--- a/Source/URLEncodedFormEncoder.swift
+++ b/Source/URLEncodedFormEncoder.swift
@@ -48,15 +48,17 @@ public final class URLEncodedFormEncoder {
         case brackets
         /// No brackets are appended to the key and the key is encoded as is.
         case noBrackets
-        /// Brackets containing the item index appended. This matches the jQuery and Node.js behavior.
+        /// Brackets containing the item index are appended. This matches the jQuery and Node.js behavior.
         case indexInBrackets
 
         /// Encodes the key according to the encoding.
         ///
-        /// - Parameter key:    The `key` to encode.
-        /// - Parameter index:  When this enum instance is `.indexInBrackets`, the `index` to encode.
+        /// - Parameters:
+        ///     - key:      The `key` to encode.
+        ///     - index:   When this enum instance is `.indexInBrackets`, the `index` to encode.
+        ///
         /// - Returns:          The encoded key.
-        func encode(_ key: String, index: Int) -> String {
+        func encode(_ key: String, atIndex index: Int) -> String {
             switch self {
             case .brackets: return "\(key)[]"
             case .noBrackets: return key
@@ -935,7 +937,7 @@ final class URLEncodedFormSerializer {
 
     func serialize(_ array: [URLEncodedFormComponent], forKey key: String) -> String {
         var segments: [String] = array.enumerated().map { index, component in
-            let keyPath = arrayEncoding.encode(key, index: index)
+            let keyPath = arrayEncoding.encode(key, atIndex: index)
             return serialize(component, forKey: keyPath)
         }
         segments = alphabetizeKeyValuePairs ? segments.sorted() : segments

--- a/Tests/ParameterEncoderTests.swift
+++ b/Tests/ParameterEncoderTests.swift
@@ -511,6 +511,61 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         // Then
         XCTAssertFalse(result.isSuccess)
     }
+    
+    func testThatEncodableClassWithNoInheritanceCanBeEncodedWithIndexInBrackets() {
+        // Given
+        let encoder = URLEncodedFormEncoder(arrayEncoding: .indexInBrackets)
+        let parameters = ["foo": [EncodableSuperclass()]]
+        
+        // When
+        let result = Result<String, Error> { try encoder.encode(parameters) }
+        
+        // Then
+        XCTAssertEqual(result.success, "foo%5B0%5D%5Bone%5D=one&foo%5B0%5D%5Bthree%5D=1&foo%5B0%5D%5Btwo%5D=2")
+    }
+    
+    // TODO: Test the other subclasses and structs.
+    // - EncodableStruct
+    // - NestedEncodableStruct
+    // - EncodableSubclass
+    // - ManuallyEncodableSubclass
+    // - ManuallyEncodableStruct
+    
+    func testThatArrayNestedDictionaryIntValueCanBeEncodedWithIndexInBrackets() {
+        // Given
+        let encoder = URLEncodedFormEncoder(arrayEncoding: .indexInBrackets)
+        let parameters = ["foo": [["bar": 2], ["qux": 3], ["quy": 4]]]
+        
+        // When
+        let result = Result<String, Error> { try encoder.encode(parameters) }
+        
+        // Then
+        XCTAssertEqual(result.success, "foo%5B0%5D%5Bbar%5D=2&foo%5B1%5D%5Bqux%5D=3&foo%5B2%5D%5Bquy%5D=4")
+    }
+    
+    func testThatArrayNestedDictionaryStringValueCanBeEncodedWithIndexInBrackets() {
+        // Given
+        let encoder = URLEncodedFormEncoder(arrayEncoding: .indexInBrackets)
+        let parameters = ["foo": [["bar": "2"], ["qux": "3"], ["quy": "4"]]]
+        
+        // When
+        let result = Result<String, Error> { try encoder.encode(parameters) }
+        
+        // Then
+        XCTAssertEqual(result.success, "foo%5B0%5D%5Bbar%5D=2&foo%5B1%5D%5Bqux%5D=3&foo%5B2%5D%5Bquy%5D=4")
+    }
+    
+    func testThatArrayNestedDictionaryBoolValueCanBeEncodedWithIndexInBrackets() {
+        // Given
+        let encoder = URLEncodedFormEncoder(arrayEncoding: .indexInBrackets)
+        let parameters = ["foo": [["bar": true], ["qux": false], ["quy": true]]]
+        
+        // When
+        let result = Result<String, Error> { try encoder.encode(parameters) }
+        
+        // Then
+        XCTAssertEqual(result.success, "foo%5B0%5D%5Bbar%5D=1&foo%5B1%5D%5Bqux%5D=0&foo%5B2%5D%5Bquy%5D=1")
+    }
 
     func testThatArraysCanBeEncodedWithoutBrackets() {
         // Given

--- a/Tests/ParameterEncoderTests.swift
+++ b/Tests/ParameterEncoderTests.swift
@@ -512,7 +512,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         XCTAssertFalse(result.isSuccess)
     }
     
-    func testThatEncodableClassWithNoInheritanceCanBeEncodedWithIndexInBrackets() {
+    func testThatEncodableSuperclassCanBeEncodedWithIndexInBrackets() {
         // Given
         let encoder = URLEncodedFormEncoder(arrayEncoding: .indexInBrackets)
         let parameters = ["foo": [EncodableSuperclass()]]
@@ -524,12 +524,57 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         XCTAssertEqual(result.success, "foo%5B0%5D%5Bone%5D=one&foo%5B0%5D%5Bthree%5D=1&foo%5B0%5D%5Btwo%5D=2")
     }
     
-    // TODO: Test the other subclasses and structs.
-    // - EncodableStruct
-    // - NestedEncodableStruct
-    // - EncodableSubclass
-    // - ManuallyEncodableSubclass
-    // - ManuallyEncodableStruct
+    func testThatEncodableSubclassCanBeEncodedWithIndexInBrackets() {
+        // Given
+        let encoder = URLEncodedFormEncoder(arrayEncoding: .indexInBrackets)
+        let parameters = EncodableSubclass()
+
+        // When
+        let result = Result<String, Error> { try encoder.encode(parameters) }
+
+        // Then
+        let expected = "five%5Ba%5D=a&five%5Bb%5D=b&four%5B0%5D=1&four%5B1%5D=2&four%5B2%5D=3&one=one&three=1&two=2"
+        XCTAssertEqual(result.success, expected)
+    }
+    
+    func testThatManuallyEncodableSubclassCanBeEncodedWithIndexInBrackets() {
+        // Given
+        let encoder = URLEncodedFormEncoder(arrayEncoding: .indexInBrackets)
+        let parameters = ManuallyEncodableSubclass()
+
+        // When
+        let result = Result<String, Error> { try encoder.encode(parameters) }
+
+        // Then
+        let expected = "five%5Ba%5D=a&five%5Bb%5D=b&four%5Bfive%5D=2&four%5Bfour%5D=one"
+        XCTAssertEqual(result.success, expected)
+    }
+    
+    func testThatEncodableStructCanBeEncodedWithIndexInBrackets() {
+        // Given
+        let encoder = URLEncodedFormEncoder(arrayEncoding: .indexInBrackets)
+        let parameters = EncodableStruct()
+
+        // When
+        let result = Result<String, Error> { try encoder.encode(parameters) }
+
+        // Then
+        let expected = "five%5Ba%5D=a&four%5B0%5D=1&four%5B1%5D=2&four%5B2%5D=3&one=one&seven%5Ba%5D=a&six%5Ba%5D%5Bb%5D=b&three=1&two=2"
+        XCTAssertEqual(result.success, expected)
+    }
+    
+    func testThatManuallyEncodableStructCanBeEncodedWithIndexInBrackets() {
+        // Given
+        let encoder = URLEncodedFormEncoder(arrayEncoding: .indexInBrackets)
+        let parameters = ManuallyEncodableStruct()
+
+        // When
+        let result = Result<String, Error> { try encoder.encode(parameters) }
+
+        // then
+        let expected = "root%5B0%5D%5B0%5D=1&root%5B0%5D%5B1%5D=2&root%5B0%5D%5B2%5D=3&root%5B1%5D%5Ba%5D%5Bstring%5D=string&root%5B2%5D%5B0%5D%5B0%5D=1&root%5B2%5D%5B0%5D%5B1%5D=2&root%5B2%5D%5B0%5D%5B2%5D=3"
+        XCTAssertEqual(result.success, expected)
+    }
     
     func testThatArrayNestedDictionaryIntValueCanBeEncodedWithIndexInBrackets() {
         // Given

--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -205,6 +205,22 @@ final class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             XCTFail("Test encountered unexpected error: \(error)")
         }
     }
+    
+    func testURLParameterEncodeArrayNestedDictionaryValueParameterWithIndex() {
+        do {
+            // Given
+            let encoding = URLEncoding(arrayEncoding: .indexInBrackets)
+            let parameters = ["foo": ["a", 1, true, ["bar": 2], ["qux": 3], ["quy": ["quz": 3]]]]
+            
+            // When
+            let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
+            
+            // Then
+            XCTAssertEqual(urlRequest.url?.query, "foo%5B0%5D=a&foo%5B1%5D=1&foo%5B2%5D=1&foo%5B3%5D%5Bbar%5D=2&foo%5B4%5D%5Bqux%5D=3&foo%5B5%5D%5Bquy%5D%5Bquz%5D=3")
+        } catch {
+            XCTFail("Test encountered unexpected error: \(error)")
+        }
+    }
 
     func testURLParameterEncodeStringKeyArrayValueParameterWithoutBrackets() {
         do {


### PR DESCRIPTION
### Issue Link :link:
- #1839 
- #2431

### Goals :soccer:

There is no real specification for how to encode URL parameters like arrays and dictionaries.

For `["foo": ["a", 1, true, ["bar": 2], ["qux": 3], ["quy": ["quz": 3]]]]`

1. default `.brackets` encode is:
`foo[]=a&foo[]=1&foo[]=1&foo[][bar]=2&foo[][qux]=3&foo[][quy][quz]=3`

2. `.noBrackets` encode is:
`foo=a&foo=1&foo=1&foo[bar]=2&foo[qux]=3&foo[quy][quz]=3`

3. [jQuery](https://api.jquery.com/jQuery.param/#example-1) >=1.4 and Node.js package [query-string](https://www.npmjs.com/package/query-string) provide index style:
`foo[0]=a&foo[1]=1&foo[2]=1&foo[3][bar]=2&foo[4][qux]=3&foo[5][quy][quz]=3`

### Implementation Details :construction:

A new `ArrayEncoding` enumeration case is added to both `URLEncoding` and `URLEncodedFormEncoder`. The cases now are `.brackets` and `.noBrackets` and `.indexInBrackets`. The `arrayEncoding` option passed to the initializer is used to control the array key serialization in `URLEncodedFormEncoder` and `URLEncoding`.

### Testing Details :mag:

New tests were added to the `ParameterEncoderTests` and `ParameterEncodingTests` suites. They follow the same naming convention but with an  appended `WithIndexInBrackets` suffix.

### Note:

This PR continues the work started at #3015.
