### PR TITLE
Add visionOS support to the Cocoapods podspec, bump min version

### DIFF
--- a/Alamofire.podspec
+++ b/Alamofire.podspec
@@ -8,13 +8,15 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/Alamofire/Alamofire.git', :tag => s.version }
   s.documentation_url = 'https://alamofire.github.io/Alamofire/'
 
-  # Ensure developers won't hit CocoaPods/CocoaPods#11402 with the resource
+  # 1.12.0: Ensure developers won't hit CocoaPods/CocoaPods#11402 with the resource
   # bundle for the privacy manifest.
-  s.cocoapods_version = '>= 1.12.0'
+  # 1.13.0: visionOS is recognized as a platform.
+  s.cocoapods_version = '>= 1.13.0'
 
   s.ios.deployment_target = '10.0'
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
+  s.visionos.deployment_target = '1.0'
   s.watchos.deployment_target = '3.0'
 
   s.swift_versions = ['5']


### PR DESCRIPTION
### Issue Link :link:
https://github.com/Alamofire/Alamofire/issues/3844

### Goals :soccer:
Adds the ability to use Alamofire with Cocoapods on visionOS.

### Implementation Details :construction:
As `visionos` was introduced in Cocoapods 1.13.0, the minimum required version was bumped as well.

### Testing Details :mag:
N/A
