### PR TITLE
Add output to terminal flag

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -983,7 +983,7 @@ extension Request {
             let host = url.host,
             let method = request.httpMethod else { return "$ curl command could not be created" }
 
-        var components = ["$ curl -v"]
+        var components = ["$ curl -v --output -"]
 
         components.append("-X \(method)")
 


### PR DESCRIPTION
Added "--output -" to curl in order to print the response in the terminal when executing the cURL  on it

### Issue Link :link:
cURL throws a warning when executing on the terminal

```sh 
Warning: Binary output can mess up your terminal. Use "--output -" to tell 
Warning: curl to output it to your terminal anyway, or consider "--output 
Warning: <FILE>" to save to a file.
* Failure writing output to destination
* stopped the pause stream!
```

### Goals :soccer:
When copying and executing the cURL on the terminal a warning appears telling that the output should be indicated
