### PR TITLE
Fix: Extract failingURL from URLError in AFError.sessionTaskFailed

### DIFF
--- a/Source/Core/AFError.swift
+++ b/Source/Core/AFError.swift
@@ -374,8 +374,14 @@ extension AFError {
 
     /// The `URL` associated with the error.
     public var url: URL? {
-        guard case let .multipartEncodingFailed(reason) = self else { return nil }
-        return reason.url
+        switch self {
+        case let .multipartEncodingFailed(reason):
+            return reason.url
+        case let .sessionTaskFailed(error):
+            return (error as? URLError)?.failingURL
+        default:
+            return nil
+        }
     }
 
     /// The underlying `Error` responsible for generating the failure associated with `.sessionInvalidated`,

--- a/Tests/AFErrorURLTests.swift
+++ b/Tests/AFErrorURLTests.swift
@@ -1,0 +1,101 @@
+//
+//  AFErrorURLTests.swift
+//
+//  Copyright (c) 2014-2018 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Alamofire
+import Foundation
+import XCTest
+
+final class AFErrorURLTestCase: BaseTestCase {
+    func testThatSessionTaskFailedWithURLErrorContainingFailingURLReturnsURL() {
+        // Given
+        let failingURL = URL(string: "https://example.com/api/endpoint")!
+        // Create URLError with failingURL in userInfo (as URLSession does)
+        let urlError = URLError(.networkConnectionLost, userInfo: [NSURLErrorFailingURLErrorKey: failingURL])
+        let error = AFError.sessionTaskFailed(error: urlError)
+
+        // When
+        let url = error.url
+
+        // Then
+        XCTAssertNotNil(url, "URL should not be nil when URLError contains failingURL")
+        XCTAssertEqual(url, failingURL, "URL should match the failingURL from URLError")
+    }
+
+    func testThatSessionTaskFailedWithURLErrorWithoutFailingURLReturnsNil() {
+        // Given
+        let urlError = URLError(.networkConnectionLost)
+        let error = AFError.sessionTaskFailed(error: urlError)
+
+        // When
+        let url = error.url
+
+        // Then
+        XCTAssertNil(url, "URL should be nil when URLError doesn't contain failingURL")
+    }
+
+    func testThatSessionTaskFailedWithNonURLErrorReturnsNil() {
+        // Given
+        let customError = NSError(domain: "CustomErrorDomain", code: 123, userInfo: nil)
+        let error = AFError.sessionTaskFailed(error: customError)
+
+        // When
+        let url = error.url
+
+        // Then
+        XCTAssertNil(url, "URL should be nil when error is not a URLError")
+    }
+
+    func testThatMultipartEncodingFailedStillReturnsURL() {
+        // Given
+        let fileURL = URL(string: "file:///path/to/file.jpg")!
+        let reason = AFError.MultipartEncodingFailureReason.bodyPartURLInvalid(url: fileURL)
+        let error = AFError.multipartEncodingFailed(reason: reason)
+
+        // When
+        let url = error.url
+
+        // Then
+        XCTAssertEqual(url, fileURL, "URL should match the fileURL from multipart encoding failure reason")
+    }
+
+    func testThatOtherErrorCasesReturnNil() {
+        // Given
+        let errors: [AFError] = [
+            .explicitlyCancelled,
+            .invalidURL(url: "invalid"),
+            .sessionDeinitialized,
+            .parameterEncodingFailed(reason: .missingURL),
+            .requestAdaptationFailed(error: NSError(domain: "Test", code: 1, userInfo: nil)),
+            .responseValidationFailed(reason: .dataFileNil),
+            .responseSerializationFailed(reason: .inputDataNilOrZeroLength),
+            .urlRequestValidationFailed(reason: .bodyDataInGETRequest(Data()))
+        ]
+
+        // When & Then
+        for error in errors {
+            XCTAssertNil(error.url, "URL should be nil for \(error)")
+        }
+    }
+}
+


### PR DESCRIPTION
- Updated AFError.url property to extract failingURL from URLError instances
- Added comprehensive test coverage for url property in sessionTaskFailed cases
- Fixes issue where url property returned nil for sessionTaskFailed errors

Resolves #3965

### Issue Link :link:
(https://github.com/Alamofire/Alamofire/issues/3965)

### Goals :soccer:
- Fix the `AFError.url` property to return the failing URL for `.sessionTaskFailed` cases
- Enable reliable error handling and logging when the URL that caused the failure is needed
- Eliminate the need for manual workarounds to extract the failing URL from `URLError`
- Maintain backward compatibility with existing error handling code


### Implementation Details :construction:
**Problem:**
The `url` property of `AFError` returned `nil` for `.sessionTaskFailed` cases, even when the underlying `URLError` contained a `failingURL`. This prevented reliable error handling or logging when the URL that caused the failure was needed. Users had to manually extract the URL using workarounds like:
```swift
static func extractURL(error: AFError) -> URL? {
    switch error {
    case .sessionTaskFailed(let error):
        (error as? URLError)?.failingURL
    default:
        error.url
    }
}
```

**Solution:**
Updated the `url` computed property in `AFError` to extract the `failingURL` from `URLError` instances when the error is `.sessionTaskFailed`. The implementation:

- Changed from a `guard` statement to a `switch` statement for better extensibility
- Added handling for `.sessionTaskFailed` cases to extract `failingURL` from `URLError` instances
- Preserved existing behavior for `.multipartEncodingFailed` cases
- Returns `nil` for all other cases (maintains backward compatibility)

**Files Changed:**
- `Source/Core/AFError.swift`: Updated `url` property (lines 375-384)
- `Tests/AFErrorURLTests.swift`: New test file with comprehensive coverage

**Example Usage:**
```swift
func handle(error: AFError) {
    if let url = error.url {
        print("Request failed for URL: \(url)")
        // Now works for sessionTaskFailed errors without manual extraction!
    }
}
```
### Testing Details :mag:
Added comprehensive test coverage in `Tests/AFErrorURLTests.swift` with 5 test cases:

1. **testThatSessionTaskFailedWithURLErrorContainingFailingURLReturnsURL**: Verifies that when a `URLError` contains a `failingURL`, the `url` property correctly returns it
2. **testThatSessionTaskFailedWithURLErrorWithoutFailingURLReturnsNil**: Ensures `nil` is returned when `URLError` doesn't contain a `failingURL`
3. **testThatSessionTaskFailedWithNonURLErrorReturnsNil**: Verifies `nil` is returned for non-`URLError` instances
4. **testThatMultipartEncodingFailedStillReturnsURL**: Confirms existing functionality for `.multipartEncodingFailed` still works correctly
5. **testThatOtherErrorCasesReturnNil**: Validates that all other error cases continue to return `nil` as expected

**Test Results:**
- ✅ All new tests pass
- ✅ All existing tests pass (verified with full test suite using ⌘U in Xcode)
- ✅ No breaking changes (backward compatible)
- ✅ Code compiles without warnings
