### PR TITLE
Fix visionOS Target Build Settings

### DIFF
--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -2218,6 +2218,7 @@
 					"@loader_path/Frameworks",
 				);
 				SDKROOT = xros;
+				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "xros xrsimulator";
 				TARGETED_DEVICE_FAMILY = 7;
 			};
@@ -2236,6 +2237,7 @@
 					"@loader_path/Frameworks",
 				);
 				SDKROOT = xros;
+				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "xros xrsimulator";
 				TARGETED_DEVICE_FAMILY = 7;
 			};


### PR DESCRIPTION
### Goals :soccer:
The build settings "Skip Install" is missing in visionOS target, which cloud cause the archive invalid when a project linked to the visionOS framework.

### Implementation Details :construction:
Set the "Skip Install" in visionOS target to YES

### Testing Details :mag:
No Test change.
