### PR TITLE
Fix typo in the quick help of HTTPHeaders

### DIFF
--- a/Source/HTTPHeaders.swift
+++ b/Source/HTTPHeaders.swift
@@ -47,7 +47,7 @@ public struct HTTPHeaders {
     ///
     /// - Parameters:
     ///   - name:  The `HTTPHeader` name.
-    ///   - value: The `HTTPHeader value.
+    ///   - value: The `HTTPHeader` value.
     public mutating func add(name: String, value: String) {
         update(HTTPHeader(name: name, value: value))
     }
@@ -63,7 +63,7 @@ public struct HTTPHeaders {
     ///
     /// - Parameters:
     ///   - name:  The `HTTPHeader` name.
-    ///   - value: The `HTTPHeader value.
+    ///   - value: The `HTTPHeader` value.
     public mutating func update(name: String, value: String) {
         update(HTTPHeader(name: name, value: value))
     }
@@ -263,7 +263,7 @@ extension HTTPHeader {
         return authorization("Basic \(credential)")
     }
 
-    /// Returns a `Bearer` `Authorization` header using the `bearerToken` provided
+    /// Returns a `Bearer` `Authorization` header using the `bearerToken` provided.
     ///
     /// - Parameter bearerToken: The bearer token.
     ///


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
- Fix typo in the quick help of `HTTPHeaders.swift`

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
1. Fix typo in `add(name:value:)`, `update(name:value:)` method's quick help of HTTPHeaders.

|before|after|
|--|--|
|<img width="350" src="https://github.com/Alamofire/Alamofire/assets/51712973/626913dc-7ab0-425d-abe6-ac68f42ebece">|<img width="350" src="https://github.com/Alamofire/Alamofire/assets/51712973/b503f9c4-62d2-42fb-a4a0-b197fc9bb32d">|

2. Add a missing period in the sentence.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
No testing is needed as the change is in the comment.