### PR TITLE
Update Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,12 +293,8 @@ jobs:
       - name: Clone
         uses: actions/checkout@v3
       - name: SPM Windows Build
-        shell: cmd
         run: |
-          cd ${{ github.workspace }}
-          set SDKROOT=%SystemDrive%\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk
-          %SystemDrive%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swift-build.exe --build-tests -c debug -Xlinker /INCREMENTAL:NO -v
-          if not exist .build\x86_64-unknown-windows-msvc\debug\Alamofire.swiftmodule exit 1
+          swift build --build-tests -c debug -Xlinker /INCREMENTAL:NO -v
   CodeQL:
     name: Analyze with CodeQL
     runs-on: macOS-13


### PR DESCRIPTION
Adjust the command for building on Windows.  The installer should take care of the setup of the environment.  The actions setup already refresh the environment on behalf of the user.  This should allow us to avoid requiring resetting the environment.  The `cd` is implicit in the GHA execution.