### PR TITLE
Add Upload Progress Test

### DIFF
--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -565,6 +565,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
     }
 }
 
+#if !canImport(FoundationNetworking) // Avoid when using swift-corelibs-foundation
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class UploadConcurrencyTests: BaseTestCase {
     func testThatDelayedUploadStreamResultsInMultipleProgressValues() async throws {
@@ -652,6 +653,7 @@ final class UploadConcurrencyTests: BaseTestCase {
         XCTAssertEqual(response?.value?.bytes, baseData.count * count)
     }
 }
+#endif
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class ClosureAPIConcurrencyTests: BaseTestCase {

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -566,8 +566,8 @@ final class DataStreamConcurrencyTests: BaseTestCase {
 }
 
 // Avoid when using swift-corelibs-foundation.
-// Older Xcodes don't have async fulfillment.
-#if !canImport(FoundationNetworking) && swift(>=5.7)
+// Only Xcode 14.3+ has async fulfillment.
+#if !canImport(FoundationNetworking) && swift(>=5.8)
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class UploadConcurrencyTests: BaseTestCase {
     func testThatDelayedUploadStreamResultsInMultipleProgressValues() async throws {

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -565,7 +565,9 @@ final class DataStreamConcurrencyTests: BaseTestCase {
     }
 }
 
-#if !canImport(FoundationNetworking) // Avoid when using swift-corelibs-foundation
+// Avoid when using swift-corelibs-foundation.
+// Older Xcodes don't have async fulfillment.
+#if !canImport(FoundationNetworking) && swift(>=5.7)
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class UploadConcurrencyTests: BaseTestCase {
     func testThatDelayedUploadStreamResultsInMultipleProgressValues() async throws {

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -77,6 +77,7 @@ struct Endpoint {
         case responseHeaders
         case status(Int)
         case stream(count: Int)
+        case upload
         case xml
 
         var string: String {
@@ -117,6 +118,8 @@ struct Endpoint {
                 return "/status/\(code)"
             case let .stream(count):
                 return "/stream/\(count)"
+            case .upload:
+                return "/upload"
             case .xml:
                 return "/xml"
             }
@@ -216,6 +219,8 @@ struct Endpoint {
     static func stream(_ count: Int) -> Endpoint {
         Endpoint(path: .stream(count: count))
     }
+
+    static let upload: Endpoint = .init(path: .upload, method: .post, headers: [.contentType("application/octet-stream")])
 
     static var xml: Endpoint {
         Endpoint(path: .xml, headers: [.contentType("application/xml")])
@@ -405,4 +410,8 @@ struct TestParameters: Encodable {
     static let `default` = TestParameters(property: "property")
 
     let property: String
+}
+
+struct UploadResponse: Decodable {
+    let bytes: Int
 }


### PR DESCRIPTION
### Issue Link :link:
#3722

### Goals :soccer:
This PR adds a test to show that intermediate upload progress values are properly received.

One this I noticed here is that, when multiple progress values are issued, it's not guaranteed that there's a final 100% progress value.

### Testing Details :mag:
This test uploads from a stream with a delay between each buffer to ensure that `URLSession` properly issues at least 2 upload progress callbacks.
