### PR TITLE
Fix typo in AdvancedUsage.md

### DIFF
--- a/Documentation/AdvancedUsage.md
+++ b/Documentation/AdvancedUsage.md
@@ -1285,7 +1285,7 @@ By default, `DataTask` and `DownloadTask` values do not cancel the underlying re
 ```swift
 let request = AF.request(...) // Creates the DataRequest.
 let task = Task { // Produces a `Task<DataResponse<TestResponse, AFError>, Never> value.
-    await request.serializingDecodable(TestResponse.self, automaticallyCancelling: true).response
+    await request.serializingDecodable(TestResponse.self, automaticallyCancelling: false).response
 }
 
 // Later...

--- a/Documentation/AdvancedUsage.md
+++ b/Documentation/AdvancedUsage.md
@@ -1285,7 +1285,7 @@ By default, `DataTask` and `DownloadTask` values do not cancel the underlying re
 ```swift
 let request = AF.request(...) // Creates the DataRequest.
 let task = Task { // Produces a `Task<DataResponse<TestResponse, AFError>, Never> value.
-    await request.serializingDecodable(TestResponse.self, automaticallyCancelling: false).response
+    await request.serializingDecodable(TestResponse.self).response
 }
 
 // Later...


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
- Fix typo in AdvancedUsage.md
  - The description says that the default value is `false`, but the sample code is `true`.
<img width="1212" alt="스크린샷 2022-06-10 오후 6 43 21" src="https://user-images.githubusercontent.com/13270453/173038550-26583abc-c602-48a9-aa84-d4e039b41d46.png">

