### PR TITLE
Require Swift 5.6 Compiler for Concurrency Support

### DIFF
--- a/Source/Concurrency.swift
+++ b/Source/Concurrency.swift
@@ -22,7 +22,7 @@
 //  THE SOFTWARE.
 //
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6.0) && canImport(_Concurrency)
 
 import Foundation
 

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -22,7 +22,7 @@
 //  THE SOFTWARE.
 //
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6.0) && canImport(_Concurrency)
 
 import Alamofire
 import XCTest


### PR DESCRIPTION
### Issue Link :link:
#3529 

### Goals :soccer:
This PR bumps the Swift compiler version required to build the concurrency features to 5.6, as Xcode 13.3.1 finally fixes the long line of bugs Apple shipped. Unfortunately I can't precisely require 13.3.1, just 5.6, which also shipped with Xcode 13.3, so the BitCode bug can still hit people, but it's fixed simply by updating Xcode.

### Implementation Details :construction:
This PR simply bumps the required version to build, not functional changes.

### Testing Details :mag:
Concurrency tests also bumped to require Swift 5.6.
