### PR TITLE
Add Separate Response Hooks

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -10,7 +10,6 @@
 
 # format options
 
---closingparen same-line
 --commas inline
 --comments indent
 --decimalgrouping 3,5

--- a/Documentation/AdvancedUsage.md
+++ b/Documentation/AdvancedUsage.md
@@ -435,9 +435,64 @@ AF.request(...)
     }
 ```
 
-#### Response
+#### `HTTPURLResponse`s
 
-Each `Request` may have an `HTTPURLResponse` value available once the request is complete. This value is only available if the request wasn’t cancelled and didn’t fail to make the network request. Additionally, if the request is retried, only the _last_ response is available. Intermediate responses can be derived from the `URLSessionTask`s in the `tasks` property.
+Alamofire receives `HTTPURLResponse` values from its underlying `URLSession` as the session starts the connection to the server. These values can be received in an `onHTTPResponse` closure and used to determine whether the request should continue or be cancelled. Both `DataRequest` / `UploadRequest` and `DataStreamRequest` provide these hooks. 
+
+In the case of `DataStreamRequest`, this event can be used in conjunction with the stream handlers to parse `HTTPURLResponse`s as part of the stream handling. To guarantee proper event ordering in that case, ensure the same `DispatchQueue` is used for both APIs. By default both APIs use `.main` for the completion handler, so this should only be a concern if you customize the queue used in either case.
+
+In the case of multiple `.onHTTPResponse` calls on a request, only the last one will be called.
+
+In it's simplest form `onHTTPResponse` simply provides the `HTTPURLResponse` value.
+
+```swift
+AF.request(...)
+    .onHTTPResponse { response in
+        print(response)
+    }
+```
+
+If control over the future of the request is desired, a completion handler value is provided which returns a `Request.ResponseDisposition` value.
+
+```swift
+AF.request(...)
+    .onHTTPResponse { response, completionHandler in
+        print(response)
+        completionHandler(.allow)
+    }
+```
+
+> The `completionHandler` MUST be called otherwise the request will hang until it times out.
+
+The `completionHandler` can also be used to cancel the request. This acts much like `cancel()` being called on the request itself.
+
+```swift
+AF.request(...)
+    .onHTTPResponse { response, completionHandler in
+        print(response)
+        completionHandler(.cancel)
+    }
+```
+
+Additionally, there are forms of both versions of `onHTTPResponse` available which provide `async` closures, allowing the use of `await` in the body. These versions are available on Swift 5.7 and above.
+
+```swift
+AF.request(...)
+    .onHTTPResponse { response in
+        await someAsyncMethod()
+        return .allow
+    }
+```
+
+Finally, an async stream of `HTTPURLResponse` values can also be used.
+
+```swift
+let responses = AF.request(...).httpResponses()
+
+for await response in responses {
+    print(response)
+}
+```
 
 #### `URLSessionTaskMetrics`
 

--- a/Source/Concurrency.swift
+++ b/Source/Concurrency.swift
@@ -195,6 +195,7 @@ extension DataRequest {
     ///              so any synchronous calls in it will execute in that context.
     ///
     /// - Returns:   The instance.
+    @_disfavoredOverload
     @discardableResult
     public func onHTTPResponse(
         perform handler: @escaping @Sendable (_ response: HTTPURLResponse) async -> ResponseDisposition
@@ -714,6 +715,7 @@ extension DataStreamRequest {
     ///              so any synchronous calls in it will execute in that context.
     ///
     /// - Returns:   The instance.
+    @_disfavoredOverload
     @discardableResult
     public func onHTTPResponse(on queue: DispatchQueue = .main, perform handler: @escaping @Sendable (HTTPURLResponse) async -> ResponseDisposition) -> Self {
         onHTTPResponse { response, completionHandler in

--- a/Source/Concurrency.swift
+++ b/Source/Concurrency.swift
@@ -717,8 +717,8 @@ extension DataStreamRequest {
     /// - Returns:   The instance.
     @_disfavoredOverload
     @discardableResult
-    public func onHTTPResponse(on queue: DispatchQueue = .main, perform handler: @escaping @Sendable (HTTPURLResponse) async -> ResponseDisposition) -> Self {
-        onHTTPResponse { response, completionHandler in
+    public func onHTTPResponse(perform handler: @escaping @Sendable (HTTPURLResponse) async -> ResponseDisposition) -> Self {
+        onHTTPResponse(on: underlyingQueue) { response, completionHandler in
             Task {
                 let disposition = await handler(response)
                 completionHandler(disposition)
@@ -740,7 +740,7 @@ extension DataStreamRequest {
     ///
     /// - Returns:   The instance.
     @discardableResult
-    public func onHTTPResponse(on queue: DispatchQueue = .main, perform handler: @escaping @Sendable (HTTPURLResponse) async -> Void) -> Self {
+    public func onHTTPResponse(perform handler: @escaping @Sendable (HTTPURLResponse) async -> Void) -> Self {
         onHTTPResponse { response in
             await handler(response)
             return .allow

--- a/Source/Concurrency.swift
+++ b/Source/Concurrency.swift
@@ -181,6 +181,7 @@ extension DataRequest {
         }
     }
 
+    #if swift(>=5.7)
     /// Sets an async closure returning a `Request.ResponseDisposition`, called whenever the `DataRequest` produces an
     /// `HTTPURLResponse`.
     ///
@@ -230,6 +231,7 @@ extension DataRequest {
 
         return self
     }
+    #endif
 
     /// Creates a `DataTask` to `await` a `Data` value.
     ///
@@ -701,6 +703,7 @@ extension DataStreamRequest {
         }
     }
 
+    #if swift(>=5.7)
     /// Sets an async closure returning a `Request.ResponseDisposition`, called whenever the `DataStreamRequest`
     /// produces an `HTTPURLResponse`.
     ///
@@ -748,6 +751,7 @@ extension DataStreamRequest {
 
         return self
     }
+    #endif
 
     /// Creates a `DataStreamTask` used to `await` streams of serialized values.
     ///

--- a/Source/EventMonitor.swift
+++ b/Source/EventMonitor.swift
@@ -69,6 +69,9 @@ public protocol EventMonitor {
 
     // MARK: URLSessionDataDelegate Events
 
+    /// Event called during `URLSessionDataDelegate`'s `urlSession(_:dataTask:didReceive:completionHandler:)` method.
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse)
+
     /// Event called during `URLSessionDataDelegate`'s `urlSession(_:dataTask:didReceive:)` method.
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data)
 
@@ -244,6 +247,7 @@ extension EventMonitor {
                            didFinishCollecting metrics: URLSessionTaskMetrics) {}
     public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {}
     public func urlSession(_ session: URLSession, taskIsWaitingForConnectivity task: URLSessionTask) {}
+    public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse) {}
     public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {}
     public func urlSession(_ session: URLSession,
                            dataTask: URLSessionDataTask,
@@ -378,6 +382,10 @@ public final class CompositeEventMonitor: EventMonitor {
     @available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *)
     public func urlSession(_ session: URLSession, taskIsWaitingForConnectivity task: URLSessionTask) {
         performEvent { $0.urlSession(session, taskIsWaitingForConnectivity: task) }
+    }
+
+    public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse) {
+        performEvent { $0.urlSession(session, dataTask: dataTask, didReceive: response) }
     }
 
     public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
@@ -593,6 +601,9 @@ open class ClosureEventMonitor: EventMonitor {
     /// Closure called on the `urlSession(_:taskIsWaitingForConnectivity:)` event.
     open var taskIsWaitingForConnectivity: ((URLSession, URLSessionTask) -> Void)?
 
+    /// Closure called on the `urlSession(_:dataTask:didReceive:completionHandler:)` event.
+    open var dataTaskDidReceiveResponse: ((URLSession, URLSessionDataTask, URLResponse) -> Void)?
+
     /// Closure that receives the `urlSession(_:dataTask:didReceive:)` event.
     open var dataTaskDidReceiveData: ((URLSession, URLSessionDataTask, Data) -> Void)?
 
@@ -739,6 +750,10 @@ open class ClosureEventMonitor: EventMonitor {
     @available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *)
     open func urlSession(_ session: URLSession, taskIsWaitingForConnectivity task: URLSessionTask) {
         taskIsWaitingForConnectivity?(session, task)
+    }
+
+    open func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse) {
+        dataTaskDidReceiveResponse?(session, dataTask, response)
     }
 
     open func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {

--- a/Source/NetworkReachabilityManager.swift
+++ b/Source/NetworkReachabilityManager.swift
@@ -194,7 +194,8 @@ open class NetworkReachabilityManager {
                 let description = weakManager.manager?.flags?.readableDescription ?? "nil"
 
                 return Unmanaged.passRetained(description as CFString)
-            })
+            }
+        )
         let callback: SCNetworkReachabilityCallBack = { _, flags, info in
             guard let info = info else { return }
 

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -939,6 +939,23 @@ public class Request {
     }
 }
 
+extension Request {
+    /// Type indicating how a `DataRequest` or `DataStreamRequest` should proceed after receiving an `HTTPURLResponse`.
+    public enum ResponseDisposition {
+        /// Allow the request to continue normally.
+        case allow
+        /// Cancel the request, similar to calling `cancel()`.
+        case cancel
+
+        var sessionDisposition: URLSession.ResponseDisposition {
+            switch self {
+            case .allow: return .allow
+            case .cancel: return .cancel
+            }
+        }
+    }
+}
+
 // MARK: - Protocol Conformances
 
 extension Request: Equatable {
@@ -1212,6 +1229,15 @@ public class DataRequest: Request {
         return self
     }
 
+    /// Sets a closure called whenever the `DataRequest` produces an `HTTPURLResponse` and providing a completion
+    /// handler to return a `ResponseDisposition` value.
+    ///
+    /// - Parameters:
+    ///   - queue:   `DispatchQueue` on which the closure will be called. `.main` by default.
+    ///   - handler: Closure called when the instance produces an `HTTPURLResponse`. The `completionHandler` provided
+    ///              MUST be called, otherwise the request will never complete.
+    ///
+    /// - Returns:   The instance.
     @discardableResult
     public func onHTTPResponse(
         on queue: DispatchQueue = .main,
@@ -1225,6 +1251,13 @@ public class DataRequest: Request {
         return self
     }
 
+    /// Sets a closure called whenever the `DataRequest` produces an `HTTPURLResponse`.
+    ///
+    /// - Parameters:
+    ///   - queue:   `DispatchQueue` on which the closure will be called. `.main` by default.
+    ///   - handler: Closure called when the instance produces an `HTTPURLResponse`.
+    ///
+    /// - Returns:   The instance.
     @discardableResult
     public func onHTTPResponse(on queue: DispatchQueue = .main,
                                perform handler: @escaping (HTTPURLResponse) -> Void) -> Self {
@@ -1460,6 +1493,15 @@ public final class DataStreamRequest: Request {
     }
     #endif
 
+    /// Sets a closure called whenever the `DataRequest` produces an `HTTPURLResponse` and providing a completion
+    /// handler to return a `ResponseDisposition` value.
+    ///
+    /// - Parameters:
+    ///   - queue:   `DispatchQueue` on which the closure will be called. `.main` by default.
+    ///   - handler: Closure called when the instance produces an `HTTPURLResponse`. The `completionHandler` provided
+    ///              MUST be called, otherwise the request will never complete.
+    ///
+    /// - Returns:   The instance.
     @discardableResult
     public func onHTTPResponse(
         on queue: DispatchQueue = .main,
@@ -1473,6 +1515,13 @@ public final class DataStreamRequest: Request {
         return self
     }
 
+    /// Sets a closure called whenever the `DataRequest` produces an `HTTPURLResponse`.
+    ///
+    /// - Parameters:
+    ///   - queue:   `DispatchQueue` on which the closure will be called. `.main` by default.
+    ///   - handler: Closure called when the instance produces an `HTTPURLResponse`.
+    ///
+    /// - Returns:   The instance.
     @discardableResult
     public func onHTTPResponse(on queue: DispatchQueue = .main,
                                perform handler: @escaping (HTTPURLResponse) -> Void) -> Self {
@@ -2013,16 +2062,3 @@ extension UploadRequest.Uploadable: UploadableConvertible {
 
 /// A type that can be converted to an upload, whether from an `UploadRequest.Uploadable` or `URLRequestConvertible`.
 public protocol UploadConvertible: UploadableConvertible & URLRequestConvertible {}
-
-public enum ResponseDisposition {
-    case allow
-    case cancel
-    case end
-
-    var sessionDisposition: URLSession.ResponseDisposition {
-        switch self {
-        case .allow: return .allow
-        case .cancel, .end: return .cancel
-        }
-    }
-}

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1223,7 +1223,7 @@ public class DataRequest: Request {
     @discardableResult
     public func onResponse(on queue: DispatchQueue = .main,
                            perform handler: @escaping (HTTPURLResponse) -> Void) -> Self {
-        onResponse(on: queue) { response in
+        onResponse(on: queue) { response -> ResponseDisposition in
             handler(response)
             return .allow
         }
@@ -1464,7 +1464,7 @@ public final class DataStreamRequest: Request {
 
     @discardableResult
     public func onResponse(on queue: DispatchQueue = .main, perform handler: @escaping (HTTPURLResponse) -> Void) -> Self {
-        onResponse(on: queue) { response in
+        onResponse(on: queue) { response -> ResponseDisposition in
             handler(response)
             return .allow
         }

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -1238,6 +1238,7 @@ public class DataRequest: Request {
     ///              MUST be called, otherwise the request will never complete.
     ///
     /// - Returns:   The instance.
+    @_disfavoredOverload
     @discardableResult
     public func onHTTPResponse(
         on queue: DispatchQueue = .main,
@@ -1502,6 +1503,7 @@ public final class DataStreamRequest: Request {
     ///              MUST be called, otherwise the request will never complete.
     ///
     /// - Returns:   The instance.
+    @_disfavoredOverload
     @discardableResult
     public func onHTTPResponse(
         on queue: DispatchQueue = .main,

--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -416,7 +416,9 @@ public class Request {
     func didCancel() {
         dispatchPrecondition(condition: .onQueue(underlyingQueue))
 
-        error = error ?? AFError.explicitlyCancelled
+        $mutableState.write { mutableState in
+            mutableState.error = mutableState.error ?? AFError.explicitlyCancelled
+        }
 
         eventMonitor?.requestDidCancel(self)
     }
@@ -1173,6 +1175,7 @@ public class DataRequest: Request {
                 httpResponseHandler.handler(response) { disposition in
                     if disposition == .cancel {
                         self.$mutableState.write { mutableState in
+                            mutableState.state = .cancelled
                             mutableState.error = mutableState.error ?? AFError.explicitlyCancelled
                         }
                     }
@@ -1430,6 +1433,7 @@ public final class DataStreamRequest: Request {
                 httpResponseHandler.handler(response) { disposition in
                     if disposition == .cancel {
                         self.$mutableState.write { mutableState in
+                            mutableState.state = .cancelled
                             mutableState.error = mutableState.error ?? AFError.explicitlyCancelled
                         }
                     }

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -433,6 +433,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
         XCTAssertEqual(datas.count, 2)
     }
 
+    #if swift(>=5.8)
     func testThatDataStreamHasAsyncOnHTTPResponse() async {
         // Given
         let session = stored(Session())
@@ -519,6 +520,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
         XCTAssertTrue(request.isCancelled, "onHTTPResponse cancelled request isCancelled should be true")
         XCTAssertTrue(request.error?.isExplicitlyCancelledError == true, "onHTTPResponse cancelled request error should be explicitly cancelled")
     }
+    #endif
 
     func testThatDataStreamTaskCanStreamStrings() async {
         // Given

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -433,7 +433,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
         XCTAssertEqual(datas.count, 2)
     }
 
-    #if swift(>=5.8)
+    #if swift(>=5.8) && canImport(Darwin)
     func testThatDataStreamHasAsyncOnHTTPResponse() async {
         // Given
         let session = stored(Session())

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -35,6 +35,10 @@ final class DataRequestConcurrencyTests: BaseTestCase {
 
         // When
         let value = try await session.request(.get)
+            .onResponse { response in
+                debugPrint(response)
+                return .cancel
+            }
             .serializingResponse(using: .data)
             .value
 

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -35,10 +35,6 @@ final class DataRequestConcurrencyTests: BaseTestCase {
 
         // When
         let value = try await session.request(.get)
-            .onResponse { response in
-                debugPrint(response)
-                return .cancel
-            }
             .serializingResponse(using: .data)
             .value
 

--- a/Tests/DataStreamTests.swift
+++ b/Tests/DataStreamTests.swift
@@ -28,7 +28,7 @@ import XCTest
 final class DataStreamTests: BaseTestCase {
     func testThatDataCanBeStreamedOnMainQueue() {
         // Given
-        let expectedSize = 10
+        let expectedSize = 5
         var accumulatedData = Data()
         var initialResponse: HTTPURLResponse?
         var response: HTTPURLResponse?
@@ -76,7 +76,7 @@ final class DataStreamTests: BaseTestCase {
         }
 
         // Given
-        let expectedSize = 10
+        let expectedSize = 5
         var accumulatedData = Data()
         var initialResponse: HTTPURLResponse?
         var response: HTTPURLResponse?
@@ -127,7 +127,7 @@ final class DataStreamTests: BaseTestCase {
         }
 
         // Given
-        let expectedSize = 10
+        let expectedSize = 5
         var responses: [TestResponse] = []
         var initialResponse: HTTPURLResponse?
         var response: HTTPURLResponse?

--- a/Tests/DataStreamTests.swift
+++ b/Tests/DataStreamTests.swift
@@ -85,6 +85,7 @@ final class DataStreamTests: BaseTestCase {
         var streamCalled = 0
         let didReceiveResponse = expectation(description: "stream should receive response once")
         let didReceive = expectation(description: "stream should receive once")
+        didReceive.expectedFulfillmentCount = expectedSize
         let didComplete = expectation(description: "stream should complete")
 
         // When
@@ -114,7 +115,7 @@ final class DataStreamTests: BaseTestCase {
 
         // Then
         XCTAssertEqual(response?.statusCode, 200)
-        XCTAssertEqual(streamCalled, 1)
+        XCTAssertEqual(streamCalled, expectedSize)
         XCTAssertEqual(initialResponse, response)
         XCTAssertEqual(accumulatedData.count, expectedSize)
         XCTAssertTrue(streamOnMain)

--- a/Tests/DataStreamTests.swift
+++ b/Tests/DataStreamTests.swift
@@ -348,7 +348,7 @@ final class DataStreamTests: BaseTestCase {
                 }
             }
 
-        wait(for: [firstReceive, firstCompletion], timeout: timeout, enforceOrder: true)
+        wait(for: [onHTTPResponse, firstReceive, firstCompletion], timeout: timeout, enforceOrder: true)
         wait(for: [secondReceive, secondCompletion], timeout: timeout, enforceOrder: true)
 
         // Then

--- a/Tests/DataStreamTests.swift
+++ b/Tests/DataStreamTests.swift
@@ -40,7 +40,7 @@ final class DataStreamTests: BaseTestCase {
 
         // When
         AF.streamRequest(.bytes(expectedSize))
-            .onResponse { response in
+            .onHTTPResponse { response in
                 initialResponse = response
                 didReceiveResponse.fulfill()
             }
@@ -90,7 +90,7 @@ final class DataStreamTests: BaseTestCase {
 
         // When
         AF.streamRequest(.chunked(expectedSize))
-            .onResponse { response in
+            .onHTTPResponse { response in
                 initialResponse = response
                 didReceiveResponse.fulfill()
             }
@@ -142,7 +142,7 @@ final class DataStreamTests: BaseTestCase {
 
         // When
         AF.streamRequest(.payloads(expectedSize))
-            .onResponse { response in
+            .onHTTPResponse { response in
                 initialResponse = response
                 didReceiveResponse.fulfill()
             }
@@ -190,7 +190,7 @@ final class DataStreamTests: BaseTestCase {
 
         // When
         AF.streamRequest(.bytes(expectedSize))
-            .onResponse { response in
+            .onHTTPResponse { response in
                 initialResponse = response
                 didReceiveResponse.fulfill()
             }


### PR DESCRIPTION
### Issue Link :link:
#3401

### Goals :soccer:
This PR adds `onHTTPResponse` closure hooks to `DataRequest` / `UploadRequest` and `DataStreamRequest` to enable the cancellation of requests before data is transferred, requests that need to check response info for later parsing, or peculiar requests that may trigger multiple response callbacks, like MJPEG streams.

### Implementation Details :construction:
Like the other value hooks, this API accepts a single closure. The only unique bit here is that there's second, disfavored, version of the API that allows the user to return `ResponseDisposition` value to cancel or end the request without the body.

### Testing Details :mag:
Streaming tests are being updated to check these events always fire before the other events. More tests are needed around cancellation or ending behavior to ensure that's really possible.
