### PR TITLE
Add ArrayEncoding.custom to URLEncodedFormEncoder and ParameterEncoding.

### DIFF
--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -87,6 +87,8 @@ public struct URLEncoding: ParameterEncoding {
         case noBrackets
         /// Brackets containing the item index are appended. This matches the jQuery and Node.js behavior.
         case indexInBrackets
+        /// Provide a custom array key encoding with the given closure.
+        case custom((String, Int) -> String)
 
         func encode(key: String, atIndex index: Int) -> String {
             switch self {
@@ -96,6 +98,7 @@ public struct URLEncoding: ParameterEncoding {
                 return key
             case .indexInBrackets:
                 return "\(key)[\(index)]"
+            case let .custom(encoding): return encoding(key, index)
             }
         }
     }

--- a/Source/URLEncodedFormEncoder.swift
+++ b/Source/URLEncodedFormEncoder.swift
@@ -60,6 +60,8 @@ public final class URLEncodedFormEncoder {
         case noBrackets
         /// Brackets containing the item index are appended. This matches the jQuery and Node.js behavior.
         case indexInBrackets
+        /// Provide a custom array key encoding with the given closure.
+        case custom((String, Int) -> String)
 
         /// Encodes the key according to the encoding.
         ///
@@ -73,6 +75,7 @@ public final class URLEncodedFormEncoder {
             case .brackets: return "\(key)[]"
             case .noBrackets: return key
             case .indexInBrackets: return "\(key)[\(index)]"
+            case let .custom(encoding): return encoding(key, index)
             }
         }
     }

--- a/Tests/ParameterEncoderTests.swift
+++ b/Tests/ParameterEncoderTests.swift
@@ -624,6 +624,20 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         XCTAssertEqual(result.success, "array=1&array=2")
     }
 
+    func testThatArraysCanBeEncodedWithCustomClosure() {
+        // Given
+        let encoder = URLEncodedFormEncoder(arrayEncoding: .custom({ key, index in
+          "\(key).\(index+1)"
+        }))
+        let parameters = ["array": [1, 2]]
+
+        // When
+        let result = Result<String, Error> { try encoder.encode(parameters) }
+
+        // Then
+        XCTAssertEqual(result.success, "array.1=1&array.2=2")
+    }
+
     func testThatBoolsCanBeLiteralEncoded() {
         // Given
         let encoder = URLEncodedFormEncoder(boolEncoding: .literal)


### PR DESCRIPTION
### Goals :soccer:
Let the user define a custom key formatting for arrays.

### Implementation Details :construction:
This helps for uncommon formats such as in the AWS API where it expects Array.1.Key or Array.member.1.Key. Rather than add specifics for those, providing a simple customization helps overcome this.

This follows other `.custom` conventions in the encoding options.

### Testing Details :mag:
Added a test under `ParameterEncodingTests.testThatArraysCanBeEncodedWithCustomClosure` that covers the change consistent with the other array encoding tests.
