### PR TITLE
Prevent Duplicate Serializer Completion Calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
             name: "watchOS 11.5"
             testPlan: "watchOS"
             xcode: "Xcode_16.4"
-            runsOn: macOS-15
+            runsOn: self-xcode164
           - destination: "OS=11.4,name=Apple Watch Series 10 (46mm)"
             name: "watchOS 11.4"
             testPlan: "watchOS"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,26 +163,6 @@ jobs:
             testPlan: "iOS"
             xcode: "Xcode_16.0"
             runsOn: self-xcode160
-          # - destination: "OS=17.5,name=iPhone 15 Pro"
-          #   name: "iOS 17.5"
-          #   testPlan: "iOS"
-          #   xcode: "Xcode_15.4"
-          #   runsOn: macOS-14
-          # - destination: "OS=17.3,name=iPhone 15 Pro"
-          #   name: "iOS 17.3"
-          #   testPlan: "iOS"
-          #   xcode: "Xcode_15.3"
-          #   runsOn: macOS-14
-          # - destination: "OS=17.2,name=iPhone 15 Pro"
-          #   name: "iOS 17.2"
-          #   testPlan: "iOS"
-          #   xcode: "Xcode_15.2"
-          #   runsOn: macOS-14
-          # - destination: "OS=17.0,name=iPhone 15 Pro"
-          #   name: "iOS 17.0"
-          #   testPlan: "iOS"
-          #   xcode: "Xcode_15.0.1"
-          #   runsOn: macOS-14
     steps:
       - uses: actions/checkout@v6
       - name: Install Firewalk
@@ -208,37 +188,17 @@ jobs:
             name: "tvOS 18.2"
             testPlan: "tvOS"
             xcode: "Xcode_16.2"
-            runsOn: macOS-15
+            runsOn: self-xcode162
           - destination: "OS=18.1,name=Apple TV"
             name: "tvOS 18.1"
             testPlan: "tvOS"
             xcode: "Xcode_16.1"
-            runsOn: firebreak
+            runsOn: self-xcode161
           - destination: "OS=18.0,name=Apple TV"
             name: "tvOS 18.0"
             testPlan: "tvOS"
             xcode: "Xcode_16.0"
-            runsOn: firebreak
-          # - destination: "OS=17.5,name=Apple TV"
-          #   name: "tvOS 17.5"
-          #   testPlan: "tvOS"
-          #   xcode: "Xcode_15.4"
-          #   runsOn: macOS-14
-          # - destination: "OS=17.4,name=Apple TV"
-          #   name: "tvOS 17.4"
-          #   testPlan: "tvOS"
-          #   xcode: "Xcode_15.4"
-          #   runsOn: macOS-14
-          # - destination: "OS=17.2,name=Apple TV"
-          #   name: "tvOS 17.2"
-          #   testPlan: "tvOS"
-          #   xcode: "Xcode_15.2"
-          #   runsOn: macOS-14
-          # - destination: "OS=17.0,name=Apple TV"
-          #   name: "tvOS 17.0"
-          #   testPlan: "tvOS"
-          #   xcode: "Xcode_15.0.1"
-          #   runsOn: macOS-14
+            runsOn: self-xcode160
     steps:
       - uses: actions/checkout@v6
       - name: Install Firewalk
@@ -285,24 +245,6 @@ jobs:
             scheme: "Alamofire visionOS"
             xcode: "Xcode_16.0"
             runsOn: firebreak
-          # - destination: "OS=1.2,name=Apple Vision Pro"
-          #   name: "visionOS 1.2"
-          #   testPlan: "visionOS"
-          #   scheme: "Alamofire visionOS"
-          #   xcode: "Xcode_15.4"
-          #   runsOn: macOS-14
-          # - destination: "OS=1.1,name=Apple Vision Pro"
-          #   name: "visionOS 1.1"
-          #   testPlan: "visionOS"
-          #   scheme: "Alamofire visionOS"
-          #   xcode: "Xcode_15.4"
-          #   runsOn: macOS-14
-          # - destination: "OS=1.0,name=Apple Vision Pro"
-          #   name: "visionOS 1.0"
-          #   testPlan: "visionOS"
-          #   scheme: "Alamofire visionOS"
-          #   xcode: "Xcode_15.2"
-          #   runsOn: macOS-14
     steps:
       - uses: actions/checkout@v6
       - name: Install Firewalk
@@ -328,37 +270,22 @@ jobs:
             name: "watchOS 11.4"
             testPlan: "watchOS"
             xcode: "Xcode_16.4"
-            runsOn: firebreak
-          # - destination: "OS=11.2,name=Apple Watch Series 10 (46mm)"
-          #   name: "watchOS 11.2"
-          #   testPlan: "watchOS"
-          #   xcode: "Xcode_16.2"
-          #   runsOn: macOS-15
+            runsOn: self-xcode164
+          - destination: "OS=11.2,name=Apple Watch Series 10 (46mm)"
+            name: "watchOS 11.2"
+            testPlan: "watchOS"
+            xcode: "Xcode_16.2"
+            runsOn: self-xcode162
           - destination: "OS=11.1,name=Apple Watch Series 10 (46mm)"
             name: "watchOS 11.1"
             testPlan: "watchOS"
-            xcode: "Xcode_16.4"
-            runsOn: firebreak
+            xcode: "Xcode_16.1"
+            runsOn: self-xcode161
           - destination: "OS=11.0,name=Apple Watch Series 10 (46mm)"
             name: "watchOS 11.0"
             testPlan: "watchOS"
-            xcode: "Xcode_16.4"
-            runsOn: firebreak
-          # - destination: "OS=10.5,name=Apple Watch Series 9 (45mm)"
-          #   name: "watchOS 10.5"
-          #   testPlan: "watchOS"
-          #   xcode: "Xcode_15.4"
-          #   runsOn: macOS-14
-          # - destination: "OS=10.2,name=Apple Watch Series 9 (45mm)"
-          #   name: "watchOS 10.2"
-          #   testPlan: "watchOS"
-          #   xcode: "Xcode_15.2"
-          #   runsOn: macOS-14
-          # - destination: "OS=10.0,name=Apple Watch Series 9 (45mm)"
-          #   name: "watchOS 10.0"
-          #   testPlan: "watchOS"
-          #   xcode: "Xcode_15.0.1"
-          #   runsOn: macOS-14
+            xcode: "Xcode_16.0"
+            runsOn: self-xcode160
     steps:
       - uses: actions/checkout@v6
       - name: Install Firewalk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,31 +220,31 @@ jobs:
             testPlan: "visionOS"
             scheme: "Alamofire visionOS"
             xcode: "Xcode_16.4"
-            runsOn: macOS-15
+            runsOn: self-xcode164
           - destination: "OS=2.4,name=Apple Vision Pro"
             name: "visionOS 2.4"
             testPlan: "visionOS"
             scheme: "Alamofire visionOS"
             xcode: "Xcode_16.4"
-            runsOn: macOS-15
+            runsOn: self-xcode164
           - destination: "OS=2.3,name=Apple Vision Pro"
             name: "visionOS 2.3"
             testPlan: "visionOS"
             scheme: "Alamofire visionOS"
             xcode: "Xcode_16.3"
-            runsOn: macOS-15
+            runsOn: self-xcode163
           - destination: "OS=2.1,name=Apple Vision Pro"
             name: "visionOS 2.1"
             testPlan: "visionOS"
             scheme: "Alamofire visionOS"
             xcode: "Xcode_16.1"
-            runsOn: firebreak
+            runsOn: self-xcode161
           - destination: "OS=2.0,name=Apple Vision Pro"
             name: "visionOS 2.0"
             testPlan: "visionOS"
             scheme: "Alamofire visionOS"
             xcode: "Xcode_16.0"
-            runsOn: firebreak
+            runsOn: self-xcode160
     steps:
       - uses: actions/checkout@v6
       - name: Install Firewalk

--- a/.swiftformat
+++ b/.swiftformat
@@ -13,7 +13,7 @@
 --exponentgrouping disabled
 --extensionacl on-declarations
 --fractiongrouping disabled
---ifdef no-indent
+--ifdef preserve
 --importgrouping testable-top
 --operatorfunc no-space
 --nospaceoperators ..<, ...
@@ -29,5 +29,11 @@
 
 --enable isEmpty
 --disable andOperator
+--disable docComments
+--disable noForceTryInTests
+--disable noForceUnwrapInTests
 --disable opaqueGenericParameters
+--disable simplifyGenericConstraints
+--disable wrapFunctionBodies
 --disable wrapMultilineStatementBraces
+--disable wrapPropertyBodies

--- a/Source/Core/DownloadRequest.swift
+++ b/Source/Core/DownloadRequest.swift
@@ -85,9 +85,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
     /// provided file name.
     static let defaultDestinationURL: @Sendable (URL) -> URL = { url in
         let filename = "Alamofire_\(url.lastPathComponent)"
-        let destination = url.deletingLastPathComponent().appendingPathComponent(filename)
-
-        return destination
+        return url.deletingLastPathComponent().appendingPathComponent(filename)
     }
 
     // MARK: Downloadable

--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -110,7 +110,7 @@ public class Request: @unchecked Sendable {
         /// Response serialization closures that handle response parsing.
         var responseSerializers: [@Sendable () -> Void] = []
         /// Whether a serializer has been enqueued for execution. Ensure only one can be enqueued at a time.
-        /// Should be set back to false only when the serializer has completed successfully.
+        /// Should be set back to false only when the serializer has completed successfully or will be retried.
         var isResponseSerializerEnqueued = false
         /// Response serialization completion closures for successful serializers, executed once all response serializers are complete.
         var responseSerializerCompletions: [@Sendable () -> Void] = []

--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -109,6 +109,9 @@ public class Request: @unchecked Sendable {
         var urlSessionTaskHandler: (queue: DispatchQueue, handler: @Sendable (URLSessionTask) -> Void)?
         /// Response serialization closures that handle response parsing.
         var responseSerializers: [@Sendable () -> Void] = []
+        /// Whether a serializer has been enqueued for execution. Ensure only one can be enqueued at a time.
+        /// Should be set back to false only when the serializer has completed successfully.
+        var isResponseSerializerEnqueued = false
         /// Response serialization completion closures for successful serializers, executed once all response serializers are complete.
         var responseSerializerCompletions: [@Sendable () -> Void] = []
         /// Whether response serializer processing is finished.
@@ -580,12 +583,15 @@ public class Request: @unchecked Sendable {
 
     /// Processes the next response serializer and calls all completions if response serialization is complete.
     func processNextResponseSerializer() {
-        let executeOutside: () -> Void = mutableState.write { mutableState in
+        let executeOutside: (() -> Void)? = mutableState.write { mutableState in
+            guard !mutableState.isResponseSerializerEnqueued else { return nil }
+
             let responseSerializerIndex = mutableState.responseSerializerCompletions.count
             let isAvailableSerializer = responseSerializerIndex < mutableState.responseSerializers.count
             let responseSerializer = isAvailableSerializer ? mutableState.responseSerializers[responseSerializerIndex] : nil
 
             if let responseSerializer {
+                mutableState.isResponseSerializerEnqueued = true
                 return { self.serializationQueue.async { responseSerializer() } }
             } else {
                 let completions = mutableState.responseSerializerCompletions
@@ -612,7 +618,7 @@ public class Request: @unchecked Sendable {
             }
         }
 
-        executeOutside()
+        executeOutside?()
     }
 
     /// Notifies the `Request` that the response serializer is complete.
@@ -620,7 +626,10 @@ public class Request: @unchecked Sendable {
     /// - Parameter completion: The completion handler provided with the response serializer, called when all serializers
     ///                         are complete.
     func responseSerializerDidComplete(completion: @escaping @Sendable () -> Void) {
-        mutableState.write { $0.responseSerializerCompletions.append(completion) }
+        mutableState.write { mutableState in
+            mutableState.isResponseSerializerEnqueued = false
+            mutableState.responseSerializerCompletions.append(completion)
+        }
         processNextResponseSerializer()
     }
 
@@ -635,6 +644,7 @@ public class Request: @unchecked Sendable {
             mutableState.error = nil
             mutableState.isFinishing = false
             mutableState.responseSerializerCompletions = []
+            mutableState.isResponseSerializerEnqueued = false
         }
     }
 

--- a/Source/Features/AuthenticationInterceptor.swift
+++ b/Source/Features/AuthenticationInterceptor.swift
@@ -361,9 +361,7 @@ public final class AuthenticationInterceptor<AuthenticatorType>: RequestIntercep
             attempts += 1
         }
 
-        let isRefreshExcessive = refreshAttemptsWithinWindow >= refreshWindow.maximumAttempts
-
-        return isRefreshExcessive
+        return refreshAttemptsWithinWindow >= refreshWindow.maximumAttempts
     }
 
     private func handleRefreshSuccess(_ credential: Credential, insideLock mutableState: inout MutableState) {

--- a/Source/Features/URLEncodedFormEncoder.swift
+++ b/Source/Features/URLEncodedFormEncoder.swift
@@ -279,11 +279,9 @@ public final class URLEncodedFormEncoder {
                 searchRange = lowerCaseRange.upperBound..<searchRange.upperBound
             }
             words.append(wordStart..<searchRange.upperBound)
-            let result = words.map { range in
+            return words.map { range in
                 key[range].lowercased()
             }.joined(separator: separator)
-
-            return result
         }
     }
 
@@ -462,9 +460,7 @@ public final class URLEncodedFormEncoder {
                                                   keyPathEncoding: keyPathEncoding,
                                                   spaceEncoding: spaceEncoding,
                                                   allowedCharacters: allowedCharacters)
-        let query = serializer.serialize(object)
-
-        return query
+        return serializer.serialize(object)
     }
 
     /// Encodes the value as `Data`. This is performed by first creating an encoded `String` and then returning the
@@ -769,25 +765,21 @@ extension _URLEncodedFormEncoder.KeyedContainer: KeyedEncodingContainerProtocol 
     }
 
     func nestedSingleValueEncoder(for key: Key) -> any SingleValueEncodingContainer {
-        let container = _URLEncodedFormEncoder.SingleValueContainer(context: context,
-                                                                    codingPath: nestedCodingPath(for: key),
-                                                                    boolEncoding: boolEncoding,
-                                                                    dataEncoding: dataEncoding,
-                                                                    dateEncoding: dateEncoding,
-                                                                    nilEncoding: nilEncoding)
-
-        return container
+        _URLEncodedFormEncoder.SingleValueContainer(context: context,
+                                                    codingPath: nestedCodingPath(for: key),
+                                                    boolEncoding: boolEncoding,
+                                                    dataEncoding: dataEncoding,
+                                                    dateEncoding: dateEncoding,
+                                                    nilEncoding: nilEncoding)
     }
 
     func nestedUnkeyedContainer(forKey key: Key) -> any UnkeyedEncodingContainer {
-        let container = _URLEncodedFormEncoder.UnkeyedContainer(context: context,
-                                                                codingPath: nestedCodingPath(for: key),
-                                                                boolEncoding: boolEncoding,
-                                                                dataEncoding: dataEncoding,
-                                                                dateEncoding: dateEncoding,
-                                                                nilEncoding: nilEncoding)
-
-        return container
+        _URLEncodedFormEncoder.UnkeyedContainer(context: context,
+                                                codingPath: nestedCodingPath(for: key),
+                                                boolEncoding: boolEncoding,
+                                                dataEncoding: dataEncoding,
+                                                dateEncoding: dateEncoding,
+                                                nilEncoding: nilEncoding)
     }
 
     func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
@@ -1118,9 +1110,7 @@ final class URLEncodedFormSerializer {
         var allowedCharactersWithSpace = allowedCharacters
         allowedCharactersWithSpace.insert(charactersIn: " ")
         let escapedQuery = query.addingPercentEncoding(withAllowedCharacters: allowedCharactersWithSpace) ?? query
-        let spaceEncodedQuery = spaceEncoding.encode(escapedQuery)
-
-        return spaceEncodedQuery
+        return spaceEncoding.encode(escapedQuery)
     }
 }
 

--- a/Tests/CacheTests.swift
+++ b/Tests/CacheTests.swift
@@ -86,9 +86,7 @@ final class CacheTestCase: BaseTestCase {
                 return configuration
             }()
 
-            let manager = Session(configuration: configuration)
-
-            return manager
+            return Session(configuration: configuration)
         }()
 
         primeCachedResponses()

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -794,7 +794,7 @@ final class UploadConcurrencyTests: BaseTestCase {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class WebSocketConcurrencyTests: BaseTestCase {
-    func testThatMessageEventsCanBeStreamed() async throws {
+    func testThatMessageEventsCanBeStreamed() async {
         // Given
         let session = stored(Session())
         let receivedEvent = expectation(description: "receivedEvent")
@@ -810,7 +810,7 @@ final class WebSocketConcurrencyTests: BaseTestCase {
         // Then
     }
 
-    func testThatMessagesCanBeStreamed() async throws {
+    func testThatMessagesCanBeStreamed() async {
         // Given
         let session = stored(Session())
 

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -42,6 +42,36 @@ final class DataRequestConcurrencyTests: BaseTestCase {
         XCTAssertNotNil(value)
     }
 
+    func testThatDataTaskCanBeCancelledConcurrently() async {
+        // Tests fix for https://github.com/Alamofire/Alamofire/issues/3978
+        // Given
+        let session = Session()
+
+        // When: a single request has multiple DataTasks attached.
+        for _ in 0..<100 {
+            let request = session.request(.get)
+            let first = Task {
+                await request
+                    .serializingDecodable(TestResponse.self)
+                    .response
+            }
+            let second = Task {
+                await request
+                    .serializingDecodable(TestResponse.self)
+                    .response
+            }
+
+            async let firstResponse = first.value
+            async let secondResponse = second.value
+            // When: both tasks are cancelled concurrently.
+            async let firstCancel: Void = Task { @Sendable in first.cancel() }.value
+            async let secondCancel: Void = Task { @Sendable in second.cancel() }.value
+
+            // Then: all awaits parts should complete without continuation misuse.
+            _ = await (firstResponse, secondResponse, firstCancel, secondCancel)
+        }
+    }
+
     func testThat500ResponseCanBeRetried() async throws {
         // Given
         let session = stored(Session())

--- a/Tests/InspectorEventMonitor.swift
+++ b/Tests/InspectorEventMonitor.swift
@@ -22,9 +22,8 @@
 //  THE SOFTWARE.
 //
 
-import Foundation
-
 @testable import Alamofire
+import Foundation
 
 final class InspectorEventMonitor: EventMonitor {
     let label: String

--- a/Tests/MultipartFormDataTests.swift
+++ b/Tests/MultipartFormDataTests.swift
@@ -36,7 +36,7 @@ enum BoundaryGenerator {
     }
 
     static func boundary(forBoundaryType boundaryType: BoundaryType, boundaryKey: String) -> String {
-        let boundary = switch boundaryType {
+        switch boundaryType {
         case .initial:
             "--\(boundaryKey)\(EncodingCharacters.crlf)"
         case .encapsulated:
@@ -44,8 +44,6 @@ enum BoundaryGenerator {
         case .final:
             "\(EncodingCharacters.crlf)--\(boundaryKey)--\(EncodingCharacters.crlf)"
         }
-
-        return boundary
     }
 
     static func boundaryData(boundaryType: BoundaryType, boundaryKey: String) -> Data {
@@ -197,9 +195,8 @@ class MultipartFormDataEncodingTestCase: BaseTestCase {
             expectedData.append(BoundaryGenerator.boundaryData(boundaryType: .initial, boundaryKey: boundary))
             expectedData.append(Data((
                 "Content-Disposition: form-data; name=\"unicorn\"; filename=\"unicorn.png\"\(crlf)" +
-                    "Content-Type: image/png\(crlf)\(crlf)").utf8
-            )
-            )
+                    "Content-Type: image/png\(crlf)\(crlf)"
+            ).utf8))
             expectedData.append(try! Data(contentsOf: unicornImageURL))
             expectedData.append(BoundaryGenerator.boundaryData(boundaryType: .final, boundaryKey: boundary))
 
@@ -236,16 +233,14 @@ class MultipartFormDataEncodingTestCase: BaseTestCase {
             expectedData.append(BoundaryGenerator.boundaryData(boundaryType: .initial, boundaryKey: boundary))
             expectedData.append(Data((
                 "Content-Disposition: form-data; name=\"unicorn\"; filename=\"unicorn.png\"\(crlf)" +
-                    "Content-Type: image/png\(crlf)\(crlf)").utf8
-            )
-            )
+                    "Content-Type: image/png\(crlf)\(crlf)"
+            ).utf8))
             expectedData.append(try! Data(contentsOf: unicornImageURL))
             expectedData.append(BoundaryGenerator.boundaryData(boundaryType: .encapsulated, boundaryKey: boundary))
             expectedData.append(Data((
                 "Content-Disposition: form-data; name=\"rainbow\"; filename=\"rainbow.jpg\"\(crlf)" +
-                    "Content-Type: image/jpeg\(crlf)\(crlf)").utf8
-            )
-            )
+                    "Content-Type: image/jpeg\(crlf)\(crlf)"
+            ).utf8))
             expectedData.append(try! Data(contentsOf: rainbowImageURL))
             expectedData.append(BoundaryGenerator.boundaryData(boundaryType: .final, boundaryKey: boundary))
 
@@ -286,9 +281,8 @@ class MultipartFormDataEncodingTestCase: BaseTestCase {
             expectedData.append(BoundaryGenerator.boundaryData(boundaryType: .initial, boundaryKey: boundary))
             expectedData.append(Data((
                 "Content-Disposition: form-data; name=\"unicorn\"; filename=\"unicorn.png\"\(crlf)" +
-                    "Content-Type: image/png\(crlf)\(crlf)").utf8
-            )
-            )
+                    "Content-Type: image/png\(crlf)\(crlf)"
+            ).utf8))
             expectedData.append(try! Data(contentsOf: unicornImageURL))
             expectedData.append(BoundaryGenerator.boundaryData(boundaryType: .final, boundaryKey: boundary))
 
@@ -338,16 +332,14 @@ class MultipartFormDataEncodingTestCase: BaseTestCase {
             expectedData.append(BoundaryGenerator.boundaryData(boundaryType: .initial, boundaryKey: boundary))
             expectedData.append(Data((
                 "Content-Disposition: form-data; name=\"unicorn\"; filename=\"unicorn.png\"\(crlf)" +
-                    "Content-Type: image/png\(crlf)\(crlf)").utf8
-            )
-            )
+                    "Content-Type: image/png\(crlf)\(crlf)"
+            ).utf8))
             expectedData.append(try! Data(contentsOf: unicornImageURL))
             expectedData.append(BoundaryGenerator.boundaryData(boundaryType: .encapsulated, boundaryKey: boundary))
             expectedData.append(Data((
                 "Content-Disposition: form-data; name=\"rainbow\"; filename=\"rainbow.jpg\"\(crlf)" +
-                    "Content-Type: image/jpeg\(crlf)\(crlf)").utf8
-            )
-            )
+                    "Content-Type: image/jpeg\(crlf)\(crlf)"
+            ).utf8))
             expectedData.append(try! Data(contentsOf: rainbowImageURL))
             expectedData.append(BoundaryGenerator.boundaryData(boundaryType: .final, boundaryKey: boundary))
 
@@ -394,22 +386,19 @@ class MultipartFormDataEncodingTestCase: BaseTestCase {
             expectedData.append(BoundaryGenerator.boundaryData(boundaryType: .initial, boundaryKey: boundary))
             expectedData.append(Data(
                 "Content-Disposition: form-data; name=\"lorem\"\(crlf)\(crlf)".utf8
-            )
-            )
+            ))
             expectedData.append(loremData)
             expectedData.append(BoundaryGenerator.boundaryData(boundaryType: .encapsulated, boundaryKey: boundary))
             expectedData.append(Data((
                 "Content-Disposition: form-data; name=\"unicorn\"; filename=\"unicorn.png\"\(crlf)" +
-                    "Content-Type: image/png\(crlf)\(crlf)").utf8
-            )
-            )
+                    "Content-Type: image/png\(crlf)\(crlf)"
+            ).utf8))
             expectedData.append(try! Data(contentsOf: unicornImageURL))
             expectedData.append(BoundaryGenerator.boundaryData(boundaryType: .encapsulated, boundaryKey: boundary))
             expectedData.append(Data((
                 "Content-Disposition: form-data; name=\"rainbow\"; filename=\"rainbow.jpg\"\(crlf)" +
-                    "Content-Type: image/jpeg\(crlf)\(crlf)").utf8
-            )
-            )
+                    "Content-Type: image/jpeg\(crlf)\(crlf)"
+            ).utf8))
             expectedData.append(try! Data(contentsOf: rainbowImageURL))
             expectedData.append(BoundaryGenerator.boundaryData(boundaryType: .final, boundaryKey: boundary))
 
@@ -533,9 +522,8 @@ final class MultipartFormDataWriteEncodedDataToDiskTestCase: BaseTestCase {
             expectedFileData.append(BoundaryGenerator.boundaryData(boundaryType: .initial, boundaryKey: boundary))
             expectedFileData.append(Data((
                 "Content-Disposition: form-data; name=\"unicorn\"; filename=\"unicorn.png\"\(crlf)" +
-                    "Content-Type: image/png\(crlf)\(crlf)").utf8
-            )
-            )
+                    "Content-Type: image/png\(crlf)\(crlf)"
+            ).utf8))
             expectedFileData.append(try! Data(contentsOf: unicornImageURL))
             expectedFileData.append(BoundaryGenerator.boundaryData(boundaryType: .final, boundaryKey: boundary))
 
@@ -575,16 +563,14 @@ final class MultipartFormDataWriteEncodedDataToDiskTestCase: BaseTestCase {
             expectedFileData.append(BoundaryGenerator.boundaryData(boundaryType: .initial, boundaryKey: boundary))
             expectedFileData.append(Data((
                 "Content-Disposition: form-data; name=\"unicorn\"; filename=\"unicorn.png\"\(crlf)" +
-                    "Content-Type: image/png\(crlf)\(crlf)").utf8
-            )
-            )
+                    "Content-Type: image/png\(crlf)\(crlf)"
+            ).utf8))
             expectedFileData.append(try! Data(contentsOf: unicornImageURL))
             expectedFileData.append(BoundaryGenerator.boundaryData(boundaryType: .encapsulated, boundaryKey: boundary))
             expectedFileData.append(Data((
                 "Content-Disposition: form-data; name=\"rainbow\"; filename=\"rainbow.jpg\"\(crlf)" +
-                    "Content-Type: image/jpeg\(crlf)\(crlf)").utf8
-            )
-            )
+                    "Content-Type: image/jpeg\(crlf)\(crlf)"
+            ).utf8))
             expectedFileData.append(try! Data(contentsOf: rainbowImageURL))
             expectedFileData.append(BoundaryGenerator.boundaryData(boundaryType: .final, boundaryKey: boundary))
 
@@ -630,8 +616,8 @@ final class MultipartFormDataWriteEncodedDataToDiskTestCase: BaseTestCase {
             expectedFileData.append(BoundaryGenerator.boundaryData(boundaryType: .initial, boundaryKey: boundary))
             expectedFileData.append(Data((
                 "Content-Disposition: form-data; name=\"unicorn\"; filename=\"unicorn.png\"\(crlf)" +
-                    "Content-Type: image/png\(crlf)\(crlf)").utf8
-            ))
+                    "Content-Type: image/png\(crlf)\(crlf)"
+            ).utf8))
             expectedFileData.append(unicornImageData.prefix(Int(expectedFileStreamUploadLength)))
             expectedFileData.append(BoundaryGenerator.boundaryData(boundaryType: .final, boundaryKey: boundary))
 
@@ -675,9 +661,8 @@ final class MultipartFormDataWriteEncodedDataToDiskTestCase: BaseTestCase {
             expectedFileData.append(BoundaryGenerator.boundaryData(boundaryType: .initial, boundaryKey: boundary))
             expectedFileData.append(Data((
                 "Content-Disposition: form-data; name=\"unicorn\"; filename=\"unicorn.png\"\(crlf)" +
-                    "Content-Type: image/png\(crlf)\(crlf)").utf8
-            )
-            )
+                    "Content-Type: image/png\(crlf)\(crlf)"
+            ).utf8))
             expectedFileData.append(try! Data(contentsOf: unicornImageURL))
             expectedFileData.append(BoundaryGenerator.boundaryData(boundaryType: .final, boundaryKey: boundary))
 
@@ -730,16 +715,14 @@ final class MultipartFormDataWriteEncodedDataToDiskTestCase: BaseTestCase {
             expectedFileData.append(BoundaryGenerator.boundaryData(boundaryType: .initial, boundaryKey: boundary))
             expectedFileData.append(Data((
                 "Content-Disposition: form-data; name=\"unicorn\"; filename=\"unicorn.png\"\(crlf)" +
-                    "Content-Type: image/png\(crlf)\(crlf)").utf8
-            )
-            )
+                    "Content-Type: image/png\(crlf)\(crlf)"
+            ).utf8))
             expectedFileData.append(try! Data(contentsOf: unicornImageURL))
             expectedFileData.append(BoundaryGenerator.boundaryData(boundaryType: .encapsulated, boundaryKey: boundary))
             expectedFileData.append(Data((
                 "Content-Disposition: form-data; name=\"rainbow\"; filename=\"rainbow.jpg\"\(crlf)" +
-                    "Content-Type: image/jpeg\(crlf)\(crlf)").utf8
-            )
-            )
+                    "Content-Type: image/jpeg\(crlf)\(crlf)"
+            ).utf8))
             expectedFileData.append(try! Data(contentsOf: rainbowImageURL))
             expectedFileData.append(BoundaryGenerator.boundaryData(boundaryType: .final, boundaryKey: boundary))
 
@@ -789,22 +772,19 @@ final class MultipartFormDataWriteEncodedDataToDiskTestCase: BaseTestCase {
             expectedFileData.append(BoundaryGenerator.boundaryData(boundaryType: .initial, boundaryKey: boundary))
             expectedFileData.append(Data(
                 "Content-Disposition: form-data; name=\"lorem\"\(crlf)\(crlf)".utf8
-            )
-            )
+            ))
             expectedFileData.append(loremData)
             expectedFileData.append(BoundaryGenerator.boundaryData(boundaryType: .encapsulated, boundaryKey: boundary))
             expectedFileData.append(Data((
                 "Content-Disposition: form-data; name=\"unicorn\"; filename=\"unicorn.png\"\(crlf)" +
-                    "Content-Type: image/png\(crlf)\(crlf)").utf8
-            )
-            )
+                    "Content-Type: image/png\(crlf)\(crlf)"
+            ).utf8))
             expectedFileData.append(try! Data(contentsOf: unicornImageURL))
             expectedFileData.append(BoundaryGenerator.boundaryData(boundaryType: .encapsulated, boundaryKey: boundary))
             expectedFileData.append(Data((
                 "Content-Disposition: form-data; name=\"rainbow\"; filename=\"rainbow.jpg\"\(crlf)" +
-                    "Content-Type: image/jpeg\(crlf)\(crlf)").utf8
-            )
-            )
+                    "Content-Type: image/jpeg\(crlf)\(crlf)"
+            ).utf8))
             expectedFileData.append(try! Data(contentsOf: rainbowImageURL))
             expectedFileData.append(BoundaryGenerator.boundaryData(boundaryType: .final, boundaryKey: boundary))
 

--- a/Tests/OfflineRetrierTests.swift
+++ b/Tests/OfflineRetrierTests.swift
@@ -1,13 +1,12 @@
 #if canImport(Network)
+@testable import Alamofire
 import Dispatch
 import Testing
-
-@testable import Alamofire
 
 @Suite("OfflineRetrierTests")
 struct OfflineRetrierTests {
     @Test
-    func requestIsRetriedWhenConnectivityIsRestored() async throws {
+    func requestIsRetriedWhenConnectivityIsRestored() async {
         // Given
         let didStop = Protected(false)
         let monitor = PathMonitor { queue, onResult in
@@ -33,7 +32,7 @@ struct OfflineRetrierTests {
     }
 
     @Test
-    func requestIsNotRetriedWhenTheErrorIsNotOfflineError() async throws {
+    func requestIsNotRetriedWhenTheErrorIsNotOfflineError() async {
         // Given
         let didStop = Protected(false)
         let monitor = PathMonitor { queue, onResult in
@@ -59,7 +58,7 @@ struct OfflineRetrierTests {
     }
 
     @Test
-    func requestIsNotRetriedWhenPathTimesOut() async throws {
+    func requestIsNotRetriedWhenPathTimesOut() async {
         // Given
         let didStop = Protected(false)
         let pathAvailable: Protected<DispatchWorkItem?> = .init(nil)
@@ -88,7 +87,7 @@ struct OfflineRetrierTests {
     }
 
     @Test
-    func sessionWideRetrierCanRetryMultipleRequests() async throws {
+    func sessionWideRetrierCanRetryMultipleRequests() async {
         // Given
         let didStop = Protected(false)
         let pathAvailable: Protected<DispatchWorkItem?> = .init(nil)
@@ -121,7 +120,7 @@ struct OfflineRetrierTests {
     }
 
     @Test
-    func sessionWideRetrierCanRetryMultipleRequestsTwice() async throws {
+    func sessionWideRetrierCanRetryMultipleRequestsTwice() async {
         // Given
         let didStop = Protected(false)
         let pathAvailable: Protected<DispatchWorkItem?> = .init(nil)
@@ -166,7 +165,7 @@ struct OfflineRetrierTests {
     }
 
     @Test
-    func sessionWideRetrierCanTimeOutMultipleRequests() async throws {
+    func sessionWideRetrierCanTimeOutMultipleRequests() async {
         // Given
         let didStop = Protected(false)
         let pathAvailable: Protected<DispatchWorkItem?> = .init(nil)
@@ -199,7 +198,7 @@ struct OfflineRetrierTests {
     }
 
     @Test
-    func offlineRetrierNeverStartsOrStopsWhenImmediatelyDeinited() async throws {
+    func offlineRetrierNeverStartsOrStopsWhenImmediatelyDeinited() {
         // Given
         let didStart = Protected(false)
         let didStop = Protected(false)

--- a/Tests/ProtectedTests.swift
+++ b/Tests/ProtectedTests.swift
@@ -24,7 +24,6 @@
 
 @testable
 import Alamofire
-
 import XCTest
 
 final class ProtectedTests: BaseTestCase {

--- a/Tests/RequestInterceptorTests.swift
+++ b/Tests/RequestInterceptorTests.swift
@@ -22,10 +22,9 @@
 //  THE SOFTWARE.
 //
 
+@testable import Alamofire
 import Foundation
 import Testing
-
-@testable import Alamofire
 
 private struct MockError: Error {}
 private struct RetryError: Error {}
@@ -35,7 +34,7 @@ private struct RetryError: Error {}
 @Suite
 struct RetryResultTests {
     @Test
-    func retryRequiredProperty() async throws {
+    func retryRequiredProperty() {
         // Given, When
         let retry = RetryResult.retry
         let retryWithDelay = RetryResult.retryWithDelay(1.0)
@@ -50,7 +49,7 @@ struct RetryResultTests {
     }
 
     @Test
-    func delayProperty() async throws {
+    func delayProperty() {
         // Given, When
         let retry = RetryResult.retry
         let retryWithDelay = RetryResult.retryWithDelay(1.0)
@@ -85,7 +84,7 @@ struct RetryResultTests {
 @Suite
 struct AdapterTests {
     @Test
-    func thatAdapterCallsAdaptHandler() async throws {
+    func thatAdapterCallsAdaptHandler() {
         // Given
         let urlRequest = Endpoint().urlRequest
         let session = Session()
@@ -107,7 +106,7 @@ struct AdapterTests {
     }
 
     @Test
-    func thatAdapterCallsAdaptHandlerWithStateAPI() async throws {
+    func thatAdapterCallsAdaptHandlerWithStateAPI() {
         // Given
         let urlRequest = Endpoint().urlRequest
         let session = Session()
@@ -132,7 +131,7 @@ struct AdapterTests {
     }
 
     @Test
-    func thatAdapterCallsRequestRetrierDefaultImplementationInProtocolExtension() async throws {
+    func thatAdapterCallsRequestRetrierDefaultImplementationInProtocolExtension() {
         // Given
         let session = Session(startRequestsImmediately: false)
         let request = session.request(.default)
@@ -149,7 +148,7 @@ struct AdapterTests {
     }
 
     @Test
-    func thatAdapterCanBeImplementedAsynchronously() async throws {
+    func thatAdapterCanBeImplementedAsynchronously() async {
         // Given
         let urlRequest = Endpoint().urlRequest
         let session = Session()
@@ -178,7 +177,7 @@ struct AdapterTests {
 @Suite
 struct RetrierTests {
     @Test
-    func thatRetrierCallsRetryHandler() async throws {
+    func thatRetrierCallsRetryHandler() {
         // Given
         let session = Session(startRequestsImmediately: false)
         let request = session.request(.default)
@@ -196,7 +195,7 @@ struct RetrierTests {
     }
 
     @Test
-    func thatRetrierCallsRequestAdapterDefaultImplementationInProtocolExtension() async throws {
+    func thatRetrierCallsRequestAdapterDefaultImplementationInProtocolExtension() {
         // Given
         let urlRequest = Endpoint().urlRequest
         let session = Session()
@@ -213,7 +212,7 @@ struct RetrierTests {
     }
 
     @Test
-    func thatRetrierCanBeImplementedAsynchronously() async throws {
+    func thatRetrierCanBeImplementedAsynchronously() async {
         // Given
         let session = Session(startRequestsImmediately: false)
         let request = session.request(.default)
@@ -376,7 +375,7 @@ struct InterceptorTests {
     }
 
     @Test
-    func thatInterceptorCanAdaptRequestAsynchronously() async throws {
+    func thatInterceptorCanAdaptRequestAsynchronously() async {
         // Given
         let urlRequest = Endpoint().urlRequest
         let session = Session()
@@ -455,7 +454,7 @@ struct InterceptorTests {
     }
 
     @Test
-    func thatInterceptorCanRetryRequestAsynchronously() async throws {
+    func thatInterceptorCanRetryRequestAsynchronously() async {
         // Given
         let session = Session(startRequestsImmediately: false)
         let request = session.request(.default)
@@ -551,7 +550,7 @@ struct InterceptorTests {
 @Suite
 struct InterceptorRequestTests {
     @Test
-    func thatRetryPolicyRetriesRequestTimeout() async throws {
+    func thatRetryPolicyRetriesRequestTimeout() async {
         // Given
         let interceptor = InspectorInterceptor(RetryPolicy(retryLimit: 1, exponentialBackoffScale: 0.1))
         let urlRequest = Endpoint.delay(1).modifying(\.timeout, to: 0.01)

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -1005,9 +1005,7 @@ final class RequestCURLDescriptionTestCase: BaseTestCase {
         let configuration = URLSessionConfiguration.af.default
         configuration.headers = headers
 
-        let session = Session(configuration: configuration, requestSetup: .eager)
-
-        return session
+        return Session(configuration: configuration, requestSetup: .eager)
     }()
 
     let sessionWithContentTypeHeader: Session = {
@@ -1017,9 +1015,7 @@ final class RequestCURLDescriptionTestCase: BaseTestCase {
         let configuration = URLSessionConfiguration.af.default
         configuration.headers = headers
 
-        let session = Session(configuration: configuration, requestSetup: .eager)
-
-        return session
+        return Session(configuration: configuration, requestSetup: .eager)
     }()
 
     func sessionWithCookie(_ cookie: HTTPCookie) -> Session {
@@ -1033,9 +1029,7 @@ final class RequestCURLDescriptionTestCase: BaseTestCase {
         let configuration = URLSessionConfiguration.af.default
         configuration.httpShouldSetCookies = false
 
-        let session = Session(configuration: configuration, requestSetup: .eager)
-
-        return session
+        return Session(configuration: configuration, requestSetup: .eager)
     }()
 
     // MARK: Tests

--- a/Tests/ServerTrustEvaluatorTests.swift
+++ b/Tests/ServerTrustEvaluatorTests.swift
@@ -53,9 +53,7 @@ private enum TestCertificates {
     static func certificate(filename: String) -> SecCertificate {
         let filePath = Bundle.test.path(forResource: filename, ofType: "cer")!
         let data = try! Data(contentsOf: URL(fileURLWithPath: filePath))
-        let certificate = SecCertificateCreateWithData(nil, data as CFData)!
-
-        return certificate
+        return SecCertificateCreateWithData(nil, data as CFData)!
     }
 }
 
@@ -80,7 +78,7 @@ private enum TestTrusts {
     case leafValidDNSNameWithIncorrectIntermediate
 
     var trust: SecTrust {
-        let trust: SecTrust = switch self {
+        switch self {
         case .leafWildcard:
             TestTrusts.trustWithCertificates([TestCertificates.leafWildcard,
                                               TestCertificates.intermediateCA1,
@@ -125,8 +123,6 @@ private enum TestTrusts {
                                               TestCertificates.intermediateCA1,
                                               TestCertificates.rootCA])
         }
-
-        return trust
     }
 
     static func trustWithCertificates(_ certificates: [SecCertificate]) -> SecTrust {
@@ -1304,7 +1300,7 @@ class ServerTrustPolicyPinPublicKeysTestCase: ServerTrustPolicyTestCase {
 // MARK: -
 
 class ServerTrustPolicyDisableEvaluationTestCase: ServerTrustPolicyTestCase {
-    func testThatCertificateChainMissingIntermediateCertificatePassesEvaluation() throws {
+    func testThatCertificateChainMissingIntermediateCertificatePassesEvaluation() {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafValidDNSNameMissingIntermediate.trust
@@ -1317,7 +1313,7 @@ class ServerTrustPolicyDisableEvaluationTestCase: ServerTrustPolicyTestCase {
         XCTAssertTrue(result.isSuccess, "server trust should pass evaluation")
     }
 
-    func testThatExpiredLeafCertificatePassesEvaluation() throws {
+    func testThatExpiredLeafCertificatePassesEvaluation() {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafExpired.trust
@@ -1350,7 +1346,7 @@ class ServerTrustPolicyCompositeTestCase: ServerTrustPolicyTestCase {
 //        XCTAssertTrue(result.isSuccess, "server trust should pass evaluation")
 //    }
 
-    func testThatNonAnchoredRootCertificateChainFailsEvaluationWithoutHostValidation() throws {
+    func testThatNonAnchoredRootCertificateChainFailsEvaluationWithoutHostValidation() {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.trustWithCertificates([TestCertificates.leafValidDNSName,
@@ -1366,7 +1362,7 @@ class ServerTrustPolicyCompositeTestCase: ServerTrustPolicyTestCase {
         XCTAssertFalse(result.isSuccess, "server trust should not pass evaluation")
     }
 
-    func testThatExpiredLeafCertificateFailsDefaultAndRevocationComposite() throws {
+    func testThatExpiredLeafCertificateFailsDefaultAndRevocationComposite() {
         // Given
         let host = "test.alamofire.org"
         let serverTrust = TestTrusts.leafExpired.trust

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -131,7 +131,7 @@ final class SessionTestCase: BaseTestCase {
             let result = mutableState.write { mutableState in
                 mutableState.adaptCalledCount += 1
 
-                let result: Result<URLRequest, any Error> = Result {
+                return Result {
                     if mutableState.throwsErrorOnFirstAdapt {
                         mutableState.throwsErrorOnFirstAdapt = false
                         throw AFError.invalidURL(url: "/adapt/error/1")
@@ -152,8 +152,6 @@ final class SessionTestCase: BaseTestCase {
 
                     return urlRequest
                 }
-
-                return result
             }
 
             completion(result)
@@ -1286,7 +1284,7 @@ final class SessionTestCase: BaseTestCase {
     }
 
     @MainActor
-    func testThatSessionCallsRequestRetrierForAllResponseSerializersThatThrowError() throws {
+    func testThatSessionCallsRequestRetrierForAllResponseSerializersThatThrowError() {
         // Given
         let handler = RequestHandler(throwsErrorOnRetry: true)
 
@@ -1341,7 +1339,7 @@ final class SessionTestCase: BaseTestCase {
     }
 
     @MainActor
-    func testThatSessionRetriesRequestImmediatelyWhenResponseSerializerRequestsRetry() throws {
+    func testThatSessionRetriesRequestImmediatelyWhenResponseSerializerRequestsRetry() {
         // Given
         let handler = RequestHandler()
         let session = Session()

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -38,9 +38,7 @@ private enum TestCertificates {
     static func certificate(filename: String) -> SecCertificate {
         let filePath = Bundle.test.path(forResource: filename, ofType: "cer")!
         let data = try! Data(contentsOf: URL(fileURLWithPath: filePath))
-        let certificate = SecCertificateCreateWithData(nil, data as CFData)!
-
-        return certificate
+        return SecCertificateCreateWithData(nil, data as CFData)!
     }
 }
 

--- a/Tests/URLProtocolTests.swift
+++ b/Tests/URLProtocolTests.swift
@@ -41,9 +41,7 @@ class ProxyURLProtocol: URLProtocol {
             return configuration
         }()
 
-        let session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
-
-        return session
+        return URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
     }()
 
     weak var activeTask: URLSessionTask?

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -357,7 +357,7 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
     }
 
     @MainActor
-    func testThatCustomBoundaryCanBeSetWhenUploadingMultipartFormData() throws {
+    func testThatCustomBoundaryCanBeSetWhenUploadingMultipartFormData() {
         // Given
         let uploadData = Data("upload_data".utf8)
 


### PR DESCRIPTION
### Issue Link :link:
Fixes #3978

### Goals :soccer:
This PR fixes the possible duplicate completion handler calls that cause #3978.

Due to multiple paths into `processNextResponseSerializer()` there was a logical race where the same response serializer could be completed multiple times when cancelled, leading to a concurrency runtime crash due to resuming a continuation more than once. 

### Implementation Details :construction:
Additional state was added to track whether a `Request` had currently enqueued a serializer which is checked upon entering `processNextResponseSerializer()`, allowing it to return early if a serializer is in flight. This ensures that no matter how many times `processNextResponseSerializer()` is called, only one attempt will enqueue a particular serializer and, potentially, its completion.

### Testing Details :mag:
Additional test added which could locally reproduce the issue.
