### PR TITLE
Deprecate publishDecodable variants with incorrect parameter name

### DIFF
--- a/Source/Combine.swift
+++ b/Source/Combine.swift
@@ -197,22 +197,9 @@ extension DataRequest {
                         on: queue)
     }
 
-    /// Creates a `DataResponsePublisher` for this instance and uses a `DecodableResponseSerializer` to serialize the
-    /// response.
-    ///
-    /// - Parameters:
-    ///   - type:                 `Decodable` type to which to decode response `Data`. Inferred from the context by default.
-    ///   - queue:                `DispatchQueue` on which the `DataResponse` will be published. `.main` by default.
-    ///   - preprocessor:         `DataPreprocessor` which filters the `Data` before serialization.
-    ///                           `PassthroughPreprocessor()` by default.
-    ///   - decoder:              `DataDecoder` instance used to decode response `Data`. `JSONDecoder()` by default.
-    ///   - emptyResponseCodes:   `Set<Int>` of HTTP status codes for which empty responses are allowed. `[204, 205]` by
-    ///                           default.
-    ///   - emptyResponseMethods: `Set<HTTPMethod>` of `HTTPMethod`s for which empty responses are allowed, regardless
-    ///                           of status code. `[.head]` by default.
-    ///
-    /// - Returns:                The `DataResponsePublisher`.
+    @_disfavoredOverload
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    @available(*, deprecated, message: "Renamed publishDecodable(type:queue:preprocessor:decoder:emptyResponseCodes:emptyRequestMethods).")
     public func publishDecodable<T: Decodable>(type: T.Type = T.self,
                                                queue: DispatchQueue = .main,
                                                preprocessor: DataPreprocessor = DecodableResponseSerializer<T>.defaultDataPreprocessor,
@@ -223,6 +210,36 @@ extension DataRequest {
                                                            decoder: decoder,
                                                            emptyResponseCodes: emptyResponseCodes,
                                                            emptyRequestMethods: emptyResponseMethods),
+                        on: queue)
+    }
+
+    /// Creates a `DataResponsePublisher` for this instance and uses a `DecodableResponseSerializer` to serialize the
+    /// response.
+    ///
+    /// - Parameters:
+    ///   - type:                `Decodable` type to which to decode response `Data`. Inferred from the context by
+    ///                          default.
+    ///   - queue:               `DispatchQueue` on which the `DataResponse` will be published. `.main` by default.
+    ///   - preprocessor:        `DataPreprocessor` which filters the `Data` before serialization.
+    ///                          `PassthroughPreprocessor()` by default.
+    ///   - decoder:             `DataDecoder` instance used to decode response `Data`. `JSONDecoder()` by default.
+    ///   - emptyResponseCodes:  `Set<Int>` of HTTP status codes for which empty responses are allowed. `[204, 205]` by
+    ///                          default.
+    ///   - emptyRequestMethods: `Set<HTTPMethod>` of `HTTPMethod`s for which empty responses are allowed, regardless of
+    ///                          status code. `[.head]` by default.
+    ///
+    /// - Returns:               The `DataResponsePublisher`.
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    public func publishDecodable<T: Decodable>(type: T.Type = T.self,
+                                               queue: DispatchQueue = .main,
+                                               preprocessor: DataPreprocessor = DecodableResponseSerializer<T>.defaultDataPreprocessor,
+                                               decoder: DataDecoder = JSONDecoder(),
+                                               emptyResponseCodes: Set<Int> = DecodableResponseSerializer<T>.defaultEmptyResponseCodes,
+                                               emptyRequestMethods: Set<HTTPMethod> = DecodableResponseSerializer<T>.defaultEmptyRequestMethods) -> DataResponsePublisher<T> {
+        publishResponse(using: DecodableResponseSerializer(dataPreprocessor: preprocessor,
+                                                           decoder: decoder,
+                                                           emptyResponseCodes: emptyResponseCodes,
+                                                           emptyRequestMethods: emptyRequestMethods),
                         on: queue)
     }
 
@@ -538,7 +555,7 @@ extension DownloadRequest {
                         on: queue)
     }
 
-    /// Creates a `DataResponsePublisher` for this instance and uses a `StringResponseSerializer` to serialize the
+    /// Creates a `DownloadResponsePublisher` for this instance and uses a `StringResponseSerializer` to serialize the
     /// response.
     ///
     /// - Parameters:
@@ -567,22 +584,9 @@ extension DownloadRequest {
                         on: queue)
     }
 
-    /// Creates a `DataResponsePublisher` for this instance and uses a `DecodableResponseSerializer` to serialize the
-    /// response.
-    ///
-    /// - Parameters:
-    ///   - type:                 `Decodable` type to which to decode response `Data`. Inferred from the context by default.
-    ///   - queue:                `DispatchQueue` on which the `DataResponse` will be published. `.main` by default.
-    ///   - preprocessor:         `DataPreprocessor` which filters the `Data` before serialization.
-    ///                           `PassthroughPreprocessor()` by default.
-    ///   - decoder:              `DataDecoder` instance used to decode response `Data`. `JSONDecoder()` by default.
-    ///   - emptyResponseCodes:   `Set<Int>` of HTTP status codes for which empty responses are allowed. `[204, 205]` by
-    ///                           default.
-    ///   - emptyResponseMethods: `Set<HTTPMethod>` of `HTTPMethod`s for which empty responses are allowed, regardless
-    ///                           of status code. `[.head]` by default.
-    ///
-    /// - Returns:                The `DownloadResponsePublisher`.
+    @_disfavoredOverload
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    @available(*, deprecated, message: "Renamed publishDecodable(type:queue:preprocessor:decoder:emptyResponseCodes:emptyRequestMethods).")
     public func publishDecodable<T: Decodable>(type: T.Type = T.self,
                                                queue: DispatchQueue = .main,
                                                preprocessor: DataPreprocessor = DecodableResponseSerializer<T>.defaultDataPreprocessor,
@@ -593,6 +597,35 @@ extension DownloadRequest {
                                                            decoder: decoder,
                                                            emptyResponseCodes: emptyResponseCodes,
                                                            emptyRequestMethods: emptyResponseMethods),
+                        on: queue)
+    }
+
+    /// Creates a `DownloadResponsePublisher` for this instance and uses a `DecodableResponseSerializer` to serialize
+    /// the response.
+    ///
+    /// - Parameters:
+    ///   - type:                `Decodable` type to which to decode response `Data`. Inferred from the context by default.
+    ///   - queue:               `DispatchQueue` on which the `DataResponse` will be published. `.main` by default.
+    ///   - preprocessor:        `DataPreprocessor` which filters the `Data` before serialization.
+    ///                          `PassthroughPreprocessor()` by default.
+    ///   - decoder:             `DataDecoder` instance used to decode response `Data`. `JSONDecoder()` by default.
+    ///   - emptyResponseCodes:  `Set<Int>` of HTTP status codes for which empty responses are allowed. `[204, 205]` by
+    ///                          default.
+    ///   - emptyRequestMethods: `Set<HTTPMethod>` of `HTTPMethod`s for which empty responses are allowed, regardless
+    ///                          of status code. `[.head]` by default.
+    ///
+    /// - Returns:               The `DownloadResponsePublisher`.
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    public func publishDecodable<T: Decodable>(type: T.Type = T.self,
+                                               queue: DispatchQueue = .main,
+                                               preprocessor: DataPreprocessor = DecodableResponseSerializer<T>.defaultDataPreprocessor,
+                                               decoder: DataDecoder = JSONDecoder(),
+                                               emptyResponseCodes: Set<Int> = DecodableResponseSerializer<T>.defaultEmptyResponseCodes,
+                                               emptyRequestMethods: Set<HTTPMethod> = DecodableResponseSerializer<T>.defaultEmptyRequestMethods) -> DownloadResponsePublisher<T> {
+        publishResponse(using: DecodableResponseSerializer(dataPreprocessor: preprocessor,
+                                                           decoder: decoder,
+                                                           emptyResponseCodes: emptyResponseCodes,
+                                                           emptyRequestMethods: emptyRequestMethods),
                         on: queue)
     }
 }

--- a/Tests/ParameterEncoderTests.swift
+++ b/Tests/ParameterEncoderTests.swift
@@ -511,19 +511,19 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         // Then
         XCTAssertFalse(result.isSuccess)
     }
-    
+
     func testThatEncodableSuperclassCanBeEncodedWithIndexInBrackets() {
         // Given
         let encoder = URLEncodedFormEncoder(arrayEncoding: .indexInBrackets)
         let parameters = ["foo": [EncodableSuperclass()]]
-        
+
         // When
         let result = Result<String, Error> { try encoder.encode(parameters) }
-        
+
         // Then
         XCTAssertEqual(result.success, "foo%5B0%5D%5Bone%5D=one&foo%5B0%5D%5Bthree%5D=1&foo%5B0%5D%5Btwo%5D=2")
     }
-    
+
     func testThatEncodableSubclassCanBeEncodedWithIndexInBrackets() {
         // Given
         let encoder = URLEncodedFormEncoder(arrayEncoding: .indexInBrackets)
@@ -536,7 +536,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let expected = "five%5Ba%5D=a&five%5Bb%5D=b&four%5B0%5D=1&four%5B1%5D=2&four%5B2%5D=3&one=one&three=1&two=2"
         XCTAssertEqual(result.success, expected)
     }
-    
+
     func testThatManuallyEncodableSubclassCanBeEncodedWithIndexInBrackets() {
         // Given
         let encoder = URLEncodedFormEncoder(arrayEncoding: .indexInBrackets)
@@ -549,7 +549,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let expected = "five%5Ba%5D=a&five%5Bb%5D=b&four%5Bfive%5D=2&four%5Bfour%5D=one"
         XCTAssertEqual(result.success, expected)
     }
-    
+
     func testThatEncodableStructCanBeEncodedWithIndexInBrackets() {
         // Given
         let encoder = URLEncodedFormEncoder(arrayEncoding: .indexInBrackets)
@@ -562,7 +562,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let expected = "five%5Ba%5D=a&four%5B0%5D=1&four%5B1%5D=2&four%5B2%5D=3&one=one&seven%5Ba%5D=a&six%5Ba%5D%5Bb%5D=b&three=1&two=2"
         XCTAssertEqual(result.success, expected)
     }
-    
+
     func testThatManuallyEncodableStructCanBeEncodedWithIndexInBrackets() {
         // Given
         let encoder = URLEncodedFormEncoder(arrayEncoding: .indexInBrackets)
@@ -575,39 +575,39 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let expected = "root%5B0%5D%5B0%5D=1&root%5B0%5D%5B1%5D=2&root%5B0%5D%5B2%5D=3&root%5B1%5D%5Ba%5D%5Bstring%5D=string&root%5B2%5D%5B0%5D%5B0%5D=1&root%5B2%5D%5B0%5D%5B1%5D=2&root%5B2%5D%5B0%5D%5B2%5D=3"
         XCTAssertEqual(result.success, expected)
     }
-    
+
     func testThatArrayNestedDictionaryIntValueCanBeEncodedWithIndexInBrackets() {
         // Given
         let encoder = URLEncodedFormEncoder(arrayEncoding: .indexInBrackets)
         let parameters = ["foo": [["bar": 2], ["qux": 3], ["quy": 4]]]
-        
+
         // When
         let result = Result<String, Error> { try encoder.encode(parameters) }
-        
+
         // Then
         XCTAssertEqual(result.success, "foo%5B0%5D%5Bbar%5D=2&foo%5B1%5D%5Bqux%5D=3&foo%5B2%5D%5Bquy%5D=4")
     }
-    
+
     func testThatArrayNestedDictionaryStringValueCanBeEncodedWithIndexInBrackets() {
         // Given
         let encoder = URLEncodedFormEncoder(arrayEncoding: .indexInBrackets)
         let parameters = ["foo": [["bar": "2"], ["qux": "3"], ["quy": "4"]]]
-        
+
         // When
         let result = Result<String, Error> { try encoder.encode(parameters) }
-        
+
         // Then
         XCTAssertEqual(result.success, "foo%5B0%5D%5Bbar%5D=2&foo%5B1%5D%5Bqux%5D=3&foo%5B2%5D%5Bquy%5D=4")
     }
-    
+
     func testThatArrayNestedDictionaryBoolValueCanBeEncodedWithIndexInBrackets() {
         // Given
         let encoder = URLEncodedFormEncoder(arrayEncoding: .indexInBrackets)
         let parameters = ["foo": [["bar": true], ["qux": false], ["quy": true]]]
-        
+
         // When
         let result = Result<String, Error> { try encoder.encode(parameters) }
-        
+
         // Then
         XCTAssertEqual(result.success, "foo%5B0%5D%5Bbar%5D=1&foo%5B1%5D%5Bqux%5D=0&foo%5B2%5D%5Bquy%5D=1")
     }

--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -205,16 +205,16 @@ final class URLParameterEncodingTestCase: ParameterEncodingTestCase {
             XCTFail("Test encountered unexpected error: \(error)")
         }
     }
-    
+
     func testURLParameterEncodeArrayNestedDictionaryValueParameterWithIndex() {
         do {
             // Given
             let encoding = URLEncoding(arrayEncoding: .indexInBrackets)
             let parameters = ["foo": ["a", 1, true, ["bar": 2], ["qux": 3], ["quy": ["quz": 3]]]]
-            
+
             // When
             let urlRequest = try encoding.encode(self.urlRequest, with: parameters)
-            
+
             // Then
             XCTAssertEqual(urlRequest.url?.query, "foo%5B0%5D=a&foo%5B1%5D=1&foo%5B2%5D=1&foo%5B3%5D%5Bbar%5D=2&foo%5B4%5D%5Bqux%5D=3&foo%5B5%5D%5Bquy%5D%5Bquz%5D=3")
         } catch {


### PR DESCRIPTION
### Goals :soccer:
This PR deprecates the forms of `publishDecodable` which used a `emptyResponseMethods` parameter name, as it was supposed to be `emptyRequestMethods`.

### Implementation Details :construction:
Typical deprecation but can't use the `rename` variant because it was a parameter, not a method, that was renamed. Also used `@_disfavoredOverload` so that existing uses continue to compile.

### Testing Details :mag:
No testing changes, as they picked up the new overload correctly.
