### PR TITLE
Make HTTPHeaders Sendable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,7 @@ jobs:
       image: ${{ matrix.image }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: ${{ matrix.image }}
         run: swift build --build-tests -c debug
   Android:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
       - name: Install Firewalk
         run: brew install alamofire/alamofire/firewalk || brew upgrade alamofire/alamofire/firewalk xcbeautify && firewalk &
       - name: Test SPM
-        run: swift test -c debug | ${{ matrix.outputFilter }}
+        run: swift test -c debug 2>&1 | ${{ matrix.outputFilter }}
   Linux:
     name: Linux
     runs-on: ubuntu-latest
@@ -283,6 +283,11 @@ jobs:
           - image: swift:5.9-centos7
           - image: swift:5.9-amazonlinux2
           - image: swift:5.9-rhel-ubi9
+          - image: swift:5.10-focal
+          - image: swift:5.10-jammy
+          - image: swift:5.10-centos7
+          - image: swift:5.10-amazonlinux2
+          - image: swift:5.10-rhel-ubi9
           - image: swiftlang/swift:nightly-focal
           - image: swiftlang/swift:nightly-jammy
           - image: swiftlang/swift:nightly-amazonlinux2
@@ -290,7 +295,7 @@ jobs:
       image: ${{ matrix.image }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: ${{ matrix.image }}
         run: swift build --build-tests -c debug
   Android:
@@ -315,6 +320,9 @@ jobs:
           - branch: swift-5.9-release
             tag: 5.9-RELEASE
             name: Windows Swift 5.9
+          - branch: swift-5.10-release
+            tag: 5.10-RELEASE
+            name: Windows Swift 5.10
     steps:
       - name: Setup
         uses: compnerd/gha-setup-swift@main

--- a/Source/Core/HTTPHeaders.swift
+++ b/Source/Core/HTTPHeaders.swift
@@ -25,7 +25,7 @@
 import Foundation
 
 /// An order-preserving and case-insensitive representation of HTTP headers.
-public struct HTTPHeaders {
+public struct HTTPHeaders: Equatable, Hashable, Sendable {
     private var headers: [HTTPHeader] = []
 
     /// Creates an empty instance.
@@ -185,7 +185,7 @@ extension HTTPHeaders: CustomStringConvertible {
 // MARK: - HTTPHeader
 
 /// A representation of a single HTTP header's name / value pair.
-public struct HTTPHeader: Hashable {
+public struct HTTPHeader: Equatable, Hashable, Sendable {
     /// Name of the header.
     public let name: String
 


### PR DESCRIPTION
### Goals :soccer:
Similar to `HTTPMethod` in #3848, `HTTPHeaders` is trivially `Sendable`, so add the conformance (and others).

### Implementation Details :construction:
Explicitly declared conformances.

### Testing Details :mag:
No additional tests, conformances are synthesized.
