### PR TITLE
Fix 2020 and 2021 Deprecation Warnings

### DIFF
--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -508,20 +508,6 @@ open class MultipartFormData {
         }
     }
 
-    // MARK: - Private - Mime Type
-
-    private func mimeType(forPathExtension pathExtension: String) -> String {
-        #if !(os(Linux) || os(Windows))
-        if
-            let id = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, pathExtension as CFString, nil)?.takeRetainedValue(),
-            let contentType = UTTypeCopyPreferredTagWithClass(id, kUTTagClassMIMEType)?.takeRetainedValue() {
-            return contentType as String
-        }
-        #endif
-
-        return "application/octet-stream"
-    }
-
     // MARK: - Private - Content Headers
 
     private func contentHeaders(withName name: String, fileName: String? = nil, mimeType: String? = nil) -> HTTPHeaders {
@@ -555,3 +541,34 @@ open class MultipartFormData {
         bodyPartError = AFError.multipartEncodingFailed(reason: reason)
     }
 }
+
+#if canImport(UniformTypeIdentifiers)
+import UniformTypeIdentifiers
+
+extension MultipartFormData {
+    // MARK: - Private - Mime Type
+
+    private func mimeType(forPathExtension pathExtension: String) -> String {
+        UTType(filenameExtension: pathExtension)?.preferredMIMEType ?? "application/octet-stream"
+    }
+}
+
+#else
+
+extension MultipartFormData {
+    // MARK: - Private - Mime Type
+
+    private func mimeType(forPathExtension pathExtension: String) -> String {
+        #if !(os(Linux) || os(Windows))
+        if
+            let id = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, pathExtension as CFString, nil)?.takeRetainedValue(),
+            let contentType = UTTypeCopyPreferredTagWithClass(id, kUTTagClassMIMEType)?.takeRetainedValue() {
+            return contentType as String
+        }
+        #endif
+
+        return "application/octet-stream"
+    }
+}
+
+#endif

--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -549,7 +549,17 @@ extension MultipartFormData {
     // MARK: - Private - Mime Type
 
     private func mimeType(forPathExtension pathExtension: String) -> String {
-        UTType(filenameExtension: pathExtension)?.preferredMIMEType ?? "application/octet-stream"
+        if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, *) {
+            return UTType(filenameExtension: pathExtension)?.preferredMIMEType ?? "application/octet-stream"
+        } else {
+            if
+                let id = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, pathExtension as CFString, nil)?.takeRetainedValue(),
+                let contentType = UTTypeCopyPreferredTagWithClass(id, kUTTagClassMIMEType)?.takeRetainedValue() {
+                return contentType as String
+            }
+
+            return "application/octet-stream"
+        }
     }
 }
 

--- a/Source/ServerTrustEvaluation.swift
+++ b/Source/ServerTrustEvaluation.swift
@@ -604,6 +604,7 @@ extension AlamofireExtension where ExtendedType == SecTrust {
         certificates.af.publicKeys
     }
 
+    #if swift(>=5.5) // Xcode 13 / 2021 SDKs.
     /// The `SecCertificate`s contained in `self`.
     public var certificates: [SecCertificate] {
         if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
@@ -614,6 +615,14 @@ extension AlamofireExtension where ExtendedType == SecTrust {
             }
         }
     }
+    #else
+    /// The `SecCertificate`s contained in `self`.
+    public var certificates: [SecCertificate] {
+        (0..<SecTrustGetCertificateCount(type)).compactMap { index in
+            SecTrustGetCertificateAtIndex(type, index)
+        }
+    }
+    #endif
 
     /// The `Data` values for all certificates contained in `self`.
     public var certificateData: [Data] {

--- a/Source/ServerTrustEvaluation.swift
+++ b/Source/ServerTrustEvaluation.swift
@@ -606,8 +606,12 @@ extension AlamofireExtension where ExtendedType == SecTrust {
 
     /// The `SecCertificate`s contained i `self`.
     public var certificates: [SecCertificate] {
-        (0..<SecTrustGetCertificateCount(type)).compactMap { index in
-            SecTrustGetCertificateAtIndex(type, index)
+        if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
+            return (SecTrustCopyCertificateChain(type) as? [SecCertificate]) ?? []
+        } else {
+            return (0..<SecTrustGetCertificateCount(type)).compactMap { index in
+                SecTrustGetCertificateAtIndex(type, index)
+            }
         }
     }
 
@@ -699,7 +703,11 @@ extension AlamofireExtension where ExtendedType == SecCertificate {
 
         guard let createdTrust = trust, trustCreationStatus == errSecSuccess else { return nil }
 
-        return SecTrustCopyPublicKey(createdTrust)
+        if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, *) {
+            return SecTrustCopyKey(createdTrust)
+        } else {
+            return SecTrustCopyPublicKey(createdTrust)
+        }
     }
 }
 

--- a/Source/ServerTrustEvaluation.swift
+++ b/Source/ServerTrustEvaluation.swift
@@ -604,7 +604,7 @@ extension AlamofireExtension where ExtendedType == SecTrust {
         certificates.af.publicKeys
     }
 
-    /// The `SecCertificate`s contained i `self`.
+    /// The `SecCertificate`s contained in `self`.
     public var certificates: [SecCertificate] {
         if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
             return (SecTrustCopyCertificateChain(type) as? [SecCertificate]) ?? []
@@ -696,6 +696,9 @@ extension AlamofireExtension where ExtendedType == [SecCertificate] {
 extension SecCertificate: AlamofireExtended {}
 extension AlamofireExtension where ExtendedType == SecCertificate {
     /// The public key for `self`, if it can be extracted.
+    ///
+    /// - Note: On 2020 OSes and newer, only RSA and ECDSA keys are supported.
+    ///
     public var publicKey: SecKey? {
         let policy = SecPolicyCreateBasicX509()
         var trust: SecTrust?

--- a/Tests/Bundle+AlamofireTests.swift
+++ b/Tests/Bundle+AlamofireTests.swift
@@ -32,7 +32,7 @@ extension Bundle {
         #else
         bundle = Bundle(for: BaseTestCase.self)
         #endif
-        
+
         return bundle
     }
 }

--- a/Tests/DataStreamTests.swift
+++ b/Tests/DataStreamTests.swift
@@ -113,7 +113,7 @@ final class DataStreamTests: BaseTestCase {
         guard #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
             throw XCTSkip("Older OSes do not separate chunked payloads in callbacks.")
         }
-        
+
         // Given
         let expectedSize = 10
         var responses: [TestResponse] = []

--- a/Tests/Request+AlamofireTests.swift
+++ b/Tests/Request+AlamofireTests.swift
@@ -32,7 +32,7 @@ extension DataRequest {
     func validate(performing closure: @escaping () -> Void) -> Self {
         validate { _, _, _ in
             closure()
-            
+
             return .success(())
         }
         .validate()


### PR DESCRIPTION
### Issue Link :link:
Fixes #3554

### Goals :soccer:
This PR fixes a few deprecations warnings from the last couple years for those forcing Alamofire to build with a higher deployment target than normal.

### Implementation Details :construction:
* `SecTrustGetCertificateAtIndex` has been replaced by `SecTrustCopyCertificateChain`. This replacement is thread safe, returning all certificates at once.
* `SecTrustCopyPublicKey` has been replaced by `SecTrustCopyKey`. This replacement limits keys to RSA and ECDSA signature types.
* Gross CoreFoundation type identifiers API has been replaced by the UniformTypeIdentifiers framework.

### Testing Details :mag:
No additional tests, existing suite should catch regressions.
