### PR TITLE
Make `Empty` `Hashable`

### DIFF
--- a/Source/Features/ResponseSerialization.swift
+++ b/Source/Features/ResponseSerialization.swift
@@ -413,7 +413,7 @@ public protocol EmptyResponse: Sendable {
 }
 
 /// Type representing an empty value. Use `Empty.value` to get the static instance.
-public struct Empty: Codable, Sendable {
+public struct Empty: Hashable, Codable, Sendable {
     /// Static `Empty` instance used for all `Empty` responses.
     public static let value = Empty()
 }

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -698,7 +698,7 @@ final class DecodableResponseSerializerTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.success)
+        XCTAssertEqual(result.success, Empty.value)
         XCTAssertNil(result.failure)
     }
 
@@ -713,7 +713,7 @@ final class DecodableResponseSerializerTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.success)
+        XCTAssertEqual(result.success, Empty.value)
         XCTAssertNil(result.failure)
     }
 
@@ -728,7 +728,7 @@ final class DecodableResponseSerializerTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.success)
+        XCTAssertEqual(result.success, Empty.value)
         XCTAssertNil(result.failure)
     }
 
@@ -743,7 +743,7 @@ final class DecodableResponseSerializerTests: BaseTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(result.success)
+        XCTAssertEqual(result.success, Empty.value)
         XCTAssertNil(result.failure)
     }
 


### PR DESCRIPTION
### Goals :soccer:
This PR adds `Hashable` (and therefore `Equatable`) to Alamofire's `Empty` type, so it can meet more generic constraints for responses.

### Implementation Details :construction:
Synthesized conformance made public.

### Testing Details :mag:
Updated some usage tests to check equals.
