### PR TITLE
Set `@Sendable` on refresh method in Authenticator

### DIFF
--- a/Source/Features/AuthenticationInterceptor.swift
+++ b/Source/Features/AuthenticationInterceptor.swift
@@ -81,7 +81,7 @@ public protocol Authenticator: AnyObject, Sendable {
     ///   - credential: The `Credential` to refresh.
     ///   - session:    The `Session` requiring the refresh.
     ///   - completion: The closure to be executed once the refresh is complete.
-    func refresh(_ credential: Credential, for session: Session, completion: @escaping (Result<Credential, any Error>) -> Void)
+    func refresh(_ credential: Credential, for session: Session, completion: @Sendable @escaping (Result<Credential, any Error>) -> Void)
 
     /// Determines whether the `URLRequest` failed due to an authentication error based on the `HTTPURLResponse`.
     ///


### PR DESCRIPTION
### Goals :soccer:

After upgrading to version 5.10.0, the following error occurred, so I tried to fix it with this PR.

![image](https://github.com/user-attachments/assets/861c79a7-28e2-4b98-a118-140453c31405)

### Environments

- Xcode: 16.0
- Swift: 6.0
- Strict Concurrency Checking: Complete 