### PR TITLE
Use MPTCP by default if available

### DIFF
--- a/Source/Extensions/URLSessionConfiguration+Alamofire.swift
+++ b/Source/Extensions/URLSessionConfiguration+Alamofire.swift
@@ -27,19 +27,30 @@ import Foundation
 extension URLSessionConfiguration: AlamofireExtended {}
 extension AlamofireExtension where ExtendedType: URLSessionConfiguration {
     /// Alamofire's default configuration. Same as `URLSessionConfiguration.default` but adds Alamofire default
-    /// `Accept-Language`, `Accept-Encoding`, and `User-Agent` headers.
+    /// `Accept-Language`, `Accept-Encoding`, and `User-Agent` headers. Enables handover MPTCP by default
+    /// on iOS 11+
     public static var `default`: URLSessionConfiguration {
         let configuration = URLSessionConfiguration.default
         configuration.headers = .default
+        #if TARGET_OS_IOS
+        if #available(iOS 11, *){
+            configuration.multipathServiceType = .handover
+        }
+        #endif
 
         return configuration
     }
 
     /// `.ephemeral` configuration with Alamofire's default `Accept-Language`, `Accept-Encoding`, and `User-Agent`
-    /// headers.
+    /// headers. Enables handover MPTCP by default on iOS 11+
     public static var ephemeral: URLSessionConfiguration {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.headers = .default
+        #if TARGET_OS_IOS
+        if #available(iOS 11, *){
+            configuration.multipathServiceType = .handover
+        }
+        #endif
 
         return configuration
     }


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
Improve the network reliability of apps using Alamofire by enabling Multipath TCP by default, in Handover Mode. This
TCP extension allows to use multiple network interfaces in case of deterioration of the connection on one of them
Sources: 
- https://www.mptcp.dev
- https://developer.apple.com/documentation/foundation/urlsessionconfiguration/improving_network_reliability_using_multipath_tcp

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
Set the property `multipathServiceType` of the `URLSessionConfiguration` objects `default` and `ephemeral`

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
Ran again the tests to make sure that everything was still working fine. No additional tests seems needed