### PR TITLE
Fix Validator Sendability

### DIFF
--- a/Source/Core/DataRequest.swift
+++ b/Source/Core/DataRequest.swift
@@ -143,7 +143,7 @@ public class DataRequest: Request, @unchecked Sendable {
     @preconcurrency
     @discardableResult
     public func validate(_ validation: @escaping Validation) -> Self {
-        let validator: () -> Void = { [unowned self] in
+        let validator: @Sendable () -> Void = { [unowned self] in
             guard error == nil, let response else { return }
 
             let result = validation(request, response, data)

--- a/Source/Core/DataStreamRequest.swift
+++ b/Source/Core/DataStreamRequest.swift
@@ -199,7 +199,7 @@ public final class DataStreamRequest: Request, @unchecked Sendable {
     /// - Returns:              The `DataStreamRequest`.
     @discardableResult
     public func validate(_ validation: @escaping Validation) -> Self {
-        let validator: () -> Void = { [unowned self] in
+        let validator: @Sendable () -> Void = { [unowned self] in
             guard error == nil, let response else { return }
 
             let result = validation(request, response)

--- a/Source/Core/DownloadRequest.swift
+++ b/Source/Core/DownloadRequest.swift
@@ -303,7 +303,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
     /// - Returns:              The instance.
     @discardableResult
     public func validate(_ validation: @escaping Validation) -> Self {
-        let validator: () -> Void = { [unowned self] in
+        let validator: @Sendable () -> Void = { [unowned self] in
             guard error == nil, let response else { return }
 
             let result = validation(request, response, fileURL)

--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -188,7 +188,7 @@ public class Request: @unchecked Sendable {
     // MARK: Validators
 
     /// `Validator` callback closures that store the validation calls enqueued.
-    let validators = Protected<[() -> Void]>([])
+    let validators = Protected<[@Sendable () -> Void]>([])
 
     // MARK: URLRequests
 

--- a/Source/Features/Validation.swift
+++ b/Source/Features/Validation.swift
@@ -155,6 +155,7 @@ extension DataRequest {
     /// - Parameter acceptableStatusCodes: `Sequence` of acceptable response status codes.
     ///
     /// - Returns:                         The instance.
+    @preconcurrency
     @discardableResult
     public func validate<S: Sequence>(statusCode acceptableStatusCodes: S) -> Self where S.Iterator.Element == Int, S: Sendable {
         validate { [unowned self] _, response, _ in
@@ -169,6 +170,7 @@ extension DataRequest {
     /// - parameter contentType: The acceptable content types, which may specify wildcard types and/or subtypes.
     ///
     /// - returns: The request.
+    @preconcurrency
     @discardableResult
     public func validate<S: Sequence>(contentType acceptableContentTypes: @escaping @Sendable @autoclosure () -> S) -> Self where S.Iterator.Element == String, S: Sendable {
         validate { [unowned self] _, response, data in
@@ -203,6 +205,7 @@ extension DataStreamRequest {
     /// - Parameter acceptableStatusCodes: `Sequence` of acceptable response status codes.
     ///
     /// - Returns:                         The instance.
+    @preconcurrency
     @discardableResult
     public func validate<S: Sequence>(statusCode acceptableStatusCodes: S) -> Self where S.Iterator.Element == Int, S: Sendable {
         validate { [unowned self] _, response in
@@ -217,6 +220,7 @@ extension DataStreamRequest {
     /// - parameter contentType: The acceptable content types, which may specify wildcard types and/or subtypes.
     ///
     /// - returns: The request.
+    @preconcurrency
     @discardableResult
     public func validate<S: Sequence>(contentType acceptableContentTypes: @escaping @Sendable @autoclosure () -> S) -> Self where S.Iterator.Element == String, S: Sendable {
         validate { [unowned self] _, response in
@@ -256,6 +260,7 @@ extension DownloadRequest {
     /// - Parameter acceptableStatusCodes: `Sequence` of acceptable response status codes.
     ///
     /// - Returns:                         The instance.
+    @preconcurrency
     @discardableResult
     public func validate<S: Sequence>(statusCode acceptableStatusCodes: S) -> Self where S.Iterator.Element == Int, S: Sendable {
         validate { [unowned self] _, response, _ in
@@ -270,6 +275,7 @@ extension DownloadRequest {
     /// - parameter contentType: The acceptable content types, which may specify wildcard types and/or subtypes.
     ///
     /// - returns: The request.
+    @preconcurrency
     @discardableResult
     public func validate<S: Sequence>(contentType acceptableContentTypes: @escaping @Sendable @autoclosure () -> S) -> Self where S.Iterator.Element == String, S: Sendable {
         validate { [unowned self] _, response, fileURL in


### PR DESCRIPTION
### Issue Link :link:
Fixes #3919

### Goals :soccer:
This PR makes the validation system `Sendable`, fixing a runtime crash when the consuming app is built in Swift 6 mode.

### Implementation Details :construction:
Adds `@Sendable` to the validation closures, and ensures the returned `Error` is actually `Error & Sendable`.

### Testing Details :mag:
No additional tests.
