### PR TITLE
fix: iOS v11 deprecation for SPM with tools version >=5.9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ import PackageDescription
 
 let package = Package(name: "Alamofire",
                       platforms: [.macOS(.v10_13),
-                                  .iOS(.v11),
-                                  .tvOS(.v11),
+                                  .iOS(.v12),
+                                  .tvOS(.v12),
                                   .watchOS(.v4)],
                       products: [
                           .library(name: "Alamofire", targets: ["Alamofire"]),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -27,8 +27,8 @@ import PackageDescription
 
 let package = Package(name: "Alamofire",
                       platforms: [.macOS(.v10_13),
-                                  .iOS(.v11),
-                                  .tvOS(.v11),
+                                  .iOS(.v12),
+                                  .tvOS(.v12),
                                   .watchOS(.v4)],
                       products: [
                           .library(name: "Alamofire", targets: ["Alamofire"]),


### PR DESCRIPTION
iOS v11 deprecation https://developer.apple.com/documentation/packagedescription/supportedplatform/iosversion/v11
