### PR TITLE
Replace #file with #fileID

### DIFF
--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -1498,7 +1498,6 @@
 				};
 			};
 			buildConfigurationList = F8111E2D19A95C8B0040E7D1 /* Build configuration list for PBXProject "Alamofire" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -1506,6 +1505,7 @@
 				Base,
 			);
 			mainGroup = F8111E2919A95C8B0040E7D1;
+			preferredProjectObjectVersion = 77;
 			productRefGroup = F8111E3419A95C8B0040E7D1 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";

--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -711,9 +711,9 @@
 		319917B8209CE53A00103A19 /* OperationQueue+Alamofire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperationQueue+Alamofire.swift"; sourceTree = "<group>"; };
 		319ECEA025EC96E8001C38CA /* ci.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = ci.yml; sourceTree = "<group>"; };
 		319ECEA125EC96E8001C38CA /* PULL_REQUEST_TEMPLATE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = PULL_REQUEST_TEMPLATE.md; sourceTree = "<group>"; };
-		319ECEA225EC96E8001C38CA /* BUG_REPORT.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = BUG_REPORT.md; sourceTree = "<group>"; };
+		319ECEA225EC96E8001C38CA /* bug_report.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = bug_report.md; sourceTree = "<group>"; };
 		319ECEA425EC96E8001C38CA /* config.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = config.yml; sourceTree = "<group>"; };
-		319ECEA525EC9710001C38CA /* FEATURE_REQUEST.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = FEATURE_REQUEST.md; sourceTree = "<group>"; };
+		319ECEA525EC9710001C38CA /* feature_request.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = feature_request.md; sourceTree = "<group>"; };
 		31B2CA9521AA25CD005B371A /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		31B3DE3A25C11CEA00760641 /* Concurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Concurrency.swift; sourceTree = "<group>"; };
 		31B3DE4E25C120D800760641 /* ConcurrencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcurrencyTests.swift; sourceTree = "<group>"; };
@@ -944,8 +944,8 @@
 		319ECEA325EC96E8001C38CA /* ISSUE_TEMPLATE */ = {
 			isa = PBXGroup;
 			children = (
-				319ECEA225EC96E8001C38CA /* BUG_REPORT.md */,
-				319ECEA525EC9710001C38CA /* FEATURE_REQUEST.md */,
+				319ECEA225EC96E8001C38CA /* bug_report.md */,
+				319ECEA525EC9710001C38CA /* feature_request.md */,
 				319ECEA425EC96E8001C38CA /* config.yml */,
 			);
 			path = ISSUE_TEMPLATE;

--- a/Source/Core/AFError.swift
+++ b/Source/Core/AFError.swift
@@ -236,7 +236,7 @@ extension Error {
     }
 
     /// Returns the instance cast as an `AFError`. If casting fails, a `fatalError` with the specified `message` is thrown.
-    public func asAFError(orFailWith message: @autoclosure () -> String, file: StaticString = #file, line: UInt = #line) -> AFError {
+    public func asAFError(orFailWith message: @autoclosure () -> String, file: StaticString = #fileID, line: UInt = #line) -> AFError {
         guard let afError = self as? AFError else {
             fatalError(message(), file: file, line: line)
         }


### PR DESCRIPTION
### Issue Link :link:
Resolves #4002 

### Goals :soccer:
This PR replaces the one use of `#file` with `#fileID`, as the language hasn't fully migrated. Swift through Xcode seems to already use the `#file = #fileID` behavior, so this may only change for non-Apple platforms or when compiled with certain flags.

### Testing Details :mag:
None, only passed through a fatal error.