### PR TITLE
Sort acceptable content-types in error messages

### DIFF
--- a/Source/Validation.swift
+++ b/Source/Validation.swift
@@ -117,7 +117,7 @@ extension Request {
             }
 
             let error: AFError = {
-                let reason: ErrorReason = .missingContentType(acceptableContentTypes: Array(acceptableContentTypes))
+                let reason: ErrorReason = .missingContentType(acceptableContentTypes: acceptableContentTypes.sorted())
                 return AFError.responseValidationFailed(reason: reason)
             }()
 
@@ -131,7 +131,7 @@ extension Request {
         }
 
         let error: AFError = {
-            let reason: ErrorReason = .unacceptableContentType(acceptableContentTypes: Array(acceptableContentTypes),
+            let reason: ErrorReason = .unacceptableContentType(acceptableContentTypes: acceptableContentTypes.sorted(),
                                                                responseContentType: responseContentType)
 
             return AFError.responseValidationFailed(reason: reason)


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
To make serialization error texts less random which comes in handy when you log those errors from you mobile apps. 

Currently I get errors like:
```
Request failed due to an underlying Alamofire error: Response Content-Type "image/webp" does not match any acceptable types: application/octet-stream,image/bmp,image/gif,image/heic,image/heif,image/ico,image/jp2,image/jpeg,image/jpg,image/png,image/tiff...
```
where acceptable types are listed in a random order. By making error texts more deterministic we get better compression on the errors storage and also a more reliable error counter
