### PR TITLE
get activeRequests from Session

### DIFF
--- a/Source/Session.swift
+++ b/Source/Session.swift
@@ -1262,3 +1262,9 @@ extension Session: SessionStateProvider {
         requestTaskMap.requests.forEach { $0.finish(error: AFError.sessionInvalidated(error: error)) }
     }
 }
+
+extension Session {
+    public func getActiveRequests() -> [Request] {
+        return Array(self.activeRequests)
+    }
+}


### PR DESCRIPTION
### Goals :soccer:
because i need to sent log `activeRequests` when process in 
`func refresh(_ credential: Credential, for session: Session, completion: @escaping (Result<Credential, Error>) -> Void)` 
but in `Session` the `activeRequests` is an internal var.
e.g. when refresh complete or fail i need to log this event.
