### PR TITLE
Cancel Without Resume Data When Possible

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1721,7 +1721,7 @@ public class DownloadRequest: Request {
             } else {
                 // Resume to ensure metrics are gathered.
                 task.resume()
-                task.cancel(byProducingResumeData: { _ in })
+                task.cancel()
                 self.underlyingQueue.async { self.didCancelTask(task) }
             }
         }


### PR DESCRIPTION
### Issue Link :link:
#3536

### Goals :soccer:
This PR reverts the fix from #3102 as it doesn't seem to actually affect Alamofire, perhaps due to our use of locking around cancellation.

### Implementation Details :construction:
Just call `cancel()` rather than `cancel(producingResumeData:)` with an empty closure, as doing produced resume data unconditionally and won't be cleaned up until temp storage is purged.

### Testing Details :mag:
Original tests intact, nothing new. Should continue passing on all OSes. Added older OS coverage in another PR to ensure that `DownloadRequest`'s tests continue to pass.