### PR TITLE
Adopt macOS-12 Runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,9 @@ jobs:
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire macOS" -destination "platform=macOS" clean test | xcpretty
   Catalyst:
     name: Test Catalyst
-    runs-on: macOS-11
+    runs-on: macOS-12
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.3.1.app/Contents/Developer
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
@@ -84,10 +84,7 @@ jobs:
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "platform=macOS" clean test | xcpretty
   Latest:
     name: Test Latest (iOS, tvOS, watchOS)
-    runs-on: firebreak
-    defaults:
-      run:
-        shell: "/usr/bin/arch -arch arm64e /bin/zsh {0}"
+    runs-on: macOS-12
     env:
       DEVELOPER_DIR: "/Applications/Xcode_13.3.1.app/Contents/Developer"
     timeout-minutes: 10
@@ -107,7 +104,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Firewalk
-        run: brew install alamofire/alamofire/firewalk || brew upgrade alamofire/alamofire/firewalk && firewalk &
+        run: brew install alamofire/alamofire/firewalk && firewalk &
       - name: ${{ matrix.name }}
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "${{ matrix.scheme }}" -destination "${{ matrix.destination }}" clean test | xcpretty
   iOS:
@@ -117,7 +114,7 @@ jobs:
       run:
         shell: "/usr/bin/arch -arch arm64e /bin/zsh {0}"
     env:
-      DEVELOPER_DIR: "/Applications/Xcode_13.3.app/Contents/Developer"
+      DEVELOPER_DIR: "/Applications/Xcode_13.3.1.app/Contents/Developer"
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -186,9 +183,9 @@ jobs:
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire watchOS" -destination "${{ matrix.destination }}" clean test | xcpretty
   Thread_Sanitizer:
     name: Test Thread Sanitizer
-    runs-on: macOS-11
+    runs-on: macOS-12
     env:
-      DEVELOPER_DIR: "/Applications/Xcode_13.2.1.app/Contents/Developer"
+      DEVELOPER_DIR: "/Applications/Xcode_13.3.1.app/Contents/Developer"
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -199,15 +196,15 @@ jobs:
             testPlan: "macOS-TS"
             name: "macOS Thread Sanitizer"
           - scheme: "Alamofire iOS"
-            destination: "OS=15.2,name=iPhone 13 Pro"
+            destination: "OS=15.4,name=iPhone 13 Pro"
             testPlan: "iOS-TS"
             name: "iOS Thread Sanitizer"
           - scheme: "Alamofire tvOS"
-            destination: "OS=15.2,name=Apple TV"
+            destination: "OS=15.4,name=Apple TV"
             testPlan: "tvOS-TS"
             name: "tvOS Thread Sanitizer"
           - scheme: "Alamofire watchOS"
-            destination: "OS=8.3,name=Apple Watch Series 7 - 45mm"
+            destination: "OS=8.5,name=Apple Watch Series 7 - 45mm"
             testPlan: "watchOS-TS"
             name: "watchOS Thread Sanitizer"
     steps:
@@ -218,21 +215,6 @@ jobs:
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "${{ matrix.scheme }}" -destination "${{ matrix.destination }}" -testPlan "${{ matrix.testPlan }}" clean test | xcpretty
   SPM:
     name: Test with SPM
-    runs-on: firebreak
-    defaults:
-      run:
-        shell: "/usr/bin/arch -arch arm64e /bin/zsh {0}"
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode_13.3.1.app/Contents/Developer"
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Firewalk
-        run: brew install alamofire/alamofire/firewalk || brew upgrade alamofire/alamofire/firewalk && firewalk &
-      - name: Test SPM
-        run: swift test -c debug
-  SPM_Older:
-    name: Test with SPM
     runs-on: ${{ matrix.runsOn }}
     env:
       DEVELOPER_DIR: "/Applications/${{ matrix.xcode }}/Contents/Developer"
@@ -241,6 +223,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - xcode: "Xcode_13.3.1.app"
+            runsOn: macOS-12
+            name: "macOS 12, SPM 5.6 Build"
           - xcode: "Xcode_13.2.1.app"
             runsOn: macOS-11
             name: "macOS 11, SPM 5.5 Build"
@@ -286,7 +271,7 @@ jobs:
     - uses: seanmiddleditch/gha-setup-vsdevenv@master
     - name: Install Swift
       run: |
-        Install-Binary -Url "https://download.swift.org/swift-5.6.1-release/windows10/swift-5.6.1-RELEASE/swift-5.6.1-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+        Install-Binary -Url "https://download.swift.org/swift-5.6-release/windows10/swift-5.6-RELEASE/swift-5.6-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
     - name: Set Environment Variables
       run: |
         echo "SDKROOT=C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append


### PR DESCRIPTION
### Goals :soccer:
This PR refactor our CI jobs (again!) to use the new macOS-12 image where possible.

### Testing Details :mag:
This PR allows more usage of GitHub runners with Firewalk picking up the older OS targets.
