### PR TITLE
Fix typo in the quick help of AFError

### DIFF
--- a/Source/AFError.swift
+++ b/Source/AFError.swift
@@ -35,7 +35,7 @@ public enum AFError: Error {
     public enum MultipartEncodingFailureReason {
         /// The `fileURL` provided for reading an encodable body part isn't a file `URL`.
         case bodyPartURLInvalid(url: URL)
-        /// The filename of the `fileURL` provided has either an empty `lastPathComponent` or `pathExtension.
+        /// The filename of the `fileURL` provided has either an empty `lastPathComponent` or `pathExtension`.
         case bodyPartFilenameInvalid(in: URL)
         /// The file at the `fileURL` provided was not reachable.
         case bodyPartFileNotReachable(at: URL)
@@ -185,7 +185,7 @@ public enum AFError: Error {
     }
     #endif
 
-    /// The underlying reason the `.urlRequestValidationFailed`
+    /// The underlying reason the `.urlRequestValidationFailed` error occurred.
     public enum URLRequestValidationFailureReason {
         /// URLRequest with GET method had body data.
         case bodyDataInGETRequest(Data)


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
- Fix typo in the quick help of `AFError.swift`

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
1. Fix typo in `bodyPartFilenameInvalid(in:)` case's quick helf of `pathExtension`.

|before|after|
|--|--|
|<img width="350" src="https://github.com/Alamofire/Alamofire/assets/51712973/3d20ae86-6661-4caf-b90d-5bea77a8e2f1">|<img width="350" src="https://github.com/Alamofire/Alamofire/assets/51712973/56a5cd69-bf57-4188-9ddf-2d93f0e25f1c">|

2. Match the `URLRequestValidationFailureReason`'s description style with other error reason.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
No testing is needed as the change is in the comment.