### PR TITLE
Make Empty conform to `Sendable`

### DIFF
--- a/Source/ResponseSerialization.swift
+++ b/Source/ResponseSerialization.swift
@@ -875,7 +875,7 @@ public protocol EmptyResponse {
 }
 
 /// Type representing an empty value. Use `Empty.value` to get the static instance.
-public struct Empty: Codable {
+public struct Empty: Codable, Sendable {
     /// Static `Empty` instance used for all `Empty` responses.
     public static let value = Empty()
 }


### PR DESCRIPTION
### Goals :soccer:
Make the `Empty` struct conform to `Sendable` to prepare for strict concurrency.

### Implementation Details :construction:
I was running into this warning while migrating our codebase for strict concurrency, related to `Empty` not being `Sendable`:
<img width="709" alt="CleanShot 2024-01-18 at 10 57 09@2x" src="https://github.com/Alamofire/Alamofire/assets/4329185/2f12a555-ce0a-4dd7-ae47-c85f0d699641">

I could fix it for now using:

```swift
import Alamofire

extension Empty: @unchecked Sendable { }
```

But I'd obviously love to see this being added to the core library.