### PR TITLE
feat: Replace #file with #fileID in AFError.asAFError

### DIFF
--- a/Source/Core/AFError.swift
+++ b/Source/Core/AFError.swift
@@ -236,7 +236,7 @@ extension Error {
     }
 
     /// Returns the instance cast as an `AFError`. If casting fails, a `fatalError` with the specified `message` is thrown.
-    public func asAFError(orFailWith message: @autoclosure () -> String, file: StaticString = #file, line: UInt = #line) -> AFError {
+    public func asAFError(orFailWith message: @autoclosure () -> String, file: StaticString = #fileID, line: UInt = #line) -> AFError {
         guard let afError = self as? AFError else {
             fatalError(message(), file: file, line: line)
         }


### PR DESCRIPTION
Replaces #file with #fileID to prevent leaking absolute file paths in binary distributions, as per Swift 5.3+ recommendation.\n\nCloses #4002