### PR TITLE
Move Package to Swift 5.9, Add 5.8 Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,8 +216,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - xcode: "Xcode_14.3"
+          - xcode: "Xcode_15.0"
             runsOn: firebreak
+            name: "macOS 13, SPM 5.9.0 Test"
+          - xcode: "Xcode_14.3"
+            runsOn: macOS-13
             name: "macOS 13, SPM 5.8.0 Test"
           - xcode: "Xcode_14.2"
             runsOn: macOS-12

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.8
 //
 //  Package.swift
 //


### PR DESCRIPTION
### Goals :soccer:
This PR moves the Package.swift to Swift 5.9 and adds an explicit 5.8 version.
