### PR TITLE
Fix: Return AFError instead of fatalError when retryError is not AFError

### DIFF
--- a/Source/Core/DataRequest.swift
+++ b/Source/Core/DataRequest.swift
@@ -291,7 +291,7 @@ public class DataRequest: Request, @unchecked Sendable {
                         didComplete = { completionHandler(response) }
 
                     case let .doNotRetryWithError(retryError):
-                        let result: AFResult<Serializer.SerializedObject> = .failure(retryError.asAFError(orFailWith: "Received retryError was not already AFError"))
+                        let result: AFResult<Serializer.SerializedObject> = .failure(retryError.asAFError(or: .requestRetryFailed(retryError: retryError, originalError: serializerError)))
 
                         let response = DataResponse(request: self.request,
                                                     response: self.response,


### PR DESCRIPTION
### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
