### PR TITLE
Don't Attempt Retry When Cancelled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,15 @@ jobs:
           - xcode: "Xcode_12.4.app"
             runsOn: macOS-10.15
             name: "macOS 10.15, Xcode 12.4, Swift 5.3"
+          - xcode: "Xcode_12.3.app"
+            runsOn: macOS-10.15
+            name: "macOS 10.15, Xcode 12.3, Swift 5.3"
+          - xcode: "Xcode_12.2.app"
+            runsOn: macOS-10.15
+            name: "macOS 10.15, Xcode 12.2, Swift 5.3"
+          - xcode: "Xcode_12.1.1.app"
+            runsOn: macOS-10.15
+            name: "macOS 10.15, Xcode 12.1.1, Swift 5.3"
     steps:
       - uses: actions/checkout@v3
       - name: Install Firewalk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,23 +1,23 @@
 name: "Alamofire CI"
 
-on: 
+on:
   push:
-    branches: 
+    branches:
       - master
       - hotfix
     paths:
-      - 'Source/**'
-      - 'Tests/**'
       - '.github/workflows/**'
       - 'Package.swift'
+      - 'Source/**'
+      - 'Tests/**'
   pull_request:
     paths:
-      - 'Source/**'
-      - 'Tests/**'
       - '.github/workflows/**'
       - 'Package.swift'
+      - 'Source/**'
+      - 'Tests/**'
 
-concurrency: 
+concurrency:
   group: ${{ github.ref_name }}
   cancel-in-progress: true
 jobs:
@@ -31,47 +31,61 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - xcode: "Xcode_14.0.1.app"
+            runsOn: macOS-12
+            name: "macOS 12, Xcode 14.0.1, Swift 5.7.0"
+            testPlan: "macOS"
           - xcode: "Xcode_13.4.1.app"
             runsOn: macOS-12
             name: "macOS 12, Xcode 13.4.1, Swift 5.6.1"
+            testPlan: "macOS-NoTS"
           - xcode: "Xcode_13.3.1.app"
             runsOn: macOS-12
             name: "macOS 12, Xcode 13.3.1, Swift 5.6"
+            testPlan: "macOS-NoTS"
           - xcode: "Xcode_13.2.1.app"
             runsOn: macOS-11
             name: "macOS 11, Xcode 13.2.1, Swift 5.5.2"
+            testPlan: "macOS-NoTS"
           - xcode: "Xcode_13.1.app"
             runsOn: macOS-11
             name: "macOS 11, Xcode 13.1, Swift 5.5.1"
+            testPlan: "macOS-NoTS"
           - xcode: "Xcode_13.0.app"
             runsOn: macOS-11
             name: "macOS 11, Xcode 13.0, Swift 5.5.0"
+            testPlan: "macOS-NoTS"
           - xcode: "Xcode_12.5.1.app"
             runsOn: macOS-11
             name: "macOS 11, Xcode 12.5.1, Swift 5.4"
+            testPlan: "macOS-NoTS"
           - xcode: "Xcode_12.4.app"
             runsOn: macOS-10.15
             name: "macOS 10.15, Xcode 12.4, Swift 5.3"
+            testPlan: "macOS-NoTS"
           - xcode: "Xcode_12.3.app"
             runsOn: macOS-10.15
             name: "macOS 10.15, Xcode 12.3, Swift 5.3"
+            testPlan: "macOS-NoTS"
           - xcode: "Xcode_12.2.app"
             runsOn: macOS-10.15
             name: "macOS 10.15, Xcode 12.2, Swift 5.3"
+            testPlan: "macOS-NoTS"
           - xcode: "Xcode_12.1.1.app"
             runsOn: macOS-10.15
             name: "macOS 10.15, Xcode 12.1.1, Swift 5.3"
+            testPlan: "macOS-NoTS"
     steps:
       - uses: actions/checkout@v3
       - name: Install Firewalk
         run: "brew install alamofire/alamofire/firewalk && firewalk &"
       - name: ${{ matrix.name }}
-        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire macOS" -destination "platform=macOS" clean test | xcpretty
+        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire macOS" -destination "platform=macOS" -testPlan "${{ matrix.testPlan }}" clean test | xcpretty
   Catalyst:
     name: Test Catalyst
     runs-on: macOS-12
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.4.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_14.0.1.app/Contents/Developer
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
@@ -83,19 +97,19 @@ jobs:
     name: Test Latest (iOS, tvOS, watchOS)
     runs-on: macOS-12
     env:
-      DEVELOPER_DIR: "/Applications/Xcode_13.4.1.app/Contents/Developer"
+      DEVELOPER_DIR: "/Applications/Xcode_14.0.1.app/Contents/Developer"
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
         include:
-          - destination: "OS=15.5,name=iPhone 13 Pro"
+          - destination: "OS=16.0,name=iPhone 14 Pro"
             name: "iOS"
             scheme: "Alamofire iOS"
-          - destination: "OS=15.4,name=Apple TV"
+          - destination: "OS=16.0,name=Apple TV"
             name: "tvOS"
             scheme: "Alamofire tvOS"
-          - destination: "OS=8.5,name=Apple Watch Series 7 - 45mm"
+          - destination: "OS=9.0,name=Apple Watch Series 8 - 45mm"
             name: "watchOS"
             scheme: "Alamofire watchOS"
     steps:
@@ -105,21 +119,24 @@ jobs:
       - name: ${{ matrix.name }}
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "${{ matrix.scheme }}" -destination "${{ matrix.destination }}" clean test | xcpretty
   iOS:
-    name: "Test iOS"
+    name: "Test Old iOS"
     runs-on: firebreak
     env:
-      DEVELOPER_DIR: "/Applications/Xcode_13.4.1.app/Contents/Developer"
+      DEVELOPER_DIR: "/Applications/Xcode_14.0.1.app/Contents/Developer"
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
         include:
+          - destination: "OS=15.5,name=iPhone 13 Pro"
+            name: "iOS 15.5"
+            testPlan: "iOS-NoTS"
           - destination: "OS=14.5,name=iPhone 12 Pro"
             name: "iOS 14.5"
-            testPlan: "iOS"
+            testPlan: "iOS-NoTS"
           - destination: "OS=13.7,name=iPhone 11 Pro"
             name: "iOS 13.7"
-            testPlan: "iOS"
+            testPlan: "iOS-NoTS"
           - destination: "OS=12.4,name=iPhone Xs"
             name: "iOS 12.4"
             testPlan: "iOS-Old"
@@ -133,18 +150,21 @@ jobs:
     name: Test tvOS
     runs-on: firebreak
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.4.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_14.0.1.app/Contents/Developer
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
         include:
+          - destination: "OS=15.4,name=Apple TV"
+            name: "tvOS 15.4"
+            testPlan: "tvOS-NoTS"
           - destination: "OS=14.5,name=Apple TV"
             name: "tvOS 14.5"
-            testPlan: "tvOS"
+            testPlan: "tvOS-NoTS"
           - destination: "OS=13.4,name=Apple TV"
             name: "tvOS 13.4"
-            testPlan: "tvOS"
+            testPlan: "tvOS-NoTS"
           - destination: "OS=12.4,name=Apple TV"
             name: "tvOS 12.4"
             testPlan: "tvOS-Old"
@@ -156,54 +176,26 @@ jobs:
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire tvOS" -destination "${{ matrix.destination }}" -testPlan "${{ matrix.testPlan }}" clean test | xcpretty
   watchOS:
     name: Test watchOS
-    runs-on: macOS-11
+    runs-on: firebreak
     env:
-      DEVELOPER_DIR: /Applications/Xcode_12.5.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_14.0.1.app/Contents/Developer
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
         include:
+          - destination: "OS=8.5,name=Apple Watch Series 7 - 45mm"
+            name: "watchOS 8.5"
+            testPlan: "watchOS-NoTS"
           - destination: "OS=7.4,name=Apple Watch Series 6 - 44mm"
             name: "watchOS 7.4"
+            testPlan: "watchOS-NoTS"
     steps:
       - uses: actions/checkout@v3
       - name: Install Firewalk
         run: brew install alamofire/alamofire/firewalk && firewalk &
       - name: ${{ matrix.name}}
-        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire watchOS" -destination "${{ matrix.destination }}" clean test | xcpretty
-  Thread_Sanitizer:
-    name: Test Thread Sanitizer
-    runs-on: firebreak
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode_13.4.1.app/Contents/Developer"
-    timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - scheme: "Alamofire macOS"
-            destination: "platform=macOS"
-            testPlan: "macOS-TS"
-            name: "macOS Thread Sanitizer"
-          - scheme: "Alamofire iOS"
-            destination: "OS=15.5,name=iPhone 13 Pro"
-            testPlan: "iOS-TS"
-            name: "iOS Thread Sanitizer"
-          - scheme: "Alamofire tvOS"
-            destination: "OS=15.4,name=Apple TV"
-            testPlan: "tvOS-TS"
-            name: "tvOS Thread Sanitizer"
-          - scheme: "Alamofire watchOS"
-            destination: "OS=8.5,name=Apple Watch Series 7 - 45mm"
-            testPlan: "watchOS-TS"
-            name: "watchOS Thread Sanitizer"
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Firewalk
-        run: brew install alamofire/alamofire/firewalk || brew upgrade alamofire/alamofire/firewalk && firewalk &
-      - name: ${{ matrix.name }}
-        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "${{ matrix.scheme }}" -destination "${{ matrix.destination }}" -testPlan "${{ matrix.testPlan }}" clean test | xcpretty
+        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire watchOS" -destination "${{ matrix.destination }}" -testPlan "${{ matrix.testPlan }}" clean test | xcpretty
   SPM:
     name: Test with SPM
     runs-on: ${{ matrix.runsOn }}
@@ -214,40 +206,36 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - xcode: "Xcode_14.0.1.app"
+            runsOn: macOS-12
+            name: "macOS 12, SPM 5.7.0 Test"
           - xcode: "Xcode_13.4.1.app"
             runsOn: macOS-12
             name: "macOS 12, SPM 5.6.1 Test"
-            action: swift test -c debug
           - xcode: "Xcode_13.3.1.app"
             runsOn: macOS-12
             name: "macOS 12, SPM 5.6 Test"
-            action: swift test -c debug
           - xcode: "Xcode_13.2.1.app"
             runsOn: macOS-11
             name: "macOS 11, SPM 5.5.2 Test"
-            action: swift test -c debug
           - xcode: "Xcode_13.1.app"
             runsOn: macOS-11
             name: "macOS 11, SPM 5.5.1 Test"
-            action: swift test -c debug
           - xcode: "Xcode_13.0.app"
             runsOn: macOS-11
             name: "macOS 11, SPM 5.5 Test"
-            action: swift test -c debug
           - xcode: "Xcode_12.5.1.app"
             runsOn: macOS-11
             name: "macOS 11, SPM 5.4 Build"
-            action: swift build -c debug
           - xcode: "Xcode_12.4.app"
             runsOn: macOS-10.15
             name: "macOS 10.15, SPM 5.3 Build"
-            action: swift build -c debug
     steps:
       - uses: actions/checkout@v3
       - name: Install Firewalk
         run: brew install alamofire/alamofire/firewalk && firewalk &
       - name: Test SPM
-        run: ${{ matrix.action }}
+        run: swift build -c debug
   Linux:
     name: Linux
     runs-on: ubuntu-latest
@@ -255,14 +243,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: swift:5.6.1-bionic
-          - image: swift:5.6.1-focal
-          - image: swift:5.6.1-centos7
-          - image: swift:5.6.1-amazonlinux2
+          - image: swift:5.7-bionic
+          - image: swift:5.7-focal
+          - image: swift:5.7-centos7
+          - image: swift:5.7-amazonlinux2
           - image: swiftlang/swift:nightly-bionic
           - image: swiftlang/swift:nightly-focal
           - image: swiftlang/swift:nightly-jammy
-          # - image: swiftlang/swift:nightly-centos7 # Currently ignored since git doesn't work.
+          - image: swiftlang/swift:nightly-centos7
           - image: swiftlang/swift:nightly-centos8
           - image: swiftlang/swift:nightly-amazonlinux2
     container:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           - destination: "OS=16.0,name=Apple TV"
             name: "tvOS"
             scheme: "Alamofire tvOS"
-          - destination: "OS=9.0,name=Apple Watch Series 8 - 45mm"
+          - destination: "OS=9.0,name=Apple Watch Series 8 (45mm)"
             name: "watchOS"
             scheme: "Alamofire watchOS"
     steps:
@@ -250,7 +250,7 @@ jobs:
           - image: swiftlang/swift:nightly-bionic
           - image: swiftlang/swift:nightly-focal
           - image: swiftlang/swift:nightly-jammy
-          - image: swiftlang/swift:nightly-centos7
+          # - image: swiftlang/swift:nightly-centos7
           - image: swiftlang/swift:nightly-centos8
           - image: swiftlang/swift:nightly-amazonlinux2
     container:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,10 +184,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - destination: "OS=8.5,name=Apple Watch Series 7 - 45mm"
+          - destination: "OS=8.5,name=Apple Watch Series 7 (45mm)"
             name: "watchOS 8.5"
             testPlan: "watchOS-NoTS"
-          - destination: "OS=7.4,name=Apple Watch Series 6 - 44mm"
+          - destination: "OS=7.4,name=Apple Watch Series 6 (44mm)"
             name: "watchOS 7.4"
             testPlan: "watchOS-NoTS"
     steps:

--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -498,14 +498,14 @@
 		312D1E0B1FC2551400E51FF1 /* Usage.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = Usage.md; path = Documentation/Usage.md; sourceTree = "<group>"; };
 		312D1E0C1FC2551400E51FF1 /* AdvancedUsage.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = AdvancedUsage.md; path = Documentation/AdvancedUsage.md; sourceTree = "<group>"; };
 		31425AC0241F098000EE3CCC /* InternalRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalRequestTests.swift; sourceTree = "<group>"; };
-		3145E0E227977AA300949557 /* iOS-TS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "iOS-TS.xctestplan"; sourceTree = "<group>"; };
-		3145E0E32797A8EF00949557 /* tvOS-TS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "tvOS-TS.xctestplan"; sourceTree = "<group>"; };
+		3145E0E227977AA300949557 /* iOS-NoTS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "iOS-NoTS.xctestplan"; sourceTree = "<group>"; };
+		3145E0E32797A8EF00949557 /* tvOS-NoTS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "tvOS-NoTS.xctestplan"; sourceTree = "<group>"; };
 		3145E0E42797A8EF00949557 /* tvOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = tvOS.xctestplan; sourceTree = "<group>"; };
 		3145E0E52797A8EF00949557 /* tvOS-Old.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "tvOS-Old.xctestplan"; sourceTree = "<group>"; };
 		3145E0E62797D91600949557 /* watchOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = watchOS.xctestplan; sourceTree = "<group>"; };
-		3145E0E72797D94200949557 /* watchOS-TS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "watchOS-TS.xctestplan"; sourceTree = "<group>"; };
+		3145E0E72797D94200949557 /* watchOS-NoTS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "watchOS-NoTS.xctestplan"; sourceTree = "<group>"; };
 		3145E0E82797D9E700949557 /* macOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = macOS.xctestplan; sourceTree = "<group>"; };
-		3145E0E92797D9E900949557 /* macOS-TS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "macOS-TS.xctestplan"; sourceTree = "<group>"; };
+		3145E0E92797D9E900949557 /* macOS-NoTS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "macOS-NoTS.xctestplan"; sourceTree = "<group>"; };
 		314998E927A6560600ABB856 /* Request+AlamofireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Request+AlamofireTests.swift"; sourceTree = "<group>"; };
 		31501E872196962A005829F2 /* ParameterEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParameterEncoderTests.swift; sourceTree = "<group>"; };
 		31577E0A2676E72D001C7532 /* FUNDING.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = FUNDING.yml; sourceTree = "<group>"; };
@@ -751,14 +751,14 @@
 			isa = PBXGroup;
 			children = (
 				31EF4BF627964B520048A19D /* iOS-Old.xctestplan */,
-				3145E0E227977AA300949557 /* iOS-TS.xctestplan */,
+				3145E0E227977AA300949557 /* iOS-NoTS.xctestplan */,
 				31EF4BF5279646450048A19D /* iOS.xctestplan */,
-				3145E0E92797D9E900949557 /* macOS-TS.xctestplan */,
+				3145E0E92797D9E900949557 /* macOS-NoTS.xctestplan */,
 				3145E0E82797D9E700949557 /* macOS.xctestplan */,
 				3145E0E52797A8EF00949557 /* tvOS-Old.xctestplan */,
-				3145E0E32797A8EF00949557 /* tvOS-TS.xctestplan */,
+				3145E0E32797A8EF00949557 /* tvOS-NoTS.xctestplan */,
 				3145E0E42797A8EF00949557 /* tvOS.xctestplan */,
-				3145E0E72797D94200949557 /* watchOS-TS.xctestplan */,
+				3145E0E72797D94200949557 /* watchOS-NoTS.xctestplan */,
 				3145E0E62797D91600949557 /* watchOS.xctestplan */,
 			);
 			path = "Test Plans";

--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -750,13 +750,13 @@
 		31EF4BF4279646000048A19D /* Test Plans */ = {
 			isa = PBXGroup;
 			children = (
-				31EF4BF627964B520048A19D /* iOS-Old.xctestplan */,
 				3145E0E227977AA300949557 /* iOS-NoTS.xctestplan */,
+				31EF4BF627964B520048A19D /* iOS-Old.xctestplan */,
 				31EF4BF5279646450048A19D /* iOS.xctestplan */,
 				3145E0E92797D9E900949557 /* macOS-NoTS.xctestplan */,
 				3145E0E82797D9E700949557 /* macOS.xctestplan */,
-				3145E0E52797A8EF00949557 /* tvOS-Old.xctestplan */,
 				3145E0E32797A8EF00949557 /* tvOS-NoTS.xctestplan */,
+				3145E0E52797A8EF00949557 /* tvOS-Old.xctestplan */,
 				3145E0E42797A8EF00949557 /* tvOS.xctestplan */,
 				3145E0E72797D94200949557 /* watchOS-NoTS.xctestplan */,
 				3145E0E62797D91600949557 /* watchOS.xctestplan */,
@@ -921,11 +921,7 @@
 			isa = PBXGroup;
 			children = (
 				312D1E0C1FC2551400E51FF1 /* AdvancedUsage.md */,
-				4CE292321EF4A393008DA555 /* CHANGELOG.md */,
-				4CE292331EF4A393008DA555 /* CONTRIBUTING.md */,
-				4CE292311EF4A393008DA555 /* README.md */,
 				312D1E0B1FC2551400E51FF1 /* Usage.md */,
-				319ECE9E25EC96E8001C38CA /* .github */,
 				4C9E88361F5FB39F000BEC61 /* Migration Guides */,
 			);
 			name = Documentation;
@@ -934,9 +930,13 @@
 		4CE292381EF4B116008DA555 /* Deployment */ = {
 			isa = PBXGroup;
 			children = (
+				319ECE9E25EC96E8001C38CA /* .github */,
 				4CE292391EF4B12B008DA555 /* Alamofire.podspec */,
+				4CE292321EF4A393008DA555 /* CHANGELOG.md */,
+				4CE292331EF4A393008DA555 /* CONTRIBUTING.md */,
 				4CF3B4281F5FC7900075BE59 /* LICENSE */,
 				31B2CA9521AA25CD005B371A /* Package.swift */,
+				4CE292311EF4A393008DA555 /* README.md */,
 			);
 			name = Deployment;
 			sourceTree = "<group>";

--- a/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire iOS.xcscheme
+++ b/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire iOS.xcscheme
@@ -77,7 +77,7 @@
             reference = "container:Tests/Test Plans/iOS-Old.xctestplan">
          </TestPlanReference>
          <TestPlanReference
-            reference = "container:Tests/Test Plans/iOS-TS.xctestplan">
+            reference = "container:Tests/Test Plans/iOS-NoTS.xctestplan">
          </TestPlanReference>
       </TestPlans>
       <Testables>

--- a/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire macOS.xcscheme
+++ b/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire macOS.xcscheme
@@ -75,7 +75,7 @@
             default = "YES">
          </TestPlanReference>
          <TestPlanReference
-            reference = "container:Tests/Test Plans/macOS-TS.xctestplan">
+            reference = "container:Tests/Test Plans/macOS-NoTS.xctestplan">
          </TestPlanReference>
       </TestPlans>
       <Testables>

--- a/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire tvOS.xcscheme
+++ b/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire tvOS.xcscheme
@@ -74,7 +74,7 @@
             default = "YES">
          </TestPlanReference>
          <TestPlanReference
-            reference = "container:Tests/Test Plans/tvOS-TS.xctestplan">
+            reference = "container:Tests/Test Plans/tvOS-NoTS.xctestplan">
          </TestPlanReference>
          <TestPlanReference
             reference = "container:Tests/Test Plans/tvOS-Old.xctestplan">

--- a/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire watchOS.xcscheme
+++ b/Alamofire.xcodeproj/xcshareddata/xcschemes/Alamofire watchOS.xcscheme
@@ -52,7 +52,7 @@
             default = "YES">
          </TestPlanReference>
          <TestPlanReference
-            reference = "container:Tests/Test Plans/watchOS-TS.xctestplan">
+            reference = "container:Tests/Test Plans/watchOS-NoTS.xctestplan">
          </TestPlanReference>
       </TestPlans>
       <Testables>

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -493,7 +493,7 @@ public class Request {
     func retryOrFinish(error: AFError?) {
         dispatchPrecondition(condition: .onQueue(underlyingQueue))
 
-        guard let error = error, let delegate = delegate else { finish(); return }
+        guard !isCancelled, let error = error, let delegate = delegate else { finish(); return }
 
         delegate.retryResult(for: self, dueTo: error) { retryResult in
             switch retryResult {

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -240,7 +240,7 @@ extension DataRequest {
 
                 self.eventMonitor?.request(self, didParseResponse: response)
 
-                guard let serializerError = result.failure, let delegate = self.delegate else {
+                guard !self.isCancelled, let serializerError = result.failure, let delegate = self.delegate else {
                     self.responseSerializerDidComplete { queue.async { completionHandler(response) } }
                     return
                 }

--- a/Source/ServerTrustEvaluation.swift
+++ b/Source/ServerTrustEvaluation.swift
@@ -715,11 +715,15 @@ extension AlamofireExtension where ExtendedType == SecCertificate {
 
         guard let createdTrust = trust, trustCreationStatus == errSecSuccess else { return nil }
 
+        #if swift(>=5.3.1) // SecTrustCopyKey not visible in Xcode <= 12.1, despite being a 2020 API.
         if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, *) {
             return SecTrustCopyKey(createdTrust)
         } else {
             return SecTrustCopyPublicKey(createdTrust)
         }
+        #else
+        return SecTrustCopyPublicKey(createdTrust)
+        #endif
     }
 }
 

--- a/Tests/RetryPolicyTests.swift
+++ b/Tests/RetryPolicyTests.swift
@@ -153,25 +153,26 @@ class BaseRetryPolicyTestCase: BaseTestCase {
 
 final class RetryPolicyTestCase: BaseRetryPolicyTestCase {
     // MARK: Tests - Retry
-    
+
     func testThatRetryIsNotPerformedOnCancelledRequests() {
         // Given
-        let retrier = Retrier { _, _, _, completion in
+        let retrier = InspectorInterceptor(Retrier { _, _, _, completion in
             completion(.retry)
-        }
+        })
         let session = Session(interceptor: retrier)
         let didFinish = expectation(description: "didFinish request")
-        
+
         // When
         let request = session.request(.default).responseDecodable(of: TestResponse.self) { _ in
             didFinish.fulfill()
         }
         request.cancel()
-        
+
         waitForExpectations(timeout: timeout)
-        
+
         // Then
         XCTAssertTrue(request.isCancelled)
+        XCTAssertEqual(retrier.retryCalledCount, 0)
     }
 
     func testThatRetryPolicyRetriesRequestsBelowRetryLimit() {

--- a/Tests/RetryPolicyTests.swift
+++ b/Tests/RetryPolicyTests.swift
@@ -153,6 +153,26 @@ class BaseRetryPolicyTestCase: BaseTestCase {
 
 final class RetryPolicyTestCase: BaseRetryPolicyTestCase {
     // MARK: Tests - Retry
+    
+    func testThatRetryIsNotPerformedOnCancelledRequests() {
+        // Given
+        let retrier = Retrier { _, _, _, completion in
+            completion(.retry)
+        }
+        let session = Session(interceptor: retrier)
+        let didFinish = expectation(description: "didFinish request")
+        
+        // When
+        let request = session.request(.default).responseDecodable(of: TestResponse.self) { _ in
+            didFinish.fulfill()
+        }
+        request.cancel()
+        
+        waitForExpectations(timeout: timeout)
+        
+        // Then
+        XCTAssertTrue(request.isCancelled)
+    }
 
     func testThatRetryPolicyRetriesRequestsBelowRetryLimit() {
         // Given

--- a/Tests/Test Plans/iOS-NoTS.xctestplan
+++ b/Tests/Test Plans/iOS-NoTS.xctestplan
@@ -4,7 +4,7 @@
       "id" : "06BDBD92-3173-4395-90BF-851B80FF1162",
       "name" : "Default",
       "options" : {
-        "threadSanitizerEnabled" : true
+
       }
     }
   ],
@@ -21,8 +21,8 @@
       ],
       "target" : {
         "containerPath" : "container:Alamofire.xcodeproj",
-        "identifier" : "F829C6B11A7A94F100A2CD59",
-        "name" : "Alamofire macOS Tests"
+        "identifier" : "F8111E3D19A95C8B0040E7D1",
+        "name" : "Alamofire iOS Tests"
       }
     }
   ],

--- a/Tests/Test Plans/iOS.xctestplan
+++ b/Tests/Test Plans/iOS.xctestplan
@@ -4,7 +4,7 @@
       "id" : "06BDBD92-3173-4395-90BF-851B80FF1162",
       "name" : "Default",
       "options" : {
-
+        "threadSanitizerEnabled" : true
       }
     }
   ],

--- a/Tests/Test Plans/macOS-NoTS.xctestplan
+++ b/Tests/Test Plans/macOS-NoTS.xctestplan
@@ -4,7 +4,7 @@
       "id" : "06BDBD92-3173-4395-90BF-851B80FF1162",
       "name" : "Default",
       "options" : {
-        "threadSanitizerEnabled" : true
+
       }
     }
   ],
@@ -21,8 +21,8 @@
       ],
       "target" : {
         "containerPath" : "container:Alamofire.xcodeproj",
-        "identifier" : "4CF626F71BA7CB3E0011A099",
-        "name" : "Alamofire tvOS Tests"
+        "identifier" : "F829C6B11A7A94F100A2CD59",
+        "name" : "Alamofire macOS Tests"
       }
     }
   ],

--- a/Tests/Test Plans/macOS.xctestplan
+++ b/Tests/Test Plans/macOS.xctestplan
@@ -4,7 +4,7 @@
       "id" : "06BDBD92-3173-4395-90BF-851B80FF1162",
       "name" : "Default",
       "options" : {
-
+        "threadSanitizerEnabled" : true
       }
     }
   ],

--- a/Tests/Test Plans/tvOS-NoTS.xctestplan
+++ b/Tests/Test Plans/tvOS-NoTS.xctestplan
@@ -1,7 +1,7 @@
 {
   "configurations" : [
     {
-      "id" : "13FE6F19-6B66-4BD2-862D-9F091CA8B792",
+      "id" : "06BDBD92-3173-4395-90BF-851B80FF1162",
       "name" : "Default",
       "options" : {
 
@@ -9,8 +9,7 @@
     }
   ],
   "defaultOptions" : {
-    "codeCoverage" : false,
-    "threadSanitizerEnabled" : true
+    "codeCoverage" : false
   },
   "testTargets" : [
     {
@@ -22,8 +21,8 @@
       ],
       "target" : {
         "containerPath" : "container:Alamofire.xcodeproj",
-        "identifier" : "31293064263E17D600473CEA",
-        "name" : "Alamofire watchOS Tests"
+        "identifier" : "4CF626F71BA7CB3E0011A099",
+        "name" : "Alamofire tvOS Tests"
       }
     }
   ],

--- a/Tests/Test Plans/tvOS.xctestplan
+++ b/Tests/Test Plans/tvOS.xctestplan
@@ -4,7 +4,7 @@
       "id" : "06BDBD92-3173-4395-90BF-851B80FF1162",
       "name" : "Default",
       "options" : {
-
+        "threadSanitizerEnabled" : true
       }
     }
   ],

--- a/Tests/Test Plans/watchOS-NoTS.xctestplan
+++ b/Tests/Test Plans/watchOS-NoTS.xctestplan
@@ -1,10 +1,10 @@
 {
   "configurations" : [
     {
-      "id" : "06BDBD92-3173-4395-90BF-851B80FF1162",
+      "id" : "13FE6F19-6B66-4BD2-862D-9F091CA8B792",
       "name" : "Default",
       "options" : {
-        "threadSanitizerEnabled" : true
+
       }
     }
   ],
@@ -21,8 +21,8 @@
       ],
       "target" : {
         "containerPath" : "container:Alamofire.xcodeproj",
-        "identifier" : "F8111E3D19A95C8B0040E7D1",
-        "name" : "Alamofire iOS Tests"
+        "identifier" : "31293064263E17D600473CEA",
+        "name" : "Alamofire watchOS Tests"
       }
     }
   ],

--- a/Tests/Test Plans/watchOS.xctestplan
+++ b/Tests/Test Plans/watchOS.xctestplan
@@ -4,7 +4,7 @@
       "id" : "13FE6F19-6B66-4BD2-862D-9F091CA8B792",
       "name" : "Default",
       "options" : {
-
+        "threadSanitizerEnabled" : true
       }
     }
   ],


### PR DESCRIPTION
### Issue Link :link:
Fixess #3639 and #3640

### Goals :soccer:
This PR adds an additional cancellation check before starting the retry flow to ensure retriers which don't handle cancellation or have a maximum retry count don't enter an infinite loop.

This PR also adds a workaround for Xcode 12.1 and below where `SecTrustCopyKey` wasn't available, despite being available on the .0 OS releases. ☹️ 

This PR also updates the CI configuration for Xcode 14.

### Implementation Details :construction:
A single check is added to ensure the retry processes never starts when the request is already cancelled.

### Testing Details :mag:
Added test to ensure retriers aren't called when a request is cancelled.
