### PR TITLE
feat: add RequestDeduplicator to coalesce concurrent identical DataRequests

### DIFF
--- a/Source/Features/RequestDeduplicator.swift
+++ b/Source/Features/RequestDeduplicator.swift
@@ -1,0 +1,167 @@
+//
+//  RequestDeduplicator.swift
+//
+//  Copyright (c) 2026 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+/// Coordinates concurrent `DataRequest`s for identical resources to avoid redundant network calls.
+///
+/// When multiple callers request the same resource simultaneously, `RequestDeduplicator` returns the same underlying
+/// `DataRequest` to all of them. Each caller can attach its own response handlers; all handlers are invoked when the
+/// single network call completes.
+///
+/// ```swift
+/// let deduplicator = RequestDeduplicator()
+///
+/// // Only one HTTP request goes over the wire; both handlers receive the same response.
+/// let req1 = deduplicator.request(using: session, "https://api.example.com/feed")
+///     .responseDecodable(of: Feed.self) { response in /* update screen A */ }
+///
+/// let req2 = deduplicator.request(using: session, "https://api.example.com/feed")
+///     .responseDecodable(of: Feed.self) { response in /* update screen B */ }
+/// ```
+///
+/// **Cancellation**
+/// Cancelling any one of the returned `DataRequest`s cancels the underlying request for **all** callers, since they
+/// all hold a reference to the same object. This is intentional for the current implementation.
+public final class RequestDeduplicator: @unchecked Sendable {
+    // MARK: - Types
+
+    /// Closure that maps a resolved `URL` and `HTTPMethod` to a deduplication key.
+    ///
+    /// Return `nil` to opt out of deduplication for a particular request; a fresh `DataRequest` is created instead.
+    public typealias KeyProvider = @Sendable (_ url: URL, _ method: HTTPMethod) -> String?
+
+    private enum Outcome {
+        case existing(DataRequest)
+        case new(DataRequest)
+    }
+
+    private struct State {
+        var inflightRequests: [String: DataRequest] = [:]
+    }
+
+    // MARK: - Properties
+
+    /// Default key strategy: `"<METHOD>:<absoluteURL>"`.
+    ///
+    /// Two requests share a key — and are therefore deduplicated — when they target the same absolute URL with the
+    /// same HTTP method.
+    public static let defaultKeyProvider: KeyProvider = { url, method in
+        "\(method.rawValue):\(url.absoluteString)"
+    }
+
+    private let keyProvider: KeyProvider
+    private let state = Protected(State())
+
+    // MARK: - Initialization
+
+    /// Creates a `RequestDeduplicator` using the default key strategy (HTTP method + absolute URL).
+    public init() {
+        keyProvider = Self.defaultKeyProvider
+    }
+
+    /// Creates a `RequestDeduplicator` with a custom key provider.
+    ///
+    /// Use a custom provider when the default strategy is too coarse (e.g. to ignore query parameters)
+    /// or too broad (e.g. to deduplicate across methods).
+    ///
+    /// - Parameter keyProvider: Closure returning the deduplication key for a given `URL` and `HTTPMethod`.
+    ///                          Return `nil` to bypass deduplication for a specific request.
+    public init(keyProvider: @escaping KeyProvider) {
+        self.keyProvider = keyProvider
+    }
+
+    // MARK: - Request
+
+    /// Returns a `DataRequest` for the specified resource, reusing an in-flight request when a duplicate is detected.
+    ///
+    /// If no request with the computed key is currently in-flight, a new `DataRequest` is created via `session`
+    /// and stored. The stored reference is cleared automatically once the request finishes or fails, so subsequent
+    /// calls for the same resource always start a fresh request.
+    ///
+    /// - Parameters:
+    ///   - session:         `Session` used to create new `DataRequest`s.
+    ///   - url:             `URLConvertible` value for the request.
+    ///   - method:          `HTTPMethod` for the request. `.get` by default.
+    ///   - parameters:      `Parameters` to encode into the request. `nil` by default.
+    ///   - encoding:        `ParameterEncoding` to apply. `URLEncoding.default` by default.
+    ///   - headers:         `HTTPHeaders` to attach. `nil` by default.
+    ///   - interceptor:     `RequestInterceptor` for per-request adapt/retry logic. `nil` by default.
+    ///   - requestModifier: `Session.RequestModifier` applied before the `URLRequest` is sent. `nil` by default.
+    ///
+    /// - Returns: An existing in-flight `DataRequest` when a duplicate key is detected, or a new one otherwise.
+    @discardableResult
+    public func request(using session: Session,
+                        _ url: URLConvertible,
+                        method: HTTPMethod = .get,
+                        parameters: Parameters? = nil,
+                        encoding: ParameterEncoding = URLEncoding.default,
+                        headers: HTTPHeaders? = nil,
+                        interceptor: (any RequestInterceptor)? = nil,
+                        requestModifier: Session.RequestModifier? = nil) -> DataRequest {
+        // Resolve the URL before acquiring the lock so the key provider receives a stable, Sendable value.
+        guard let resolvedURL = try? url.asURL(),
+              let key = keyProvider(resolvedURL, method) else {
+            return session.request(url,
+                                   method: method,
+                                   parameters: parameters,
+                                   encoding: encoding,
+                                   headers: headers,
+                                   interceptor: interceptor,
+                                   requestModifier: requestModifier)
+        }
+
+        let outcome: Outcome = state.write { state in
+            if let existing = state.inflightRequests[key] {
+                return .existing(existing)
+            }
+
+            // session.request() dispatches its setup work asynchronously onto Session.rootQueue,
+            // so it returns immediately and holding the lock here is safe.
+            let newRequest = session.request(url,
+                                             method: method,
+                                             parameters: parameters,
+                                             encoding: encoding,
+                                             headers: headers,
+                                             interceptor: interceptor,
+                                             requestModifier: requestModifier)
+            state.inflightRequests[key] = newRequest
+            return .new(newRequest)
+        }
+
+        switch outcome {
+        case .existing(let request):
+            return request
+
+        case .new(let request):
+            // Cleanup is registered outside the lock. Alamofire invokes response handlers immediately
+            // upon registration when the request has already finished (e.g. from URLCache), ensuring
+            // the map entry is always cleared regardless of timing.
+            request.response { [weak self] _ in
+                self?.state.write { $0.inflightRequests.removeValue(forKey: key) }
+            }
+            return request
+        }
+    }
+}

--- a/Tests/RequestDeduplicatorTests.swift
+++ b/Tests/RequestDeduplicatorTests.swift
@@ -1,0 +1,186 @@
+//
+//  RequestDeduplicatorTests.swift
+//
+//  Copyright (c) 2026 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+@testable import Alamofire
+import Testing
+
+@Suite
+struct RequestDeduplicatorTests {
+    // MARK: - Key Provider
+
+    @Test
+    func defaultKeyProviderEncodesMethodAndAbsoluteURL() {
+        // Given
+        let url = URL(string: "https://api.example.com/feed?page=1")!
+
+        // When
+        let getKey = RequestDeduplicator.defaultKeyProvider(url, .get)
+        let postKey = RequestDeduplicator.defaultKeyProvider(url, .post)
+
+        // Then: key includes both method and full URL so method changes produce distinct keys.
+        #expect(getKey == "GET:https://api.example.com/feed?page=1")
+        #expect(postKey == "POST:https://api.example.com/feed?page=1")
+        #expect(getKey != postKey)
+    }
+
+    // MARK: - Deduplication
+
+    @Test
+    func concurrentRequestsForTheSameURLReturnTheSameDataRequest() async {
+        // Given
+        let session = Session()
+        let deduplicator = RequestDeduplicator()
+
+        // When: two calls are made before either request completes.
+        let first = deduplicator.request(using: session, .endpoints(.status(200), .get))
+        let second = deduplicator.request(using: session, .endpoints(.status(200), .get))
+
+        // Then: both variables point to the same DataRequest object.
+        #expect(first === second)
+
+        // Then: the shared request produces a single network task.
+        _ = await first.serializingData().result
+        #expect(first.tasks.count == 1)
+    }
+
+    @Test
+    func bothCallersReceiveASuccessfulResponseViaTheSharedRequest() async {
+        // Given
+        let session = Session()
+        let deduplicator = RequestDeduplicator()
+
+        // When
+        let first = deduplicator.request(using: session, .endpoints(.status(200), .get))
+        let second = deduplicator.request(using: session, .endpoints(.status(200), .get))
+
+        // Then: response handlers attached by each caller both succeed.
+        async let firstResult = first.serializingData().result
+        async let secondResult = second.serializingData().result
+        await #expect(firstResult.isSuccess == true)
+        await #expect(secondResult.isSuccess == true)
+    }
+
+    @Test
+    func requestsForDifferentURLsAreNotDeduplicated() {
+        // Given
+        let session = Session()
+        let deduplicator = RequestDeduplicator()
+
+        // When: two requests target different endpoints.
+        let first = deduplicator.request(using: session, .endpoints(.status(200), .get))
+        let second = deduplicator.request(using: session, .endpoints(.status(201), .get))
+
+        // Then: distinct DataRequest objects are returned.
+        #expect(first !== second)
+    }
+
+    @Test
+    func requestsWithDifferentHTTPMethodsAreNotDeduplicated() {
+        // Given
+        let session = Session()
+        let deduplicator = RequestDeduplicator()
+        let url = URL(string: "https://httpbin.org/anything")!
+
+        // When: same URL, different method.
+        let getRequest = deduplicator.request(using: session, url, method: .get)
+        let postRequest = deduplicator.request(using: session, url, method: .post)
+
+        // Then: the method is part of the key, so these are independent requests.
+        #expect(getRequest !== postRequest)
+    }
+
+    @Test
+    func inflightEntryIsClearedAfterCompletionAllowingFreshDeduplication() async {
+        // Given
+        let session = Session()
+        let deduplicator = RequestDeduplicator()
+
+        // When: the first request runs to completion.
+        // The internal cleanup response handler is registered before the serializingData handler,
+        // so the in-flight map entry is guaranteed to be removed before the await below returns.
+        let first = deduplicator.request(using: session, .endpoints(.status(200), .get))
+        _ = await first.serializingData().result
+
+        // When: a new request is made for the same URL.
+        let second = deduplicator.request(using: session, .endpoints(.status(200), .get))
+
+        // Then: the map was cleared, so a distinct DataRequest is created.
+        #expect(first !== second)
+    }
+
+    // MARK: - Key Provider Customisation
+
+    @Test
+    func returningNilFromKeyProviderBypassesDeduplication() {
+        // Given
+        let session = Session()
+        // When: key provider always opts out.
+        let deduplicator = RequestDeduplicator { _, _ in nil }
+
+        // When
+        let first = deduplicator.request(using: session, .endpoints(.status(200), .get))
+        let second = deduplicator.request(using: session, .endpoints(.status(200), .get))
+
+        // Then: each call produces an independent DataRequest.
+        #expect(first !== second)
+    }
+
+    @Test
+    func customKeyProviderCanWidenDeduplicationBoundaryAcrossMethods() {
+        // Given
+        let session = Session()
+        // When: custom key ignores the HTTP method — GET and POST to the same URL share a key.
+        let deduplicator = RequestDeduplicator { url, _ in url.absoluteString }
+        let url = URL(string: "https://httpbin.org/anything")!
+
+        // When
+        let getRequest = deduplicator.request(using: session, url, method: .get)
+        let postRequest = deduplicator.request(using: session, url, method: .post)
+
+        // Then: same key → same DataRequest.
+        #expect(getRequest === postRequest)
+    }
+
+    @Test
+    func urlResolutionFailureBypassesDeduplication() {
+        // Given
+        let session = Session()
+        let deduplicator = RequestDeduplicator()
+
+        // When: URLConvertible fails to resolve — deduplication is skipped and Session handles the error.
+        let first = deduplicator.request(using: session, ThrowingURL())
+        let second = deduplicator.request(using: session, ThrowingURL())
+
+        // Then: each call produces a distinct (failed) DataRequest.
+        #expect(first !== second)
+    }
+}
+
+// MARK: - Helpers
+
+/// A `URLConvertible` that always throws, used to exercise the URL-resolution failure path.
+private struct ThrowingURL: URLConvertible {
+    private enum TestError: Error { case alwaysThrows }
+    func asURL() throws -> URL { throw TestError.alwaysThrows }
+}


### PR DESCRIPTION
Closes #2239

## Problem

When multiple parts of an app simultaneously request the same resource — a common scenario on screens with several independent components — Alamofire creates a separate `URLSessionDataTask` for each call. The network is hit N times for identical data.

AlamofireImage has solved this for image downloads via its `ImageDownloader`. This PR brings the same capability to the base library in a general, type-safe way.

## Solution

`RequestDeduplicator` is a lightweight coordinator (~80 lines) that sits in front of `Session`. It tracks in-flight `DataRequest`s by a deduplication key and returns the **same `DataRequest` object** to every concurrent caller with the same key.

Because all callers hold a reference to the same object, each can attach its own independent response handlers — they all fire when the single network task completes. No extra queuing, no shared mutable response state.

```swift
let deduplicator = RequestDeduplicator()

// Only one URLSessionDataTask is created; both handlers receive the same response.
let req1 = deduplicator.request(using: session, "https://api.example.com/feed")
    .responseDecodable(of: Feed.self) { updateHomeScreen($0) }

let req2 = deduplicator.request(using: session, "https://api.example.com/feed")
    .responseDecodable(of: Feed.self) { updateWidgetScreen($0) }
```

## Design decisions

**No new protocol / no subclassing.** `RequestDeduplicator` is a standalone coordinator, not a `RequestInterceptor`. Deduplication is a *creation-time* concern — it must decide before a `DataRequest` exists whether to create one at all. The interceptor pipeline runs *after* creation, so it cannot serve this role.

**Thread safety via `Protected<State>` / `os_unfair_lock`.** Identical to `AuthenticationInterceptor` and `OfflineRetrier`. The `session.request()` call inside the write closure is safe because Alamofire dispatches its setup work asynchronously onto `Session.rootQueue`; the lock is never held across a blocking call.

**Automatic cleanup via a response handler.** A `.response { }` handler registered on each new request removes the in-flight entry when the request finishes or fails. This handler is registered *before* any caller-added handlers (which are added after `deduplicator.request()` returns), so the map is guaranteed to be cleared before callers' completions fire.

**Customisable key.** The default strategy is `"METHOD:absoluteURL"`. A `KeyProvider` closure lets callers widen (e.g. ignore query parameters) or narrow (e.g. include a header value) the deduplication boundary. Returning `nil` opts a specific request out entirely.

**Known limitation — cancellation.** Cancelling any one of the returned `DataRequest`s cancels the underlying task for all callers, since they all hold a reference to the same object. This matches AlamofireImage's behaviour and is documented in the API. Per-caller reference counting is left as a future enhancement.

## Files changed

| File | Change |
|------|--------|
| `Source/Features/RequestDeduplicator.swift` | New — implementation (~130 lines with doc comments) |
| `Tests/RequestDeduplicatorTests.swift` | New — 9 tests using Swift Testing, Given/When/Then |

## Tests

```
✔ defaultKeyProviderEncodesMethodAndAbsoluteURL
✔ concurrentRequestsForTheSameURLReturnTheSameDataRequest
✔ bothCallersReceiveASuccessfulResponseViaTheSharedRequest
✔ requestsForDifferentURLsAreNotDeduplicated
✔ requestsWithDifferentHTTPMethodsAreNotDeduplicated
✔ inflightEntryIsClearedAfterCompletionAllowingFreshDeduplication
✔ returningNilFromKeyProviderBypassesDeduplication
✔ customKeyProviderCanWidenDeduplicationBoundaryAcrossMethods
✔ urlResolutionFailureBypassesDeduplication
```