### PR TITLE
Fix typos in the quick help of files

### DIFF
--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -131,7 +131,7 @@ public class Request {
     public var state: State { mutableState.state }
     /// Returns whether `state` is `.initialized`.
     public var isInitialized: Bool { state == .initialized }
-    /// Returns whether `state is `.resumed`.
+    /// Returns whether `state` is `.resumed`.
     public var isResumed: Bool { state == .resumed }
     /// Returns whether `state` is `.suspended`.
     public var isSuspended: Bool { state == .suspended }

--- a/Source/Features/ResponseSerialization.swift
+++ b/Source/Features/ResponseSerialization.swift
@@ -128,7 +128,7 @@ extension ResponseSerializer {
             .map { emptyRequestMethods.contains($0) }
     }
 
-    /// Determines whether the `response` allows empty response bodies, if `response` exists`.
+    /// Determines whether the `response` allows empty response bodies, if `response` exists.
     ///
     /// - Parameter response: `HTTPURLResponse` to evaluate.
     ///

--- a/Source/Features/ServerTrustEvaluation.swift
+++ b/Source/Features/ServerTrustEvaluation.swift
@@ -760,7 +760,7 @@ extension AlamofireExtension where ExtendedType == OSStatus {
 
 extension SecTrustResultType: AlamofireExtended {}
 extension AlamofireExtension where ExtendedType == SecTrustResultType {
-    /// Returns whether `self is `.unspecified` or `.proceed`.
+    /// Returns whether `self` is `.unspecified` or `.proceed`.
     public var isSuccess: Bool {
         type == .unspecified || type == .proceed
     }

--- a/Source/Features/URLEncodedFormEncoder.swift
+++ b/Source/Features/URLEncodedFormEncoder.swift
@@ -445,7 +445,7 @@ public final class URLEncodedFormEncoder {
 
     /// Encodes the `value` as a URL form encoded `String`.
     ///
-    /// - Parameter value: The `Encodable` value.`
+    /// - Parameter value: The `Encodable` value.
     ///
     /// - Returns:         The encoded `String`.
     /// - Throws:          An `Error` or `EncodingError` instance if encoding fails.


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
- Fix typos in the quick help of `Request.swift`, `ResponseSerialization.swift`, `ServerTrustEvaluation.swift`, `URLEncodedFormEncoder.swift`

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
1. `Request.swift` -> `isResumed`

|before|after|
|--|--|
|<img width="350" src="https://github.com/Alamofire/Alamofire/assets/51712973/8a5b9abf-2d66-460d-b831-d5d9ce3f48f9">|<img width="350" src="https://github.com/Alamofire/Alamofire/assets/51712973/68797322-15aa-4ba2-896f-75b3bb757720">|

2. `ResponseSerialization.swift` -> `responseAllowsEmptyResponseData(_:)`

|before|after|
|--|--|
|<img width="350" src="https://github.com/Alamofire/Alamofire/assets/51712973/ceb68e06-19bb-4f3a-a8fa-261fdf646d9f">|<img width="350" src="https://github.com/Alamofire/Alamofire/assets/51712973/4cd98ceb-8de9-4cab-9879-969453536a4f">|

3. `ServerTrustEvaluation.swift` -> `AlamofireExtension` -> `isSuccess`

|before|after|
|--|--|
|<img width="350" src="https://github.com/Alamofire/Alamofire/assets/51712973/aa5ca255-9893-48bc-8a4d-e77a9735eb40">|<img width="350" src="https://github.com/Alamofire/Alamofire/assets/51712973/43180633-4019-47c1-8556-e9ed2610426e">|

4. `URLEncodedFormEncoder.swift` -> `encode(_:)`

|before|after|
|--|--|
|<img width="350" src="https://github.com/Alamofire/Alamofire/assets/51712973/44f0b62f-83c3-4bdf-a126-37a436eef10d">|<img width="350" src="https://github.com/Alamofire/Alamofire/assets/51712973/b3fee803-6bbd-4aca-941e-1551d99f565f">|


### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
No testing is needed as the change is in the comment.