### PR TITLE
Update links for repositories moved to the swiftlang org on GitHub

### DIFF
--- a/docs/Classes/URLEncodedFormEncoder.html
+++ b/docs/Classes/URLEncodedFormEncoder.html
@@ -732,7 +732,7 @@ replacing spaces with <code>%20</code>.</p>
                       <div class="abstract">
                         <p>Encoding to use for keys.</p>
 
-<p>This type is derived from <a href="https://github.com/apple/swift/blob/6aa313b8dd5f05135f7f878eccc1db6f9fbe34ff/stdlib/public/Darwin/Foundation/JSONEncoder.swift#L128"><code>JSONEncoder</code>&lsquo;s <code>KeyEncodingStrategy</code></a>
+<p>This type is derived from <a href="https://github.com/swiftlang/swift/blob/6aa313b8dd5f05135f7f878eccc1db6f9fbe34ff/stdlib/public/Darwin/Foundation/JSONEncoder.swift#L128"><code>JSONEncoder</code>&lsquo;s <code>KeyEncodingStrategy</code></a>
 and <a href="https://github.com/MaxDesiatov/XMLCoder/blob/master/Sources/XMLCoder/Encoder/XMLEncoder.swift#L102"><code>XMLEncoder</code>s <code>KeyEncodingStrategy</code></a>.</p>
 
                         <a href="../Classes/URLEncodedFormEncoder/KeyEncoding.html" class="slightly-smaller">See more</a>

--- a/docs/Classes/URLEncodedFormEncoder/KeyEncoding.html
+++ b/docs/Classes/URLEncodedFormEncoder/KeyEncoding.html
@@ -572,7 +572,7 @@
               </div>
             <p>Encoding to use for keys.</p>
 
-<p>This type is derived from <a href="https://github.com/apple/swift/blob/6aa313b8dd5f05135f7f878eccc1db6f9fbe34ff/stdlib/public/Darwin/Foundation/JSONEncoder.swift#L128"><code>JSONEncoder</code>&lsquo;s <code>KeyEncodingStrategy</code></a>
+<p>This type is derived from <a href="https://github.com/swiftlang/swift/blob/6aa313b8dd5f05135f7f878eccc1db6f9fbe34ff/stdlib/public/Darwin/Foundation/JSONEncoder.swift#L128"><code>JSONEncoder</code>&lsquo;s <code>KeyEncodingStrategy</code></a>
 and <a href="https://github.com/MaxDesiatov/XMLCoder/blob/master/Sources/XMLCoder/Encoder/XMLEncoder.swift#L102"><code>XMLEncoder</code>s <code>KeyEncodingStrategy</code></a>.</p>
 
           </div>


### PR DESCRIPTION
### Goals :soccer:
Update links for repositories moved to the swiftlang org on GitHub.

Update the link

+ https://github.com/apple/swift/ => https://github.com/swiftlang/swift/

This appears on production at
+ https://alamofire.github.io/Alamofire/Classes/URLEncodedFormEncoder/KeyEncoding.html => [JSONEncoder‘s KeyEncodingStrategy]
