### PR TITLE
Fix typo: Adding a dot in localizedDescription

### DIFF
--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -710,7 +710,7 @@ extension AFError.ParameterEncodingFailureReason {
     var localizedDescription: String {
         switch self {
         case .missingURL:
-            return "URL request to encode was missing a URL"
+            return "URL request to encode was missing a URL."
         case let .jsonEncodingFailed(error):
             return "JSON could not be encoded because of error:\n\(error.localizedDescription)"
         case let .customEncodingFailed(error):


### PR DESCRIPTION
### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->
Fixing Type: Adding a dot with localizedDescription

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
AFError

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
I added a dot at the end of one localizedDescription. There's other description has a dot, but only this isn't. 

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
