### PR TITLE
Fix testThatDatesCanBeEncodedAsFormatted test fails due to current calendar mismatches with expected result

### DIFF
--- a/Tests/ParameterEncoderTests.swift
+++ b/Tests/ParameterEncoderTests.swift
@@ -730,6 +730,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSS"
         dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        dateFormatter.calendar = Calendar(identifier: .gregorian)
 
         let encoder = URLEncodedFormEncoder(dateEncoding: .formatted(dateFormatter))
         let parameters = ["date": Date(timeIntervalSinceReferenceDate: 123.456)]


### PR DESCRIPTION
### Goals :soccer:
Currently test function `testThatDatesCanBeEncodedAsFormatted` fails when trying to run tests from simulator that is not using Gregorian calendar while the assertion is expecting date in Gregorian format. The goal should be running tests passed for all simulator calendar settings.

### Implementation Details :construction:
Force `DateFormatter` in the test function `testThatDatesCanBeEncodedAsFormatted` to be Gregorian so that it will be run tests passed for all simulator calendar settings.

