### PR TITLE
Updated to right usage of #if on Apple platforms

### DIFF
--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -24,6 +24,10 @@
 
 import Foundation
 
+#if canImport(Security)
+import Security
+#endif
+
 /// `AFError` is the error type returned by Alamofire. It encompasses a few different types of errors, each with
 /// their own associated reasons.
 public enum AFError: Error {
@@ -129,7 +133,7 @@ public enum AFError: Error {
         case invalidEmptyResponse(type: String)
     }
 
-    #if !(os(Linux) || os(Windows))
+    #if canImport(Security)
     /// Underlying reason a server trust evaluation error occurred.
     public enum ServerTrustFailureReason {
         /// The output of a server trust evaluation.
@@ -211,7 +215,7 @@ public enum AFError: Error {
     case responseValidationFailed(reason: ResponseValidationFailureReason)
     /// Response serialization failed.
     case responseSerializationFailed(reason: ResponseSerializationFailureReason)
-    #if !(os(Linux) || os(Windows))
+    #if canImport(Security)
     /// `ServerTrustEvaluating` instance threw an error during trust evaluation.
     case serverTrustEvaluationFailed(reason: ServerTrustFailureReason)
     #endif
@@ -314,7 +318,7 @@ extension AFError {
         return false
     }
 
-    #if !(os(Linux) || os(Windows))
+    #if canImport(Security)
     /// Returns whether the instance is `.serverTrustEvaluationFailed`. When `true`, the `underlyingError` property will
     /// contain the associated value.
     public var isServerTrustEvaluationError: Bool {
@@ -393,7 +397,7 @@ extension AFError {
             return reason.underlyingError
         case let .responseSerializationFailed(reason):
             return reason.underlyingError
-        #if !(os(Linux) || os(Windows))
+        #if canImport(Security)
         case let .serverTrustEvaluationFailed(reason):
             return reason.underlyingError
         #endif
@@ -451,7 +455,7 @@ extension AFError {
         return destination
     }
 
-    #if !(os(Linux) || os(Windows))
+    #if canImport(Security)
     /// The download resume data of any underlying network error. Only produced by `DownloadRequest`s.
     public var downloadResumeData: Data? {
         (underlyingError as? URLError)?.userInfo[NSURLSessionDownloadTaskResumeData] as? Data
@@ -610,7 +614,7 @@ extension AFError.ResponseSerializationFailureReason {
     }
 }
 
-#if !(os(Linux) || os(Windows))
+#if canImport(Security)
 extension AFError.ServerTrustFailureReason {
     var output: AFError.ServerTrustFailureReason.Output? {
         switch self {
@@ -688,7 +692,7 @@ extension AFError: LocalizedError {
             """
         case let .sessionInvalidated(error):
             return "Session was invalidated with error: \(error?.localizedDescription ?? "No description.")"
-        #if !(os(Linux) || os(Windows))
+        #if canImport(Security)
         case let .serverTrustEvaluationFailed(reason):
             return "Server trust evaluation failed due to reason: \(reason.localizedDescription)"
         #endif
@@ -822,7 +826,7 @@ extension AFError.ResponseValidationFailureReason {
     }
 }
 
-#if !(os(Linux) || os(Windows))
+#if canImport(Security)
 extension AFError.ServerTrustFailureReason {
     var localizedDescription: String {
         switch self {

--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -24,10 +24,12 @@
 
 import Foundation
 
+#if canImport(Darwin)
 #if os(iOS) || os(watchOS) || os(tvOS)
 import MobileCoreServices
-#elseif os(macOS)
+#else
 import CoreServices
+#endif
 #endif
 
 /// Constructs `multipart/form-data` for uploads within an HTTP or HTTPS body. There are currently two ways to encode
@@ -583,7 +585,7 @@ extension MultipartFormData {
     // MARK: - Private - Mime Type
 
     private func mimeType(forPathExtension pathExtension: String) -> String {
-        #if !(os(Linux) || os(Windows))
+        #if canImport(Darwin)
         if
             let id = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, pathExtension as CFString, nil)?.takeRetainedValue(),
             let contentType = UTTypeCopyPreferredTagWithClass(id, kUTTagClassMIMEType)?.takeRetainedValue() {

--- a/Source/NetworkReachabilityManager.swift
+++ b/Source/NetworkReachabilityManager.swift
@@ -22,7 +22,7 @@
 //  THE SOFTWARE.
 //
 
-#if !(os(watchOS) || os(Linux) || os(Windows))
+#if canImport(SystemConfiguration)
 
 import Foundation
 import SystemConfiguration

--- a/Source/Protected.swift
+++ b/Source/Protected.swift
@@ -55,7 +55,7 @@ extension NSLock: Lock {}
 
 #endif
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if canImport(Darwin)
 /// An `os_unfair_lock` wrapper.
 final class UnfairLock: Lock {
     private let unfairLock: os_unfair_lock_t
@@ -84,7 +84,7 @@ final class UnfairLock: Lock {
 @propertyWrapper
 @dynamicMemberLookup
 final class Protected<T> {
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    #if canImport(Darwin)
     private let lock = UnfairLock()
     #elseif os(Linux) || os(Windows)
     private let lock = NSLock()

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1315,7 +1315,7 @@ public final class DataStreamRequest: Request {
 
     func didReceive(data: Data) {
         $streamMutableState.write { state in
-            #if !(os(Linux) || os(Windows))
+            #if canImport(Darwin)
             if let stream = state.outputStream {
                 underlyingQueue.async {
                     var bytes = Array(data)
@@ -1356,7 +1356,7 @@ public final class DataStreamRequest: Request {
         return self
     }
 
-    #if !(os(Linux) || os(Windows))
+    #if canImport(Darwin)
     /// Produces an `InputStream` that receives the `Data` received by the instance.
     ///
     /// - Note: The `InputStream` produced by this method must have `open()` called before being able to read `Data`.
@@ -1554,7 +1554,7 @@ public class DownloadRequest: Request {
     ///
     /// - Note: For more information about `resumeData`, see [Apple's documentation](https://developer.apple.com/documentation/foundation/urlsessiondownloadtask/1411634-cancel).
     public var resumeData: Data? {
-        #if !(os(Linux) || os(Windows))
+        #if canImport(Darwin)
         return $mutableDownloadState.resumeData ?? error?.downloadResumeData
         #else
         return $mutableDownloadState.resumeData

--- a/Source/ServerTrustEvaluation.swift
+++ b/Source/ServerTrustEvaluation.swift
@@ -48,7 +48,7 @@ open class ServerTrustManager {
         self.evaluators = evaluators
     }
 
-    #if !(os(Linux) || os(Windows))
+    #if canImport(Security)
     /// Returns the `ServerTrustEvaluating` value for the given host, if one is set.
     ///
     /// By default, this method will return the policy that perfectly matches the given host. Subclasses could override
@@ -91,7 +91,7 @@ public protocol ServerTrustEvaluating {
 
 // MARK: - Server Trust Evaluators
 
-#if !(os(Linux) || os(Windows))
+#if canImport(Security)
 /// An evaluator which uses the default server trust evaluation while allowing you to control whether to validate the
 /// host provided by the challenge. Applications are encouraged to always validate the host in production environments
 /// to guarantee the validity of the server's certificate chain.

--- a/Source/SessionDelegate.swift
+++ b/Source/SessionDelegate.swift
@@ -94,7 +94,7 @@ extension SessionDelegate: URLSessionTaskDelegate {
         case NSURLAuthenticationMethodHTTPBasic, NSURLAuthenticationMethodHTTPDigest, NSURLAuthenticationMethodNTLM,
              NSURLAuthenticationMethodNegotiate:
             evaluation = attemptCredentialAuthentication(for: challenge, belongingTo: task)
-        #if !(os(Linux) || os(Windows))
+        #if canImport(Security)
         case NSURLAuthenticationMethodServerTrust:
             evaluation = attemptServerTrustAuthentication(with: challenge)
         case NSURLAuthenticationMethodClientCertificate:
@@ -111,7 +111,7 @@ extension SessionDelegate: URLSessionTaskDelegate {
         completionHandler(evaluation.disposition, evaluation.credential)
     }
 
-    #if !(os(Linux) || os(Windows))
+    #if canImport(Security)
     /// Evaluates the server trust `URLAuthenticationChallenge` received.
     ///
     /// - Parameter challenge: The `URLAuthenticationChallenge`.

--- a/Tests/AFError+AlamofireTests.swift
+++ b/Tests/AFError+AlamofireTests.swift
@@ -335,7 +335,7 @@ extension AFError.ResponseValidationFailureReason {
 
 // MARK: -
 
-#if !(os(Linux) || os(Windows))
+#if canImport(Security)
 extension AFError.ServerTrustFailureReason {
     var isNoRequiredEvaluator: Bool {
         if case .noRequiredEvaluator = self { return true }

--- a/Tests/AuthenticationInterceptorTests.swift
+++ b/Tests/AuthenticationInterceptorTests.swift
@@ -289,7 +289,7 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
 
     // MARK: - Tests - Retry
 
-    #if !(os(Linux) || os(Windows)) // URLRequest to /invalid/path is a fatal error.
+    #if canImport(Darwin) // URLRequest to /invalid/path is a fatal error.
     func testThatInterceptorDoesNotRetryWithoutResponse() {
         // Given
         let credential = TestCredential()

--- a/Tests/DataStreamTests.swift
+++ b/Tests/DataStreamTests.swift
@@ -321,7 +321,7 @@ final class DataStreamTests: BaseTestCase {
         XCTAssertNil(decodingError)
     }
 
-    #if !(os(Linux) || os(Windows))
+    #if canImport(Darwin)
     func testThatDataStreamRequestProducesWorkingInputStream() {
         // Given
         let expect = expectation(description: "stream complete")

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -557,7 +557,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
 
         XCTAssertNotNil(response?.resumeData)
         XCTAssertNotNil(download.resumeData)
-        #if !(os(Linux) || os(Windows))
+        #if canImport(Darwin)
         XCTAssertNotNil(download.error?.downloadResumeData)
         XCTAssertEqual(download.error?.downloadResumeData, response?.resumeData)
         #endif

--- a/Tests/NetworkReachabilityManagerTests.swift
+++ b/Tests/NetworkReachabilityManagerTests.swift
@@ -22,7 +22,7 @@
 //  THE SOFTWARE.
 //
 
-#if canImport(SytemConfiguration)
+#if canImport(SystemConfiguration)
 
 @testable import Alamofire
 import Foundation

--- a/Tests/ServerTrustEvaluatorTests.swift
+++ b/Tests/ServerTrustEvaluatorTests.swift
@@ -22,7 +22,7 @@
 //  THE SOFTWARE.
 //
 
-#if !(os(Linux) || os(Windows))
+#if canImport(Security)
 
 import Alamofire
 import Foundation

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -22,7 +22,7 @@
 //  THE SOFTWARE.
 //
 
-#if !(os(Linux) || os(Windows))
+#if canImport(Security)
 
 import Alamofire
 import Foundation


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

The goals here is to improve the right usage of `#if` statements on Apple platforms.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

This #3738 can be improved to guarantee a better compilation conditions by using the correct framework related to each piece of code. After some revision, I found that Alamofire uses `!(os(Linux) || os(Windows))` which is not a great solution. So, depending on the context of each code updated, I change these `#if` to `canImport(Darwin)` or `canImport(Security)`.

Also, it isn't necessary to add on the `@available` and `#available` the `xrOS 1.0`. This is some Swift compiler bug since it chose the right branch. You can check [here](https://github.com/apple/swift-nio-ssl/pull/436#event-9605890831).

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

I didn't implement any new feature.