### PR TITLE
Change xrOS platform to visionOS

### DIFF
--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -550,7 +550,7 @@ extension MultipartFormData {
 
     private func mimeType(forPathExtension pathExtension: String) -> String {
         #if swift(>=5.9)
-        if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, xrOS 1, *) {
+        if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, visionOS 1, *) {
             return UTType(filenameExtension: pathExtension)?.preferredMIMEType ?? "application/octet-stream"
         } else {
             if

--- a/Source/ServerTrustEvaluation.swift
+++ b/Source/ServerTrustEvaluation.swift
@@ -182,7 +182,7 @@ public final class RevocationTrustEvaluator: ServerTrustEvaluating {
         }
 
         #if swift(>=5.9)
-        if #available(iOS 12, macOS 10.14, tvOS 12, watchOS 5, xrOS 1, *) {
+        if #available(iOS 12, macOS 10.14, tvOS 12, watchOS 5, visionOS 1, *) {
             try trust.af.evaluate(afterApplying: SecPolicy.af.revocation(options: options))
         } else {
             try trust.af.validate(policy: SecPolicy.af.revocation(options: options)) { status, result in
@@ -607,7 +607,7 @@ extension AlamofireExtension where ExtendedType == SecTrust {
     /// The `SecCertificate`s contained in `self`.
     public var certificates: [SecCertificate] {
         #if swift(>=5.9)
-        if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, xrOS 1, *) {
+        if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, visionOS 1, *) {
             return (SecTrustCopyCertificateChain(type) as? [SecCertificate]) ?? []
         } else {
             return (0..<SecTrustGetCertificateCount(type)).compactMap { index in
@@ -640,7 +640,7 @@ extension AlamofireExtension where ExtendedType == SecTrust {
     /// - Throws: An `AFError.serverTrustEvaluationFailed` instance with a `.defaultEvaluationFailed` reason.
     public func performDefaultValidation(forHost host: String) throws {
         #if swift(>=5.9)
-        if #available(iOS 12, macOS 10.14, tvOS 12, watchOS 5, xrOS 1, *) {
+        if #available(iOS 12, macOS 10.14, tvOS 12, watchOS 5, visionOS 1, *) {
             try evaluate(afterApplying: SecPolicy.af.default)
         } else {
             try validate(policy: SecPolicy.af.default) { status, result in
@@ -665,7 +665,7 @@ extension AlamofireExtension where ExtendedType == SecTrust {
     /// - Throws:         An `AFError.serverTrustEvaluationFailed` instance with a `.defaultEvaluationFailed` reason.
     public func performValidation(forHost host: String) throws {
         #if swift(>=5.9)
-        if #available(iOS 12, macOS 10.14, tvOS 12, watchOS 5, xrOS 1, *) {
+        if #available(iOS 12, macOS 10.14, tvOS 12, watchOS 5, visionOS 1, *) {
             try evaluate(afterApplying: SecPolicy.af.hostname(host))
         } else {
             try validate(policy: SecPolicy.af.hostname(host)) { status, result in
@@ -741,7 +741,7 @@ extension AlamofireExtension where ExtendedType == SecCertificate {
         guard let createdTrust = trust, trustCreationStatus == errSecSuccess else { return nil }
 
         #if swift(>=5.9)
-        if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, xrOS 1, *) {
+        if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, visionOS 1, *) {
             return SecTrustCopyKey(createdTrust)
         } else {
             return SecTrustCopyPublicKey(createdTrust)

--- a/Tests/ServerTrustEvaluatorTests.swift
+++ b/Tests/ServerTrustEvaluatorTests.swift
@@ -156,7 +156,7 @@ extension SecTrust {
     /// Evaluates `self` and returns `true` if the evaluation succeeds with a value of `.unspecified` or `.proceed`.
     var isValid: Bool {
         #if swift(>=5.9)
-        if #available(iOS 12, macOS 10.14, tvOS 12, watchOS 5, xrOS 1, *) {
+        if #available(iOS 12, macOS 10.14, tvOS 12, watchOS 5, visionOS 1, *) {
             return Result { try af.evaluate() }.isSuccess
         } else {
             return Result { try af.validate { _, _ in TrustError.invalid } }.isSuccess

--- a/Tests/SessionDelegateTests.swift
+++ b/Tests/SessionDelegateTests.swift
@@ -26,6 +26,7 @@
 import Foundation
 import XCTest
 
+@MainActor
 final class SessionDelegateTestCase: BaseTestCase {
     // MARK: - Tests - Redirects
 
@@ -115,10 +116,10 @@ final class SessionDelegateTestCase: BaseTestCase {
     func testThatAppropriateNotificationsAreCalledWithRequestForDataRequest() {
         // Given
         let session = Session(startRequestsImmediately: false)
-        var resumedRequest: Request?
-        var resumedTaskRequest: Request?
-        var completedTaskRequest: Request?
-        var completedRequest: Request?
+        let resumedRequest = Protected<Request?>(nil)
+        let resumedTaskRequest = Protected<Request?>(nil)
+        let completedTaskRequest = Protected<Request?>(nil)
+        let completedRequest = Protected<Request?>(nil)
         var requestResponse: DataResponse<Data?, AFError>?
         let expect = expectation(description: "request should complete")
 
@@ -130,25 +131,25 @@ final class SessionDelegateTestCase: BaseTestCase {
         expectation(forNotification: Request.didResumeNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
-            resumedRequest = notification.request
+            resumedRequest.write { $0 = notification.request }
             return true
         }
         expectation(forNotification: Request.didResumeTaskNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
-            resumedTaskRequest = notification.request
+            resumedTaskRequest.write { $0 = notification.request }
             return true
         }
         expectation(forNotification: Request.didCompleteTaskNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
-            completedTaskRequest = notification.request
+            completedTaskRequest.write { $0 = notification.request }
             return true
         }
         expectation(forNotification: Request.didFinishNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
-            completedRequest = notification.request
+            completedRequest.write { $0 = notification.request }
             return true
         }
 
@@ -161,18 +162,18 @@ final class SessionDelegateTestCase: BaseTestCase {
         XCTAssertNotNil(resumedTaskRequest)
         XCTAssertNotNil(completedTaskRequest)
         XCTAssertNotNil(completedRequest)
-        XCTAssertEqual(resumedRequest, completedRequest)
-        XCTAssertEqual(resumedTaskRequest, completedTaskRequest)
+        XCTAssertEqual(resumedRequest.wrappedValue, completedRequest.wrappedValue)
+        XCTAssertEqual(resumedTaskRequest.wrappedValue, completedTaskRequest.wrappedValue)
         XCTAssertEqual(requestResponse?.response?.statusCode, 200)
     }
 
     func testThatDidCompleteNotificationIsCalledWithRequestForDownloadRequests() {
         // Given
         let session = Session(startRequestsImmediately: false)
-        var resumedRequest: Request?
-        var resumedTaskRequest: Request?
-        var completedTaskRequest: Request?
-        var completedRequest: Request?
+        let resumedRequest = Protected<Request?>(nil)
+        let resumedTaskRequest = Protected<Request?>(nil)
+        let completedTaskRequest = Protected<Request?>(nil)
+        let completedRequest = Protected<Request?>(nil)
         var requestResponse: DownloadResponse<URL?, AFError>?
         let expect = expectation(description: "request should complete")
 
@@ -184,25 +185,25 @@ final class SessionDelegateTestCase: BaseTestCase {
         expectation(forNotification: Request.didResumeNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
-            resumedRequest = notification.request
+            resumedRequest.write { $0 = notification.request }
             return true
         }
         expectation(forNotification: Request.didResumeTaskNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
-            resumedTaskRequest = notification.request
+            resumedTaskRequest.write { $0 = notification.request }
             return true
         }
         expectation(forNotification: Request.didCompleteTaskNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
-            completedTaskRequest = notification.request
+            completedTaskRequest.write { $0 = notification.request }
             return true
         }
         expectation(forNotification: Request.didFinishNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
-            completedRequest = notification.request
+            completedRequest.write { $0 = notification.request }
             return true
         }
 
@@ -215,8 +216,8 @@ final class SessionDelegateTestCase: BaseTestCase {
         XCTAssertNotNil(resumedTaskRequest)
         XCTAssertNotNil(completedTaskRequest)
         XCTAssertNotNil(completedRequest)
-        XCTAssertEqual(resumedRequest, completedRequest)
-        XCTAssertEqual(resumedTaskRequest, completedTaskRequest)
+        XCTAssertEqual(resumedRequest.wrappedValue, completedRequest.wrappedValue)
+        XCTAssertEqual(resumedTaskRequest.wrappedValue, completedTaskRequest.wrappedValue)
         XCTAssertEqual(requestResponse?.response?.statusCode, 200)
     }
 }

--- a/Tests/SessionDelegateTests.swift
+++ b/Tests/SessionDelegateTests.swift
@@ -26,7 +26,6 @@
 import Foundation
 import XCTest
 
-@MainActor
 final class SessionDelegateTestCase: BaseTestCase {
     // MARK: - Tests - Redirects
 


### PR DESCRIPTION
### Goals :soccer:
This PR updates the `xrOS` platform to `visionOS` now that the Xcode betas know about that platform.

