### PR TITLE
Remove @propertyWrapper From Protected

### DIFF
--- a/Source/Combine.swift
+++ b/Source/Combine.swift
@@ -91,23 +91,22 @@ public struct DataResponsePublisher<Value>: Publisher {
         where Downstream.Input == Output {
         typealias Failure = Downstream.Failure
 
-        @Protected
-        private var downstream: Downstream?
+        private let downstream: Protected<Downstream?>
         private let request: DataRequest
         private let responseHandler: Handler
 
         init(request: DataRequest, responseHandler: @escaping Handler, downstream: Downstream) {
             self.request = request
             self.responseHandler = responseHandler
-            self.downstream = downstream
+            self.downstream = Protected(downstream)
         }
 
         func request(_ demand: Subscribers.Demand) {
             assert(demand > 0)
 
-            guard let downstream = downstream else { return }
+            guard let downstream = downstream.read({ $0 }) else { return }
 
-            self.downstream = nil
+            self.downstream.write(nil)
             responseHandler { response in
                 _ = downstream.receive(response)
                 downstream.receive(completion: .finished)
@@ -116,7 +115,7 @@ public struct DataResponsePublisher<Value>: Publisher {
 
         func cancel() {
             request.cancel()
-            downstream = nil
+            downstream.write(nil)
         }
     }
 }
@@ -312,23 +311,22 @@ public struct DataStreamPublisher<Value>: Publisher {
         where Downstream.Input == Output {
         typealias Failure = Downstream.Failure
 
-        @Protected
-        private var downstream: Downstream?
+        private let downstream: Protected<Downstream?>
         private let request: DataStreamRequest
         private let streamHandler: Handler
 
         init(request: DataStreamRequest, streamHandler: @escaping Handler, downstream: Downstream) {
             self.request = request
             self.streamHandler = streamHandler
-            self.downstream = downstream
+            self.downstream = Protected(downstream)
         }
 
         func request(_ demand: Subscribers.Demand) {
             assert(demand > 0)
 
-            guard let downstream = downstream else { return }
+            guard let downstream = downstream.read({ $0 }) else { return }
 
-            self.downstream = nil
+            self.downstream.write(nil)
             streamHandler { stream in
                 _ = downstream.receive(stream)
                 if case .complete = stream.event {
@@ -339,7 +337,7 @@ public struct DataStreamPublisher<Value>: Publisher {
 
         func cancel() {
             request.cancel()
-            downstream = nil
+            downstream.write(nil)
         }
     }
 }
@@ -462,23 +460,22 @@ public struct DownloadResponsePublisher<Value>: Publisher {
         where Downstream.Input == Output {
         typealias Failure = Downstream.Failure
 
-        @Protected
-        private var downstream: Downstream?
+        private let downstream: Protected<Downstream?>
         private let request: DownloadRequest
         private let responseHandler: Handler
 
         init(request: DownloadRequest, responseHandler: @escaping Handler, downstream: Downstream) {
             self.request = request
             self.responseHandler = responseHandler
-            self.downstream = downstream
+            self.downstream = Protected(downstream)
         }
 
         func request(_ demand: Subscribers.Demand) {
             assert(demand > 0)
 
-            guard let downstream = downstream else { return }
+            guard let downstream = downstream.read({ $0 }) else { return }
 
-            self.downstream = nil
+            self.downstream.write(nil)
             responseHandler { response in
                 _ = downstream.receive(response)
                 downstream.receive(completion: .finished)
@@ -487,7 +484,7 @@ public struct DownloadResponsePublisher<Value>: Publisher {
 
         func cancel() {
             request.cancel()
-            downstream = nil
+            downstream.write(nil)
         }
     }
 }

--- a/Source/MultipartUpload.swift
+++ b/Source/MultipartUpload.swift
@@ -28,8 +28,8 @@ import Foundation
 final class MultipartUpload {
     lazy var result = Result { try build() }
 
-    @Protected
-    private(set) var multipartFormData: MultipartFormData
+    private let multipartFormData: Protected<MultipartFormData>
+
     let encodingMemoryThreshold: UInt64
     let request: URLRequestConvertible
     let fileManager: FileManager
@@ -40,13 +40,13 @@ final class MultipartUpload {
         self.encodingMemoryThreshold = encodingMemoryThreshold
         self.request = request
         fileManager = multipartFormData.fileManager
-        self.multipartFormData = multipartFormData
+        self.multipartFormData = Protected(multipartFormData)
     }
 
     func build() throws -> UploadRequest.Uploadable {
         let uploadable: UploadRequest.Uploadable
-        if $multipartFormData.contentLength < encodingMemoryThreshold {
-            let data = try $multipartFormData.read { try $0.encode() }
+        if multipartFormData.contentLength < encodingMemoryThreshold {
+            let data = try multipartFormData.read { try $0.encode() }
 
             uploadable = .data(data)
         } else {
@@ -58,7 +58,7 @@ final class MultipartUpload {
             try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true, attributes: nil)
 
             do {
-                try $multipartFormData.read { try $0.writeEncodedData(to: fileURL) }
+                try multipartFormData.read { try $0.writeEncodedData(to: fileURL) }
             } catch {
                 // Cleanup after attempted write if it fails.
                 try? fileManager.removeItem(at: fileURL)
@@ -76,7 +76,7 @@ extension MultipartUpload: UploadConvertible {
     func asURLRequest() throws -> URLRequest {
         var urlRequest = try request.asURLRequest()
 
-        $multipartFormData.read { multipartFormData in
+        multipartFormData.read { multipartFormData in
             urlRequest.headers.add(.contentType(multipartFormData.contentType))
         }
 

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -1153,7 +1153,7 @@ extension DataStreamRequest {
             }
         }
 
-        $streamMutableState.write { $0.streams.append(parser) }
+        streamMutableState.write { $0.streams.append(parser) }
         appendStreamCompletion(on: queue, stream: stream)
 
         return self
@@ -1195,7 +1195,7 @@ extension DataStreamRequest {
             }
         }
 
-        $streamMutableState.write { $0.streams.append(parser) }
+        streamMutableState.write { $0.streams.append(parser) }
         appendStreamCompletion(on: queue, stream: stream)
 
         return self
@@ -1230,14 +1230,14 @@ extension DataStreamRequest {
             }
         }
 
-        $streamMutableState.write { $0.streams.append(parser) }
+        streamMutableState.write { $0.streams.append(parser) }
         appendStreamCompletion(on: queue, stream: stream)
 
         return self
     }
 
     private func updateAndCompleteIfPossible() {
-        $streamMutableState.write { state in
+        streamMutableState.write { state in
             state.numberOfExecutingStreams -= 1
 
             guard state.numberOfExecutingStreams == 0, !state.enqueuedCompletionEvents.isEmpty else { return }

--- a/Tests/ProtectedTests.swift
+++ b/Tests/ProtectedTests.swift
@@ -35,12 +35,12 @@ final class ProtectedTests: BaseTestCase {
 
         // When
         DispatchQueue.concurrentPerform(iterations: 10_000) { i in
-            _ = protected.wrappedValue
-            protected.wrappedValue = "\(i)"
+            _ = protected.read { $0 }
+            protected.write("\(i)")
         }
 
         // Then
-        XCTAssertNotEqual(protected.wrappedValue, initialValue)
+        XCTAssertNotEqual(protected.read { $0 }, initialValue)
     }
 
     func testThatProtectedAPIIsSafe() {
@@ -51,21 +51,21 @@ final class ProtectedTests: BaseTestCase {
         // When
         DispatchQueue.concurrentPerform(iterations: 10_000) { i in
             _ = protected.read { $0 }
-            protected.write { $0 = "\(i)" }
+            protected.write("\(i)")
         }
 
         // Then
-        XCTAssertNotEqual(protected.wrappedValue, initialValue)
+        XCTAssertNotEqual(protected.read { $0 }, initialValue)
     }
 }
 
 final class ProtectedWrapperTests: BaseTestCase {
-    @Protected var value = "value"
+    let value = Protected("value")
 
     override func setUp() {
         super.setUp()
 
-        value = "value"
+        value.write("value")
     }
 
     func testThatWrappedValuesAreAccessedSafely() {
@@ -75,66 +75,11 @@ final class ProtectedWrapperTests: BaseTestCase {
         // When
         DispatchQueue.concurrentPerform(iterations: 10_000) { i in
             _ = value
-            value = "\(i)"
+            value.write("\(i)")
         }
 
         // Then
         XCTAssertNotEqual(value, initialValue)
-    }
-
-    func testThatProjectedAPIIsAccessedSafely() {
-        // Given
-        let initialValue = value
-
-        // When
-        DispatchQueue.concurrentPerform(iterations: 10_000) { i in
-            _ = $value.read { $0 }
-            $value.write { $0 = "\(i)" }
-        }
-
-        // Then
-        XCTAssertNotEqual(value, initialValue)
-    }
-
-    func testThatDynamicMembersAreAccessedSafely() {
-        // Given
-        let count = Protected<Int>(0)
-
-        // When
-        DispatchQueue.concurrentPerform(iterations: 10_000) { _ in
-            count.wrappedValue = value.count
-        }
-
-        // Then
-        XCTAssertEqual(count.wrappedValue, 5)
-    }
-
-    func testThatDynamicMemberPropertiesAreAccessedSafely() {
-        // Given
-        let string = Protected<String>("test")
-        let count = Protected<Int>(0)
-
-        // When
-        DispatchQueue.concurrentPerform(iterations: 10_000) { _ in
-            count.wrappedValue = string.wrappedValue.count
-        }
-
-        // Then
-        XCTAssertEqual(string.wrappedValue.count, count.wrappedValue)
-    }
-
-    func testThatLocalWrapperInstanceWorkCorrectly() {
-        // Given
-        @Protected var string = "test"
-        @Protected var count = 0
-
-        // When
-        DispatchQueue.concurrentPerform(iterations: 10_000) { _ in
-            count = string.count
-        }
-
-        // Then
-        XCTAssertEqual(string.count, count)
     }
 
     func testThatDynamicMembersAreSetSafely() {
@@ -148,7 +93,7 @@ final class ProtectedWrapperTests: BaseTestCase {
         }
 
         // Then
-        XCTAssertNotEqual(mutable.wrappedValue.value, "value")
+        XCTAssertNotEqual(mutable.value, "value")
     }
 }
 
@@ -176,9 +121,9 @@ final class ProtectedHighContentionTests: BaseTestCase {
 
     // MARK: - Properties
 
-    @Protected var stringContainer = StringContainer()
-    @Protected var stringContainerWrite = StringContainerWriteState()
-    @Protected var stringContainerRead = StringContainerReadState()
+    let stringContainer = Protected(StringContainer())
+    let stringContainerWrite = Protected(StringContainerWriteState())
+    let stringContainerRead = Protected(StringContainerReadState())
 
     func testConcurrentReadWriteBlocks() {
         // Given
@@ -228,7 +173,7 @@ final class ProtectedHighContentionTests: BaseTestCase {
         for _ in 1...totalOperations {
             queue1.async {
                 // Moves the last string element to the beginning of the string array
-                let result: Int = self.$stringContainer.write { stringContainer in
+                let result: Int = self.stringContainer.write { stringContainer in
                     let lastElement = stringContainer.stringArray.removeLast()
                     stringContainer.totalStrings = stringContainer.stringArray.count
 
@@ -238,7 +183,7 @@ final class ProtectedHighContentionTests: BaseTestCase {
                     return stringContainer.totalStrings
                 }
 
-                self.$stringContainerWrite.write { mutableState in
+                self.stringContainerWrite.write { mutableState in
                     mutableState.results.append(result)
 
                     if mutableState.results.count == totalOperations {
@@ -253,7 +198,7 @@ final class ProtectedHighContentionTests: BaseTestCase {
 
             queue2.async {
                 // Moves the first string element to the end of the string array
-                self.$stringContainer.write { stringContainer in
+                self.stringContainer.write { stringContainer in
                     let firstElement = stringContainer.stringArray.remove(at: 0)
                     stringContainer.totalStrings = stringContainer.stringArray.count
 
@@ -261,7 +206,7 @@ final class ProtectedHighContentionTests: BaseTestCase {
                     stringContainer.totalStrings = stringContainer.stringArray.count
                 }
 
-                self.$stringContainerWrite.write { mutableState in
+                self.stringContainerWrite.write { mutableState in
                     mutableState.completedWrites += 1
 
                     if mutableState.completedWrites == totalOperations {
@@ -285,9 +230,9 @@ final class ProtectedHighContentionTests: BaseTestCase {
             queue1.async {
                 // Reads the total string count in the string array
                 // Using the wrapped value (no $) instead of the wrapper itself triggers the thread sanitizer.
-                let result = self.$stringContainer.totalStrings
+                let result = self.stringContainer.totalStrings
 
-                self.$stringContainerRead.write {
+                self.stringContainerRead.write {
                     $0.results1.append(result)
 
                     if $0.results1.count == totalOperations {
@@ -302,9 +247,9 @@ final class ProtectedHighContentionTests: BaseTestCase {
 
             queue2.async {
                 // Reads the total string count in the string array
-                let result = self.$stringContainer.read { $0.totalStrings }
+                let result = self.stringContainer.read { $0.totalStrings }
 
-                self.$stringContainerRead.write {
+                self.stringContainerRead.write {
                     $0.results2.append(result)
 
                     if $0.results2.count == totalOperations {

--- a/Tests/ProtectedTests.swift
+++ b/Tests/ProtectedTests.swift
@@ -70,16 +70,16 @@ final class ProtectedWrapperTests: BaseTestCase {
 
     func testThatWrappedValuesAreAccessedSafely() {
         // Given
-        let initialValue = value
+        let initialValue = value.read { $0 }
 
         // When
         DispatchQueue.concurrentPerform(iterations: 10_000) { i in
-            _ = value
+            _ = value.read { $0 }
             value.write("\(i)")
         }
 
         // Then
-        XCTAssertNotEqual(value, initialValue)
+        XCTAssertNotEqual(value.read { $0 }, initialValue)
     }
 
     func testThatDynamicMembersAreSetSafely() {

--- a/Tests/SessionDelegateTests.swift
+++ b/Tests/SessionDelegateTests.swift
@@ -130,25 +130,25 @@ final class SessionDelegateTestCase: BaseTestCase {
         expectation(forNotification: Request.didResumeNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
-            resumedRequest.write { $0 = notification.request }
+            resumedRequest.write(notification.request)
             return true
         }
         expectation(forNotification: Request.didResumeTaskNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
-            resumedTaskRequest.write { $0 = notification.request }
+            resumedTaskRequest.write(notification.request)
             return true
         }
         expectation(forNotification: Request.didCompleteTaskNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
-            completedTaskRequest.write { $0 = notification.request }
+            completedTaskRequest.write(notification.request)
             return true
         }
         expectation(forNotification: Request.didFinishNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
-            completedRequest.write { $0 = notification.request }
+            completedRequest.write(notification.request)
             return true
         }
 
@@ -161,8 +161,8 @@ final class SessionDelegateTestCase: BaseTestCase {
         XCTAssertNotNil(resumedTaskRequest)
         XCTAssertNotNil(completedTaskRequest)
         XCTAssertNotNil(completedRequest)
-        XCTAssertEqual(resumedRequest.wrappedValue, completedRequest.wrappedValue)
-        XCTAssertEqual(resumedTaskRequest.wrappedValue, completedTaskRequest.wrappedValue)
+        XCTAssertEqual(resumedRequest, completedRequest)
+        XCTAssertEqual(resumedTaskRequest, completedTaskRequest)
         XCTAssertEqual(requestResponse?.response?.statusCode, 200)
     }
 
@@ -184,25 +184,25 @@ final class SessionDelegateTestCase: BaseTestCase {
         expectation(forNotification: Request.didResumeNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
-            resumedRequest.write { $0 = notification.request }
+            resumedRequest.write(notification.request)
             return true
         }
         expectation(forNotification: Request.didResumeTaskNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
-            resumedTaskRequest.write { $0 = notification.request }
+            resumedTaskRequest.write(notification.request)
             return true
         }
         expectation(forNotification: Request.didCompleteTaskNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
-            completedTaskRequest.write { $0 = notification.request }
+            completedTaskRequest.write(notification.request)
             return true
         }
         expectation(forNotification: Request.didFinishNotification, object: nil) { notification in
             guard let receivedRequest = notification.request, receivedRequest == request else { return false }
 
-            completedRequest.write { $0 = notification.request }
+            completedRequest.write(notification.request)
             return true
         }
 
@@ -215,8 +215,8 @@ final class SessionDelegateTestCase: BaseTestCase {
         XCTAssertNotNil(resumedTaskRequest)
         XCTAssertNotNil(completedTaskRequest)
         XCTAssertNotNil(completedRequest)
-        XCTAssertEqual(resumedRequest.wrappedValue, completedRequest.wrappedValue)
-        XCTAssertEqual(resumedTaskRequest.wrappedValue, completedTaskRequest.wrappedValue)
+        XCTAssertEqual(resumedRequest, completedRequest)
+        XCTAssertEqual(resumedTaskRequest, completedTaskRequest)
         XCTAssertEqual(requestResponse?.response?.statusCode, 200)
     }
 }


### PR DESCRIPTION
### Goals :soccer:
Use of a property wrapper is not thread-safe beyond access of the `wrappedValue` so for a while now Alamofire has had the implicit rule of always accessing `Protected` values through the wrapper using `$`. We can make this completely safe by removing the `@propertyWrapper` conformance altogether and always forcing direct use of `Protected`. This is somewhat less ergonomic but should be safer in the long run.