### PR TITLE
Fix a typo in the method quick help of ParameterEncoding and ResponseSerialization

### DIFF
--- a/Source/ParameterEncoding.swift
+++ b/Source/ParameterEncoding.swift
@@ -297,7 +297,7 @@ public struct JSONEncoding: ParameterEncoding {
     ///
     /// - Parameters:
     ///   - urlRequest: `URLRequestConvertible` value into which the object will be encoded.
-    ///   - jsonObject: `Any` value (must be JSON compatible` to be encoded into the `URLRequest`. `nil` by default.
+    ///   - jsonObject: `Any` value (must be JSON compatible) to be encoded into the `URLRequest`. `nil` by default.
     ///
     /// - Returns:      The encoded `URLRequest`.
     /// - Throws:       Any `Error` produced during encoding.

--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -31,7 +31,7 @@ public protocol DataResponseSerializerProtocol {
     /// The type of serialized object to be created.
     associatedtype SerializedObject
 
-    /// Serialize the response `Data` into the provided type..
+    /// Serialize the response `Data` into the provided type.
     ///
     /// - Parameters:
     ///   - request:  `URLRequest` which was used to perform the request, if any.
@@ -49,7 +49,7 @@ public protocol DownloadResponseSerializerProtocol {
     /// The type of serialized object to be created.
     associatedtype SerializedObject
 
-    /// Serialize the downloaded response `Data` from disk into the provided type..
+    /// Serialize the downloaded response `Data` from disk into the provided type.
     ///
     /// - Parameters:
     ///   - request:  `URLRequest` which was used to perform the request, if any.


### PR DESCRIPTION
### Implementation Details :construction:
1. Fix a typo in `encode` method's quick help of `JSONEncoding`.

|Before|After|
|:-----:|:----:|
|<img width="352" alt="before" src="https://github.com/Alamofire/Alamofire/assets/83946704/e1d2463e-f830-4a86-a6d3-2bcf9d1a575a">|<img width="361" alt="after" src="https://github.com/Alamofire/Alamofire/assets/83946704/01ff31d1-bcd0-4845-85e0-27c665e10fb4">|

2. Fix a typo in `serialize` method's quick help of `DataResponseSerializerProtocol`
3. Fix a typo in `serializeDownload` method's quick help of `DownloadResponseSerializerProtocol`


### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
