### PR TITLE
feat: Add URL extraction support to AFError

### DIFF
--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -576,6 +576,11 @@
 		E4202FD51B667AA100C997FB /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C23EB421B327C5B0090E0BC /* MultipartFormData.swift */; };
 		E4202FD61B667AA100C997FB /* ServerTrustEvaluation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C811F8C1B51856D00E0F59A /* ServerTrustEvaluation.swift */; };
 		E4202FD81B667AA100C997FB /* Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDE2C421AF89F0900BABAE5 /* Validation.swift */; };
+		F327496E2E6745BF007772D1 /* AFErrorURLExtractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F327496D2E6745BF007772D1 /* AFErrorURLExtractionTests.swift */; };
+		F327496F2E6745BF007772D1 /* AFErrorURLExtractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F327496D2E6745BF007772D1 /* AFErrorURLExtractionTests.swift */; };
+		F32749702E6745BF007772D1 /* AFErrorURLExtractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F327496D2E6745BF007772D1 /* AFErrorURLExtractionTests.swift */; };
+		F32749712E6745BF007772D1 /* AFErrorURLExtractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F327496D2E6745BF007772D1 /* AFErrorURLExtractionTests.swift */; };
+		F32749722E6745BF007772D1 /* AFErrorURLExtractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F327496D2E6745BF007772D1 /* AFErrorURLExtractionTests.swift */; };
 		F8111E6119A9674D0040E7D1 /* ParameterEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8111E5C19A9674D0040E7D1 /* ParameterEncodingTests.swift */; };
 		F829C6B81A7A94F100A2CD59 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4DD67C0B1A5C55C900ED2280 /* Alamofire.framework */; };
 		F829C6BE1A7A950600A2CD59 /* ParameterEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8111E5C19A9674D0040E7D1 /* ParameterEncodingTests.swift */; };
@@ -764,6 +769,7 @@
 		4CFD6B132201338E00FFB5E3 /* CachedResponseHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedResponseHandlerTests.swift; sourceTree = "<group>"; };
 		4DD67C0B1A5C55C900ED2280 /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4202FE01B667AA100C997FB /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F327496D2E6745BF007772D1 /* AFErrorURLExtractionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AFErrorURLExtractionTests.swift; sourceTree = "<group>"; };
 		F8111E3319A95C8B0040E7D1 /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8111E3719A95C8B0040E7D1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F8111E3E19A95C8B0040E7D1 /* Alamofire iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Alamofire iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1061,6 +1067,7 @@
 				F86AEFE51AE6A282007D9C76 /* TLSEvaluationTests.swift */,
 				4CCFA7991B2BE71600B6F460 /* URLProtocolTests.swift */,
 				F8AE910119D28DCC0078C7B2 /* ValidationTests.swift */,
+				F327496D2E6745BF007772D1 /* AFErrorURLExtractionTests.swift */,
 			);
 			name = Features;
 			sourceTree = "<group>";
@@ -1762,6 +1769,7 @@
 				31293090263E184500473CEA /* TLSEvaluationTests.swift in Sources */,
 				31293075263E183C00473CEA /* SessionDelegateTests.swift in Sources */,
 				314998ED27A6560600ABB856 /* Request+AlamofireTests.swift in Sources */,
+				F327496E2E6745BF007772D1 /* AFErrorURLExtractionTests.swift in Sources */,
 				3129308B263E184500473CEA /* CacheTests.swift in Sources */,
 				3129307A263E183C00473CEA /* UploadTests.swift in Sources */,
 				31293091263E184500473CEA /* URLProtocolTests.swift in Sources */,
@@ -1858,6 +1866,7 @@
 				317339092A43BE9000D4EA0A /* RequestTests.swift in Sources */,
 				3173390A2A43BE9000D4EA0A /* ResponseTests.swift in Sources */,
 				3173390B2A43BE9000D4EA0A /* SessionDelegateTests.swift in Sources */,
+				F32749722E6745BF007772D1 /* AFErrorURLExtractionTests.swift in Sources */,
 				3173390C2A43BE9000D4EA0A /* SessionTests.swift in Sources */,
 				3173390D2A43BE9000D4EA0A /* UploadTests.swift in Sources */,
 				3173390E2A43BE9000D4EA0A /* AFError+AlamofireTests.swift in Sources */,
@@ -1954,6 +1963,7 @@
 				4CF627141BA7CC240011A099 /* BaseTestCase.swift in Sources */,
 				4C7DD7ED224C627300249836 /* Result+AlamofireTests.swift in Sources */,
 				314998EC27A6560600ABB856 /* Request+AlamofireTests.swift in Sources */,
+				F327496F2E6745BF007772D1 /* AFErrorURLExtractionTests.swift in Sources */,
 				3106FB6323F8C53A007FAB43 /* ProtectedTests.swift in Sources */,
 				4CB0080F2455FE9700C38783 /* AuthenticationInterceptorTests.swift in Sources */,
 				31727424218BB9A50039FFCC /* TestHelpers.swift in Sources */,
@@ -2148,6 +2158,7 @@
 				4C256A531B096C770065714F /* BaseTestCase.swift in Sources */,
 				4C7DD7EB224C627300249836 /* Result+AlamofireTests.swift in Sources */,
 				314998EA27A6560600ABB856 /* Request+AlamofireTests.swift in Sources */,
+				F32749702E6745BF007772D1 /* AFErrorURLExtractionTests.swift in Sources */,
 				3106FB6123F8C53A007FAB43 /* ProtectedTests.swift in Sources */,
 				4CB0080D2455FE9700C38783 /* AuthenticationInterceptorTests.swift in Sources */,
 				31727422218BB9A50039FFCC /* TestHelpers.swift in Sources */,
@@ -2195,6 +2206,7 @@
 				F829C6BF1A7A950600A2CD59 /* RequestTests.swift in Sources */,
 				4C7DD7EC224C627300249836 /* Result+AlamofireTests.swift in Sources */,
 				314998EB27A6560600ABB856 /* Request+AlamofireTests.swift in Sources */,
+				F32749712E6745BF007772D1 /* AFErrorURLExtractionTests.swift in Sources */,
 				3106FB6223F8C53A007FAB43 /* ProtectedTests.swift in Sources */,
 				4CB0080E2455FE9700C38783 /* AuthenticationInterceptorTests.swift in Sources */,
 				31727423218BB9A50039FFCC /* TestHelpers.swift in Sources */,

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -628,6 +628,31 @@ AF.request("https://httpbin.org/get").responseDecodable(of: DecodableType.self, 
 }
 ```
 
+#### Extracting URLs from `AFError`
+
+When a request fails, `AFError` instances may contain URL information that can be useful for debugging or error tracking. The `url` property attempts to extract URL information from various error types:
+
+```swift
+AF.request("https://invalid-url.example").responseData { response in
+    switch response.result {
+    case .success:
+        // Handle success
+        break
+    case let .failure(error):
+        if let failingURL = error.url {
+            print("Request failed for URL: \(failingURL)")
+        }
+        
+        // For .invalidURL errors, use .urlConvertible for the original input
+        if case .invalidURL = error, let original = error.urlConvertible {
+            print("Invalid URL input: \(original)")
+        }
+    }
+}
+```
+
+Not all `AFError` types contain URL information. Due to Alamofire's architecture, errors don't automatically include the request URL. The `url` property extracts URLs from underlying errors (like `URLError`) or error-specific contexts (like file URLs in multipart failures). For errors without URL context, use `response.request?.url` to access the original request URL.
+
 ### Response Caching
 
 Response caching is handled on the system framework level by [`URLCache`](https://developer.apple.com/reference/foundation/urlcache). It provides a composite in-memory and on-disk cache and lets you manipulate the sizes of both the in-memory and on-disk portions.

--- a/Tests/AFErrorURLExtractionTests.swift
+++ b/Tests/AFErrorURLExtractionTests.swift
@@ -1,0 +1,461 @@
+//
+//  AFErrorURLExtractionTests.swift
+//
+//  Copyright (c) 2014-2018 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Alamofire
+import Foundation
+import XCTest
+
+final class AFErrorURLExtractionTests: XCTestCase {
+    
+    // MARK: - multipartEncodingFailed
+
+    func testMultipartEncodingFailedWithURL() {
+        // Given
+        let httpURL = URL(string: "https://example.com/image.jpg")!
+        let reason = AFError.MultipartEncodingFailureReason.bodyPartURLInvalid(url: httpURL)
+        
+        // When
+        let error = AFError.multipartEncodingFailed(reason: reason)
+        
+        // Then
+        XCTAssertEqual(error.url, httpURL)
+    }
+    
+    func testMultipartEncodingFailedWithoutURL() {
+        // Given
+        let underlyingError = NSError(domain: "TestDomain", code: 1, userInfo: nil)
+        let reason = AFError.MultipartEncodingFailureReason.outputStreamWriteFailed(error: underlyingError)
+        
+        // When
+        let error = AFError.multipartEncodingFailed(reason: reason)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+
+    // MARK: - responseValidationFailed
+
+    func testResponseValidationFailedWithURL() {
+        // Given
+        let fileURL = URL(fileURLWithPath: "/tmp/response_data.json")
+        let reason = AFError.ResponseValidationFailureReason.dataFileReadFailed(at: fileURL)
+        
+        // When
+        let error = AFError.responseValidationFailed(reason: reason)
+        
+        // Then
+        XCTAssertEqual(error.url, fileURL)
+    }
+    
+    func testResponseValidationFailedWithoutURL() {
+        // Given
+        let reason = AFError.ResponseValidationFailureReason.dataFileNil
+        
+        // When
+        let error = AFError.responseValidationFailed(reason: reason)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+
+    // MARK: - responseSerializationFailed
+
+    func testResponseSerializationFailedWithURL() {
+        // Given
+        let fileURL = URL(fileURLWithPath: "/tmp/response.json")
+        let reason = AFError.ResponseSerializationFailureReason.inputFileReadFailed(at: fileURL)
+        
+        // When
+        let error = AFError.responseSerializationFailed(reason: reason)
+        
+        // Then
+        XCTAssertEqual(error.url, fileURL)
+    }
+    
+    func testResponseSerializationFailedWithoutURL() {
+        // Given
+        let reason = AFError.ResponseSerializationFailureReason.inputDataNilOrZeroLength
+        
+        // When
+        let error = AFError.responseSerializationFailed(reason: reason)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+
+    // MARK: - invalidURL
+
+    func testInvalidURLWithInvalidString() {
+        // Given
+        let invalidString = ""  // Empty string cannot create valid URL
+        
+        // When
+        let error = AFError.invalidURL(url: invalidString)
+        
+        // Then
+        XCTAssertNil(error.url)  // invalidURL error means URL is invalid
+    }
+    
+    func testInvalidURLWithInvalidURLComponents() {
+        // Given
+        var components = URLComponents()
+        components.scheme = "http"
+        // Missing host makes URLComponents.url nil, causing asURL() to throw
+        
+        // When
+        let error = AFError.invalidURL(url: components)
+        
+        // Then
+        XCTAssertNil(error.url)  // invalidURL error means URL is invalid
+    }
+
+    // MARK: - sessionTaskFailed
+
+    func testSessionTaskFailedWithURLError() {
+        // Given
+        let requestURL = URL.nonexistentDomain
+        let urlError = URLError(.notConnectedToInternet, userInfo: [NSURLErrorFailingURLErrorKey: requestURL])
+        
+        // When
+        let error = AFError.sessionTaskFailed(error: urlError)
+        
+        // Then
+        XCTAssertEqual(error.url, requestURL)
+    }
+    
+    func testSessionTaskFailedWithoutURL() {
+        // Given
+        let underlyingError = NSError(domain: "TestDomain", code: 1, userInfo: nil)
+        
+        // When
+        let error = AFError.sessionTaskFailed(error: underlyingError)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+
+    // MARK: - sessionInvalidated
+
+    func testSessionInvalidatedWithURLError() {
+        // Given
+        let requestURL = URL.nonexistentDomain
+        let urlError = URLError(.networkConnectionLost, userInfo: [NSURLErrorFailingURLErrorKey: requestURL])
+        
+        // When
+        let error = AFError.sessionInvalidated(error: urlError)
+        
+        // Then
+        XCTAssertEqual(error.url, requestURL)
+    }
+    
+    func testSessionInvalidatedWithNilError() {
+        // Given
+        // When
+        let error = AFError.sessionInvalidated(error: nil)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+    
+    func testSessionInvalidatedWithNonURLError() {
+        // Given
+        let underlyingError = NSError(domain: "SessionDomain", code: 2, userInfo: nil)
+        
+        // When
+        let error = AFError.sessionInvalidated(error: underlyingError)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+
+    // MARK: - requestAdaptationFailed
+
+    func testRequestAdaptationFailedWithCustomError() {
+        // Given
+        let adaptationError = NSError(domain: "AdapterDomain", code: 401, userInfo: [NSLocalizedDescriptionKey: "Authentication failed"])
+        
+        // When
+        let error = AFError.requestAdaptationFailed(error: adaptationError)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+    
+    func testRequestAdaptationFailedWithURLError() {
+        // Given
+        let requestURL = URL.nonexistentDomain
+        let urlError = URLError(.badURL, userInfo: [NSURLErrorFailingURLErrorKey: requestURL])
+        
+        // When
+        let error = AFError.requestAdaptationFailed(error: urlError)
+        
+        // Then
+        XCTAssertEqual(error.url, requestURL)
+    }
+
+    // MARK: - requestRetryFailed
+
+    func testRequestRetryFailedWithURLInOriginalError() {
+        // Given
+        let requestURL = URL.nonexistentDomain
+        let originalError = URLError(.timedOut, userInfo: [NSURLErrorFailingURLErrorKey: requestURL])
+        let retryError = NSError(domain: "RetryDomain", code: 500, userInfo: [NSLocalizedDescriptionKey: "Token refresh failed"])
+        
+        // When
+        let error = AFError.requestRetryFailed(retryError: retryError, originalError: originalError)
+        
+        // Then
+        XCTAssertEqual(error.url, requestURL)
+    }
+    
+    func testRequestRetryFailedWithURLInRetryError() {
+        // Given
+        let retryURL = URL.nonexistentDomain
+        let originalError = NSError(domain: "NetworkDomain", code: 100, userInfo: nil)
+        let retryError = URLError(.badURL, userInfo: [NSURLErrorFailingURLErrorKey: retryURL])
+        
+        // When
+        let error = AFError.requestRetryFailed(retryError: retryError, originalError: originalError)
+        
+        // Then
+        XCTAssertEqual(error.url, retryURL)
+    }
+    
+    func testRequestRetryFailedWithoutURL() {
+        // Given
+        let originalError = NSError(domain: "NetworkDomain", code: 100, userInfo: nil)
+        let retryError = NSError(domain: "RetryDomain", code: 500, userInfo: nil)
+        
+        // When
+        let error = AFError.requestRetryFailed(retryError: retryError, originalError: originalError)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+    
+    func testRequestRetryFailedWithURLInBothErrors() {
+        // Given
+        let originalURL = URL.nonexistentDomain
+        let retryURL = URL(string: "https://retry.example.com")!
+        let originalError = URLError(.timedOut, userInfo: [NSURLErrorFailingURLErrorKey: originalURL])
+        let retryError = URLError(.badURL, userInfo: [NSURLErrorFailingURLErrorKey: retryURL])
+        
+        // When
+        let error = AFError.requestRetryFailed(retryError: retryError, originalError: originalError)
+        
+        // Then
+        XCTAssertEqual(error.url, originalURL)  // Should prefer originalError's URL
+    }
+
+    // MARK: - downloadedFileMoveFailed
+
+    func testDownloadedFileMoveFailedURLIsNil() {
+        // Given
+        let sourceURL = FileManager.temporaryDirectoryURL.appendingPathComponent("download.tmp")
+        let destinationURL = FileManager.temporaryDirectoryURL.appendingPathComponent("file.pdf")
+        let moveError = NSError(domain: NSCocoaErrorDomain, code: NSFileWriteNoPermissionError, userInfo: nil)
+        
+        // When
+        let error = AFError.downloadedFileMoveFailed(error: moveError, source: sourceURL, destination: destinationURL)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+    
+    func testDownloadedFileMoveFailedWithURLErrorStillReturnsNil() {
+        // Given
+        let sourceURL = FileManager.temporaryDirectoryURL.appendingPathComponent("download.tmp")
+        let destinationURL = FileManager.temporaryDirectoryURL.appendingPathComponent("file.pdf")
+        let urlError = URLError(.fileDoesNotExist, userInfo: [NSURLErrorFailingURLErrorKey: sourceURL])
+        
+        // When
+        let error = AFError.downloadedFileMoveFailed(error: urlError, source: sourceURL, destination: destinationURL)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+
+    // MARK: - createURLRequestFailed
+
+    func testCreateURLRequestFailedURLIsNil() {
+        // Given
+        let encodingError = NSError(domain: "EncodingDomain", code: 400, userInfo: [NSLocalizedDescriptionKey: "Parameter encoding failed"])
+        
+        // When
+        let error = AFError.createURLRequestFailed(error: encodingError)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+    
+    func testCreateURLRequestFailedWithURLErrorStillReturnsNil() {
+        // Given
+        let requestURL = URL.nonexistentDomain
+        let urlError = URLError(.badURL, userInfo: [NSURLErrorFailingURLErrorKey: requestURL])
+        
+        // When
+        let error = AFError.createURLRequestFailed(error: urlError)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+
+    // MARK: - createUploadableFailed
+
+    func testCreateUploadableFailedURLIsNil() {
+        // Given
+        let uploadError = NSError(domain: "UploadDomain", code: 500, userInfo: [NSLocalizedDescriptionKey: "File upload preparation failed"])
+        
+        // When
+        let error = AFError.createUploadableFailed(error: uploadError)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+    
+    func testCreateUploadableFailedWithURLErrorStillReturnsNil() {
+        // Given
+        let fileURL = URL(fileURLWithPath: "/tmp/upload_file.txt")
+        let urlError = URLError(.fileDoesNotExist, userInfo: [NSURLErrorFailingURLErrorKey: fileURL])
+        
+        // When
+        let error = AFError.createUploadableFailed(error: urlError)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+
+    // MARK: - parameterEncoderFailed
+
+    func testParameterEncoderFailedURLIsNil() {
+        // Given
+        let reason = AFError.ParameterEncoderFailureReason.missingRequiredComponent(.url)
+        
+        // When
+        let error = AFError.parameterEncoderFailed(reason: reason)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+    
+    func testParameterEncoderFailedWithErrorStillReturnsNil() {
+        // Given
+        let encodingError = NSError(domain: "EncoderDomain", code: 100, userInfo: [NSLocalizedDescriptionKey: "Custom encoding failed"])
+        let reason = AFError.ParameterEncoderFailureReason.encoderFailed(error: encodingError)
+        
+        // When
+        let error = AFError.parameterEncoderFailed(reason: reason)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+
+    // MARK: - parameterEncodingFailed
+
+    func testParameterEncodingFailedURLIsNil() {
+        // Given
+        let reason = AFError.ParameterEncodingFailureReason.missingURL
+        
+        // When
+        let error = AFError.parameterEncodingFailed(reason: reason)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+    
+    func testParameterEncodingFailedWithErrorStillReturnsNil() {
+        // Given
+        let jsonError = NSError(domain: NSCocoaErrorDomain, code: 3840, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON"])
+        let reason = AFError.ParameterEncodingFailureReason.jsonEncodingFailed(error: jsonError)
+        
+        // When
+        let error = AFError.parameterEncodingFailed(reason: reason)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+
+    // MARK: - serverTrustEvaluationFailed
+
+    #if canImport(Security)
+    func testServerTrustEvaluationFailedURLIsNil() {
+        // Given
+        let reason = AFError.ServerTrustFailureReason.noRequiredEvaluator(host: "example.com")
+        
+        // When
+        let error = AFError.serverTrustEvaluationFailed(reason: reason)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+    
+    func testServerTrustEvaluationFailedWithErrorStillReturnsNil() {
+        // Given
+        let trustError = NSError(domain: "SecurityDomain", code: -9802, userInfo: [NSLocalizedDescriptionKey: "Certificate validation failed"])
+        let reason = AFError.ServerTrustFailureReason.trustEvaluationFailed(error: trustError)
+        
+        // When
+        let error = AFError.serverTrustEvaluationFailed(reason: reason)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+    #endif
+
+    // MARK: - explicitlyCancelled
+
+    func testExplicitlyCancelledURLIsNil() {
+        // Given
+        // When
+        let error = AFError.explicitlyCancelled
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+
+    // MARK: - sessionDeinitialized
+
+    func testSessionDeinitializedURLIsNil() {
+        // Given
+        // When
+        let error = AFError.sessionDeinitialized
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+
+    // MARK: - urlRequestValidationFailed
+
+    func testURLRequestValidationFailedURLIsNil() {
+        // Given
+        let invalidBodyData = "invalid body in GET".data(using: .utf8)!
+        let reason = AFError.URLRequestValidationFailureReason.bodyDataInGETRequest(invalidBodyData)
+        
+        // When
+        let error = AFError.urlRequestValidationFailed(reason: reason)
+        
+        // Then
+        XCTAssertNil(error.url)
+    }
+}


### PR DESCRIPTION
## Summary
Implements URL extraction functionality for AFError to enable developers to retrieve request URLs from error contexts. This addresses the limitation where errors don't automatically include the originating request URL.

## Changes
- **AFError**: Added public `url` computed property with URL extraction logic for all error types
- **Test Suite**: Added comprehensive test coverage with 34 test cases
- **Documentation**: Updated Usage.md with URL extraction examples

## Features
- **URL Extraction from Errors**: Extract URLs from 17 different AFError types, including support for nested errors and URLError.failingURL

## Usage
```swift
// Extract URL from AFError
AF.request("https://api.example.com/data").responseData { response in
    if case .failure(let error) = response.result {
        if let failingURL = error.url {
            print("Request failed for URL: \(failingURL)")
        }
    }
}

// Handle errors without URL (use response.request?.url as fallback)
if error.url == nil {
    let requestURL = response.request?.url
}
```

## Testing
- [ ] Added 34 unit tests covering all 17 AFError types
- [ ] Tests verify both URL extraction and nil returns for appropriate error types  
- [ ] Executed full test suite using Firewalk to ensure no regressions