### PR TITLE
Add @Sendable to RetryPolicy.retry's completion

### DIFF
--- a/Source/Features/RetryPolicy.swift
+++ b/Source/Features/RetryPolicy.swift
@@ -308,7 +308,7 @@ open class RetryPolicy: @unchecked Sendable, RequestInterceptor {
     open func retry(_ request: Request,
                     for session: Session,
                     dueTo error: any Error,
-                    completion: @escaping (RetryResult) -> Void) {
+                    completion: @escaping @Sendable (RetryResult) -> Void) {
         if request.retryCount < retryLimit, shouldRetry(request: request, dueTo: error) {
             completion(.retryWithDelay(pow(Double(exponentialBackoffBase), Double(request.retryCount)) * exponentialBackoffScale))
         } else {


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
Adding on to #3906, this PR adds `@Sendable` to the completion handler of RetryPolicy's retry function