### PR TITLE
Remove duplicate rules in .swiftformat

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -3,11 +3,6 @@
 --symlinks ignore
 --swiftversion 5.7
 
-# rules
---enable isEmpty
---disable andOperator
---disable wrapMultilineStatementBraces
-
 # format options
 
 --commas inline
@@ -32,5 +27,6 @@
 # rules
 
 --enable isEmpty
---disable wrapMultilineStatementBraces
+--disable andOperator
 --disable opaqueGenericParameters
+--disable wrapMultilineStatementBraces


### PR DESCRIPTION
### Goals :soccer:
- Remove duplicate rules
  - isEmpty
  - wrapMultilineStatementBraces
- Merge the rules that are split into two parts into one
  - andOperator
- Sort disable rules alphabetically
