### PR TITLE
Update URL Conversion Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
     name: "Test Old iOS"
     runs-on: firebreak
     env:
-      DEVELOPER_DIR: "/Applications/Xcode_14.2.app/Contents/Developer"
+      DEVELOPER_DIR: "/Applications/Xcode_14.3.app/Contents/Developer"
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -135,11 +135,30 @@ jobs:
         run: brew install alamofire/alamofire/firewalk || brew upgrade alamofire/alamofire/firewalk && firewalk &
       - name: ${{ matrix.name }}
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "${{ matrix.destination }}" -testPlan "${{ matrix.testPlan }}" clean test | xcpretty
+  Beta:
+    name: "Test Beta iOS"
+    runs-on: firebreak
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode_15.0.app/Contents/Developer"
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - destination: "OS=17.0,name=iPhone 14 Pro"
+            name: "iOS 17.0"
+            testPlan: "iOS"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Firewalk
+        run: brew install alamofire/alamofire/firewalk || brew upgrade alamofire/alamofire/firewalk && firewalk &
+      - name: ${{ matrix.name }}
+        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "${{ matrix.destination }}" -testPlan "${{ matrix.testPlan }}" clean test | xcpretty
   tvOS:
     name: Test Old tvOS
     runs-on: firebreak
     env:
-      DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_14.3.app/Contents/Developer
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -164,7 +183,7 @@ jobs:
     name: Test Old watchOS
     runs-on: firebreak
     env:
-      DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_14.3.app/Contents/Developer
     timeout-minutes: 10
     strategy:
       fail-fast: false

--- a/Alamofire.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Alamofire.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -498,7 +498,7 @@ final class ClosureAPIConcurrencyTests: BaseTestCase {
                      tasks: [URLSessionTask],
                      descriptions: [String],
                      response: AFDataResponse<TestResponse>)
-        #if swift(>=5.9)
+        #if swift(>=5.10)
         values = try! await (uploadProgress, downloadProgress, requests, tasks, descriptions, response)
         #else
         values = await (uploadProgress, downloadProgress, requests, tasks, descriptions, response)

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -531,7 +531,7 @@ final class SessionTestCase: BaseTestCase {
     func testThatDataRequestWithInvalidURLStringThrowsResponseHandlerError() {
         // Given
         let session = Session()
-        let url = Endpoint().url.absoluteString.appending("/äëïöü")
+        let url = ""
         let expectation = expectation(description: "Request should fail with error")
 
         var response: DataResponse<Data?, AFError>?
@@ -556,7 +556,7 @@ final class SessionTestCase: BaseTestCase {
     func testThatDownloadRequestWithInvalidURLStringThrowsResponseHandlerError() {
         // Given
         let session = Session()
-        let url = Endpoint().url.absoluteString.appending("/äëïöü")
+        let url = ""
         let expectation = expectation(description: "Download should fail with error")
 
         var response: DownloadResponse<URL?, AFError>?
@@ -582,7 +582,7 @@ final class SessionTestCase: BaseTestCase {
     func testThatUploadDataRequestWithInvalidURLStringThrowsResponseHandlerError() {
         // Given
         let session = Session()
-        let url = Endpoint().url.absoluteString.appending("/äëïöü")
+        let url = ""
         let expectation = expectation(description: "Upload should fail with error")
 
         var response: DataResponse<Data?, AFError>?
@@ -607,7 +607,7 @@ final class SessionTestCase: BaseTestCase {
     func testThatUploadFileRequestWithInvalidURLStringThrowsResponseHandlerError() {
         // Given
         let session = Session()
-        let url = Endpoint().url.absoluteString.appending("/äëïöü")
+        let url = ""
         let expectation = expectation(description: "Upload should fail with error")
 
         var response: DataResponse<Data?, AFError>?
@@ -632,7 +632,7 @@ final class SessionTestCase: BaseTestCase {
     func testThatUploadStreamRequestWithInvalidURLStringThrowsResponseHandlerError() {
         // Given
         let session = Session()
-        let url = Endpoint().url.absoluteString.appending("/äëïöü")
+        let url = ""
         let expectation = expectation(description: "Upload should fail with error")
 
         var response: DataResponse<Data?, AFError>?


### PR DESCRIPTION
### Goals :soccer:
This PR updates some failing tests for the first Xcode 15 beta.

### Implementation Details :construction:
In 2023 OSes, `URL` now follows RFC 3986 and automatically encodes URL components with proper escaping. This reduces the cases where strings can't properly be converted to `URL`s automatically, so new test values had to be found. Using an empty string brings back the old behavior.

> Fixed: For apps linked on or after iOS 17 and aligned OS versions, URL parsing has updated from the obsolete RFC 1738/1808 parsing to the same RFC 3986 parsing as URLComponents. This unifies the parsing behaviors of the URL and URLComponents APIs. Now, URL automatically percent- or IDNA-encodes invalid characters to help create a valid URL.
> To check if a urlString is strictly valid according to the RFC, use the new URL(string: urlString, encodingInvalidCharacters: false) initializer. This init leaves all characters as they are and will return nil if urlString is explicitly invalid. (93368104)
