### PR TITLE
Update Package.swift to fix Xcode 14 warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,10 +26,10 @@
 import PackageDescription
 
 let package = Package(name: "Alamofire",
-                      platforms: [.macOS(.v10_12),
-                                  .iOS(.v10),
-                                  .tvOS(.v10),
-                                  .watchOS(.v3)],
+                      platforms: [.macOS(.v10_13),
+                                  .iOS(.v11),
+                                  .tvOS(.v11),
+                                  .watchOS(.v4)],
                       products: [.library(name: "Alamofire",
                                           targets: ["Alamofire"])],
                       targets: [.target(name: "Alamofire",


### PR DESCRIPTION
### Goals :soccer:
Fix Xcode 14 warnings:
The oldest supported versions are:
- macOS 10.13
- iOS 11.0
- tvOS 11.0
- watchOS 4.0 

<img width="1326" alt="Screenshot 2022-11-21 at 12 08 36" src="https://user-images.githubusercontent.com/1105813/203035814-4391a265-d431-444f-ad93-7b75094b74f2.png">

