### PR TITLE
Ignore Test Plans in Package Files

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,6 +43,6 @@ let package = Package(name: "Alamofire",
                                 .testTarget(name: "AlamofireTests",
                                             dependencies: ["Alamofire"],
                                             path: "Tests",
-                                            exclude: ["Info.plist"],
+                                            exclude: ["Info.plist", "Test Plans"],
                                             resources: [.process("Resources")])],
                       swiftLanguageVersions: [.v5])

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -43,5 +43,5 @@ let package = Package(name: "Alamofire",
                                 .testTarget(name: "AlamofireTests",
                                             dependencies: ["Alamofire"],
                                             path: "Tests",
-                                            exclude: ["Resources", "Info.plist"])],
+                                            exclude: ["Resources", "Info.plist", "Test Plans"])],
                       swiftLanguageVersions: [.v5])

--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -43,5 +43,5 @@ let package = Package(name: "Alamofire",
                                 .testTarget(name: "AlamofireTests",
                                             dependencies: ["Alamofire"],
                                             path: "Tests",
-                                            exclude: ["Resources", "Info.plist"])],
+                                            exclude: ["Resources", "Info.plist", "Test Plans"])],
                       swiftLanguageVersions: [.v5])


### PR DESCRIPTION
### Goals :soccer:
This PR ignores the recently added test plans in the Package files, fixing warnings from the package.
