### PR TITLE
Safer Custom rootQueues

### DIFF
--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -183,7 +183,9 @@ open class Session {
                             eventMonitors: [EventMonitor] = []) {
         precondition(configuration.identifier == nil, "Alamofire does not support background URLSessionConfigurations.")
 
-        let serialRootQueue = DispatchQueue(label: rootQueue.label, target: rootQueue)
+        // Retarget the incoming rootQueue for safety, unless it's the main queue, which we know is safe.
+        let serialRootQueue = (rootQueue === DispatchQueue.main) ? rootQueue : DispatchQueue(label: rootQueue.label,
+                                                                                             target: rootQueue)
         let delegateQueue = OperationQueue(maxConcurrentOperationCount: 1, underlyingQueue: serialRootQueue, name: "\(serialRootQueue.label).sessionDelegate")
         let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: delegateQueue)
 

--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -183,12 +183,13 @@ open class Session {
                             eventMonitors: [EventMonitor] = []) {
         precondition(configuration.identifier == nil, "Alamofire does not support background URLSessionConfigurations.")
 
-        let delegateQueue = OperationQueue(maxConcurrentOperationCount: 1, underlyingQueue: rootQueue, name: "org.alamofire.session.sessionDelegateQueue")
+        let serialRootQueue = DispatchQueue(label: rootQueue.label, target: rootQueue)
+        let delegateQueue = OperationQueue(maxConcurrentOperationCount: 1, underlyingQueue: serialRootQueue, name: "\(serialRootQueue.label).sessionDelegate")
         let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: delegateQueue)
 
         self.init(session: session,
                   delegate: delegate,
-                  rootQueue: rootQueue,
+                  rootQueue: serialRootQueue,
                   startRequestsImmediately: startRequestsImmediately,
                   requestQueue: requestQueue,
                   serializationQueue: serializationQueue,

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -266,6 +266,27 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertNotNil(session.serverTrustManager, "session server trust policy manager should not be nil")
     }
 
+    // MARK: Tests - Parallel Root Queue
+
+    func testThatSessionWorksCorrectlyWhenPassedAConcurrentRootQueue() {
+        // Given
+        let queue = DispatchQueue(label: "ohNoAParallelQueue", attributes: .concurrent)
+        let session = Session(rootQueue: queue)
+        let didFinish = expectation(description: "request did finish")
+        var receivedResponse: TestResponse?
+
+        // When
+        session.request(.get).responseDecodable(of: TestResponse.self) { response in
+            receivedResponse = response.value
+            didFinish.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(receivedResponse, "Should receive TestResponse.")
+    }
+
     // MARK: Tests - Default HTTP Headers
 
     func testDefaultUserAgentHeader() {

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -257,7 +257,7 @@ final class ContentTypeValidationTestCase: BaseTestCase {
         var requestError: AFError?
         var downloadError: AFError?
 
-        let acceptableContentTypes = [ // Sorted in a random order, not alphabetically
+        let acceptableContentTypes = [// Sorted in a random order, not alphabetically
             "application/octet-stream",
             "image/gif",
             "image/x-xbitmap",
@@ -271,8 +271,7 @@ final class ContentTypeValidationTestCase: BaseTestCase {
             "image/ico",
             "image/bmp",
             "image/x-ms-bmp",
-            "image/x-win-bitmap"
-        ]
+            "image/x-win-bitmap"]
 
         // When
         AF.request(endpoint)
@@ -295,22 +294,21 @@ final class ContentTypeValidationTestCase: BaseTestCase {
         XCTAssertNotNil(requestError)
         XCTAssertNotNil(downloadError)
 
-        let expectedAcceptableContentTypes = [ // Sorted in a specific order, alphabetically
-             "application/octet-stream",
-             "image/bmp",
-             "image/gif",
-             "image/ico",
-             "image/jp2",
-             "image/jpeg",
-             "image/jpg",
-             "image/png",
-             "image/tiff",
-             "image/x-bmp",
-             "image/x-icon",
-             "image/x-ms-bmp",
-             "image/x-win-bitmap",
-             "image/x-xbitmap",
-         ]
+        let expectedAcceptableContentTypes = [// Sorted in a specific order, alphabetically
+            "application/octet-stream",
+            "image/bmp",
+            "image/gif",
+            "image/ico",
+            "image/jp2",
+            "image/jpeg",
+            "image/jpg",
+            "image/png",
+            "image/tiff",
+            "image/x-bmp",
+            "image/x-icon",
+            "image/x-ms-bmp",
+            "image/x-win-bitmap",
+            "image/x-xbitmap"]
 
         for error in [requestError, downloadError] {
             XCTAssertEqual(error?.isUnacceptableContentType, true)


### PR DESCRIPTION
### Issue Link :link:
#3480

### Goals :soccer:
This PR makes `Session`'s `convenience init` a bit safer by retargeting the provided `rootQueue` onto a serial queue with the same label before using it as the `delegateQueue` and passing it to the root initializer. 

Unfortunately we can't do the same thing in the root initializer, as creating an additional layer of `DispatchQueue` once the `delegateQueue` has been created means that all of our `dispatchPrecondition(condition: .onQueue(queue))` checks fail, as the delegate queue would no longer be in the same hierarchy with the retargeted `rootQueue`. However, we do still get some benefit here, as it would've prevent the bug reported in #3480.

### Implementation Details :construction:
This PR simply creates a new serial `DispatchQueue` targeting the provided `rootQueue` to use as the actual `rootQueue`.

### Testing Details :mag:
An additional test has been added which uses a concurrent queue as the `rootQueue` to demonstrate the safety of this approach.
