### PR TITLE
Fixed the Xcode14.3 warning message for Heterogenous collection in `ParameterEncodingTests.swift`

### DIFF
--- a/Tests/ParameterEncodingTests.swift
+++ b/Tests/ParameterEncodingTests.swift
@@ -153,7 +153,7 @@ final class URLParameterEncodingTestCase: ParameterEncodingTestCase {
 
     func testURLParameterEncodeStringKeyArrayValueParameter() throws {
         // Given
-        let parameters = ["foo": ["a", 1, true]]
+        let parameters: [String: [Any]] = ["foo": ["a", 1, true]]
 
         // When
         let urlRequest = try encoding.encode(urlRequest, with: parameters)
@@ -165,7 +165,7 @@ final class URLParameterEncodingTestCase: ParameterEncodingTestCase {
     func testURLParameterEncodeArrayNestedDictionaryValueParameterWithIndex() throws {
         // Given
         let encoding = URLEncoding(arrayEncoding: .indexInBrackets)
-        let parameters = ["foo": ["a", 1, true, ["bar": 2], ["qux": 3], ["quy": ["quz": 3]]]]
+        let parameters: [String: [Any]] = ["foo": ["a", 1, true, ["bar": 2], ["qux": 3], ["quy": ["quz": 3]]]]
 
         // When
         let urlRequest = try encoding.encode(urlRequest, with: parameters)
@@ -177,7 +177,7 @@ final class URLParameterEncodingTestCase: ParameterEncodingTestCase {
     func testURLParameterEncodeStringKeyArrayValueParameterWithoutBrackets() throws {
         // Given
         let encoding = URLEncoding(arrayEncoding: .noBrackets)
-        let parameters = ["foo": ["a", 1, true]]
+        let parameters: [String: [Any]] = ["foo": ["a", 1, true]]
 
         // When
         let urlRequest = try encoding.encode(urlRequest, with: parameters)
@@ -191,7 +191,7 @@ final class URLParameterEncodingTestCase: ParameterEncodingTestCase {
         let encoding = URLEncoding(arrayEncoding: .custom { key, index in
             "\(key).\(index + 1)"
         })
-        let parameters = ["foo": ["a", 1, true]]
+        let parameters: [String: [Any]] = ["foo": ["a", 1, true]]
 
         // When
         let urlRequest = try encoding.encode(urlRequest, with: parameters)


### PR DESCRIPTION
- Fixed the warning in Xcode 14.3 `Heterogeneous collection literal could only be inferred to '[Any]'; add explicit type annotation if this is intentional`

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->

This PR intends to fix the warning message that Xcode 14.3 generates in `ParameterEncodingTests.swift`

![AlamofireSS](https://github.com/Alamofire/Alamofire/assets/43279178/31240c4b-41ad-4993-a1a0-cb0487a55b3b)


<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
In case of heterogenous collection, compiler expects to explicitly specify the type to `[Any]`. So I added the type of parameter explicitly in the definition of the `parameters` variable.
<!-- Highlight any new functionality. -->

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
This just fixes minor compiler warnings. I don't think this requires any tests.