### PR TITLE
Relax JSONResponseSerializer Sendable Requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,7 @@ jobs:
       - name: Clone
         uses: actions/checkout@v4
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: swift
       - name: Build macOS

--- a/Source/Core/DataRequest.swift
+++ b/Source/Core/DataRequest.swift
@@ -417,7 +417,7 @@ public class DataRequest: Request, @unchecked Sendable {
                              emptyResponseCodes: Set<Int> = JSONResponseSerializer.defaultEmptyResponseCodes,
                              emptyRequestMethods: Set<HTTPMethod> = JSONResponseSerializer.defaultEmptyRequestMethods,
                              options: JSONSerialization.ReadingOptions = .allowFragments,
-                             completionHandler: @Sendable @escaping (AFDataResponse<any Any & Sendable>) -> Void) -> Self {
+                             completionHandler: @Sendable @escaping (AFDataResponse<Any>) -> Void) -> Self {
         response(queue: queue,
                  responseSerializer: JSONResponseSerializer(dataPreprocessor: dataPreprocessor,
                                                             emptyResponseCodes: emptyResponseCodes,

--- a/Source/Core/DownloadRequest.swift
+++ b/Source/Core/DownloadRequest.swift
@@ -564,7 +564,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
                              emptyResponseCodes: Set<Int> = JSONResponseSerializer.defaultEmptyResponseCodes,
                              emptyRequestMethods: Set<HTTPMethod> = JSONResponseSerializer.defaultEmptyRequestMethods,
                              options: JSONSerialization.ReadingOptions = .allowFragments,
-                             completionHandler: @Sendable @escaping (AFDownloadResponse<any Any & Sendable>) -> Void) -> Self {
+                             completionHandler: @Sendable @escaping (AFDownloadResponse<Any>) -> Void) -> Self {
         response(queue: queue,
                  responseSerializer: JSONResponseSerializer(dataPreprocessor: dataPreprocessor,
                                                             emptyResponseCodes: emptyResponseCodes,

--- a/Source/Features/ResponseSerialization.swift
+++ b/Source/Features/ResponseSerialization.swift
@@ -381,7 +381,7 @@ public final class JSONResponseSerializer: ResponseSerializer {
         self.options = options
     }
 
-    public func serialize(request: URLRequest?, response: HTTPURLResponse?, data: Data?, error: (any Error)?) throws -> any Any & Sendable {
+    public func serialize(request: URLRequest?, response: HTTPURLResponse?, data: Data?, error: (any Error)?) throws -> Any {
         guard error == nil else { throw error! }
 
         guard var data, !data.isEmpty else {

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -191,7 +191,7 @@ final class ResponseJSONTestCase: BaseTestCase {
         // Given
         let expectation = expectation(description: "request should succeed")
 
-        var response: DataResponse<any Sendable, AFError>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         AF.request(.default, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -216,7 +216,7 @@ final class ResponseJSONTestCase: BaseTestCase {
         let urlString = String.invalidURL
         let expectation = expectation(description: "request should fail")
 
-        var response: DataResponse<any Sendable, AFError>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         AF.request(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -240,7 +240,7 @@ final class ResponseJSONTestCase: BaseTestCase {
         // Given
         let expectation = expectation(description: "request should succeed")
 
-        var response: DataResponse<any Sendable, AFError>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         AF.request(.default, parameters: ["foo": "bar"]).responseJSON { resp in
@@ -272,7 +272,7 @@ final class ResponseJSONTestCase: BaseTestCase {
         // Given
         let expectation = expectation(description: "request should succeed")
 
-        var response: DataResponse<any Sendable, AFError>?
+        var response: DataResponse<Any, AFError>?
 
         // When
         AF.request(.method(.post), parameters: ["foo": "bar"]).responseJSON { resp in


### PR DESCRIPTION
### Issue Link :link:
#3902 

### Goals :soccer:
This PR relaxes the `Sendable` requirement in the value returned from `JSONResponseSerialization`, as it breaks downstream consumers still using `Any`.

### Implementation Details :construction:
Reverted the type returned from `JSONResponseSerializer` from `any Any & Sendable` to just `Any`.

### Testing Details :mag:
Tests updated.
