### PR TITLE
Fix unused bufferingPolicy in StreamOf

### DIFF
--- a/Source/Concurrency.swift
+++ b/Source/Concurrency.swift
@@ -663,7 +663,7 @@ public struct StreamOf<Element>: AsyncSequence {
 
     public func makeAsyncIterator() -> Iterator {
         var continuation: AsyncStream<Element>.Continuation?
-        let stream = AsyncStream<Element> { innerContinuation in
+        let stream = AsyncStream<Element>(bufferingPolicy: bufferingPolicy) { innerContinuation in
             continuation = innerContinuation
             builder(innerContinuation)
         }


### PR DESCRIPTION
### Goals :soccer:
`StreamOf` has `bufferingPolicy` which is a private property but it's not used inside the struct. This PR uses `bufferingPolicy` to create `AsyncStream` in `makeAsyncIterator` so that the policy will be applied while interacting  `StreamOf`
