### PR TITLE
Added a Swift version check across all platforms

### DIFF
--- a/Source/Alamofire.swift
+++ b/Source/Alamofire.swift
@@ -28,6 +28,10 @@ import Foundation
 @_exported import FoundationNetworking
 #endif
 
+#if swift(<5.3)
+#error("Alamofire doesn't support Swift versions below 5.3")
+#endif
+
 /// Reference to `Session.default` for quick bootstrapping and examples.
 public let AF = Session.default
 


### PR DESCRIPTION
### Issue Link :link:

No direct issue, but prompted by the discussion here: https://forums.swift.org/t/54715

### Goals :soccer:

To reliably prevent the package from compiling when using Xcode 11 or Swift < 5.3 so the Swift Package Index can more accurately determine platform and Swift version compatibility. See the build success for watchOS with Xcode 11.6 here: https://swiftpackageindex.com/Alamofire/Alamofire/builds
