### PR TITLE
Change flatMap to map

### DIFF
--- a/Source/URLRequest+Alamofire.swift
+++ b/Source/URLRequest+Alamofire.swift
@@ -27,7 +27,7 @@ import Foundation
 extension URLRequest {
     /// Returns the `httpMethod` as Alamofire's `HTTPMethod` type.
     public var method: HTTPMethod? {
-        get { httpMethod.flatMap(HTTPMethod.init) }
+        get { httpMethod.map(HTTPMethod.init) }
         set { httpMethod = newValue?.rawValue }
     }
 


### PR DESCRIPTION
According to Apple's Documents,
[map](https://developer.apple.com/documentation/swift/optional/map(_:)-7txtz) : "Use the map method with a closure that returns a non-optional value."
[flatMap](https://developer.apple.com/documentation/swift/optional/flatmap(_:)) : "Use the flatMap method with a closure that returns an optional value."

With the HTTPMethod changed from enum to structure(#2901), the init is no longer optional
So, in this case, the existing way works normally, but I think this way is more intended function utilization. 
(map guarantee non-optional)

Thank you