### PR TITLE
Add HTTPMethod.query

### DIFF
--- a/Source/HTTPMethod.swift
+++ b/Source/HTTPMethod.swift
@@ -43,6 +43,8 @@ public struct HTTPMethod: RawRepresentable, Equatable, Hashable {
     public static let post = HTTPMethod(rawValue: "POST")
     /// `PUT` method.
     public static let put = HTTPMethod(rawValue: "PUT")
+    /// `QUERY` method.
+    public static let query = HTTPMethod(rawValue: "QUERY")
     /// `TRACE` method.
     public static let trace = HTTPMethod(rawValue: "TRACE")
 


### PR DESCRIPTION
### Goals :soccer:
This PR a static `HTTPMethod.query` value to support the [upcoming standard](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-safe-method-w-body-02). 

### Implementation Details :construction:
No changes. Unfortunately, `URLSession` won't support proper automatic handling until the 2022 release at the earliest, so full semantics may not match, but at least the header value is available.

### Testing Details :mag:
Testing can be added once NIO / Vapor has proper support, but it's not a high priority right now.
