### PR TITLE
Refactor Cache-Control Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - xcode: "Xcode_13.3.app"
+          - xcode: "Xcode_13.3.1.app"
             runsOn: firebreak
             name: "macOS 12, Swift 5.6"
             firewalk: "brew install alamofire/alamofire/firewalk || brew upgrade alamofire/alamofire/firewalk && firewalk &"
@@ -79,7 +79,7 @@ jobs:
       run:
         shell: "/usr/bin/arch -arch arm64e /bin/zsh {0}"
     env:
-      DEVELOPER_DIR: "/Applications/Xcode_13.3.app/Contents/Developer"
+      DEVELOPER_DIR: "/Applications/Xcode_13.3.1.app/Contents/Developer"
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -135,7 +135,7 @@ jobs:
       run:
         shell: "/usr/bin/arch -arch arm64e /bin/zsh {0}"
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.3.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.3.1.app/Contents/Developer
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -213,7 +213,7 @@ jobs:
       run:
         shell: "/usr/bin/arch -arch arm64e /bin/zsh {0}"
     env:
-      DEVELOPER_DIR: "/Applications/Xcode_13.3.app/Contents/Developer"
+      DEVELOPER_DIR: "/Applications/Xcode_13.3.1.app/Contents/Developer"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
@@ -250,7 +250,7 @@ jobs:
     name: Linux
     runs-on: ubuntu-20.04
     container:
-      image: swift:5.6.0-focal
+      image: swift:5.6.1-focal
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
@@ -276,7 +276,7 @@ jobs:
     - uses: seanmiddleditch/gha-setup-vsdevenv@master
     - name: Install Swift
       run: |
-        Install-Binary -Url "https://download.swift.org/swift-5.6-release/windows10/swift-5.6-RELEASE/swift-5.6-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+        Install-Binary -Url "https://download.swift.org/swift-5.6.1-release/windows10/swift-5.6.1-RELEASE/swift-5.6.1-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
     - name: Set Environment Variables
       run: |
         echo "SDKROOT=C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/Tests/CacheTests.swift
+++ b/Tests/CacheTests.swift
@@ -1,7 +1,7 @@
 //
 //  CacheTests.swift
 //
-//  Copyright (c) 2014-2018 Alamofire Software Foundation (http://alamofire.org/)
+//  Copyright (c) 2022 Alamofire Software Foundation (http://alamofire.org/)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -39,30 +39,17 @@ import XCTest
 /// - Verify whether the response came from the cache or from the network
 ///     - This is determined by whether the cached response timestamp matches the new response timestamp
 ///
-/// An important thing to note is the difference in behavior between iOS and macOS. On iOS, a response with
-/// a `Cache-Control` header value of `no-store` is still written into the `URLCache` where on macOS, it is not.
-/// The different tests below reflect and demonstrate this behavior.
-///
 /// For information about `Cache-Control` HTTP headers, please refer to RFC 2616 - Section 14.9.
 final class CacheTestCase: BaseTestCase {
     // MARK: -
 
-    enum CacheControl {
-        static let publicControl = "public"
-        static let privateControl = "private"
-        static let maxAgeNonExpired = "max-age=3600"
-        static let maxAgeExpired = "max-age=0"
-        static let noCache = "no-cache"
-        static let noStore = "no-store"
-
-        static var allValues: [String] {
-            [CacheControl.publicControl,
-             CacheControl.privateControl,
-             CacheControl.maxAgeNonExpired,
-             CacheControl.maxAgeExpired,
-             CacheControl.noCache,
-             CacheControl.noStore]
-        }
+    enum CacheControl: String, CaseIterable {
+        case publicControl = "public"
+        case privateControl = "private"
+        case maxAgeNonExpired = "max-age=3600"
+        case maxAgeExpired = "max-age=0"
+        case noCache = "no-cache"
+        case noStore = "no-store"
     }
 
     // MARK: - Properties
@@ -70,8 +57,8 @@ final class CacheTestCase: BaseTestCase {
     var urlCache: URLCache!
     var manager: Session!
 
-    var requests: [String: URLRequest] = [:]
-    var timestamps: [String: String] = [:]
+    var requests: [CacheControl: URLRequest] = [:]
+    var timestamps: [CacheControl: String] = [:]
 
     // MARK: - Setup and Teardown
 
@@ -118,25 +105,23 @@ final class CacheTestCase: BaseTestCase {
 
     // MARK: - Cache Priming Methods
 
-    /**
-     Executes a request for all `Cache-Control` header values to load the response into the `URLCache`.
-
-     This implementation leverages dispatch groups to execute all the requests as well as wait an additional
-     second before returning. This ensures the cache contains responses for all requests that are at least
-     one second old. This allows the tests to distinguish whether the subsequent responses come from the cache
-     or the network based on the timestamp of the response.
-     */
-    func primeCachedResponses() {
+    /// Executes a request for all `Cache-Control` header values to load the response into the `URLCache`.
+    ///
+    /// - Note: This implementation leverages dispatch groups to execute all the requests. This ensures the cache
+    ///         contains responses for all requests, properly aged from Firewalk. This allows the tests to distinguish
+    ///         whether the subsequent responses come from the cache or the network based on the timestamp of the
+    ///         response.
+    private func primeCachedResponses() {
         let dispatchGroup = DispatchGroup()
         let serialQueue = DispatchQueue(label: "org.alamofire.cache-tests")
 
-        for cacheControl in CacheControl.allValues {
+        for cacheControl in CacheControl.allCases {
             dispatchGroup.enter()
 
             let request = startRequest(cacheControl: cacheControl,
                                        queue: serialQueue,
                                        completion: { _, response in
-                                           let timestamp = response!.allHeaderFields["Date"] as! String
+                                           let timestamp = response!.headers["Date"]
                                            self.timestamps[cacheControl] = timestamp
 
                                            dispatchGroup.leave()
@@ -146,30 +131,21 @@ final class CacheTestCase: BaseTestCase {
         }
 
         // Wait for all requests to complete
-        _ = dispatchGroup.wait(timeout: .now() + 30)
-
-        // Pause for 1 additional second to ensure all timestamps will be different
-        dispatchGroup.enter()
-        serialQueue.asyncAfter(deadline: .now() + 1.5) {
-            dispatchGroup.leave()
-        }
-
-        // Wait for our 1 second pause to complete
-        _ = dispatchGroup.wait(timeout: .now() + 1.75)
+        _ = dispatchGroup.wait(timeout: .now() + timeout)
     }
 
     // MARK: - Request Helper Methods
 
     @discardableResult
-    func startRequest(cacheControl: String,
+    private func startRequest(cacheControl: CacheControl,
                       cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
                       queue: DispatchQueue = .main,
                       completion: @escaping (URLRequest?, HTTPURLResponse?) -> Void)
         -> URLRequest {
-        var urlRequest = Endpoint(path: .responseHeaders,
+        let urlRequest = Endpoint(path: .cache,
                                   timeout: 30,
+                                  queryItems: [.init(name: "Cache-Control", value: cacheControl.rawValue)],
                                   cachePolicy: cachePolicy).urlRequest
-        urlRequest = (try? URLEncoding.default.encode(urlRequest, with: ["Cache-Control": cacheControl])) ?? urlRequest
         let request = manager.request(urlRequest)
 
         request.response(queue: queue) { response in
@@ -181,17 +157,17 @@ final class CacheTestCase: BaseTestCase {
 
     // MARK: - Test Execution and Verification
 
-    func executeTest(cachePolicy: URLRequest.CachePolicy,
-                     cacheControl: String,
+    private func executeTest(cachePolicy: URLRequest.CachePolicy,
+                     cacheControl: CacheControl,
                      shouldReturnCachedResponse: Bool) {
         // Given
-        let expectation = self.expectation(description: "GET request to httpbin")
+        let requestDidFinish = expectation(description: "cache test request did finish")
         var response: HTTPURLResponse?
 
         // When
         startRequest(cacheControl: cacheControl, cachePolicy: cachePolicy) { _, responseResponse in
             response = responseResponse
-            expectation.fulfill()
+            requestDidFinish.fulfill()
         }
 
         waitForExpectations(timeout: timeout)
@@ -200,13 +176,13 @@ final class CacheTestCase: BaseTestCase {
         verifyResponse(response, forCacheControl: cacheControl, isCachedResponse: shouldReturnCachedResponse)
     }
 
-    func verifyResponse(_ response: HTTPURLResponse?, forCacheControl cacheControl: String, isCachedResponse: Bool) {
+    private func verifyResponse(_ response: HTTPURLResponse?, forCacheControl cacheControl: CacheControl, isCachedResponse: Bool) {
         guard let cachedResponseTimestamp = timestamps[cacheControl] else {
             XCTFail("cached response timestamp should not be nil")
             return
         }
 
-        if let response = response, let timestamp = response.allHeaderFields["Date"] as? String {
+        if let response = response, let timestamp = response.headers["Date"] {
             if isCachedResponse {
                 XCTAssertEqual(timestamp, cachedResponseTimestamp, "timestamps should be equal")
             } else {
@@ -221,12 +197,12 @@ final class CacheTestCase: BaseTestCase {
 
     func testURLCacheContainsCachedResponsesForAllRequests() {
         // Given
-        let publicRequest = requests[CacheControl.publicControl]!
-        let privateRequest = requests[CacheControl.privateControl]!
-        let maxAgeNonExpiredRequest = requests[CacheControl.maxAgeNonExpired]!
-        let maxAgeExpiredRequest = requests[CacheControl.maxAgeExpired]!
-        let noCacheRequest = requests[CacheControl.noCache]!
-        let noStoreRequest = requests[CacheControl.noStore]!
+        let publicRequest = requests[.publicControl]!
+        let privateRequest = requests[.privateControl]!
+        let maxAgeNonExpiredRequest = requests[.maxAgeNonExpired]!
+        let maxAgeExpiredRequest = requests[.maxAgeExpired]!
+        let noCacheRequest = requests[.noCache]!
+        let noStoreRequest = requests[.noStore]!
 
         // When
         let publicResponse = urlCache.cachedResponse(for: publicRequest)
@@ -248,53 +224,53 @@ final class CacheTestCase: BaseTestCase {
     func testDefaultCachePolicy() {
         let cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy
 
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.publicControl, shouldReturnCachedResponse: false)
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.privateControl, shouldReturnCachedResponse: false)
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.maxAgeNonExpired, shouldReturnCachedResponse: true)
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.maxAgeExpired, shouldReturnCachedResponse: false)
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.noCache, shouldReturnCachedResponse: false)
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.noStore, shouldReturnCachedResponse: false)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .publicControl, shouldReturnCachedResponse: false)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .privateControl, shouldReturnCachedResponse: false)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .maxAgeNonExpired, shouldReturnCachedResponse: true)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .maxAgeExpired, shouldReturnCachedResponse: false)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .noCache, shouldReturnCachedResponse: false)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .noStore, shouldReturnCachedResponse: false)
     }
 
     func testIgnoreLocalCacheDataPolicy() {
         let cachePolicy: URLRequest.CachePolicy = .reloadIgnoringLocalCacheData
 
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.publicControl, shouldReturnCachedResponse: false)
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.privateControl, shouldReturnCachedResponse: false)
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.maxAgeNonExpired, shouldReturnCachedResponse: false)
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.maxAgeExpired, shouldReturnCachedResponse: false)
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.noCache, shouldReturnCachedResponse: false)
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.noStore, shouldReturnCachedResponse: false)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .publicControl, shouldReturnCachedResponse: false)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .privateControl, shouldReturnCachedResponse: false)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .maxAgeNonExpired, shouldReturnCachedResponse: false)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .maxAgeExpired, shouldReturnCachedResponse: false)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .noCache, shouldReturnCachedResponse: false)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .noStore, shouldReturnCachedResponse: false)
     }
 
     func testUseLocalCacheDataIfExistsOtherwiseLoadFromNetworkPolicy() {
         let cachePolicy: URLRequest.CachePolicy = .returnCacheDataElseLoad
 
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.publicControl, shouldReturnCachedResponse: true)
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.privateControl, shouldReturnCachedResponse: true)
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.maxAgeNonExpired, shouldReturnCachedResponse: true)
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.maxAgeExpired, shouldReturnCachedResponse: true)
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.noCache, shouldReturnCachedResponse: true)
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.noStore, shouldReturnCachedResponse: false)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .publicControl, shouldReturnCachedResponse: true)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .privateControl, shouldReturnCachedResponse: true)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .maxAgeNonExpired, shouldReturnCachedResponse: true)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .maxAgeExpired, shouldReturnCachedResponse: true)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .noCache, shouldReturnCachedResponse: true)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .noStore, shouldReturnCachedResponse: false)
     }
 
     func testUseLocalCacheDataAndDontLoadFromNetworkPolicy() {
         let cachePolicy: URLRequest.CachePolicy = .returnCacheDataDontLoad
 
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.publicControl, shouldReturnCachedResponse: true)
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.privateControl, shouldReturnCachedResponse: true)
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.maxAgeNonExpired, shouldReturnCachedResponse: true)
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.maxAgeExpired, shouldReturnCachedResponse: true)
-        executeTest(cachePolicy: cachePolicy, cacheControl: CacheControl.noCache, shouldReturnCachedResponse: true)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .publicControl, shouldReturnCachedResponse: true)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .privateControl, shouldReturnCachedResponse: true)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .maxAgeNonExpired, shouldReturnCachedResponse: true)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .maxAgeExpired, shouldReturnCachedResponse: true)
+        executeTest(cachePolicy: cachePolicy, cacheControl: .noCache, shouldReturnCachedResponse: true)
 
         // Given
-        let expectation = self.expectation(description: "GET request to httpbin")
+        let requestDidFinish = expectation(description: "don't load from network request finished")
         var response: HTTPURLResponse?
 
         // When
-        startRequest(cacheControl: CacheControl.noStore, cachePolicy: cachePolicy) { _, responseResponse in
+        startRequest(cacheControl: .noStore, cachePolicy: cachePolicy) { _, responseResponse in
             response = responseResponse
-            expectation.fulfill()
+            requestDidFinish.fulfill()
         }
 
         waitForExpectations(timeout: timeout)

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -498,8 +498,12 @@ final class ClosureAPIConcurrencyTests: BaseTestCase {
                      tasks: [URLSessionTask],
                      descriptions: [String],
                      response: AFDataResponse<TestResponse>)
-        values = await(uploadProgress, downloadProgress, requests, tasks, descriptions, response)
-
+        #if swift(>=5.7)
+        values = try! await (uploadProgress, downloadProgress, requests, tasks, descriptions, response)
+        #else
+        values = await (uploadProgress, downloadProgress, requests, tasks, descriptions, response)
+        #endif
+        
         // Then
         XCTAssertTrue(values.uploadProgresses.isEmpty)
         XCTAssertNotNil(values.downloadProgresses.last)

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -768,8 +768,8 @@ final class DownloadResponseMapTestCase: BaseTestCase {
 
     func testThatMapPreservesFailureError() {
         // Given
-        let urlString = String.nonexistentDomain
-        let expectation = self.expectation(description: "request should fail with 404")
+        let urlString = String.invalidURL
+        let expectation = self.expectation(description: "request should fail with invalid URL")
 
         var response: DownloadResponse<String, AFError>?
 
@@ -857,7 +857,7 @@ final class DownloadResponseTryMapTestCase: BaseTestCase {
 
     func testThatTryMapPreservesFailureError() {
         // Given
-        let urlString = String.nonexistentDomain
+        let urlString = String.invalidURL
         let expectation = self.expectation(description: "request should fail with 404")
 
         var response: DownloadResponse<String, Error>?
@@ -884,7 +884,7 @@ final class DownloadResponseTryMapTestCase: BaseTestCase {
 final class DownloadResponseMapErrorTestCase: BaseTestCase {
     func testThatMapErrorTransformsFailureValue() {
         // Given
-        let urlString = String.nonexistentDomain
+        let urlString = String.invalidURL
         let expectation = self.expectation(description: "request should not succeed")
 
         var response: DownloadResponse<TestResponse, TestError>?
@@ -966,7 +966,7 @@ final class DownloadResponseTryMapErrorTestCase: BaseTestCase {
 
     func testThatTryMapErrorCatchesTransformationError() {
         // Given
-        let urlString = String.nonexistentDomain
+        let urlString = String.invalidURL
         let expectation = self.expectation(description: "request should fail")
 
         var response: DownloadResponse<Data, Error>?
@@ -998,7 +998,7 @@ final class DownloadResponseTryMapErrorTestCase: BaseTestCase {
 
     func testThatTryMapErrorTransformsError() {
         // Given
-        let urlString = String.nonexistentDomain
+        let urlString = String.invalidURL
         let expectation = self.expectation(description: "request should fail")
 
         var response: DownloadResponse<Data, Error>?

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -51,8 +51,8 @@ final class ResponseTestCase: BaseTestCase {
 
     func testThatResponseReturnsFailureResultWithOptionalDataAndError() {
         // Given
-        let urlString = String.nonexistentDomain
-        let expectation = self.expectation(description: "request should fail with invalid hostname error")
+        let urlString = String.invalidURL
+        let expectation = self.expectation(description: "request should fail with invalid URL error")
 
         var response: DataResponse<Data?, AFError>?
 
@@ -70,7 +70,6 @@ final class ResponseTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertNotNil(response?.error)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual(response?.error?.isHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -103,8 +102,8 @@ final class ResponseDataTestCase: BaseTestCase {
 
     func testThatResponseDataReturnsFailureResultWithOptionalDataAndError() {
         // Given
-        let urlString = String.nonexistentDomain
-        let expectation = self.expectation(description: "request should fail with 404")
+        let urlString = String.invalidURL
+        let expectation = self.expectation(description: "request should fail with invalid URL error")
 
         var response: DataResponse<Data, AFError>?
 
@@ -122,7 +121,6 @@ final class ResponseDataTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual(response?.error?.isHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -155,8 +153,8 @@ final class ResponseStringTestCase: BaseTestCase {
 
     func testThatResponseStringReturnsFailureResultWithOptionalDataAndError() {
         // Given
-        let urlString = String.nonexistentDomain
-        let expectation = self.expectation(description: "request should fail with 404")
+        let urlString = String.invalidURL
+        let expectation = self.expectation(description: "request should fail with invalid URL error")
 
         var response: DataResponse<String, AFError>?
 
@@ -174,7 +172,6 @@ final class ResponseStringTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual(response?.error?.isHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -208,7 +205,7 @@ final class ResponseJSONTestCase: BaseTestCase {
 
     func testThatResponseStringReturnsFailureResultWithOptionalDataAndError() {
         // Given
-        let urlString = String.nonexistentDomain
+        let urlString = String.invalidURL
         let expectation = self.expectation(description: "request should fail")
 
         var response: DataResponse<Any, AFError>?
@@ -227,7 +224,6 @@ final class ResponseJSONTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual(response?.error?.isHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 
@@ -345,7 +341,7 @@ final class ResponseJSONDecodableTestCase: BaseTestCase {
 
     func testThatResponseStringReturnsFailureResultWithOptionalDataAndError() {
         // Given
-        let urlString = String.nonexistentDomain
+        let urlString = String.invalidURL
         let expectation = self.expectation(description: "request should fail")
 
         var response: DataResponse<TestResponse, AFError>?
@@ -364,7 +360,6 @@ final class ResponseJSONDecodableTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual(response?.error?.isHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -400,8 +395,8 @@ final class ResponseMapTestCase: BaseTestCase {
 
     func testThatMapPreservesFailureError() {
         // Given
-        let urlString = String.nonexistentDomain
-        let expectation = self.expectation(description: "request should fail with 404")
+        let urlString = String.invalidURL
+        let expectation = self.expectation(description: "request should fail with invalid URL error")
 
         var response: DataResponse<String, AFError>?
 
@@ -419,7 +414,6 @@ final class ResponseMapTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.isSessionTaskError, true)
-        XCTAssertEqual(response?.error?.isHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -489,8 +483,8 @@ final class ResponseTryMapTestCase: BaseTestCase {
 
     func testThatTryMapPreservesFailureError() {
         // Given
-        let urlString = String.nonexistentDomain
-        let expectation = self.expectation(description: "request should fail with 404")
+        let urlString = String.invalidURL
+        let expectation = self.expectation(description: "request should fail with invalid URL error")
 
         var response: DataResponse<String, Error>?
 
@@ -508,7 +502,6 @@ final class ResponseTryMapTestCase: BaseTestCase {
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
         XCTAssertEqual(response?.error?.asAFError?.isSessionTaskError, true)
-        XCTAssertEqual(response?.error?.asAFError?.isHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 }
@@ -530,7 +523,7 @@ enum TransformationError: Error {
 final class ResponseMapErrorTestCase: BaseTestCase {
     func testThatMapErrorTransformsFailureValue() {
         // Given
-        let urlString = String.nonexistentDomain
+        let urlString = String.invalidURL
         let expectation = self.expectation(description: "request should not succeed")
 
         var response: DataResponse<TestResponse, TestError>?
@@ -606,7 +599,7 @@ final class ResponseTryMapErrorTestCase: BaseTestCase {
 
     func testThatTryMapErrorCatchesTransformationError() {
         // Given
-        let urlString = String.nonexistentDomain
+        let urlString = String.invalidURL
         let expectation = self.expectation(description: "request should fail")
 
         var response: DataResponse<Data, Error>?
@@ -636,7 +629,7 @@ final class ResponseTryMapErrorTestCase: BaseTestCase {
 
     func testThatTryMapErrorTransformsError() {
         // Given
-        let urlString = String.nonexistentDomain
+        let urlString = String.invalidURL
         let expectation = self.expectation(description: "request should fail")
 
         var response: DataResponse<Data, Error>?
@@ -654,13 +647,6 @@ final class ResponseTryMapErrorTestCase: BaseTestCase {
         XCTAssertNil(response?.response)
         XCTAssertNil(response?.data)
         XCTAssertEqual(response?.result.isFailure, true)
-
-        guard let error = response?.error as? TestError,
-              case let .error(underlyingError) = error
-        else { XCTFail(); return }
-
-        XCTAssertEqual(underlyingError.asAFError?.isSessionTaskError, true)
-        XCTAssertEqual(underlyingError.asAFError?.isHostURLError, true)
         XCTAssertNotNil(response?.metrics)
     }
 }

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -26,6 +26,7 @@ import Alamofire
 import Foundation
 
 extension String {
+    static let invalidURL = "invalid"
     static let nonexistentDomain = "https://nonexistent-domain.org"
 }
 
@@ -60,6 +61,7 @@ struct Endpoint {
     enum Path {
         case basicAuth(username: String, password: String)
         case bytes(count: Int)
+        case cache
         case chunked(count: Int)
         case compression(Compression)
         case delay(interval: Int)
@@ -83,6 +85,8 @@ struct Endpoint {
                 return "/basic-auth/\(username)/\(password)"
             case let .bytes(count):
                 return "/bytes/\(count)"
+            case .cache:
+                return "/cache"
             case let .chunked(count):
                 return "/chunked/\(count)"
             case let .compression(compression):
@@ -136,6 +140,8 @@ struct Endpoint {
     static func bytes(_ count: Int) -> Endpoint {
         Endpoint(path: .bytes(count: count))
     }
+
+    static let cache: Endpoint = .init(path: .cache)
 
     static func chunked(_ count: Int) -> Endpoint {
         Endpoint(path: .chunked(count: count))


### PR DESCRIPTION
### Goals :soccer:
This PR refactors our caching tests to use a new Firewalk endpoint for better performance.

### Implementation Details :construction:
This PR refactors the local types and removes the now unnecessary delays in initial request creation enabled by the new `cache` Firewalk endpoint. Execution should decrease from around 8s to 0.1s.

### Testing Details :mag:
No changes in testing logic, just cleanup and use of the new endpoint.
