### PR TITLE
Prevent header authorization multiple bearer characters

### DIFF
--- a/Source/HTTPHeaders.swift
+++ b/Source/HTTPHeaders.swift
@@ -275,7 +275,10 @@ extension HTTPHeader {
     ///
     /// - Returns:               The header.
     public static func authorization(bearerToken: String) -> HTTPHeader {
-        authorization("Bearer \(bearerToken)")
+        guard !bearerToken.contains("Bearer") else {
+            return authorization("\(bearerToken)")
+        }
+        return authorization("Bearer \(bearerToken)")
     }
 
     /// Returns an `Authorization` header.


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
Prevent and Safe to use http header authorization without multiple bearer characters.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
Use HTTPHeaders methods to add the request authorization bearer header field without multiple bearer characters.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
No new tests added.