### PR TITLE
Convert to Test Plans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     name: Test Latest (iOS, tvOS, watchOS)
     runs-on: macOS-11
     env:
-      DEVELOPER_DIR: "/Applications/Xcode_13.2.1/Contents/Developer"
+      DEVELOPER_DIR: "/Applications/Xcode_13.2.1.app/Contents/Developer"
     timeout-minutes: 10
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
       - 'Package.swift'
 
 concurrency: 
-  group: ci
+  group: ${{ github.ref_name }}
   cancel-in-progress: true
 jobs:
   macOS:
@@ -73,20 +73,25 @@ jobs:
         include:
           - destination: "OS=15.2,name=iPhone 13 Pro"
             name: "iOS 15.2"
+            testPlan: "iOS"
           - destination: "OS=14.5,name=iPhone 12 Pro"
             name: "iOS 14.5"
+            testPlan: "iOS"
           - destination: "OS=13.7,name=iPhone 11 Pro"
             name: "iOS 13.7"
-          # - destination: "OS=12.4,name=iPhone Xs"
-          #   name: "iOS 12.4"
-          # - destination: "OS=11.4,name=iPhone 7"
-          #   name: "iOS 11.4"
+            testPlan: "iOS"
+          - destination: "OS=12.4,name=iPhone Xs"
+            name: "iOS 12.4"
+            testPlan: "iOS-Old"
+          - destination: "OS=11.4,name=iPhone 7"
+            name: "iOS 11.4"
+            testPlan: "iOS-Old"
     steps:
       - uses: actions/checkout@v2
       - name: Install Firewalk
         run: brew install alamofire/alamofire/firewalk || brew upgrade alamofire/alamofire/firewalk && firewalk &
       - name: ${{ matrix.name }}
-        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "${{ matrix.destination }}" clean test | xcpretty
+        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "${{ matrix.destination }}" -testPlan "${{ matrix.testPlan }}" clean test | xcpretty
   tvOS:
     name: Test tvOS
     runs-on: firebreak

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,16 +107,25 @@ jobs:
         include:
           - destination: "OS=15.2,name=Apple TV"
             name: "tvOS 15.2"
+            testPlan: "tvOS"
           - destination: "OS=14.5,name=Apple TV"
             name: "tvOS 14.5"
+            testPlan: "tvOS"
           - destination: "OS=13.4,name=Apple TV"
             name: "tvOS 13.4"
+            testPlan: "tvOS"
+          - destination: "OS=12.4,name=Apple TV"
+            name: "tvOS 12.4"
+            testPlan: "tvOS-Old"
+          - destination: "OS=11.4,name=Apple TV"
+            name: "tvOS 11.4"
+            testPlan: "tvOS-Old"
     steps:
       - uses: actions/checkout@v2
       - name: Install Firewalk
         run: brew install alamofire/alamofire/firewalk || brew upgrade alamofire/alamofire/firewalk && firewalk &
       - name: ${{ matrix.name }}
-        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire tvOS" -destination "${{ matrix.destination }}" clean test | xcpretty
+        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire tvOS" -destination "${{ matrix.destination }}" -testPlan "${{ matrix.testPlan }}" clean test | xcpretty
   watchOS:
     name: Test watchOS
     runs-on: firebreak

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,38 @@ jobs:
         run: brew install alamofire/alamofire/firewalk || brew upgrade alamofire/alamofire/firewalk && firewalk &
       - name: ${{ matrix.name}}
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire watchOS" -destination "${{ matrix.destination }}" clean test | xcpretty
+  Thread_Sanitizer:
+    name: Test Thread Sanitizer
+    runs-on: macOS-11
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode_13.2.1.app/Contents/Developer"
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - scheme: "Alamofire macOS"
+            destination: "platform=macOS"
+            testPlan: "macOS-TS"
+            name: "macOS Thread Sanitizer"
+          - scheme: "Alamofire iOS"
+            destination: "OS=15.2,name=iPhone 13 Pro"
+            testPlan: "iOS-TS"
+            name: "iOS Thread Sanitizer"
+          - scheme: "Alamofire tvOS"
+            destination: "OS=15.2,name=Apple TV"
+            testPlan: "tvOS-TS"
+            name: "tvOS Thread Sanitizer"
+          - scheme: "Alamofire watchOS"
+            destination: "OS=8.3,name=Apple Watch Series 7 - 45mm"
+            testPlan: "watchOS-TS"
+            name: "watchOS Thread Sanitizer"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Firewalk
+        run: brew install alamofire/alamofire/firewalk && firewalk &
+      - name: ${{ matrix.name }}
+        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "${{ matrix.scheme }}" -destination "${{ matrix.destination }}" -testPlan "${{ matrix.testPlan }}" clean test | xcpretty
   SPM:
     name: Test with SPM
     runs-on: macOS-11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,31 @@ jobs:
         run: brew install alamofire/alamofire/firewalk && firewalk &
       - name: Catalyst
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "platform=macOS" clean test | xcpretty
+  Latest:
+    name: Test Latest (iOS, tvOS, watchOS)
+    runs-on: macOS-11
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode_13.2.1/Contents/Developer"
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - destination: "OS=15.2,name=iPhone 13 Pro"
+            name: "iOS 15.2"
+            scheme: "Alamofire iOS"
+          - destination: "OS=15.2,name=Apple TV"
+            name: "tvOS 15.2"
+            scheme: "Alamofire tvOS"
+          - destination: "OS=8.3,name=Apple Watch Series 7 - 45mm"
+            name: "watchOS 8.3"
+            scheme: "Alamofire watchOS"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Firewalk
+        run: brew install alamofire/alamofire/firewalk && firewalk &
+      - name: ${{ matrix.name }}
+        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "${{ matrix.scheme }}" -destination "${{ matrix.destination }}" clean test | xcpretty
   iOS:
     name: "Test iOS"
     runs-on: firebreak
@@ -71,9 +96,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - destination: "OS=15.2,name=iPhone 13 Pro"
-            name: "iOS 15.2"
-            testPlan: "iOS"
           - destination: "OS=14.5,name=iPhone 12 Pro"
             name: "iOS 14.5"
             testPlan: "iOS"
@@ -105,9 +127,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - destination: "OS=15.2,name=Apple TV"
-            name: "tvOS 15.2"
-            testPlan: "tvOS"
           - destination: "OS=14.5,name=Apple TV"
             name: "tvOS 14.5"
             testPlan: "tvOS"
@@ -139,8 +158,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - destination: "OS=8.3,name=Apple Watch Series 7 - 45mm"
-            name: "watchOS 8.3"
           - destination: "OS=7.4,name=Apple Watch Series 6 - 44mm"
             name: "watchOS 7.4"
     steps:

--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -200,6 +200,7 @@
 		31425AC1241F098000EE3CCC /* InternalRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31425AC0241F098000EE3CCC /* InternalRequestTests.swift */; };
 		31425AC2241F098000EE3CCC /* InternalRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31425AC0241F098000EE3CCC /* InternalRequestTests.swift */; };
 		31425AC3241F098000EE3CCC /* InternalRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31425AC0241F098000EE3CCC /* InternalRequestTests.swift */; };
+		3145E0EA2797DA4200949557 /* ConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B3DE4E25C120D800760641 /* ConcurrencyTests.swift */; };
 		31501E882196962A005829F2 /* ParameterEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31501E872196962A005829F2 /* ParameterEncoderTests.swift */; };
 		31501E892196962A005829F2 /* ParameterEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31501E872196962A005829F2 /* ParameterEncoderTests.swift */; };
 		31501E8A2196962A005829F2 /* ParameterEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31501E872196962A005829F2 /* ParameterEncoderTests.swift */; };
@@ -497,6 +498,10 @@
 		3145E0E32797A8EF00949557 /* tvOS-TS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "tvOS-TS.xctestplan"; sourceTree = "<group>"; };
 		3145E0E42797A8EF00949557 /* tvOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = tvOS.xctestplan; sourceTree = "<group>"; };
 		3145E0E52797A8EF00949557 /* tvOS-Old.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "tvOS-Old.xctestplan"; sourceTree = "<group>"; };
+		3145E0E62797D91600949557 /* watchOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = watchOS.xctestplan; sourceTree = "<group>"; };
+		3145E0E72797D94200949557 /* watchOS-TS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "watchOS-TS.xctestplan"; sourceTree = "<group>"; };
+		3145E0E82797D9E700949557 /* macOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = macOS.xctestplan; sourceTree = "<group>"; };
+		3145E0E92797D9E900949557 /* macOS-TS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "macOS-TS.xctestplan"; sourceTree = "<group>"; };
 		31501E872196962A005829F2 /* ParameterEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParameterEncoderTests.swift; sourceTree = "<group>"; };
 		31577E0A2676E72D001C7532 /* FUNDING.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = FUNDING.yml; sourceTree = "<group>"; };
 		315A4C55241EF28B00D57C7A /* StringEncoding+Alamofire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StringEncoding+Alamofire.swift"; sourceTree = "<group>"; };
@@ -743,9 +748,13 @@
 				31EF4BF627964B520048A19D /* iOS-Old.xctestplan */,
 				3145E0E227977AA300949557 /* iOS-TS.xctestplan */,
 				31EF4BF5279646450048A19D /* iOS.xctestplan */,
+				3145E0E92797D9E900949557 /* macOS-TS.xctestplan */,
+				3145E0E82797D9E700949557 /* macOS.xctestplan */,
 				3145E0E52797A8EF00949557 /* tvOS-Old.xctestplan */,
 				3145E0E32797A8EF00949557 /* tvOS-TS.xctestplan */,
 				3145E0E42797A8EF00949557 /* tvOS.xctestplan */,
+				3145E0E72797D94200949557 /* watchOS-TS.xctestplan */,
+				3145E0E62797D91600949557 /* watchOS.xctestplan */,
 			);
 			path = "Test Plans";
 			sourceTree = "<group>";
@@ -1476,6 +1485,7 @@
 				31293080263E184000473CEA /* AFError+AlamofireTests.swift in Sources */,
 				31293077263E183C00473CEA /* ResponseTests.swift in Sources */,
 				31293081263E184000473CEA /* FileManager+AlamofireTests.swift in Sources */,
+				3145E0EA2797DA4200949557 /* ConcurrencyTests.swift in Sources */,
 				31293076263E183C00473CEA /* DownloadTests.swift in Sources */,
 				3129308D263E184500473CEA /* ValidationTests.swift in Sources */,
 				31293084263E184500473CEA /* RetryPolicyTests.swift in Sources */,

--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -493,6 +493,7 @@
 		312D1E0B1FC2551400E51FF1 /* Usage.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = Usage.md; path = Documentation/Usage.md; sourceTree = "<group>"; };
 		312D1E0C1FC2551400E51FF1 /* AdvancedUsage.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = AdvancedUsage.md; path = Documentation/AdvancedUsage.md; sourceTree = "<group>"; };
 		31425AC0241F098000EE3CCC /* InternalRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalRequestTests.swift; sourceTree = "<group>"; };
+		3145E0E227977AA300949557 /* iOS-TS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "iOS-TS.xctestplan"; sourceTree = "<group>"; };
 		31501E872196962A005829F2 /* ParameterEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParameterEncoderTests.swift; sourceTree = "<group>"; };
 		31577E0A2676E72D001C7532 /* FUNDING.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = FUNDING.yml; sourceTree = "<group>"; };
 		315A4C55241EF28B00D57C7A /* StringEncoding+Alamofire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StringEncoding+Alamofire.swift"; sourceTree = "<group>"; };
@@ -522,6 +523,8 @@
 		31D83FCD20D5C29300D93E47 /* URLConvertible+URLRequestConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLConvertible+URLRequestConvertible.swift"; sourceTree = "<group>"; };
 		31DADDFA224811ED0051390F /* AlamofireExtended.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireExtended.swift; sourceTree = "<group>"; };
 		31ED52E61D73889D00199085 /* AFError+AlamofireTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AFError+AlamofireTests.swift"; sourceTree = "<group>"; };
+		31EF4BF5279646450048A19D /* iOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = iOS.xctestplan; sourceTree = "<group>"; };
+		31EF4BF627964B520048A19D /* iOS-Old.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "iOS-Old.xctestplan"; sourceTree = "<group>"; };
 		31F1AA4123F75AEE00C2BB80 /* Alamofire 5.0 Migration Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = "Alamofire 5.0 Migration Guide.md"; path = "Documentation/Alamofire 5.0 Migration Guide.md"; sourceTree = "<group>"; };
 		31F5085C20B50DC400FE2A0C /* URLSessionConfiguration+Alamofire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSessionConfiguration+Alamofire.swift"; sourceTree = "<group>"; };
 		31F9683B20BB70290009606F /* NSLoggingEventMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLoggingEventMonitor.swift; sourceTree = "<group>"; };
@@ -729,6 +732,16 @@
 				319ECEA425EC96E8001C38CA /* config.yml */,
 			);
 			path = ISSUE_TEMPLATE;
+			sourceTree = "<group>";
+		};
+		31EF4BF4279646000048A19D /* Test Plans */ = {
+			isa = PBXGroup;
+			children = (
+				31EF4BF5279646450048A19D /* iOS.xctestplan */,
+				31EF4BF627964B520048A19D /* iOS-Old.xctestplan */,
+				3145E0E227977AA300949557 /* iOS-TS.xctestplan */,
+			);
+			path = "Test Plans";
 			sourceTree = "<group>";
 		};
 		4C256A4E1B09656A0065714F /* Core */ = {
@@ -996,6 +1009,7 @@
 		F8111E3F19A95C8B0040E7D1 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				31EF4BF4279646000048A19D /* Test Plans */,
 				4C256A501B096C2C0065714F /* BaseTestCase.swift */,
 				31727421218BB9A50039FFCC /* TestHelpers.swift */,
 				31762DC9247738FA0025C704 /* LeaksTests.swift */,

--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -494,6 +494,9 @@
 		312D1E0C1FC2551400E51FF1 /* AdvancedUsage.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = AdvancedUsage.md; path = Documentation/AdvancedUsage.md; sourceTree = "<group>"; };
 		31425AC0241F098000EE3CCC /* InternalRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalRequestTests.swift; sourceTree = "<group>"; };
 		3145E0E227977AA300949557 /* iOS-TS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "iOS-TS.xctestplan"; sourceTree = "<group>"; };
+		3145E0E32797A8EF00949557 /* tvOS-TS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "tvOS-TS.xctestplan"; sourceTree = "<group>"; };
+		3145E0E42797A8EF00949557 /* tvOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = tvOS.xctestplan; sourceTree = "<group>"; };
+		3145E0E52797A8EF00949557 /* tvOS-Old.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "tvOS-Old.xctestplan"; sourceTree = "<group>"; };
 		31501E872196962A005829F2 /* ParameterEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParameterEncoderTests.swift; sourceTree = "<group>"; };
 		31577E0A2676E72D001C7532 /* FUNDING.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = FUNDING.yml; sourceTree = "<group>"; };
 		315A4C55241EF28B00D57C7A /* StringEncoding+Alamofire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StringEncoding+Alamofire.swift"; sourceTree = "<group>"; };
@@ -737,9 +740,12 @@
 		31EF4BF4279646000048A19D /* Test Plans */ = {
 			isa = PBXGroup;
 			children = (
-				31EF4BF5279646450048A19D /* iOS.xctestplan */,
 				31EF4BF627964B520048A19D /* iOS-Old.xctestplan */,
 				3145E0E227977AA300949557 /* iOS-TS.xctestplan */,
+				31EF4BF5279646450048A19D /* iOS.xctestplan */,
+				3145E0E52797A8EF00949557 /* tvOS-Old.xctestplan */,
+				3145E0E32797A8EF00949557 /* tvOS-TS.xctestplan */,
+				3145E0E42797A8EF00949557 /* tvOS.xctestplan */,
 			);
 			path = "Test Plans";
 			sourceTree = "<group>";

--- a/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire iOS.xcscheme
+++ b/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire iOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -68,6 +68,18 @@
             ReferencedContainer = "container:Alamofire.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Tests/Test Plans/iOS.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:Tests/Test Plans/iOS-Old.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:Tests/Test Plans/iOS-TS.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire macOS.xcscheme
+++ b/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire macOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -69,6 +69,15 @@
             ReferencedContainer = "container:Alamofire.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Tests/Test Plans/macOS.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:Tests/Test Plans/macOS-TS.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire tvOS.xcscheme
+++ b/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire tvOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -68,6 +68,18 @@
             ReferencedContainer = "container:Alamofire.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Tests/Test Plans/tvOS.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:Tests/Test Plans/tvOS-TS.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:Tests/Test Plans/tvOS-Old.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire watchOS.xcscheme
+++ b/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire watchOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -46,6 +46,15 @@
             ReferencedContainer = "container:Alamofire.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Tests/Test Plans/watchOS.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:Tests/Test Plans/watchOS-TS.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Tests/CombineTests.swift
+++ b/Tests/CombineTests.swift
@@ -1423,10 +1423,10 @@ final class DownloadRequestCombineTests: CombineTestCase {
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 class CombineTestCase: BaseTestCase {
-    var storage: Set<AnyCancellable> = []
+    private lazy var storage: Set<AnyCancellable> = { Set<AnyCancellable>() }()
 
     override func tearDown() {
-        storage = []
+        storage.removeAll()
 
         super.tearDown()
     }

--- a/Tests/Test Plans/iOS-Old.xctestplan
+++ b/Tests/Test Plans/iOS-Old.xctestplan
@@ -4,7 +4,7 @@
       "id" : "06BDBD92-3173-4395-90BF-851B80FF1162",
       "name" : "Default",
       "options" : {
-        "threadSanitizerEnabled" : true
+
       }
     }
   ],

--- a/Tests/Test Plans/iOS-Old.xctestplan
+++ b/Tests/Test Plans/iOS-Old.xctestplan
@@ -1,0 +1,30 @@
+{
+  "configurations" : [
+    {
+      "id" : "06BDBD92-3173-4395-90BF-851B80FF1162",
+      "name" : "Default",
+      "options" : {
+        "threadSanitizerEnabled" : true
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "CombineTestCase",
+        "DataRequestCombineTests",
+        "DataStreamRequestCombineTests",
+        "DownloadRequestCombineTests"
+      ],
+      "target" : {
+        "containerPath" : "container:Alamofire.xcodeproj",
+        "identifier" : "F8111E3D19A95C8B0040E7D1",
+        "name" : "Alamofire iOS Tests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/Test Plans/iOS-TS.xctestplan
+++ b/Tests/Test Plans/iOS-TS.xctestplan
@@ -1,0 +1,30 @@
+{
+  "configurations" : [
+    {
+      "id" : "06BDBD92-3173-4395-90BF-851B80FF1162",
+      "name" : "Default",
+      "options" : {
+        "threadSanitizerEnabled" : true
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "ClosureAPIConcurrencyTests",
+        "DataRequestConcurrencyTests",
+        "DataStreamConcurrencyTests",
+        "DownloadConcurrencyTests"
+      ],
+      "target" : {
+        "containerPath" : "container:Alamofire.xcodeproj",
+        "identifier" : "F8111E3D19A95C8B0040E7D1",
+        "name" : "Alamofire iOS Tests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/Test Plans/iOS.xctestplan
+++ b/Tests/Test Plans/iOS.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "06BDBD92-3173-4395-90BF-851B80FF1162",
+      "name" : "Default",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:Alamofire.xcodeproj",
+        "identifier" : "F8111E3D19A95C8B0040E7D1",
+        "name" : "Alamofire iOS Tests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/Test Plans/macOS-TS.xctestplan
+++ b/Tests/Test Plans/macOS-TS.xctestplan
@@ -1,0 +1,30 @@
+{
+  "configurations" : [
+    {
+      "id" : "06BDBD92-3173-4395-90BF-851B80FF1162",
+      "name" : "Default",
+      "options" : {
+        "threadSanitizerEnabled" : true
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "ClosureAPIConcurrencyTests",
+        "DataRequestConcurrencyTests",
+        "DataStreamConcurrencyTests",
+        "DownloadConcurrencyTests"
+      ],
+      "target" : {
+        "containerPath" : "container:Alamofire.xcodeproj",
+        "identifier" : "F829C6B11A7A94F100A2CD59",
+        "name" : "Alamofire macOS Tests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/Test Plans/macOS.xctestplan
+++ b/Tests/Test Plans/macOS.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "06BDBD92-3173-4395-90BF-851B80FF1162",
+      "name" : "Default",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:Alamofire.xcodeproj",
+        "identifier" : "F829C6B11A7A94F100A2CD59",
+        "name" : "Alamofire macOS Tests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/Test Plans/tvOS-Old.xctestplan
+++ b/Tests/Test Plans/tvOS-Old.xctestplan
@@ -9,8 +9,7 @@
     }
   ],
   "defaultOptions" : {
-    "codeCoverage" : false,
-    "threadSanitizerEnabled" : true
+    "codeCoverage" : false
   },
   "testTargets" : [
     {

--- a/Tests/Test Plans/tvOS-Old.xctestplan
+++ b/Tests/Test Plans/tvOS-Old.xctestplan
@@ -1,0 +1,35 @@
+{
+  "configurations" : [
+    {
+      "id" : "06BDBD92-3173-4395-90BF-851B80FF1162",
+      "name" : "Default",
+      "options" : {
+        "threadSanitizerEnabled" : true
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "threadSanitizerEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "ClosureAPIConcurrencyTests",
+        "CombineTestCase",
+        "DataRequestCombineTests",
+        "DataRequestConcurrencyTests",
+        "DataStreamConcurrencyTests",
+        "DataStreamRequestCombineTests",
+        "DownloadConcurrencyTests",
+        "DownloadRequestCombineTests"
+      ],
+      "target" : {
+        "containerPath" : "container:Alamofire.xcodeproj",
+        "identifier" : "4CF626F71BA7CB3E0011A099",
+        "name" : "Alamofire tvOS Tests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/Test Plans/tvOS-TS.xctestplan
+++ b/Tests/Test Plans/tvOS-TS.xctestplan
@@ -1,0 +1,30 @@
+{
+  "configurations" : [
+    {
+      "id" : "06BDBD92-3173-4395-90BF-851B80FF1162",
+      "name" : "Default",
+      "options" : {
+        "threadSanitizerEnabled" : true
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "ClosureAPIConcurrencyTests",
+        "DataRequestConcurrencyTests",
+        "DataStreamConcurrencyTests",
+        "DownloadConcurrencyTests"
+      ],
+      "target" : {
+        "containerPath" : "container:Alamofire.xcodeproj",
+        "identifier" : "4CF626F71BA7CB3E0011A099",
+        "name" : "Alamofire tvOS Tests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/Test Plans/tvOS.xctestplan
+++ b/Tests/Test Plans/tvOS.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "06BDBD92-3173-4395-90BF-851B80FF1162",
+      "name" : "Default",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:Alamofire.xcodeproj",
+        "identifier" : "4CF626F71BA7CB3E0011A099",
+        "name" : "Alamofire tvOS Tests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/Test Plans/watchOS-TS.xctestplan
+++ b/Tests/Test Plans/watchOS-TS.xctestplan
@@ -1,0 +1,31 @@
+{
+  "configurations" : [
+    {
+      "id" : "13FE6F19-6B66-4BD2-862D-9F091CA8B792",
+      "name" : "Default",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "threadSanitizerEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "ClosureAPIConcurrencyTests",
+        "DataRequestConcurrencyTests",
+        "DataStreamConcurrencyTests",
+        "DownloadConcurrencyTests"
+      ],
+      "target" : {
+        "containerPath" : "container:Alamofire.xcodeproj",
+        "identifier" : "31293064263E17D600473CEA",
+        "name" : "Alamofire watchOS Tests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/Test Plans/watchOS.xctestplan
+++ b/Tests/Test Plans/watchOS.xctestplan
@@ -1,0 +1,25 @@
+{
+  "configurations" : [
+    {
+      "id" : "13FE6F19-6B66-4BD2-862D-9F091CA8B792",
+      "name" : "Default",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "nsZombieEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:Alamofire.xcodeproj",
+        "identifier" : "31293064263E17D600473CEA",
+        "name" : "Alamofire watchOS Tests"
+      }
+    }
+  ],
+  "version" : 1
+}


### PR DESCRIPTION
### Goals :soccer:
This PR continues working towards better test coverage by converting our test targets to use test plans in order to better support testing on older OSes due to Combine linking. 

### Implementation Details :construction:
This PR adds separate test plans for new and old iOS and tvOS, as Combine needs to be ignored. Additionally, it adds thread sanitizer plans for all platforms while ignoring the concurrency features, as they don't currently play well with the sanitizer.

