### PR TITLE
Add a test function to detect a memory leak if it it happened 

### DIFF
--- a/Tests/BaseTestCase.swift
+++ b/Tests/BaseTestCase.swift
@@ -133,7 +133,7 @@ class BaseTestCase: XCTestCase {
     ///   - object: The testing object for each class.
     ///   - file: Which file that failure test happens.
     ///   - line: Which line that failure test happens.
-    @available(iOS 13.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
     func checkMemoryLeaks(_ object: AnyObject, file: StaticString = #file, line: UInt = #line) {
         addTeardownBlock { [weak object] in
             XCTAssertNil(object, "The object should be deallocated. Memory leaks may happen in the object.", file: file, line: line)

--- a/Tests/BaseTestCase.swift
+++ b/Tests/BaseTestCase.swift
@@ -126,4 +126,17 @@ class BaseTestCase: XCTestCase {
 
         waitForExpectations(timeout: timeout)
     }
+    
+    /// Check memory leaks for an object when a test operation has been finished.
+    ///
+    /// - Parameters:
+    ///   - object: The testing object for each class.
+    ///   - file: Which file that failure test happens.
+    ///   - line: Which line that failure test happens.
+    @available(iOS 13.0, *)
+    func checkMemoryLeaks(_ object: AnyObject, file: StaticString = #file, line: UInt = #line) {
+        addTeardownBlock { [weak object] in
+            XCTAssertNil(object, "The object should be deallocated. Memory leaks may happen in the object.", file: file, line: line)
+        }
+    }
 }

--- a/Tests/BaseTestCase.swift
+++ b/Tests/BaseTestCase.swift
@@ -133,10 +133,11 @@ class BaseTestCase: XCTestCase {
     ///   - object: The testing object for each class.
     ///   - file: Which file that failure test happens.
     ///   - line: Which line that failure test happens.
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
     func checkMemoryLeaks(_ object: AnyObject, file: StaticString = #file, line: UInt = #line) {
-        addTeardownBlock { [weak object] in
-            XCTAssertNil(object, "The object should be deallocated. Memory leaks may happen in the object.", file: file, line: line)
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+            addTeardownBlock { [weak object] in
+                XCTAssertNil(object, "The object should be deallocated. Memory leaks may happen in the object.", file: file, line: line)
+            }
         }
     }
 }

--- a/Tests/ParameterEncoderTests.swift
+++ b/Tests/ParameterEncoderTests.swift
@@ -730,6 +730,7 @@ final class URLEncodedFormEncoderTests: BaseTestCase {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSS"
         dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        dateFormatter.calendar = Calendar(identifier: .gregorian)
 
         let encoder = URLEncodedFormEncoder(dateEncoding: .formatted(dateFormatter))
         let parameters = ["date": Date(timeIntervalSinceReferenceDate: 123.456)]

--- a/Tests/RequestInterceptorTests.swift
+++ b/Tests/RequestInterceptorTests.swift
@@ -277,6 +277,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertEqual(interceptor.adapters.count, 1)
         XCTAssertEqual(interceptor.retriers.count, 1)
+        checkMemoryLeaksIfApplicable(interceptor)
     }
 
     func testAdapterAndRetrierDefaultInitializer() {
@@ -290,6 +291,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertEqual(interceptor.adapters.count, 1)
         XCTAssertEqual(interceptor.retriers.count, 1)
+        checkMemoryLeaksIfApplicable(interceptor)
     }
 
     func testAdaptersAndRetriersDefaultInitializer() {
@@ -303,6 +305,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertEqual(interceptor.adapters.count, 2)
         XCTAssertEqual(interceptor.retriers.count, 2)
+        checkMemoryLeaksIfApplicable(interceptor)
     }
 
     func testThatInterceptorCanBeComposedOfMultipleRequestInterceptors() {
@@ -317,6 +320,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertEqual(interceptor.adapters.count, 1)
         XCTAssertEqual(interceptor.retriers.count, 1)
+        checkMemoryLeaksIfApplicable(interceptor)
     }
 
     func testThatInterceptorCanAdaptRequestWithNoAdapters() {
@@ -333,6 +337,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertTrue(result.isSuccess)
         XCTAssertEqual(result.success, urlRequest)
+        checkMemoryLeaksIfApplicable(interceptor)
     }
 
     func testThatInterceptorCanAdaptRequestWithOneAdapter() {
@@ -351,6 +356,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertTrue(result.isFailure)
         XCTAssertTrue(result.failure is MockError)
+        checkMemoryLeaksIfApplicable(interceptor)
     }
 
     func testThatInterceptorCanAdaptRequestWithMultipleAdapters() {
@@ -370,6 +376,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertTrue(result.isFailure)
         XCTAssertTrue(result.failure is MockError)
+        checkMemoryLeaksIfApplicable(interceptor)
     }
 
     func testThatInterceptorCanAdaptRequestWithMultipleAdaptersUsingStateAPI() {
@@ -390,6 +397,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertTrue(result.isFailure)
         XCTAssertTrue(result.failure is MockError)
+        checkMemoryLeaksIfApplicable(interceptor)
     }
 
     func testThatInterceptorCanAdaptRequestAsynchronously() {
@@ -419,6 +427,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertTrue(result.isFailure)
         XCTAssertTrue(result.failure is MockError)
+        checkMemoryLeaksIfApplicable(interceptor)
     }
 
     func testThatInterceptorCanRetryRequestWithNoRetriers() {
@@ -435,6 +444,7 @@ final class InterceptorTests: BaseTestCase {
 
         // Then
         XCTAssertEqual(result, .doNotRetry)
+        checkMemoryLeaksIfApplicable(interceptor)
     }
 
     func testThatInterceptorCanRetryRequestWithOneRetrier() {
@@ -452,6 +462,7 @@ final class InterceptorTests: BaseTestCase {
 
         // Then
         XCTAssertEqual(result, .retry)
+        checkMemoryLeaksIfApplicable(interceptor)
     }
 
     func testThatInterceptorCanRetryRequestWithMultipleRetriers() {
@@ -470,6 +481,7 @@ final class InterceptorTests: BaseTestCase {
 
         // Then
         XCTAssertEqual(result, .retry)
+        checkMemoryLeaksIfApplicable(interceptor)
     }
 
     func testThatInterceptorCanRetryRequestAsynchronously() {
@@ -498,6 +510,7 @@ final class InterceptorTests: BaseTestCase {
 
         // Then
         XCTAssertEqual(result, .retry)
+        checkMemoryLeaksIfApplicable(interceptor)
     }
 
     func testThatInterceptorStopsIteratingThroughPendingRetriersWithRetryResult() {
@@ -519,6 +532,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertEqual(result, .retry)
         XCTAssertFalse(retrier2Called)
+        checkMemoryLeaksIfApplicable(interceptor)
     }
 
     func testThatInterceptorStopsIteratingThroughPendingRetriersWithRetryWithDelayResult() {
@@ -541,6 +555,7 @@ final class InterceptorTests: BaseTestCase {
         XCTAssertEqual(result, .retryWithDelay(1.0))
         XCTAssertEqual(result.delay, 1.0)
         XCTAssertFalse(retrier2Called)
+        checkMemoryLeaksIfApplicable(interceptor)
     }
 
     func testThatInterceptorStopsIteratingThroughPendingRetriersWithDoNotRetryResult() {
@@ -563,6 +578,13 @@ final class InterceptorTests: BaseTestCase {
         XCTAssertEqual(result, RetryResult.doNotRetryWithError(RetryError()))
         XCTAssertTrue(result.error is RetryError)
         XCTAssertFalse(retrier2Called)
+        checkMemoryLeaksIfApplicable(interceptor)
+    }
+    
+    private func checkMemoryLeaksIfApplicable(_ object: AnyObject, file: StaticString = #file, line: UInt = #line) {
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, *) {
+            checkMemoryLeaks(object, file: file, line: line)
+        }
     }
 }
 

--- a/Tests/RequestInterceptorTests.swift
+++ b/Tests/RequestInterceptorTests.swift
@@ -277,7 +277,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertEqual(interceptor.adapters.count, 1)
         XCTAssertEqual(interceptor.retriers.count, 1)
-        checkMemoryLeaksIfApplicable(interceptor)
+        checkMemoryLeaks(interceptor)
     }
 
     func testAdapterAndRetrierDefaultInitializer() {
@@ -291,7 +291,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertEqual(interceptor.adapters.count, 1)
         XCTAssertEqual(interceptor.retriers.count, 1)
-        checkMemoryLeaksIfApplicable(interceptor)
+        checkMemoryLeaks(interceptor)
     }
 
     func testAdaptersAndRetriersDefaultInitializer() {
@@ -305,7 +305,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertEqual(interceptor.adapters.count, 2)
         XCTAssertEqual(interceptor.retriers.count, 2)
-        checkMemoryLeaksIfApplicable(interceptor)
+        checkMemoryLeaks(interceptor)
     }
 
     func testThatInterceptorCanBeComposedOfMultipleRequestInterceptors() {
@@ -320,7 +320,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertEqual(interceptor.adapters.count, 1)
         XCTAssertEqual(interceptor.retriers.count, 1)
-        checkMemoryLeaksIfApplicable(interceptor)
+        checkMemoryLeaks(interceptor)
     }
 
     func testThatInterceptorCanAdaptRequestWithNoAdapters() {
@@ -337,7 +337,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertTrue(result.isSuccess)
         XCTAssertEqual(result.success, urlRequest)
-        checkMemoryLeaksIfApplicable(interceptor)
+        checkMemoryLeaks(interceptor)
     }
 
     func testThatInterceptorCanAdaptRequestWithOneAdapter() {
@@ -356,7 +356,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertTrue(result.isFailure)
         XCTAssertTrue(result.failure is MockError)
-        checkMemoryLeaksIfApplicable(interceptor)
+        checkMemoryLeaks(interceptor)
     }
 
     func testThatInterceptorCanAdaptRequestWithMultipleAdapters() {
@@ -376,7 +376,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertTrue(result.isFailure)
         XCTAssertTrue(result.failure is MockError)
-        checkMemoryLeaksIfApplicable(interceptor)
+        checkMemoryLeaks(interceptor)
     }
 
     func testThatInterceptorCanAdaptRequestWithMultipleAdaptersUsingStateAPI() {
@@ -397,7 +397,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertTrue(result.isFailure)
         XCTAssertTrue(result.failure is MockError)
-        checkMemoryLeaksIfApplicable(interceptor)
+        checkMemoryLeaks(interceptor)
     }
 
     func testThatInterceptorCanAdaptRequestAsynchronously() {
@@ -427,7 +427,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertTrue(result.isFailure)
         XCTAssertTrue(result.failure is MockError)
-        checkMemoryLeaksIfApplicable(interceptor)
+        checkMemoryLeaks(interceptor)
     }
 
     func testThatInterceptorCanRetryRequestWithNoRetriers() {
@@ -444,7 +444,7 @@ final class InterceptorTests: BaseTestCase {
 
         // Then
         XCTAssertEqual(result, .doNotRetry)
-        checkMemoryLeaksIfApplicable(interceptor)
+        checkMemoryLeaks(interceptor)
     }
 
     func testThatInterceptorCanRetryRequestWithOneRetrier() {
@@ -462,7 +462,7 @@ final class InterceptorTests: BaseTestCase {
 
         // Then
         XCTAssertEqual(result, .retry)
-        checkMemoryLeaksIfApplicable(interceptor)
+        checkMemoryLeaks(interceptor)
     }
 
     func testThatInterceptorCanRetryRequestWithMultipleRetriers() {
@@ -481,7 +481,7 @@ final class InterceptorTests: BaseTestCase {
 
         // Then
         XCTAssertEqual(result, .retry)
-        checkMemoryLeaksIfApplicable(interceptor)
+        checkMemoryLeaks(interceptor)
     }
 
     func testThatInterceptorCanRetryRequestAsynchronously() {
@@ -510,7 +510,7 @@ final class InterceptorTests: BaseTestCase {
 
         // Then
         XCTAssertEqual(result, .retry)
-        checkMemoryLeaksIfApplicable(interceptor)
+        checkMemoryLeaks(interceptor)
     }
 
     func testThatInterceptorStopsIteratingThroughPendingRetriersWithRetryResult() {
@@ -532,7 +532,7 @@ final class InterceptorTests: BaseTestCase {
         // Then
         XCTAssertEqual(result, .retry)
         XCTAssertFalse(retrier2Called)
-        checkMemoryLeaksIfApplicable(interceptor)
+        checkMemoryLeaks(interceptor)
     }
 
     func testThatInterceptorStopsIteratingThroughPendingRetriersWithRetryWithDelayResult() {
@@ -555,7 +555,7 @@ final class InterceptorTests: BaseTestCase {
         XCTAssertEqual(result, .retryWithDelay(1.0))
         XCTAssertEqual(result.delay, 1.0)
         XCTAssertFalse(retrier2Called)
-        checkMemoryLeaksIfApplicable(interceptor)
+        checkMemoryLeaks(interceptor)
     }
 
     func testThatInterceptorStopsIteratingThroughPendingRetriersWithDoNotRetryResult() {
@@ -578,13 +578,7 @@ final class InterceptorTests: BaseTestCase {
         XCTAssertEqual(result, RetryResult.doNotRetryWithError(RetryError()))
         XCTAssertTrue(result.error is RetryError)
         XCTAssertFalse(retrier2Called)
-        checkMemoryLeaksIfApplicable(interceptor)
-    }
-    
-    private func checkMemoryLeaksIfApplicable(_ object: AnyObject, file: StaticString = #file, line: UInt = #line) {
-        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, *) {
-            checkMemoryLeaks(object, file: file, line: line)
-        }
+        checkMemoryLeaks(interceptor)
     }
 }
 


### PR DESCRIPTION
### Goals :soccer:
Follow up from [#3766](https://github.com/Alamofire/Alamofire/issues/3766), I create a test function to check that is `RequestInterceptor` has a memory leak or not. It's becoming this pull request because it could be used with other places as well.

### Implementation Details :construction:
- Add `checkMemoryLeaks` in `BaseTestCase` so that all subclassed test classes can use this function.
- Add checking memory leaks testing for all tested functions in `InterceptorTests` class.

Example of memory leaks (It's just fake from me):
<img width="1010" alt="leak" src="https://github.com/Alamofire/Alamofire/assets/15520417/fbd70332-d0ce-4b75-b862-5fac659ef851">
