### PR TITLE
Fix example in Usage.md to use AF namespace

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -604,7 +604,7 @@ AF.request("https://httpbin.org/get").responseDecodable(of: DecodableType.self) 
 Response handlers can also be chained:
 
 ```swift
-Alamofire.request("https://httpbin.org/get")
+AF.request("https://httpbin.org/get")
     .responseString { response in
         print("Response String: \(response.value)")
     }


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

- Replaced the deprecated `Alamofire.request(...)` with `AF.request(...)` in Usage.md for consistency with Alamofire 5+ API style, and to match the explanation provided in the "AF Namespace" section.
- This change helps keep the documentation up-to-date and avoids potential confusion for new users.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

Updated the code example in the “Chained Response Handlers” section:

**Before**

```swift
Alamofire.request("https://httpbin.org/get")
  .responseString { response in
      print("Response String: \(response.value)")
  }
  .responseDecodable(of: DecodableType.self) { response in
      print("Response DecodableType: \(response.value)")
  }
```

**After**

```swift
AF.request("https://httpbin.org/get")
  .responseString { response in
      print("Response String: \(response.value)")
  }
  .responseDecodable(of: DecodableType.self) { response in
      print("Response DecodableType: \(response.value)")
  }
```

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

No testing is required as this change is limited to documentation.