### PR TITLE
Move to Swift 5.6 for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,11 @@ concurrency:
   cancel-in-progress: true
 jobs:
   macOS:
-    name: Test macOS (5.5, 5.4, 5.3)
+    name: Test macOS (5.6, 5.5, 5.4, 5.3)
     runs-on: ${{ matrix.runsOn }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
     env:
       DEVELOPER_DIR: "/Applications/${{ matrix.xcode }}/Contents/Developer"
     timeout-minutes: 10
@@ -31,19 +34,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - xcode: "Xcode_13.3.app"
+            runsOn: firebreak
+            name: "macOS 12, Swift 5.6"
+            firewalk: "brew install alamofire/alamofire/firewalk || brew upgrade alamofire/alamofire/firewalk && firewalk &"
+            shell: "/usr/bin/arch -arch arm64e /bin/zsh {0}"
           - xcode: "Xcode_13.2.1.app"
             runsOn: macOS-11
             name: "macOS 11, Swift 5.5"
+            firewalk: "brew install alamofire/alamofire/firewalk && firewalk &"
+            shell: "/usr/bin/arch -arch i386 /bin/zsh {0}"
           - xcode: "Xcode_12.5.1.app"
             runsOn: macOS-11
             name: "macOS 11, Swift 5.4"
+            firewalk: "brew install alamofire/alamofire/firewalk && firewalk &"
+            shell: "/usr/bin/arch -arch i386 /bin/zsh {0}"
           - xcode: "Xcode_12.4.app"
             runsOn: macOS-10.15
             name: "macOS 10.15, Swift 5.3"
+            firewalk: "brew install alamofire/alamofire/firewalk && firewalk &"
+            shell: "/usr/bin/arch -arch i386 /bin/zsh {0}"
     steps:
       - uses: actions/checkout@v2
       - name: Install Firewalk
-        run: brew install alamofire/alamofire/firewalk && firewalk &
+        run: ${{ matrix.firewalk }}
       - name: ${{ matrix.name }}
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire macOS" -destination "platform=macOS" clean test | xcpretty
   Catalyst:
@@ -60,27 +74,30 @@ jobs:
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "platform=macOS" clean test | xcpretty
   Latest:
     name: Test Latest (iOS, tvOS, watchOS)
-    runs-on: macOS-11
+    runs-on: firebreak
+    defaults:
+      run:
+        shell: "/usr/bin/arch -arch arm64e /bin/zsh {0}"
     env:
-      DEVELOPER_DIR: "/Applications/Xcode_13.2.1.app/Contents/Developer"
+      DEVELOPER_DIR: "/Applications/Xcode_13.3.app/Contents/Developer"
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
         include:
-          - destination: "OS=15.2,name=iPhone 13 Pro"
-            name: "iOS 15.2"
+          - destination: "OS=15.4,name=iPhone 13 Pro"
+            name: "iOS"
             scheme: "Alamofire iOS"
-          - destination: "OS=15.2,name=Apple TV"
-            name: "tvOS 15.2"
+          - destination: "OS=15.4,name=Apple TV"
+            name: "tvOS"
             scheme: "Alamofire tvOS"
-          - destination: "OS=8.3,name=Apple Watch Series 7 - 45mm"
-            name: "watchOS 8.3"
+          - destination: "OS=8.5,name=Apple Watch Series 7 - 45mm"
+            name: "watchOS"
             scheme: "Alamofire watchOS"
     steps:
       - uses: actions/checkout@v2
       - name: Install Firewalk
-        run: brew install alamofire/alamofire/firewalk && firewalk &
+        run: brew install alamofire/alamofire/firewalk || brew upgrade alamofire/alamofire/firewalk && firewalk &
       - name: ${{ matrix.name }}
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "${{ matrix.scheme }}" -destination "${{ matrix.destination }}" clean test | xcpretty
   iOS:
@@ -141,12 +158,9 @@ jobs:
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire tvOS" -destination "${{ matrix.destination }}" -testPlan "${{ matrix.testPlan }}" clean test | xcpretty
   watchOS:
     name: Test watchOS
-    runs-on: firebreak
-    defaults:
-      run:
-        shell: "/usr/bin/arch -arch arm64e /bin/zsh {0}"
+    runs-on: macOS-11
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.3.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -157,7 +171,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Firewalk
-        run: brew install alamofire/alamofire/firewalk || brew upgrade alamofire/alamofire/firewalk && firewalk &
+        run: brew install alamofire/alamofire/firewalk && firewalk &
       - name: ${{ matrix.name}}
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire watchOS" -destination "${{ matrix.destination }}" clean test | xcpretty
   Thread_Sanitizer:
@@ -236,7 +250,7 @@ jobs:
     name: Linux
     runs-on: ubuntu-20.04
     container:
-      image: swift:5.5.2-focal
+      image: swift:5.6.0-focal
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
@@ -262,7 +276,7 @@ jobs:
     - uses: seanmiddleditch/gha-setup-vsdevenv@master
     - name: Install Swift
       run: |
-        Install-Binary -Url "https://swift.org/builds/swift-5.5.2-release/windows10/swift-5.5.2-RELEASE/swift-5.5.2-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+        Install-Binary -Url "https://swift.org/builds/swift-5.6.0-release/windows10/swift-5.6.0-RELEASE/swift-5.6.0-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
     - name: Set Environment Variables
       run: |
         echo "SDKROOT=C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,7 @@ jobs:
     - uses: seanmiddleditch/gha-setup-vsdevenv@master
     - name: Install Swift
       run: |
-        Install-Binary -Url "https://swift.org/builds/swift-5.6.0-release/windows10/swift-5.6.0-RELEASE/swift-5.6.0-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+        Install-Binary -Url "https://download.swift.org/swift-5.6-release/windows10/swift-5.6-RELEASE/swift-5.6-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
     - name: Set Environment Variables
       run: |
         echo "SDKROOT=C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,17 +43,17 @@ jobs:
             runsOn: macOS-11
             name: "macOS 11, Swift 5.5"
             firewalk: "brew install alamofire/alamofire/firewalk && firewalk &"
-            shell: "/usr/bin/arch -arch i386 /bin/zsh {0}"
+            shell: "/bin/zsh {0}"
           - xcode: "Xcode_12.5.1.app"
             runsOn: macOS-11
             name: "macOS 11, Swift 5.4"
             firewalk: "brew install alamofire/alamofire/firewalk && firewalk &"
-            shell: "/usr/bin/arch -arch i386 /bin/zsh {0}"
+            shell: "/bin/zsh {0}"
           - xcode: "Xcode_12.4.app"
             runsOn: macOS-10.15
             name: "macOS 10.15, Swift 5.3"
             firewalk: "brew install alamofire/alamofire/firewalk && firewalk &"
-            shell: "/usr/bin/arch -arch i386 /bin/zsh {0}"
+            shell: "/bin/zsh {0}"
     steps:
       - uses: actions/checkout@v2
       - name: Install Firewalk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,9 +158,9 @@ jobs:
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire tvOS" -destination "${{ matrix.destination }}" -testPlan "${{ matrix.testPlan }}" clean test | xcpretty
   watchOS:
     name: Test watchOS
-    runs-on: macOS-11
+    runs-on: macOS-10.15
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_12.5.1.app/Contents/Developer
     timeout-minutes: 10
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire tvOS" -destination "${{ matrix.destination }}" -testPlan "${{ matrix.testPlan }}" clean test | xcpretty
   watchOS:
     name: Test watchOS
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     env:
       DEVELOPER_DIR: /Applications/Xcode_12.5.1.app/Contents/Developer
     timeout-minutes: 10

--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -1047,37 +1047,6 @@
 		};
 /* End PBXGroup section */
 
-/* Begin PBXHeadersBuildPhase section */
-		4CF626EC1BA7CB3E0011A099 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4DD67C081A5C55C900ED2280 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		E4202FDA1B667AA100C997FB /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F8111E3019A95C8B0040E7D1 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXHeadersBuildPhase section */
-
 /* Begin PBXNativeTarget section */
 		31293064263E17D600473CEA /* Alamofire watchOS Tests */ = {
 			isa = PBXNativeTarget;
@@ -1103,7 +1072,6 @@
 			buildPhases = (
 				4CF626EA1BA7CB3E0011A099 /* Sources */,
 				4CF626EB1BA7CB3E0011A099 /* Frameworks */,
-				4CF626EC1BA7CB3E0011A099 /* Headers */,
 				4CF626ED1BA7CB3E0011A099 /* Resources */,
 			);
 			buildRules = (
@@ -1139,7 +1107,6 @@
 			buildPhases = (
 				4DD67C061A5C55C900ED2280 /* Sources */,
 				4DD67C071A5C55C900ED2280 /* Frameworks */,
-				4DD67C081A5C55C900ED2280 /* Headers */,
 				4DD67C091A5C55C900ED2280 /* Resources */,
 			);
 			buildRules = (
@@ -1157,7 +1124,6 @@
 			buildPhases = (
 				E4202FCE1B667AA100C997FB /* Sources */,
 				E4202FD91B667AA100C997FB /* Frameworks */,
-				E4202FDA1B667AA100C997FB /* Headers */,
 				E4202FDC1B667AA100C997FB /* Resources */,
 			);
 			buildRules = (
@@ -1175,7 +1141,6 @@
 			buildPhases = (
 				F8111E2E19A95C8B0040E7D1 /* Sources */,
 				F8111E2F19A95C8B0040E7D1 /* Frameworks */,
-				F8111E3019A95C8B0040E7D1 /* Headers */,
 				F8111E3119A95C8B0040E7D1 /* Resources */,
 			);
 			buildRules = (


### PR DESCRIPTION
### Goals :soccer:
This PR updates most of the CI jobs to build the latest versions using Swift 5.6.

This PR also moves some jobs between GHA and Firebreak, as GHA *still* doesn't support macOS 12, though support should ship soon and we go switch things around again. 😭 

This PR also removes the header phases from the framework targets, as they were empty anyway and causing issues with the new build system in Xcode 13.3.