### PR TITLE
Fix URL conversion for non-ASCII characters

### DIFF
--- a/Source/Core/URLConvertible+URLRequestConvertible.swift
+++ b/Source/Core/URLConvertible+URLRequestConvertible.swift
@@ -40,8 +40,17 @@ extension String: URLConvertible {
     /// - Returns: The `URL` initialized with `self`.
     /// - Throws:  An `AFError.invalidURL` instance.
     public func asURL() throws -> URL {
-        guard let url = URL(string: self) else { throw AFError.invalidURL(url: self) }
-
+        // First try direct URL creation for performance
+        if let url = URL(string: self) {
+            return url
+        }
+        
+        // If direct creation fails, try URLComponents for better handling of non-ASCII characters
+        guard let components = URLComponents(string: self),
+              let url = components.url else {
+            throw AFError.invalidURL(url: self)
+        }
+        
         return url
     }
 }

--- a/Tests/URLConvertibleTests.swift
+++ b/Tests/URLConvertibleTests.swift
@@ -1,0 +1,140 @@
+//
+//  URLConvertibleTests.swift
+//
+//  Copyright (c) 2014-2024 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Alamofire
+import Foundation
+import XCTest
+
+final class URLConvertibleTests: BaseTestCase {
+    func testStringAsURLWithValidURL() {
+        // Given
+        let urlString = "https://httpbin.org/get"
+        
+        // When
+        let url = try? urlString.asURL()
+        
+        // Then
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.absoluteString, urlString)
+    }
+    
+    func testStringAsURLWithNonASCIICharacters() {
+        // Given
+        let urlString = "https://www.example.com/サリーサルマガンディ"
+        let expectedURLString = "https://www.example.com/%E3%82%B5%E3%83%AA%E3%83%BC%E3%82%B5%E3%83%AB%E3%83%9E%E3%82%AC%E3%83%B3%E3%83%87%E3%82%A3"
+        
+        // When
+        let url = try? urlString.asURL()
+        
+        // Then
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.absoluteString, expectedURLString)
+    }
+    
+    func testStringAsURLWithChineseCharacters() {
+        // Given
+        let urlString = "https://example.com/中文测试"
+        let expectedURLString = "https://example.com/%E4%B8%AD%E6%96%87%E6%B5%8B%E8%AF%95"
+        
+        // When
+        let url = try? urlString.asURL()
+        
+        // Then
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.absoluteString, expectedURLString)
+    }
+    
+    func testStringAsURLWithArabicCharacters() {
+        // Given
+        let urlString = "https://example.com/اختبار"
+        let expectedURLString = "https://example.com/%D8%A7%D8%AE%D8%AA%D8%A8%D8%A7%D8%B1"
+        
+        // When
+        let url = try? urlString.asURL()
+        
+        // Then
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.absoluteString, expectedURLString)
+    }
+    
+    func testStringAsURLWithMixedCharacters() {
+        // Given
+        let urlString = "https://example.com/path/文件-file/データ?query=测试&param=value"
+        
+        // When
+        let url = try? urlString.asURL()
+        
+        // Then
+        XCTAssertNotNil(url)
+        XCTAssertTrue(url!.absoluteString.contains("example.com"))
+        XCTAssertTrue(url!.absoluteString.contains("query="))
+        XCTAssertTrue(url!.absoluteString.contains("param=value"))
+    }
+    
+    func testStringAsURLWithInvalidURL() {
+        // Given
+        let urlString = "not a valid url"
+        
+        // When
+        do {
+            _ = try urlString.asURL()
+            XCTFail("Should have thrown an error")
+        } catch {
+            // Then
+            XCTAssertTrue(error is AFError)
+            if let afError = error as? AFError {
+                if case .invalidURL(let url) = afError {
+                    XCTAssertEqual(url, urlString)
+                } else {
+                    XCTFail("Wrong error type")
+                }
+            }
+        }
+    }
+    
+    func testStringAsURLWithSpaces() {
+        // Given
+        let urlString = "https://example.com/path with spaces"
+        let expectedURLString = "https://example.com/path%20with%20spaces"
+        
+        // When
+        let url = try? urlString.asURL()
+        
+        // Then
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.absoluteString, expectedURLString)
+    }
+    
+    func testStringAsURLWithSpecialCharacters() {
+        // Given
+        let urlString = "https://example.com/path?name=John+Doe&email=john@example.com"
+        
+        // When
+        let url = try? urlString.asURL()
+        
+        // Then
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.absoluteString, urlString)
+    }
+}


### PR DESCRIPTION
## Summary

  This PR fixes the URL conversion failure for strings containing non-ASCII characters by implementing URLComponents as a fallback mechanism when direct URL creation fails.

  ## Details

  ### Problem
  The current implementation of `String.asURL()` fails when the string contains non-ASCII characters (e.g., Japanese, Chinese, Arabic), throwing an `AFError.invalidURL` error. This is problematic for applications that need to handle internationalized URLs.

  ### Solution
  Modified the `asURL()` method to:
  1. First attempt direct URL creation for performance (handles most ASCII URLs)
  2. Fall back to URLComponents for better handling of non-ASCII characters
  3. Maintain the same error handling behavior

  ### Implementation
  ```swift
  public func asURL() throws -> URL {
      // First try direct URL creation for performance
      if let url = URL(string: self) {
          return url
      }

      // If direct creation fails, try URLComponents for better handling of non-ASCII characters
      guard let components = URLComponents(string: self),
            let url = components.url else {
          throw AFError.invalidURL(url: self)
      }

      return url
  }
```
  Testing

  Added comprehensive test coverage in URLConvertibleTests.swift:
  - ✅ Valid ASCII URLs (existing behavior)
  - ✅ Japanese characters (サリーサルマガンディ)
  - ✅ Chinese characters (中文测试)
  - ✅ Arabic characters (اختبار)
  - ✅ Mixed character sets with query parameters
  - ✅ URLs with spaces
  - ✅ Invalid URL error handling

  Performance Considerations

  The implementation maintains optimal performance by:
  - Attempting direct URL creation first (fast path for ASCII URLs)
  - Only using URLComponents when necessary (non-ASCII cases)
  - No performance impact for existing ASCII URL usage

  References

  - Fixes #3937
  - Implements suggestion from @jshier to use URLComponents

  Checklist

  - Code compiles without warnings
  - Unit tests pass
  - Added tests for new functionality
  - Follows existing code style
  - Maintains backward compatibility