### PR TITLE
Add automaticallyCancelling parameter to serializingDownloadedFileURL

### DIFF
--- a/Source/Concurrency.swift
+++ b/Source/Concurrency.swift
@@ -413,9 +413,15 @@ extension DownloadRequest {
 
     /// Creates a `DownloadTask` to `await` serialization of the downloaded file's `URL` on disk.
     ///
+    /// - Parameters:
+    ///   - shouldAutomaticallyCancel: `Bool` determining whether or not the request should be cancelled when the
+    ///                                enclosing async context is cancelled. Only applies to `DownloadTask`'s async
+    ///                                properties. `false` by default.
+    ///
     /// - Returns: The `DownloadTask`.
-    public func serializingDownloadedFileURL() -> DownloadTask<URL> {
-        serializingDownload(using: URLResponseSerializer())
+    public func serializingDownloadedFileURL(automaticallyCancelling shouldAutomaticallyCancel: Bool = false) -> DownloadTask<URL> {
+        serializingDownload(using: URLResponseSerializer(),
+                            automaticallyCancelling: shouldAutomaticallyCancel)
     }
 
     /// Creates a `DownloadTask` to `await` serialization of a `String` value.


### PR DESCRIPTION
### Issue Link :link:
Reported on the [Swift Forums](https://forums.swift.org/t/why-downloadrequest-s-serializingdownloadedfileurl-doesnt-have-automaticallycancelling-paramerter/56770).

### Goals :soccer:
This PR adds the `automaticallyCancelling` parameter to `serializingDownloadedFileURL`.

### Implementation Details :construction:
This PR simply adds the parameter and passes it through using the existing `serializingDownload` button.

### Testing Details :mag:
No added tests. While I could add more API coverage here, all of the tests would be functionally the same, so it seems redundant.
