### PR TITLE
Add Concurrency Example and Fix Documentation Link

### DIFF
--- a/Documentation/AdvancedUsage.md
+++ b/Documentation/AdvancedUsage.md
@@ -1249,7 +1249,7 @@ let request = AF.request(...)
 // Later...
 let stringResponse = await request.serializingString().response
 // Elsewhere...
-let decodableResponse = await request.serializingDecodable(TestResponse.self).self
+let decodableResponse = await request.serializingDecodable(TestResponse.self).response
 ```
 
 Finally, like all Swift Concurrency APIs, these `await`able properties can be used to `await` multiple requests issued in parallel. For example:

--- a/Documentation/AdvancedUsage.md
+++ b/Documentation/AdvancedUsage.md
@@ -1239,10 +1239,20 @@ let response = await task.response // Returns full DataResponse<TestResponse, AF
 // Elsewhere...
 let result = await task.result // Returns Result<TestResponse, AFError>
 // And...
-let value = try await task.value // Returns the TestResponse or throws the AFError
+let value = try await task.value // Returns the TestResponse or throws the AFError as an Error
 ```
 
-Like all Swift Concurrency APIs, these `await`able properties can be used to `await` multiple requests issued in parallel. For example:
+Similarly, and like Alamofire's existing closure and publisher-based response handlers, each request can produce multiple tasks that perform the same or different serializations.
+
+```swift
+let request = AF.request(...)
+// Later...
+let stringResponse = await request.serializingString().response
+// Elsewhere...
+let decodableResponse = await request.serializingDecodable(TestResponse.self).self
+```
+
+Finally, like all Swift Concurrency APIs, these `await`able properties can be used to `await` multiple requests issued in parallel. For example:
 
 ```swift
 async let first = AF.request(...).serializingDecodable(TestResponse.self).response

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -417,7 +417,7 @@ AF.request("https://httpbin.org/headers", headers: headers).responseDecodable(of
 }
 ```
 
-> For HTTP headers that do not change, it is recommended to set them on the `URLSessionConfiguration` so they are automatically applied to any `URLSessionTask` created by the underlying `URLSession`. For more information, see the [Session Configurations](AdvancedUsage.md#session-manager) section.
+> For HTTP headers that do not change, it is recommended to set them on the `URLSessionConfiguration` so they are automatically applied to any `URLSessionTask` created by the underlying `URLSession`. For more information, see the [Session Configurations](https://github.com/Alamofire/Alamofire/blob/master/Documentation/AdvancedUsage.md#creating-a-session-with-a-urlsessionconfiguration) section.
 
 The default Alamofire `Session` provides a default set of headers for every `Request`. These include:
 


### PR DESCRIPTION
### Issue Link :link:
Fixes #3547 and fixes #3540.

### Goals :soccer:
Adds an additional concurrency example and fixes a broken link.
