### PR TITLE
Add NilEncoding to URLEncodedFormParameterEncoder

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -343,6 +343,28 @@ You can create your own `URLEncodedFormParameterEncoder` and specify the desired
 let encoder = URLEncodedFormParameterEncoder(encoder: URLEncodedFormEncoder(spaceEncoding: .plusReplaced))
 ```
 
+##### Configuring the Encoding of Optionals
+
+There is no standard for encoding `Optional` values as part of form data. Nonetheless, Alamofire provides `NilEncoding` with the following methods for encoding optionals:
+
+- `.dropKey` - Encodes `nil` values by dropping them from the output entirely. This matches other Swift encoders. e.g. `otherValue=2`.
+- `.dropValue` - Encodes `nil` values by dropping the value from the output. e.g. `nilValue=&otherValue=2`.
+- `.null` - Encodes `nil` values as the string `null`. e.g. `nilValue=null&otherValue=2`.
+
+Additionally, custom encodings can be created by specifying an encoding closure that provides the `nil` replacement value.
+
+```swift
+extension URLEncodedFormEncoder.NilEncoding {
+  static let customEncoding = NilEncoding { "customNilValue" }
+}
+```
+
+You can create your own `URLEncodedFormParameterEncoder` and specify the desired `NilEncoding` in the initializer of the passed `URLEncodedFormEncoder`:
+
+```swift
+let encoder = URLEncodedFormParameterEncoder(encoder: URLEncodedFormEncoder(nilEncoding: .dropKey))
+```
+
 #### `JSONParameterEncoder`
 
 `JSONParameterEncoder` encodes `Encodable` values using Swift's `JSONEncoder` and sets the result as the `httpBody` of the `URLRequest`. The `Content-Type` HTTP header field of an encoded request is set to `application/json` if not already set.

--- a/Source/URLEncodedFormEncoder.swift
+++ b/Source/URLEncodedFormEncoder.swift
@@ -277,7 +277,7 @@ public final class URLEncodedFormEncoder {
     public struct NilEncoding {
         /// Encodes `nil` by dropping the entire key / value pair.
         public static let dropKey = NilEncoding { nil }
-        /// Encodes `nil` by dropping only the value. e.g. `value1=one&nilValue&value2=two`.
+        /// Encodes `nil` by dropping only the value. e.g. `value1=one&nilValue=&value2=two`.
         public static let dropValue = NilEncoding { "" }
         /// Encodes `nil` as `null`.
         public static let null = NilEncoding { "null" }

--- a/Tests/ParameterEncoderTests.swift
+++ b/Tests/ParameterEncoderTests.swift
@@ -193,30 +193,6 @@ final class URLEncodedFormParameterEncoderTests: BaseTestCase {
 }
 
 final class URLEncodedFormEncoderTests: BaseTestCase {
-    func testEncoderThrowsErrorWhenAttemptingToEncodeNilInKeyedContainer() {
-        // Given
-        let encoder = URLEncodedFormEncoder()
-        let parameters = FailingOptionalStruct(testedContainer: .keyed)
-
-        // When
-        let result = Result<String, Error> { try encoder.encode(parameters) }
-
-        // Then
-        XCTAssertTrue(result.isFailure)
-    }
-
-    func testEncoderThrowsErrorWhenAttemptingToEncodeNilInUnkeyedContainer() {
-        // Given
-        let encoder = URLEncodedFormEncoder()
-        let parameters = FailingOptionalStruct(testedContainer: .unkeyed)
-
-        // When
-        let result = Result<String, Error> { try encoder.encode(parameters) }
-
-        // Then
-        XCTAssertTrue(result.isFailure)
-    }
-
     func testEncoderCanEncodeDictionary() {
         // Given
         let encoder = URLEncodedFormEncoder()
@@ -492,18 +468,6 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         // Given
         let encoder = URLEncodedFormEncoder()
         let parameters = "string"
-
-        // When
-        let result = Result<String, Error> { try encoder.encode(parameters) }
-
-        // Then
-        XCTAssertFalse(result.isSuccess)
-    }
-
-    func testThatOptionalValuesCannotBeEncoded() {
-        // Given
-        let encoder = URLEncodedFormEncoder()
-        let parameters: [String: String?] = ["string": nil]
 
         // When
         let result = Result<String, Error> { try encoder.encode(parameters) }
@@ -826,6 +790,18 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         XCTAssertEqual(result.success, "A=oneTwoThree")
     }
 
+    func testThatNilCanBeEncodedByDroppingTheKeyByDefault() {
+        // Given
+        let encoder = URLEncodedFormEncoder()
+        let parameters: [String: String?] = ["a": nil]
+
+        // When
+        let result = Result<String, Error> { try encoder.encode(parameters) }
+
+        // Then
+        XCTAssertEqual(result.success, "")
+    }
+
     func testThatNilCanBeEncodedAsNull() {
         // Given
         let encoder = URLEncodedFormEncoder(nilEncoding: .null)
@@ -838,9 +814,9 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         XCTAssertEqual(result.success, "a=null")
     }
 
-    func testThatNilCanBeEncodedByDropping() {
+    func testThatNilCanBeEncodedByDroppingTheKey() {
         // Given
-        let encoder = URLEncodedFormEncoder()
+        let encoder = URLEncodedFormEncoder(nilEncoding: .dropKey)
         let parameters: [String: String?] = ["a": nil]
 
         // When
@@ -848,6 +824,18 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
 
         // Then
         XCTAssertEqual(result.success, "")
+    }
+
+    func testThatNilCanBeEncodedByDroppingTheValue() {
+        // Given
+        let encoder = URLEncodedFormEncoder(nilEncoding: .dropValue)
+        let parameters: [String: String?] = ["a": nil]
+
+        // When
+        let result = Result<String, Error> { try encoder.encode(parameters) }
+
+        // Then
+        XCTAssertEqual(result.success, "a=")
     }
 
     func testThatSpacesCanBeEncodedAsPluses() {

--- a/Tests/ParameterEncoderTests.swift
+++ b/Tests/ParameterEncoderTests.swift
@@ -826,6 +826,30 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         XCTAssertEqual(result.success, "A=oneTwoThree")
     }
 
+    func testThatNilCanBeEncodedAsNull() {
+        // Given
+        let encoder = URLEncodedFormEncoder(nilEncoding: .null)
+        let parameters: [String: String?] = ["a": nil]
+
+        // When
+        let result = Result<String, Error> { try encoder.encode(parameters) }
+
+        // Then
+        XCTAssertEqual(result.success, "a=null")
+    }
+
+    func testThatNilCanBeEncodedByDropping() {
+        // Given
+        let encoder = URLEncodedFormEncoder()
+        let parameters: [String: String?] = ["a": nil]
+
+        // When
+        let result = Result<String, Error> { try encoder.encode(parameters) }
+
+        // Then
+        XCTAssertEqual(result.success, "")
+    }
+
     func testThatSpacesCanBeEncodedAsPluses() {
         // Given
         let encoder = URLEncodedFormEncoder(spaceEncoding: .plusReplaced)


### PR DESCRIPTION
### Issue Link :link:
#3631

### Goals :soccer:
This PR adds a `NilEncoding` type for `URLEncodedFormParameterEncoder` so that it can handle optional values.

### Implementation Details :construction:
Like the other encodings, it allows a variety of representations. Unlike the others, it's implemented as a `struct` so it can more easily be used with custom encodings.

### Testing Details :mag:
Tests added for each encoding.
