### PR TITLE
Add `shouldRemove` in upload method to delete file after successful upload

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -830,6 +830,16 @@ let fileURL = Bundle.main.url(forResource: "video", withExtension: "mov")
 AF.upload(fileURL, to: "https://httpbin.org/post").responseDecodable(of: DecodableType.self) { response in
     debugPrint(response)
 }
+
+let tempFileURL = Bundle.main.url(forResource: "image", withExtension: "jpg")
+
+// Flag to indicate that the file should be automatically removed once uploaded
+let shouldRemove = true
+
+AF.upload(fileURL, to: "https://httpbin.org/post", shouldRemove: shouldRemove).responseDecodable(of: DecodableType.self) { response in
+    debugPrint(response)
+}
+
 ```
 
 #### Uploading Multipart Form Data

--- a/Source/Core/Session.swift
+++ b/Source/Core/Session.swift
@@ -752,6 +752,7 @@ open class Session {
     ///                      default.
     ///   - requestModifier: `RequestModifier` which will be applied to the `URLRequest` created from the provided
     ///                      parameters. `nil` by default.
+    ///   - shouldRemove: A `Bool`  indicating whether whether the source file should be automatically removed once uploaded. `false` by default.
     ///
     /// - Returns:           The created `UploadRequest`.
     open func upload(_ fileURL: URL,
@@ -760,13 +761,14 @@ open class Session {
                      headers: HTTPHeaders? = nil,
                      interceptor: RequestInterceptor? = nil,
                      fileManager: FileManager = .default,
-                     requestModifier: RequestModifier? = nil) -> UploadRequest {
+                     requestModifier: RequestModifier? = nil,
+                     shouldRemove: Bool = false) -> UploadRequest {
         let convertible = ParameterlessRequestConvertible(url: convertible,
                                                           method: method,
                                                           headers: headers,
                                                           requestModifier: requestModifier)
 
-        return upload(fileURL, with: convertible, interceptor: interceptor, fileManager: fileManager)
+        return upload(fileURL, with: convertible, interceptor: interceptor, fileManager: fileManager, shouldRemove: shouldRemove)
     }
 
     /// Creates an `UploadRequest` for the file at the given file `URL` using the `URLRequestConvertible` value and
@@ -778,13 +780,15 @@ open class Session {
     ///   - interceptor: `RequestInterceptor` value to be used by the returned `DataRequest`. `nil` by default.
     ///   - fileManager: `FileManager` instance to be used by the returned `UploadRequest`. `.default` instance by
     ///                  default.
+    ///   - shouldRemove: A `Bool`  indicating whether whether the source file should be automatically removed once uploaded. `false` by default.
     ///
     /// - Returns:       The created `UploadRequest`.
     open func upload(_ fileURL: URL,
                      with convertible: URLRequestConvertible,
                      interceptor: RequestInterceptor? = nil,
-                     fileManager: FileManager = .default) -> UploadRequest {
-        upload(.file(fileURL, shouldRemove: false), with: convertible, interceptor: interceptor, fileManager: fileManager)
+                     fileManager: FileManager = .default,
+                     shouldRemove: Bool = false) -> UploadRequest {
+        upload(.file(fileURL, shouldRemove: shouldRemove), with: convertible, interceptor: interceptor, fileManager: fileManager)
     }
 
     // MARK: InputStream

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -870,3 +870,30 @@ final class UploadRequestEventsTestCase: BaseTestCase {
         XCTAssertEqual(request.state, .cancelled)
     }
 }
+
+final class UploadFileWithDeletion: BaseTestCase {
+    func testFileUploadSuccessAndDeletion() {
+        // Given
+        let endpoint = Endpoint(path: .delay(interval: 1),
+                                method: .post,
+                                headers: [.contentType("text/plain")],
+                                timeout: 0.1)
+        
+        let fileURL = url(forResource: "utf8_string", withExtension: "txt")
+        let session = Session()
+        var response: AFDataResponse<TestResponse>?
+        let completion = expectation(description: "upload should complete and file should be deleted")
+
+        // When
+        session.upload(fileURL, with: endpoint, shouldRemove: true).responseDecodable(of: TestResponse.self) {
+            response = $0
+            completion.fulfill()
+        }
+                
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        // Then
+        XCTAssertTrue(response?.result.isSuccess == true)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path), "file should be deleted after upload")
+    }
+}


### PR DESCRIPTION
### Goals :soccer:
- Add a new parameter `shouldRemove` to the Alamofire upload function to control whether the uploaded file should be removed after upload completion.
- Write test cases to verify the functionality of the shouldRemove parameter and ensure that the file is deleted after upload.

### Implementation Details :construction:
- The addition of the `shouldRemove` parameter allows users to specify whether the file should be deleted after upload, providing more flexibility and control.
- The parameter is added to the `Session`'s `upload` function for file uploading and properly documented to maintain consistency with the naming convention used for `Uploadable`'s `case file(URL, shouldRemove: Bool)`.
- The same approach used for testing the `shouldRemove` parameter as other upload tests to maintain consistency across the codebase.


### Testing Details :mag:
Test case `testFileUploadSuccessAndDeletion` is added to existing `UploadTests` to validate the file upload success and deletion functionality.
