### PR TITLE
Fix calls of deprecated function

### DIFF
--- a/Source/Concurrency.swift
+++ b/Source/Concurrency.swift
@@ -118,9 +118,9 @@ public struct DataTask<Value> {
         get async {
             if shouldAutomaticallyCancel {
                 return await withTaskCancellationHandler {
-                    self.cancel()
-                } operation: {
                     await task.value
+                } onCancel: {
+                    self.cancel()
                 }
             } else {
                 return await task.value
@@ -287,13 +287,13 @@ extension DataRequest {
         -> DataTask<Value> {
         let task = Task {
             await withTaskCancellationHandler {
-                self.cancel()
-            } operation: {
                 await withCheckedContinuation { continuation in
                     onResponse {
                         continuation.resume(returning: $0)
                     }
                 }
+            } onCancel: {
+                self.cancel()
             }
         }
 
@@ -311,9 +311,9 @@ public struct DownloadTask<Value> {
         get async {
             if shouldAutomaticallyCancel {
                 return await withTaskCancellationHandler {
-                    self.cancel()
-                } operation: {
                     await task.value
+                } onCancel: {
+                    self.cancel()
                 }
             } else {
                 return await task.value
@@ -496,13 +496,13 @@ extension DownloadRequest {
         -> DownloadTask<Value> {
         let task = Task {
             await withTaskCancellationHandler {
-                self.cancel()
-            } operation: {
                 await withCheckedContinuation { continuation in
                     onResponse {
                         continuation.resume(returning: $0)
                     }
                 }
+            } onCancel: {
+                self.cancel()
             }
         }
 


### PR DESCRIPTION
### Goals :soccer:

`withTaskCancellationHandler(handler:operation:)` has been deprecated in Swift 5.7 in favor of `withTaskCancellationHandler(operation:onCancel:)` (see https://github.com/apple/swift/pull/60569). This PR updates all calls of the former function accordingly.

### Implementation Details :construction:
n/a

### Testing Details :mag:
n/a
