### PR TITLE
Replaced the for-loop with swift `contains` method.

### DIFF
--- a/Source/ServerTrustEvaluation.swift
+++ b/Source/ServerTrustEvaluation.swift
@@ -355,10 +355,8 @@ public final class PublicKeysTrustEvaluator: ServerTrustEvaluating {
 
         let pinnedKeysInServerKeys: Bool = {
             for serverPublicKey in trust.af.publicKeys {
-                for pinnedPublicKey in keys {
-                    if serverPublicKey == pinnedPublicKey {
-                        return true
-                    }
+                if keys.contains(serverPublicKey) {
+                    return true
                 }
             }
             return false


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
- This PR contains a minor improvement to code readability. The goal of this PR is to make Alamofire codebase even more readable and concise without breaking the existing code and functionality.
<!-- Include any relevant context. -->

### Implementation Details :construction:

The method `evaluate(_ trust: SecTrust, forHost host: String)` (in the class `PublicKeysTrustEvaluator`) throws different kind of error based on certain conditions. One of the Boolean condition is `pinnedKeysInServerKeys`. It checks for pinned keys in serverKeys using for-loop. However, this can be improved by using the Swift `contains(_:)` [method.](https://developer.apple.com/documentation/swift/array/contains(_:)) This makes the code more readable and concise.

<!-- Highlight any new functionality. -->
Performance wise I don't think there is much improvement. But it makes the code more readable.
### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
Since this was just a minor improvement to the existing code, I didn't add new test cases. However, I ran all test cases and checked my code.

## Notes
- I was thinking to even shorten the code by this:
`return trust.af.publicKeys.contains(where: { keys.contains($0) }) ` but I am not sure if this is more readable.

- This is my first open source contribution to any project. Please let me know your feedback on this.

- Let's make Alamofire even better. 🚀 