### PR TITLE
Bug: Pass queue to `responseStreamDecodable`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - xcode: "Xcode_15.4"
+            runsOn: firebreak
+            name: "macOS 14, Xcode 15.4, Swift 5.10"
+            testPlan: "macOS"
+            outputFilter: xcbeautify --renderer github-actions
           - xcode: "Xcode_15.2"
             runsOn: firebreak
-            name: "macOS 13, Xcode 15.2, Swift 5.9.2"
+            name: "macOS 14, Xcode 15.2, Swift 5.9.2"
             testPlan: "macOS"
             outputFilter: xcbeautify --renderer github-actions
           - xcode: "Xcode_15.1"
@@ -79,6 +84,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - xcode: "Xcode_15.4"
+            name: "Catalyst 15.4"
+            runsOn: firebreak
           - xcode: "Xcode_15.2"
             name: "Catalyst 15.2"
             runsOn: firebreak
@@ -107,6 +115,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - destination: "OS=17.5,name=iPhone 15 Pro"
+            name: "iOS 17.5"
+            testPlan: "iOS"
+            xcode: "Xcode_15.4"
+            runsOn: firebreak
           - destination: "OS=17.2,name=iPhone 15 Pro"
             name: "iOS 17.2"
             testPlan: "iOS"
@@ -143,6 +156,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - destination: "OS=17.5,name=Apple TV"
+            name: "tvOS 17.5"
+            testPlan: "tvOS"
+            xcode: "Xcode_15.4"
+            runsOn: firebreak
           - destination: "OS=17.2,name=Apple TV"
             name: "tvOS 17.2"
             testPlan: "tvOS"
@@ -173,16 +191,23 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runsOn }}
     env:
-      DEVELOPER_DIR: "/Applications/Xcode_15.2.app/Contents/Developer"
+      DEVELOPER_DIR: "/Applications/${{ matrix.xcode }}.app/Contents/Developer"
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
         include:
+          - destination: "OS=1.2,name=Apple Vision Pro"
+            name: "visionOS 1.2"
+            testPlan: "visionOS"
+            scheme: "Alamofire visionOS"
+            xcode: "Xcode_15.4"
+            runsOn: firebreak
           - destination: "OS=1.0,name=Apple Vision Pro"
             name: "visionOS 1.0"
             testPlan: "visionOS"
             scheme: "Alamofire visionOS"
+            xcode: "Xcode_15.2"
             runsOn: firebreak
     steps:
       - uses: actions/checkout@v4
@@ -200,6 +225,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - destination: "OS=10.5,name=Apple Watch Series 9 (45mm)"
+            name: "watchOS 10.5"
+            testPlan: "watchOS"
+            xcode: "Xcode_15.4"
+            runsOn: firebreak
           - destination: "OS=10.2,name=Apple Watch Series 9 (45mm)"
             name: "watchOS 10.2"
             testPlan: "watchOS"
@@ -236,9 +266,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - xcode: "Xcode_15.4"
+            runsOn: firebreak
+            name: "macOS 14, SPM 5.10 Test"
+            outputFilter: xcbeautify --renderer github-actions
           - xcode: "Xcode_15.2"
             runsOn: firebreak
-            name: "macOS 13, SPM 5.9.2 Test"
+            name: "macOS 14, SPM 5.9.2 Test"
             outputFilter: xcbeautify --renderer github-actions
           - xcode: "Xcode_15.1"
             runsOn: macOS-14
@@ -295,7 +329,7 @@ jobs:
       image: ${{ matrix.image }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: ${{ matrix.image }}
         run: swift build --build-tests -c debug
   Android:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,11 +135,6 @@ jobs:
             testPlan: "iOS"
             xcode: "Xcode_14.3.1"
             runsOn: macOS-13
-          - destination: "OS=15.5,name=iPhone 13 Pro"
-            name: "iOS 15.5"
-            testPlan: "iOS-NoTS"
-            xcode: "Xcode_14.3.1"
-            runsOn: macOS-12
     steps:
       - uses: actions/checkout@v4
       - name: Install Firewalk
@@ -176,11 +171,6 @@ jobs:
             testPlan: "tvOS"
             xcode: "Xcode_14.3.1"
             runsOn: macOS-13
-          - destination: "OS=15.4,name=Apple TV"
-            name: "tvOS 15.4"
-            testPlan: "tvOS-NoTS"
-            xcode: "Xcode_14.3.1"
-            runsOn: macOS-12
     steps:
       - uses: actions/checkout@v4
       - name: Install Firewalk
@@ -245,11 +235,6 @@ jobs:
             testPlan: "watchOS"
             xcode: "Xcode_14.3.1"
             runsOn: macOS-13
-          - destination: "OS=8.5,name=Apple Watch Series 7 (45mm)"
-            name: "watchOS 8.5"
-            testPlan: "watchOS-NoTS"
-            xcode: "Xcode_14.3.1"
-            runsOn: macOS-12
     steps:
       - uses: actions/checkout@v4
       - name: Install Firewalk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
             name: "iOS 15.5"
             testPlan: "iOS-NoTS"
             xcode: "Xcode_14.3.1"
-            runsOn: macOS-13
+            runsOn: macOS-12
     steps:
       - uses: actions/checkout@v4
       - name: Install Firewalk
@@ -180,7 +180,7 @@ jobs:
             name: "tvOS 15.4"
             testPlan: "tvOS-NoTS"
             xcode: "Xcode_14.3.1"
-            runsOn: macOS-13
+            runsOn: macOS-12
     steps:
       - uses: actions/checkout@v4
       - name: Install Firewalk
@@ -249,7 +249,7 @@ jobs:
             name: "watchOS 8.5"
             testPlan: "watchOS-NoTS"
             xcode: "Xcode_14.3.1"
-            runsOn: macOS-13
+            runsOn: macOS-12
     steps:
       - uses: actions/checkout@v4
       - name: Install Firewalk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,22 +309,15 @@ jobs:
         include:
           - image: swift:5.8-focal
           - image: swift:5.8-jammy
-          - image: swift:5.8-centos7
-          - image: swift:5.8-amazonlinux2
           - image: swift:5.8-rhel-ubi9
           - image: swift:5.9-focal
           - image: swift:5.9-jammy
-          - image: swift:5.9-centos7
-          - image: swift:5.9-amazonlinux2
           - image: swift:5.9-rhel-ubi9
           - image: swift:5.10-focal
           - image: swift:5.10-jammy
-          - image: swift:5.10-centos7
-          - image: swift:5.10-amazonlinux2
           - image: swift:5.10-rhel-ubi9
           - image: swiftlang/swift:nightly-focal
           - image: swiftlang/swift:nightly-jammy
-          - image: swiftlang/swift:nightly-amazonlinux2
     container:
       image: ${{ matrix.image }}
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
             name: "iOS 15.5"
             testPlan: "iOS-NoTS"
             xcode: "Xcode_14.3.1"
-            runsOn: firebreak
+            runsOn: macOS-13
     steps:
       - uses: actions/checkout@v4
       - name: Install Firewalk
@@ -180,7 +180,7 @@ jobs:
             name: "tvOS 15.4"
             testPlan: "tvOS-NoTS"
             xcode: "Xcode_14.3.1"
-            runsOn: firebreak
+            runsOn: macOS-13
     steps:
       - uses: actions/checkout@v4
       - name: Install Firewalk
@@ -249,7 +249,7 @@ jobs:
             name: "watchOS 8.5"
             testPlan: "watchOS-NoTS"
             xcode: "Xcode_14.3.1"
-            runsOn: firebreak
+            runsOn: macOS-13
     steps:
       - uses: actions/checkout@v4
       - name: Install Firewalk

--- a/Source/Core/DataStreamRequest.swift
+++ b/Source/Core/DataStreamRequest.swift
@@ -464,6 +464,7 @@ public final class DataStreamRequest: Request {
                                                       preprocessor: DataPreprocessor = PassthroughPreprocessor(),
                                                       stream: @escaping Handler<T, AFError>) -> Self {
         responseStream(using: DecodableStreamSerializer<T>(decoder: decoder, dataPreprocessor: preprocessor),
+                       on: queue,
                        stream: stream)
     }
 }

--- a/Tests/CombineTests.swift
+++ b/Tests/CombineTests.swift
@@ -1423,7 +1423,7 @@ final class DownloadRequestCombineTests: CombineTestCase {
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 class CombineTestCase: BaseTestCase {
-    private lazy var storage: Set<AnyCancellable> = { Set<AnyCancellable>() }()
+    private lazy var storage: Set<AnyCancellable> = .init()
 
     override func tearDown() {
         storage.removeAll()


### PR DESCRIPTION
### Issue Link :link:
Fixes #3878

### Goals :soccer:
This PR ensures the queue for `responseStreamDecodable` is properly passed to the underlying serializer.

### Testing Details :mag:
Tests added for methods on arbitrary queues.
