### PR TITLE
Stabilize CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,6 @@ jobs:
           - xcode: "Xcode_26.0"
             runsOn: macos-26
             name: "macOS 26, Xcode 26.0, Swift 6.2.0"
-          - xcode: "Xcode_26.0"
-            runsOn: macos-26
-            name: "macOS 26, Xcode 26.0, Swift 6.2.0"
           - xcode: "Xcode_16.4"
             runsOn: macos-15
             name: "macOS 15, Xcode 16.4, Swift 6.1.2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
           - destination: "OS=26.2,name=iPhone 17 Pro"
             name: "iOS 26.2"
             xcode: "Xcode_26.2"
-            runsOn: self-xcode262
+            runsOn: macos-26 # Run on GH since hosted runners can't find it.
           - destination: "OS=26.1,name=iPhone 17 Pro"
             name: "iOS 26.1"
             xcode: "Xcode_26.1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,7 @@ jobs:
           - destination: "OS=26.1,name=Apple Watch Series 11 (46mm)"
             name: "watchOS 26.1"
             xcode: "Xcode_26.1"
-            runsOn: macos-26
+            runsOn: self-xcode261
           - destination: "OS=26.0,name=Apple Watch Series 11 (46mm)"
             name: "watchOS 26.0"
             xcode: "Xcode_26.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         include:
           - xcode: "Xcode_26.4"
-            runsOn: self-xcode264
+            runsOn: macos-26
             name: "macOS 26, Xcode 26.4, Swift 6.3.0"
           - xcode: "Xcode_26.3"
             runsOn: macos-26
@@ -47,8 +47,8 @@ jobs:
             runsOn: macos-26
             name: "macOS 26, Xcode 26.0, Swift 6.2.0"
           - xcode: "Xcode_26.0"
-            runsOn: self-xcode260
-            name: "macOS 15, Xcode 26.0, Swift 6.2.0"
+            runsOn: macos-26
+            name: "macOS 26, Xcode 26.0, Swift 6.2.0"
           - xcode: "Xcode_16.4"
             runsOn: macos-15
             name: "macOS 15, Xcode 16.4, Swift 6.1.2"
@@ -345,7 +345,7 @@ jobs:
       matrix:
         include:
           - xcode: "Xcode_26.4"
-            runsOn: self-xcode264
+            runsOn: macos-26
             name: "macOS 26, SPM 6.3.0 Test"
           - xcode: "Xcode_26.3"
             runsOn: macOS-26

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
           - destination: "OS=26.2,name=Apple Vision Pro"
             name: "visionOS 26.2"
             xcode: "Xcode_26.2"
-            runsOn: macos-26
+            runsOn: self-xcode262
           - destination: "OS=26.1,name=Apple Vision Pro"
             name: "visionOS 26.1"
             xcode: "Xcode_26.1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,20 +47,20 @@ jobs:
             runsOn: macos-26
             name: "macOS 26, Xcode 26.0, Swift 6.2.0"
           - xcode: "Xcode_26.0"
-            runsOn: [self-macos15, self-xcode260]
+            runsOn: self-xcode260
             name: "macOS 15, Xcode 26.0, Swift 6.2.0"
           - xcode: "Xcode_16.4"
             runsOn: macos-15
             name: "macOS 15, Xcode 16.4, Swift 6.1.2"
           - xcode: "Xcode_16.3"
             runsOn: macos-15
-            name: "macOS 15, Xcode 16.1, Swift 6.1.0"
+            name: "macOS 15, Xcode 16.3, Swift 6.1.0"
           - xcode: "Xcode_16.2"
             runsOn: macos-15
             name: "macOS 15, Xcode 16.2, Swift 6.0.3"
           - xcode: "Xcode_16.1"
             runsOn: macos-15
-            name: "macOS 14, Xcode 16.1, Swift 6.0.2"
+            name: "macOS 15, Xcode 16.1, Swift 6.0.2"
           - xcode: "Xcode_16.0"
             runsOn: macos-15
             name: "macOS 15, Xcode 16.0, Swift 6.0"
@@ -203,7 +203,7 @@ jobs:
           - destination: "OS=26.1,name=Apple TV"
             name: "tvOS 26.1"
             xcode: "Xcode_26.1"
-            runsOn: macos-26
+            runsOn: self-xcode261
           - destination: "OS=26.0,name=Apple TV"
             name: "tvOS 26.0"
             xcode: "Xcode_26.0"

--- a/Alamofire.xcodeproj/project.pbxproj
+++ b/Alamofire.xcodeproj/project.pbxproj
@@ -197,6 +197,11 @@
 		312930AF263E187800473CEA /* empty_string.txt in Resources */ = {isa = PBXBuildFile; fileRef = 4CFB02F21D7D2FA20056F249 /* empty_string.txt */; };
 		312930B0263E187800473CEA /* utf8_string.txt in Resources */ = {isa = PBXBuildFile; fileRef = 4CFB02F41D7D2FA20056F249 /* utf8_string.txt */; };
 		312930B1263E187800473CEA /* utf32_string.txt in Resources */ = {isa = PBXBuildFile; fileRef = 4CFB02F31D7D2FA20056F249 /* utf32_string.txt */; };
+		312EDCED2FA4FF8000EEB257 /* MIMETypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312EDCEC2FA4FF8000EEB257 /* MIMETypeTests.swift */; };
+		312EDCEE2FA4FF8000EEB257 /* MIMETypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312EDCEC2FA4FF8000EEB257 /* MIMETypeTests.swift */; };
+		312EDCEF2FA4FF8000EEB257 /* MIMETypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312EDCEC2FA4FF8000EEB257 /* MIMETypeTests.swift */; };
+		312EDCF02FA4FF8000EEB257 /* MIMETypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312EDCEC2FA4FF8000EEB257 /* MIMETypeTests.swift */; };
+		312EDCF12FA4FF8000EEB257 /* MIMETypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312EDCEC2FA4FF8000EEB257 /* MIMETypeTests.swift */; };
 		312FC4FF2CB079E800E48EAB /* InternalHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312FC4FE2CB079E400E48EAB /* InternalHelpers.swift */; };
 		312FC5002CB079E800E48EAB /* InternalHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312FC4FE2CB079E400E48EAB /* InternalHelpers.swift */; };
 		312FC5012CB079E800E48EAB /* InternalHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312FC4FE2CB079E400E48EAB /* InternalHelpers.swift */; };
@@ -676,6 +681,7 @@
 		31293065263E17D600473CEA /* Alamofire watchOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Alamofire watchOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		312D1E0B1FC2551400E51FF1 /* Usage.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = Usage.md; path = Documentation/Usage.md; sourceTree = "<group>"; };
 		312D1E0C1FC2551400E51FF1 /* AdvancedUsage.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = AdvancedUsage.md; path = Documentation/AdvancedUsage.md; sourceTree = "<group>"; };
+		312EDCEC2FA4FF8000EEB257 /* MIMETypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIMETypeTests.swift; sourceTree = "<group>"; };
 		312FC4FE2CB079E400E48EAB /* InternalHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalHelpers.swift; sourceTree = "<group>"; };
 		31303CC22EF64B2A00EEB257 /* DispatchQueue+AlamofireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+AlamofireTests.swift"; sourceTree = "<group>"; };
 		31425AC0241F098000EE3CCC /* InternalRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalRequestTests.swift; sourceTree = "<group>"; };
@@ -1248,6 +1254,7 @@
 				31913E8A2EEA2ED800EEB257 /* InspectorEventMonitor.swift */,
 				312FC4FE2CB079E400E48EAB /* InternalHelpers.swift */,
 				31762DC9247738FA0025C704 /* LeaksTests.swift */,
+				312EDCEC2FA4FF8000EEB257 /* MIMETypeTests.swift */,
 				31F9683B20BB70290009606F /* NSLoggingEventMonitor.swift */,
 				31727421218BB9A50039FFCC /* TestHelpers.swift */,
 				4C256A4E1B09656A0065714F /* Core */,
@@ -1765,6 +1772,7 @@
 				312FC5012CB079E800E48EAB /* InternalHelpers.swift in Sources */,
 				31293080263E184000473CEA /* AFError+AlamofireTests.swift in Sources */,
 				31293077263E183C00473CEA /* ResponseTests.swift in Sources */,
+				312EDCEF2FA4FF8000EEB257 /* MIMETypeTests.swift in Sources */,
 				31293081263E184000473CEA /* FileManager+AlamofireTests.swift in Sources */,
 				3145E0EA2797DA4200949557 /* ConcurrencyTests.swift in Sources */,
 				31293076263E183C00473CEA /* DownloadTests.swift in Sources */,
@@ -1865,6 +1873,7 @@
 				312FC5022CB079E800E48EAB /* InternalHelpers.swift in Sources */,
 				317338FE2A43BE9000D4EA0A /* BaseTestCase.swift in Sources */,
 				317338FF2A43BE9000D4EA0A /* LeaksTests.swift in Sources */,
+				312EDCF12FA4FF8000EEB257 /* MIMETypeTests.swift in Sources */,
 				317339002A43BE9000D4EA0A /* NSLoggingEventMonitor.swift in Sources */,
 				317339012A43BE9000D4EA0A /* TestHelpers.swift in Sources */,
 				317339022A43BE9000D4EA0A /* AuthenticationTests.swift in Sources */,
@@ -1965,6 +1974,7 @@
 				312FC5002CB079E800E48EAB /* InternalHelpers.swift in Sources */,
 				31B51E8E2434FECB005356DB /* RequestModifierTests.swift in Sources */,
 				4CF627181BA7CC240011A099 /* RequestTests.swift in Sources */,
+				312EDCED2FA4FF8000EEB257 /* MIMETypeTests.swift in Sources */,
 				3111CE9720A7EC3A008315E2 /* ServerTrustEvaluatorTests.swift in Sources */,
 				3111CE9420A7EC32008315E2 /* ResponseSerializationTests.swift in Sources */,
 				3111CE8E20A7EBE7008315E2 /* MultipartFormDataTests.swift in Sources */,
@@ -2165,6 +2175,7 @@
 				312FC5032CB079E800E48EAB /* InternalHelpers.swift in Sources */,
 				31B51E8C2434FECB005356DB /* RequestModifierTests.swift in Sources */,
 				31ED52E81D73891B00199085 /* AFError+AlamofireTests.swift in Sources */,
+				312EDCF02FA4FF8000EEB257 /* MIMETypeTests.swift in Sources */,
 				3111CE9520A7EC39008315E2 /* ServerTrustEvaluatorTests.swift in Sources */,
 				3111CE9220A7EC30008315E2 /* ResponseSerializationTests.swift in Sources */,
 				3111CE8C20A7EBE6008315E2 /* MultipartFormDataTests.swift in Sources */,
@@ -2215,6 +2226,7 @@
 				312FC4FF2CB079E800E48EAB /* InternalHelpers.swift in Sources */,
 				31B51E8D2434FECB005356DB /* RequestModifierTests.swift in Sources */,
 				31ED52E91D73891C00199085 /* AFError+AlamofireTests.swift in Sources */,
+				312EDCEE2FA4FF8000EEB257 /* MIMETypeTests.swift in Sources */,
 				3111CE9620A7EC3A008315E2 /* ServerTrustEvaluatorTests.swift in Sources */,
 				3111CE9320A7EC31008315E2 /* ResponseSerializationTests.swift in Sources */,
 				3111CE8D20A7EBE7008315E2 /* MultipartFormDataTests.swift in Sources */,

--- a/Source/Core/DataRequest.swift
+++ b/Source/Core/DataRequest.swift
@@ -104,15 +104,12 @@ public class DataRequest: Request, @unchecked Sendable {
 
             httpResponseHandler.queue.async {
                 httpResponseHandler.handler(response) { disposition in
-                    if disposition == .cancel {
-                        self.mutableState.write { mutableState in
-                            mutableState.state = .cancelled
-                            mutableState.error = mutableState.error ?? AFError.explicitlyCancelled
-                        }
-                    }
-
                     self.underlyingQueue.async {
                         completionHandler(disposition.sessionDisposition)
+                    }
+
+                    if disposition == .cancel {
+                        self.cancel()
                     }
                 }
             }

--- a/Source/Core/DataRequest.swift
+++ b/Source/Core/DataRequest.swift
@@ -104,12 +104,12 @@ public class DataRequest: Request, @unchecked Sendable {
 
             httpResponseHandler.queue.async {
                 httpResponseHandler.handler(response) { disposition in
-                    self.underlyingQueue.async {
-                        completionHandler(disposition.sessionDisposition)
-                    }
-
                     if disposition == .cancel {
                         self.cancel()
+                    }
+
+                    self.underlyingQueue.async {
+                        completionHandler(disposition.sessionDisposition)
                     }
                 }
             }

--- a/Source/Core/DataStreamRequest.swift
+++ b/Source/Core/DataStreamRequest.swift
@@ -180,15 +180,12 @@ public final class DataStreamRequest: Request, @unchecked Sendable {
 
             httpResponseHandler.queue.async {
                 httpResponseHandler.handler(response) { disposition in
-                    if disposition == .cancel {
-                        self.mutableState.write { mutableState in
-                            mutableState.state = .cancelled
-                            mutableState.error = mutableState.error ?? AFError.explicitlyCancelled
-                        }
-                    }
-
                     self.underlyingQueue.async {
                         completionHandler(disposition.sessionDisposition)
+                    }
+
+                    if disposition == .cancel {
+                        self.cancel()
                     }
                 }
             }

--- a/Source/Core/DataStreamRequest.swift
+++ b/Source/Core/DataStreamRequest.swift
@@ -180,12 +180,12 @@ public final class DataStreamRequest: Request, @unchecked Sendable {
 
             httpResponseHandler.queue.async {
                 httpResponseHandler.handler(response) { disposition in
-                    self.underlyingQueue.async {
-                        completionHandler(disposition.sessionDisposition)
-                    }
-
                     if disposition == .cancel {
                         self.cancel()
+                    }
+
+                    self.underlyingQueue.async {
+                        completionHandler(disposition.sessionDisposition)
                     }
                 }
             }

--- a/Source/Core/DataStreamRequest.swift
+++ b/Source/Core/DataStreamRequest.swift
@@ -161,6 +161,8 @@ public final class DataStreamRequest: Request, @unchecked Sendable {
             #if !canImport(FoundationNetworking) // If we not using swift-corelibs-foundation.
             if let stream = state.outputStream {
                 underlyingQueue.async {
+                    // Ensure we can write, as the stream may have been closed while this was enqueued.
+                    guard stream.hasSpaceAvailable else { return }
                     var bytes = Array(data)
                     stream.write(&bytes, maxLength: bytes.count)
                 }
@@ -344,7 +346,9 @@ public final class DataStreamRequest: Request, @unchecked Sendable {
     @preconcurrency
     @discardableResult
     public func responseStream(on queue: DispatchQueue = .main, stream: @escaping Handler<Data, Never>) -> Self {
-        let parser = { @Sendable [unowned self] (data: Data) in
+        let parser = { @Sendable [weak self] (data: Data) in
+            guard let self else { return }
+
             queue.async {
                 self.capturingError {
                     try stream(.init(event: .stream(.success(data)), token: .init(self)))
@@ -373,7 +377,9 @@ public final class DataStreamRequest: Request, @unchecked Sendable {
     public func responseStream<Serializer: DataStreamSerializer>(using serializer: Serializer,
                                                                  on queue: DispatchQueue = .main,
                                                                  stream: @escaping Handler<Serializer.SerializedObject, AFError>) -> Self {
-        let parser = { @Sendable [unowned self] (data: Data) in
+        let parser = { @Sendable [weak self] (data: Data) in
+            guard let self else { return }
+
             serializationQueue.async {
                 // Start work on serialization queue.
                 let result = Result { try serializer.serialize(data) }
@@ -414,7 +420,9 @@ public final class DataStreamRequest: Request, @unchecked Sendable {
     @discardableResult
     public func responseStreamString(on queue: DispatchQueue = .main,
                                      stream: @escaping Handler<String, Never>) -> Self {
-        let parser = { @Sendable [unowned self] (data: Data) in
+        let parser = { @Sendable [weak self] (data: Data) in
+            guard let self else { return }
+
             serializationQueue.async {
                 // Start work on serialization queue.
                 let string = String(decoding: data, as: UTF8.self)

--- a/Source/Core/DownloadRequest.swift
+++ b/Source/Core/DownloadRequest.swift
@@ -398,7 +398,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
 
                 self.eventMonitor?.request(self, didParseResponse: response)
 
-                guard let serializerError = result.failure, let delegate = self.delegate else {
+                guard !self.isCancelled, let serializerError = result.failure, let delegate = self.delegate else {
                     self.responseSerializerDidComplete { queue.async { completionHandler(response) } }
                     return
                 }

--- a/Source/Core/DownloadRequest.swift
+++ b/Source/Core/DownloadRequest.swift
@@ -67,7 +67,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
                                                    options: Options = []) -> Destination {
         { temporaryURL, response in
             let directoryURLs = FileManager.default.urls(for: directory, in: domain)
-            let url = directoryURLs.first?.appendingPathComponent(response.suggestedFilename!) ?? temporaryURL
+            let url = response.suggestedFilename.flatMap { directoryURLs.first?.appendingPathComponent($0) } ?? temporaryURL
 
             return (url, options)
         }

--- a/Source/Core/DownloadRequest.swift
+++ b/Source/Core/DownloadRequest.swift
@@ -271,10 +271,17 @@ public final class DownloadRequest: Request, @unchecked Sendable {
 
             underlyingQueue.async { self.didCancel() }
 
-            guard let task = mutableState.tasks.last as? URLSessionDownloadTask, task.state != .completed else {
+            // Ensure we have a task. If we do, didCreateTask has been called but wouldn't have changed the task state
+            // since we just transitioned to cancelled. If we don't, didCreateTask hasn't been called yet, so we can
+            // start the finish process and return early, as didCreateTask will perform the task changes but we won't
+            // receive any task delegate callback.
+            guard let task = mutableState.tasks.last as? URLSessionDownloadTask else {
                 underlyingQueue.async { self.finish() }
                 return
             }
+            // We have a task, if it's completed, return early, as the delegate callbacks should be in flight and
+            // cancelling it will have no effect.
+            guard task.state != .completed else { return }
 
             if let completionHandler {
                 // Resume to ensure metrics are gathered.

--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -773,11 +773,14 @@ public class Request: @unchecked Sendable {
 
             underlyingQueue.async { self.didResume() }
 
-            guard let task = mutableState.tasks.last, task.state != .completed else { return true }
+            // Ensure we have a task, otherwise Session hasn't called perform yet.
+            guard let task = mutableState.tasks.last else { return true }
+            // We have a task, so we shouldn't need to trigger perform again.
+            guard task.state != .completed else { return false }
 
             task.resume()
             underlyingQueue.async { self.didResumeTask(task) }
-            return true
+            return false
         }
 
         if needsToPerform {

--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -388,15 +388,37 @@ public class Request: @unchecked Sendable {
     func didCreateTask(_ task: URLSessionTask) {
         dispatchPrecondition(condition: .onQueue(underlyingQueue))
 
-        mutableState.write { state in
-            state.tasks.append(task)
+        mutableState.write { mutableState in
+            mutableState.tasks.append(task)
 
-            guard let urlSessionTaskHandler = state.urlSessionTaskHandler else { return }
+            if let urlSessionTaskHandler = mutableState.urlSessionTaskHandler {
+                urlSessionTaskHandler.queue.async { urlSessionTaskHandler.handler(task) }
+            }
 
-            urlSessionTaskHandler.queue.async { urlSessionTaskHandler.handler(task) }
+            // Only safe because eventMonitor immediately enqueues.
+            // TODO: When switching to sync EventMonitor, restructure event order.
+            mutableState.eventMonitor?.request(self, didCreateTask: task)
+
+            // Should only have an effect if state was updated before the task was created and wasn't able update it.
+            // If this runs before a state update method (e.g. cancel()), it will still be in the initialized state and
+            // do nothing.
+            switch mutableState.state {
+            case .initialized, .finished:
+                // Do nothing.
+                break
+            case .resumed:
+                task.resume()
+                underlyingQueue.async { self.didResumeTask(task) }
+            case .suspended:
+                task.suspend()
+                underlyingQueue.async { self.didSuspendTask(task) }
+            case .cancelled:
+                // Resume to ensure metrics are gathered.
+                task.resume()
+                task.cancel()
+                underlyingQueue.async { self.didCancelTask(task) }
+            }
         }
-
-        eventMonitor?.request(self, didCreateTask: task)
     }
 
     /// Called when resumption is completed.
@@ -664,13 +686,6 @@ public class Request: @unchecked Sendable {
         uploadProgress.completedUnitCount = totalBytesSent
 
         uploadProgressHandler?.queue.async { self.uploadProgressHandler?.handler(self.uploadProgress) }
-    }
-
-    /// Perform a closure on the current `state` while locked.
-    ///
-    /// - Parameter perform: The closure to perform.
-    func withState(perform: (State) -> Void) {
-        mutableState.withState(perform: perform)
     }
 
     // MARK: Task Creation

--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -719,10 +719,17 @@ public class Request: @unchecked Sendable {
 
             underlyingQueue.async { self.didCancel() }
 
-            guard let task = mutableState.tasks.last, task.state != .completed else {
+            // Ensure we have a task. If we do, didCreateTask has been called but wouldn't have changed the task state
+            // since we just transitioned to cancelled. If we don't, didCreateTask hasn't been called yet, so we can
+            // start the finish process and return early, as didCreateTask will perform the task changes but we won't
+            // receive any task delegate callback.
+            guard let task = mutableState.tasks.last else {
                 underlyingQueue.async { self.finish() }
                 return
             }
+            // We have a task, if it's completed, return early, as the delegate callbacks should be in flight and
+            // cancelling it will have no effect.
+            guard task.state != .completed else { return }
 
             // Resume to ensure metrics are gathered.
             task.resume()

--- a/Source/Core/Session.swift
+++ b/Source/Core/Session.swift
@@ -233,7 +233,7 @@ open class Session: @unchecked Sendable {
     }
 
     deinit {
-        let requests = mutableState.read(\.requestTaskMap.requests)
+        let requests = mutableState.read(\.activeRequests)
         delegate.sessionInvalidationCleanup.write {
             for request in requests {
                 request.finish(error: .sessionDeinitialized)
@@ -1433,8 +1433,7 @@ extension Session: SessionStateProvider {
     func cancelRequestsForSessionInvalidation(with error: (any Error)?) {
         dispatchPrecondition(condition: .onQueue(rootQueue))
 
-        mutableState.read(\.requestTaskMap)
-            .requests
+        mutableState.read(\.activeRequests)
             .forEach { $0.finish(error: AFError.sessionInvalidated(error: error)) }
     }
 }

--- a/Source/Core/Session.swift
+++ b/Source/Core/Session.swift
@@ -1163,31 +1163,34 @@ open class Session: @unchecked Sendable {
     /// Starts performing the provided `Request`.
     ///
     /// - Parameter request: The `Request` to perform.
-    func perform(_ request: Request) {
+    func perform(_ request: Request, forRetry isRetrying: Bool = false) {
         rootQueue.async {
-            guard !request.isCancelled else { return }
+            self.mutableState.write { mutableState in
+                guard !request.isCancelled else { return }
+                // Try to insert, only proceeding if this is the first time or we're retrying.
+                // Protects against rapid resume -> suspend -> resume calls which may enqueue multiple performs.
+                guard mutableState.activeRequests.insert(request).inserted || isRetrying else { return }
 
-            self.mutableState.write { $0.activeRequests.insert(request) }
-
-            self.requestQueue.async {
-                // Leaf types must come first, otherwise they will cast as their superclass.
-                switch request {
-                // UploadRequest must come before DataRequest due to subtype relationship.
-                case let r as UploadRequest: self.performUploadRequest(r)
-                case let r as DataRequest: self.performDataRequest(r)
-                case let r as DownloadRequest: self.performDownloadRequest(r)
-                case let r as DataStreamRequest: self.performDataStreamRequest(r)
-                default:
-                    #if canImport(Darwin) && !canImport(FoundationNetworking)
-                    if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *),
-                       let request = request as? WebSocketRequest {
-                        self.performWebSocketRequest(request)
-                    } else {
+                self.requestQueue.async {
+                    // Leaf types must come first, otherwise they will cast as their superclass.
+                    switch request {
+                    // UploadRequest must come before DataRequest due to subtype relationship.
+                    case let r as UploadRequest: self.performUploadRequest(r)
+                    case let r as DataRequest: self.performDataRequest(r)
+                    case let r as DownloadRequest: self.performDownloadRequest(r)
+                    case let r as DataStreamRequest: self.performDataStreamRequest(r)
+                    default:
+                        #if canImport(Darwin) && !canImport(FoundationNetworking)
+                        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *),
+                           let request = request as? WebSocketRequest {
+                            self.performWebSocketRequest(request)
+                        } else {
+                            fatalError("Attempted to perform unsupported Request subclass: \(type(of: request))")
+                        }
+                        #else
                         fatalError("Attempted to perform unsupported Request subclass: \(type(of: request))")
+                        #endif
                     }
-                    #else
-                    fatalError("Attempted to perform unsupported Request subclass: \(type(of: request))")
-                    #endif
                 }
             }
         }
@@ -1336,12 +1339,7 @@ extension Session: RequestDelegate {
     public var startImmediately: Bool { startRequestsImmediately }
 
     public func readyToPerform(request: Request) {
-        mutableState.read {
-            if $0.requestTaskMap[request] == nil {
-                // Safe inside the lock since perform immediately calls async to the rootQueue.
-                perform(request)
-            }
-        }
+        perform(request)
     }
 
     public func cleanup(after request: Request) {
@@ -1370,7 +1368,7 @@ extension Session: RequestDelegate {
                 guard !request.isCancelled else { return }
 
                 request.prepareForRetry()
-                self.perform(request)
+                self.perform(request, forRetry: true)
             }
 
             if let retryDelay = timeDelay {

--- a/Source/Core/Session.swift
+++ b/Source/Core/Session.swift
@@ -235,7 +235,7 @@ open class Session: @unchecked Sendable {
     deinit {
         let requests = mutableState.read(\.activeRequests)
         delegate.sessionInvalidationCleanup.write {
-            for request in requests {
+            for request in requests where !request.isFinished {
                 request.finish(error: .sessionDeinitialized)
             }
         }

--- a/Source/Core/Session.swift
+++ b/Source/Core/Session.swift
@@ -1295,8 +1295,6 @@ open class Session: @unchecked Sendable {
         let task = request.task(for: urlRequest, using: session)
         mutableState.write { $0.requestTaskMap[request] = task }
         request.didCreateTask(task)
-
-        updateStatesForTask(task, request: request)
     }
 
     func didReceiveResumeData(_ data: Data, for request: DownloadRequest) {
@@ -1307,31 +1305,6 @@ open class Session: @unchecked Sendable {
         let task = request.task(forResumeData: data, using: session)
         mutableState.write { $0.requestTaskMap[request] = task }
         request.didCreateTask(task)
-
-        updateStatesForTask(task, request: request)
-    }
-
-    func updateStatesForTask(_ task: URLSessionTask, request: Request) {
-        dispatchPrecondition(condition: .onQueue(rootQueue))
-
-        request.withState { state in
-            switch state {
-            case .initialized, .finished:
-                // Do nothing.
-                break
-            case .resumed:
-                task.resume()
-                rootQueue.async { request.didResumeTask(task) }
-            case .suspended:
-                task.suspend()
-                rootQueue.async { request.didSuspendTask(task) }
-            case .cancelled:
-                // Resume to ensure metrics are gathered.
-                task.resume()
-                task.cancel()
-                rootQueue.async { request.didCancelTask(task) }
-            }
-        }
     }
 
     // MARK: - Adapters and Retriers

--- a/Source/Core/Session.swift
+++ b/Source/Core/Session.swift
@@ -86,12 +86,16 @@ open class Session: @unchecked Sendable {
     @available(*, deprecated, message: "Use [AlamofireNotifications()] directly.")
     public let defaultEventMonitors: [any EventMonitor] = [AlamofireNotifications()]
 
-    /// Internal map between `Request`s and any `URLSessionTasks` that may be in flight for them.
-    var requestTaskMap = RequestTaskMap()
-    /// `Set` of currently active `Request`s.
-    var activeRequests: Set<Request> = []
-    /// Completion events awaiting `URLSessionTaskMetrics`.
-    var waitingCompletions: [URLSessionTask: () -> Void] = [:]
+    struct MutableState {
+        /// Internal map between `Request`s and any `URLSessionTasks` that may be in flight for them.
+        var requestTaskMap = RequestTaskMap()
+        /// `Set` of currently active `Request`s.
+        var activeRequests: Set<Request> = []
+        /// Completion events awaiting `URLSessionTaskMetrics`.
+        var waitingCompletions: [URLSessionTask: () -> Void] = [:]
+    }
+
+    let mutableState = Protected(MutableState())
 
     /// Creates a `Session` from a `URLSession` and other parameters.
     ///
@@ -229,7 +233,13 @@ open class Session: @unchecked Sendable {
     }
 
     deinit {
-        finishRequestsForDeinit()
+        let requests = mutableState.read(\.requestTaskMap.requests)
+        delegate.sessionInvalidationCleanup.write {
+            for request in requests {
+                request.finish(error: .sessionDeinitialized)
+            }
+        }
+
         session.invalidateAndCancel()
     }
 
@@ -246,7 +256,7 @@ open class Session: @unchecked Sendable {
     ///   - action:     Closure to perform with all `Request`s.
     public func withAllRequests(perform action: @escaping @Sendable (Set<Request>) -> Void) {
         rootQueue.async {
-            action(self.activeRequests)
+            action(self.mutableState.read(\.activeRequests))
         }
     }
 
@@ -1157,7 +1167,7 @@ open class Session: @unchecked Sendable {
         rootQueue.async {
             guard !request.isCancelled else { return }
 
-            self.activeRequests.insert(request)
+            self.mutableState.write { $0.activeRequests.insert(request) }
 
             self.requestQueue.async {
                 // Leaf types must come first, otherwise they will cast as their superclass.
@@ -1283,7 +1293,7 @@ open class Session: @unchecked Sendable {
         guard !request.isCancelled else { return }
 
         let task = request.task(for: urlRequest, using: session)
-        requestTaskMap[request] = task
+        mutableState.write { $0.requestTaskMap[request] = task }
         request.didCreateTask(task)
 
         updateStatesForTask(task, request: request)
@@ -1295,7 +1305,7 @@ open class Session: @unchecked Sendable {
         guard !request.isCancelled else { return }
 
         let task = request.task(forResumeData: data, using: session)
-        requestTaskMap[request] = task
+        mutableState.write { $0.requestTaskMap[request] = task }
         request.didCreateTask(task)
 
         updateStatesForTask(task, request: request)
@@ -1341,16 +1351,6 @@ open class Session: @unchecked Sendable {
             request.interceptor ?? interceptor
         }
     }
-
-    // MARK: - Invalidation
-
-    func finishRequestsForDeinit() {
-        rootQueue.async { [requestTaskMap] in
-            for request in requestTaskMap.requests {
-                request.finish(error: AFError.sessionDeinitialized)
-            }
-        }
-    }
 }
 
 // MARK: - RequestDelegate
@@ -1363,17 +1363,16 @@ extension Session: RequestDelegate {
     public var startImmediately: Bool { startRequestsImmediately }
 
     public func readyToPerform(request: Request) {
-        rootQueue.async { [self] in
-            // TODO: Find a better condition to check.
-            // Called either when the Request is manually or automatically resumed.
-            if requestTaskMap[request] == nil {
+        mutableState.read {
+            if $0.requestTaskMap[request] == nil {
+                // Safe inside the lock since perform immediately calls async to the rootQueue.
                 perform(request)
             }
         }
     }
 
     public func cleanup(after request: Request) {
-        activeRequests.remove(request)
+        mutableState.write { $0.activeRequests.remove(request) }
     }
 
     public func retryResult(for request: Request, dueTo error: AFError, completion: @escaping @Sendable (RetryResult) -> Void) {
@@ -1416,42 +1415,55 @@ extension Session: SessionStateProvider {
     func request(for task: URLSessionTask) -> Request? {
         dispatchPrecondition(condition: .onQueue(rootQueue))
 
-        return requestTaskMap[task]
+        return mutableState.read { $0.requestTaskMap[task] }
     }
 
     func didGatherMetricsForTask(_ task: URLSessionTask) {
         dispatchPrecondition(condition: .onQueue(rootQueue))
 
-        let didDisassociate = requestTaskMap.disassociateIfNecessaryAfterGatheringMetricsForTask(task)
+        let completion: (() -> Void)? = mutableState.write { mutableState in
+            let didDisassociate = mutableState.requestTaskMap.disassociateIfNecessaryAfterGatheringMetricsForTask(task)
 
-        if didDisassociate {
-            waitingCompletions[task]?()
-            waitingCompletions[task] = nil
+            if didDisassociate {
+                let completion = mutableState.waitingCompletions[task]
+                mutableState.waitingCompletions[task] = nil
+                return completion
+            } else {
+                return nil
+            }
         }
+        completion?()
     }
 
     func didCompleteTask(_ task: URLSessionTask, completion: @escaping () -> Void) {
         dispatchPrecondition(condition: .onQueue(rootQueue))
 
-        let didDisassociate = requestTaskMap.disassociateIfNecessaryAfterCompletingTask(task)
+        let immediatelyPerformCompletion = mutableState.write { mutableState in
+            let didDisassociate = mutableState.requestTaskMap.disassociateIfNecessaryAfterCompletingTask(task)
 
-        if didDisassociate {
-            completion()
-        } else {
-            waitingCompletions[task] = completion
+            if didDisassociate {
+                return true
+            } else {
+                mutableState.waitingCompletions[task] = completion
+                return false
+            }
         }
+
+        if immediatelyPerformCompletion { completion() }
     }
 
     func credential(for task: URLSessionTask, in protectionSpace: URLProtectionSpace) -> URLCredential? {
         dispatchPrecondition(condition: .onQueue(rootQueue))
 
-        return requestTaskMap[task]?.credential ??
+        return mutableState.read { $0.requestTaskMap[task]?.credential } ??
             session.configuration.urlCredentialStorage?.defaultCredential(for: protectionSpace)
     }
 
     func cancelRequestsForSessionInvalidation(with error: (any Error)?) {
         dispatchPrecondition(condition: .onQueue(rootQueue))
 
-        requestTaskMap.requests.forEach { $0.finish(error: AFError.sessionInvalidated(error: error)) }
+        mutableState.read(\.requestTaskMap)
+            .requests
+            .forEach { $0.finish(error: AFError.sessionInvalidated(error: error)) }
     }
 }

--- a/Source/Core/Session.swift
+++ b/Source/Core/Session.swift
@@ -1433,7 +1433,9 @@ extension Session: SessionStateProvider {
     func cancelRequestsForSessionInvalidation(with error: (any Error)?) {
         dispatchPrecondition(condition: .onQueue(rootQueue))
 
-        mutableState.read(\.activeRequests)
-            .forEach { $0.finish(error: AFError.sessionInvalidated(error: error)) }
+        let requests = mutableState.read(\.activeRequests)
+        for request in requests where !request.isFinished {
+            request.finish(error: .sessionInvalidated(error: error))
+        }
     }
 }

--- a/Source/Core/Session.swift
+++ b/Source/Core/Session.swift
@@ -1345,8 +1345,8 @@ open class Session: @unchecked Sendable {
     // MARK: - Invalidation
 
     func finishRequestsForDeinit() {
-        for request in requestTaskMap.requests {
-            rootQueue.async {
+        rootQueue.async { [requestTaskMap] in
+            for request in requestTaskMap.requests {
                 request.finish(error: AFError.sessionDeinitialized)
             }
         }

--- a/Source/Core/SessionDelegate.swift
+++ b/Source/Core/SessionDelegate.swift
@@ -30,6 +30,7 @@ open class SessionDelegate: NSObject, @unchecked Sendable {
 
     weak var stateProvider: (any SessionStateProvider)?
     var eventMonitor: (any EventMonitor)?
+    var sessionInvalidationCleanup = Protected<(() -> Void)?>(nil)
 
     /// Creates an instance from the given `FileManager`.
     ///
@@ -73,7 +74,15 @@ extension SessionDelegate: URLSessionDelegate {
     open func urlSession(_ session: URLSession, didBecomeInvalidWithError error: (any Error)?) {
         eventMonitor?.urlSession(session, didBecomeInvalidWithError: error)
 
+        // When invalidated due to Session.deinit, stateProvider will already have dropped to nil.
         stateProvider?.cancelRequestsForSessionInvalidation(with: error)
+
+        let sessionInvalidationCleanup = sessionInvalidationCleanup.write {
+            let cleanup = $0
+            $0 = nil
+            return cleanup
+        }
+        sessionInvalidationCleanup?()
     }
 }
 

--- a/Source/Features/AuthenticationInterceptor.swift
+++ b/Source/Features/AuthenticationInterceptor.swift
@@ -204,6 +204,7 @@ public final class AuthenticationInterceptor<AuthenticatorType>: RequestIntercep
 
     private struct MutableState {
         var credential: Credential?
+        var credentialVersion = 0
 
         var isRefreshing = false
         var refreshTimestamps: [TimeInterval] = []
@@ -211,6 +212,11 @@ public final class AuthenticationInterceptor<AuthenticatorType>: RequestIntercep
 
         var adaptOperations: [AdaptOperation] = []
         var requestsToRetry: [@Sendable (RetryResult) -> Void] = []
+
+        mutating func updateCredential(_ credential: Credential?) {
+            self.credential = credential
+            credentialVersion += 1
+        }
     }
 
     // MARK: Properties
@@ -218,7 +224,7 @@ public final class AuthenticationInterceptor<AuthenticatorType>: RequestIntercep
     /// The `Credential` used to authenticate requests.
     public var credential: Credential? {
         get { mutableState.read(\.credential) }
-        set { mutableState.write { $0.credential = newValue } }
+        set { mutableState.write { $0.updateCredential(newValue) } }
     }
 
     let authenticator: AuthenticatorType
@@ -303,7 +309,13 @@ public final class AuthenticationInterceptor<AuthenticatorType>: RequestIntercep
         }
 
         // Do not attempt retry if there is no credential.
-        guard let credential else {
+        guard let (credential, credentialVersion): (Credential, Int) = mutableState.read({ mutableState in
+            if let credential = mutableState.credential {
+                (credential, mutableState.credentialVersion)
+            } else {
+                nil
+            }
+        }) else {
             let error = AuthenticationError.missingCredential
             completion(.doNotRetryWithError(error))
             return
@@ -315,13 +327,22 @@ public final class AuthenticationInterceptor<AuthenticatorType>: RequestIntercep
             return
         }
 
-        mutableState.write { mutableState in
+        // Otherwise, enqueue the completion for the end of refresh.
+        let immediatelyRetry = mutableState.write { mutableState in
+            guard credentialVersion == mutableState.credentialVersion else {
+                // Credential was updated during the prechecks, so immediately retry the request with the new credential.
+                return true
+            }
+            // Credential hasn't been updated, so prepare for an inflight or new refresh.
             mutableState.requestsToRetry.append(completion)
 
-            guard !mutableState.isRefreshing else { return }
+            guard !mutableState.isRefreshing else { return false }
 
             refresh(credential, for: session, insideLock: &mutableState)
+            return false
         }
+
+        if immediatelyRetry { completion(.retry) }
     }
 
     // MARK: Refresh
@@ -365,7 +386,7 @@ public final class AuthenticationInterceptor<AuthenticatorType>: RequestIntercep
     }
 
     private func handleRefreshSuccess(_ credential: Credential, insideLock mutableState: inout MutableState) {
-        mutableState.credential = credential
+        mutableState.updateCredential(credential)
 
         let adaptOperations = mutableState.adaptOperations
         let requestsToRetry = mutableState.requestsToRetry

--- a/Source/Features/AuthenticationInterceptor.swift
+++ b/Source/Features/AuthenticationInterceptor.swift
@@ -202,20 +202,32 @@ public final class AuthenticationInterceptor<AuthenticatorType>: RequestIntercep
         case adaptDeferred
     }
 
+    private enum RefreshState {
+        case idle
+        case refreshing
+        case failed(any Error)
+    }
+
     private struct MutableState {
         var credential: Credential?
         var credentialVersion = 0
 
-        var isRefreshing = false
+        var refreshState: RefreshState = .idle
         var refreshTimestamps: [TimeInterval] = []
         var refreshWindow: RefreshWindow?
 
         var adaptOperations: [AdaptOperation] = []
         var requestsToRetry: [@Sendable (RetryResult) -> Void] = []
 
+        var isRefreshing: Bool {
+            if case .refreshing = refreshState { return true }
+            return false
+        }
+
         mutating func updateCredential(_ credential: Credential?) {
             self.credential = credential
             credentialVersion += 1
+            refreshState = .idle
         }
     }
 
@@ -336,22 +348,29 @@ public final class AuthenticationInterceptor<AuthenticatorType>: RequestIntercep
             return
         }
 
-        // Otherwise, enqueue the completion for the end of refresh.
-        let immediatelyRetry = mutableState.write { mutableState in
+        // Otherwise, enqueue the completion for the end of refresh, or immediately resolve if a prior attempt already
+        // determined the outcome for this credential version.
+        let retryResult: RetryResult? = mutableState.write { mutableState in
             guard credentialVersion == mutableState.credentialVersion else {
                 // Credential was updated during the prechecks, so immediately retry the request with the new credential.
-                return true
+                return .retry
             }
-            // Credential hasn't been updated, so prepare for an inflight or new refresh.
-            mutableState.requestsToRetry.append(completion)
-
-            guard !mutableState.isRefreshing else { return false }
-
-            refresh(credential, for: session, insideLock: &mutableState)
-            return false
+            switch mutableState.refreshState {
+            case let .failed(refreshError):
+                // A refresh was already attempted and failed for this credential version.
+                // Do not queue and do not trigger another refresh.
+                return .doNotRetryWithError(refreshError)
+            case .refreshing:
+                mutableState.requestsToRetry.append(completion)
+                return nil
+            case .idle:
+                mutableState.requestsToRetry.append(completion)
+                refresh(credential, for: session, insideLock: &mutableState)
+                return nil
+            }
         }
 
-        if immediatelyRetry { completion(.retry) }
+        if let result = retryResult { completion(result) }
     }
 
     // MARK: Refresh
@@ -364,7 +383,7 @@ public final class AuthenticationInterceptor<AuthenticatorType>: RequestIntercep
         }
 
         mutableState.refreshTimestamps.append(ProcessInfo.processInfo.systemUptime)
-        mutableState.isRefreshing = true
+        mutableState.refreshState = .refreshing
 
         // Dispatch to queue to hop out of the lock in case authenticator.refresh is implemented synchronously.
         queue.async {
@@ -403,8 +422,6 @@ public final class AuthenticationInterceptor<AuthenticatorType>: RequestIntercep
         mutableState.adaptOperations.removeAll()
         mutableState.requestsToRetry.removeAll()
 
-        mutableState.isRefreshing = false
-
         // Dispatch to queue to hop out of the mutable state lock
         queue.async {
             adaptOperations.forEach { self.adapt($0.urlRequest, for: $0.session, completion: $0.completion) }
@@ -419,7 +436,7 @@ public final class AuthenticationInterceptor<AuthenticatorType>: RequestIntercep
         mutableState.adaptOperations.removeAll()
         mutableState.requestsToRetry.removeAll()
 
-        mutableState.isRefreshing = false
+        mutableState.refreshState = .failed(error)
 
         // Dispatch to queue to hop out of the mutable state lock
         queue.async {

--- a/Source/Features/AuthenticationInterceptor.swift
+++ b/Source/Features/AuthenticationInterceptor.swift
@@ -296,6 +296,12 @@ public final class AuthenticationInterceptor<AuthenticatorType>: RequestIntercep
                 return .adaptDeferred
             }
 
+            // A new request reaching this point represents a fresh request lifecycle. Any prior refresh failure is
+            // stale with respect to this request. Clear it so a subsequent failure can trigger a new refresh.
+            if case .failed = mutableState.refreshState {
+                mutableState.refreshState = .idle
+            }
+
             return .adapt(credential)
         }
 

--- a/Source/Features/AuthenticationInterceptor.swift
+++ b/Source/Features/AuthenticationInterceptor.swift
@@ -254,21 +254,30 @@ public final class AuthenticationInterceptor<AuthenticatorType>: RequestIntercep
 
     public func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping @Sendable (Result<URLRequest, any Error>) -> Void) {
         let adaptResult: AdaptResult = mutableState.write { mutableState in
-            // Queue the adapt operation if a refresh is already in place.
-            guard !mutableState.isRefreshing else {
+            // Defer only when a proactive (requiresRefresh-driven) refresh is in progress. The triggering request
+            // always appends itself to adaptOperations before isRefreshing is set, so any concurrent adapt that
+            // observes isRefreshing == true also observes a non-empty queue.
+            //
+            // When adaptOperations is empty and isRefreshing is true, the refresh was triggered by the retry path. In
+            // that case, do not defer the adaptation and perform the request using the credential so the full adapter
+            // chain, including any non-idempotent adapters earlier in the chain, reruns from scratch on retry rather
+            // than replaying stale intermediate state.
+            if mutableState.isRefreshing, !mutableState.adaptOperations.isEmpty {
+                // Refresh from requiresRefresh is running, adaptation has been deferred.
                 let operation = AdaptOperation(urlRequest: urlRequest, session: session, completion: completion)
                 mutableState.adaptOperations.append(operation)
                 return .adaptDeferred
             }
 
-            // Throw missing credential error is the credential is missing.
+            // Produce a missing credential error if the credential is missing.
             guard let credential = mutableState.credential else {
                 let error = AuthenticationError.missingCredential
                 return .doNotAdapt(error)
             }
 
-            // Queue the adapt operation and trigger refresh operation if credential requires refresh.
-            guard !credential.requiresRefresh else {
+            // Queue the adapt operation and trigger a proactive refresh if the credential requires it and no refresh
+            // is already in progress.
+            if credential.requiresRefresh, !mutableState.isRefreshing {
                 let operation = AdaptOperation(urlRequest: urlRequest, session: session, completion: completion)
                 mutableState.adaptOperations.append(operation)
                 refresh(credential, for: session, insideLock: &mutableState)

--- a/Source/Features/Concurrency.swift
+++ b/Source/Features/Concurrency.swift
@@ -360,6 +360,8 @@ extension DataRequest {
             }
         }
 
+        defer { if shouldAutomaticallyCancel && Task.isCancelled { task.cancel() } }
+
         return DataTask<Value>(request: self, task: task, shouldAutomaticallyCancel: shouldAutomaticallyCancel)
     }
 }
@@ -568,6 +570,8 @@ extension DownloadRequest {
                 self.cancel()
             }
         }
+
+        defer { if shouldAutomaticallyCancel && Task.isCancelled { task.cancel() } }
 
         return DownloadTask<Value>(request: self, task: task, shouldAutomaticallyCancel: shouldAutomaticallyCancel)
     }

--- a/Source/Features/OfflineRetrier.swift
+++ b/Source/Features/OfflineRetrier.swift
@@ -129,7 +129,9 @@ public final class OfflineRetrier: RequestAdapter, RequestRetrier, RequestInterc
 
             guard state.currentMonitor == nil else { return }
 
-            state.startListening { [unowned self] result in
+            state.startListening { [weak self] result in
+                guard let self else { return }
+
                 let retryResult: RetryResult = switch result {
                 case .pathAvailable:
                     .retry

--- a/Source/Features/Validation.swift
+++ b/Source/Features/Validation.swift
@@ -46,7 +46,7 @@ extension Request {
                 return split.components(separatedBy: "/")
             }()
 
-            if let type = components.first, let subtype = components.last {
+            if components.count == 2, let type = components.first, let subtype = components.last {
                 self.type = type
                 self.subtype = subtype
             } else {
@@ -66,9 +66,9 @@ extension Request {
 
     // MARK: Properties
 
-    var acceptableStatusCodes: Range<Int> { 200..<300 }
+    fileprivate var acceptableStatusCodes: Range<Int> { 200..<300 }
 
-    var acceptableContentTypes: [String] {
+    fileprivate var acceptableContentTypes: [String] {
         if let accept = request?.value(forHTTPHeaderField: "Accept") {
             return accept.components(separatedBy: ",")
         }
@@ -78,7 +78,7 @@ extension Request {
 
     // MARK: Status Code
 
-    func validate<S: Sequence>(statusCode acceptableStatusCodes: S,
+    fileprivate func validate<S: Sequence>(statusCode acceptableStatusCodes: S,
                                            response: HTTPURLResponse)
         -> ValidationResult
         where S.Iterator.Element == Int {
@@ -92,7 +92,7 @@ extension Request {
 
     // MARK: Content Type
 
-    func validate<S: Sequence>(contentType acceptableContentTypes: S,
+    fileprivate func validate<S: Sequence>(contentType acceptableContentTypes: S,
                                            response: HTTPURLResponse,
                                            isEmpty: Bool)
         -> ValidationResult
@@ -102,7 +102,7 @@ extension Request {
         return validate(contentType: acceptableContentTypes, response: response)
     }
 
-    func validate<S: Sequence>(contentType acceptableContentTypes: S,
+    fileprivate func validate<S: Sequence>(contentType acceptableContentTypes: S,
                                            response: HTTPURLResponse)
         -> ValidationResult
         where S.Iterator.Element == String {

--- a/Source/Features/Validation.swift
+++ b/Source/Features/Validation.swift
@@ -27,12 +27,12 @@ import Foundation
 extension Request {
     // MARK: Helper Types
 
-    fileprivate typealias ErrorReason = AFError.ResponseValidationFailureReason
+    typealias ErrorReason = AFError.ResponseValidationFailureReason
 
     /// Used to represent whether a validation succeeded or failed.
     public typealias ValidationResult = Result<Void, any(Error & Sendable)>
 
-    fileprivate struct MIMEType {
+    struct MIMEType {
         let type: String
         let subtype: String
 
@@ -66,9 +66,9 @@ extension Request {
 
     // MARK: Properties
 
-    fileprivate var acceptableStatusCodes: Range<Int> { 200..<300 }
+    var acceptableStatusCodes: Range<Int> { 200..<300 }
 
-    fileprivate var acceptableContentTypes: [String] {
+    var acceptableContentTypes: [String] {
         if let accept = request?.value(forHTTPHeaderField: "Accept") {
             return accept.components(separatedBy: ",")
         }
@@ -78,7 +78,7 @@ extension Request {
 
     // MARK: Status Code
 
-    fileprivate func validate<S: Sequence>(statusCode acceptableStatusCodes: S,
+    func validate<S: Sequence>(statusCode acceptableStatusCodes: S,
                                            response: HTTPURLResponse)
         -> ValidationResult
         where S.Iterator.Element == Int {
@@ -92,7 +92,7 @@ extension Request {
 
     // MARK: Content Type
 
-    fileprivate func validate<S: Sequence>(contentType acceptableContentTypes: S,
+    func validate<S: Sequence>(contentType acceptableContentTypes: S,
                                            response: HTTPURLResponse,
                                            isEmpty: Bool)
         -> ValidationResult
@@ -102,7 +102,7 @@ extension Request {
         return validate(contentType: acceptableContentTypes, response: response)
     }
 
-    fileprivate func validate<S: Sequence>(contentType acceptableContentTypes: S,
+    func validate<S: Sequence>(contentType acceptableContentTypes: S,
                                            response: HTTPURLResponse)
         -> ValidationResult
         where S.Iterator.Element == String {

--- a/Tests/AuthenticationInterceptorTests.swift
+++ b/Tests/AuthenticationInterceptorTests.swift
@@ -739,6 +739,59 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
     }
 
     @MainActor
+    func testThatInterceptorAllowsNewRequestsToTriggerRefreshAfterPreviousRefreshFailure() {
+        // Given
+        // A failed refresh sets .failed state on the interceptor. A subsequent, independent request
+        // that also receives a 401 must be able to trigger a fresh refresh attempt; it is not a
+        // late arrival from the failed batch and must not be permanently blocked by cached failure state.
+        let credential = TestCredential()
+        let authenticator = TestAuthenticator(refreshResult: .failure(TestAuthError.refreshNetworkFailure))
+        let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
+        let session = stored(Session())
+
+        // Phase 1 — first request triggers a refresh that fails.
+        let firstExpect = expectation(description: "first request should complete")
+        var firstResponse: AFDataResponse<Data?>?
+
+        let firstRequest = session.request(.status(401), interceptor: interceptor).validate().response {
+            firstResponse = $0
+            firstExpect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Precondition: first request failed and triggered exactly one refresh.
+        XCTAssertEqual(authenticator.applyCount, 1)
+        XCTAssertEqual(authenticator.refreshCount, 1)
+        XCTAssertEqual(authenticator.didRequestFailDueToAuthErrorCount, 1)
+        XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, 1)
+        XCTAssertEqual(firstResponse?.result.isFailure, true)
+        XCTAssertEqual(firstRequest.retryCount, 0)
+
+        // Phase 2 — a new, independent request is made after the failed refresh has fully completed.
+        let secondExpect = expectation(description: "second request should complete")
+        var secondResponse: AFDataResponse<Data?>?
+
+        let secondRequest = session.request(.status(401), interceptor: interceptor).validate().response {
+            secondResponse = $0
+            secondExpect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then: the new request must trigger its own fresh refresh attempt rather than
+        // immediately failing with the cached error left over from the previous failed refresh.
+        XCTAssertEqual(authenticator.applyCount, 2)
+        XCTAssertEqual(authenticator.refreshCount, 2) // Fails: .failed state blocks the new refresh, refreshCount stays at 1.
+        XCTAssertEqual(authenticator.didRequestFailDueToAuthErrorCount, 2)
+        XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, 2)
+        XCTAssertEqual(secondResponse?.result.isFailure, true)
+        XCTAssertEqual(secondResponse?.result.failure?.asAFError?.isRequestRetryError, true)
+        XCTAssertEqual(secondResponse?.result.failure?.asAFError?.underlyingError as? TestAuthError, .refreshNetworkFailure)
+        XCTAssertEqual(secondRequest.retryCount, 0)
+    }
+
+    @MainActor
     func testThatInterceptorTriggersRefreshWithMultipleParallelRequestsReturning401Responses() {
         // Given
         let credential = TestCredential()
@@ -954,6 +1007,513 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
 
         XCTAssertEqual(authenticator.applyCount, 0)
         XCTAssertEqual(authenticator.refreshCount, 1)
+        XCTAssertEqual(authenticator.didRequestFailDueToAuthErrorCount, 0)
+        XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, 0)
+    }
+
+    // MARK: - Tests - Additional Coverage
+
+    @MainActor
+    func testThatInterceptorHandlesMultipleSuccessiveRefreshCyclesCorrectly() {
+        // Given
+        // Two independent 401→refresh→success cycles on the same interceptor instance. Verifies that
+        // updateCredential(_:) fully resets the state machine after each successful refresh so that
+        // subsequent cycles behave identically to the first.
+        let credential = TestCredential()
+        let authenticator = TestAuthenticator()
+        let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
+        let session = stored(Session())
+
+        // When — cycle 1: request with a0 gets 401, refresh (a0 → a1), retry succeeds.
+        let firstExpect = expectation(description: "first cycle should complete")
+        var firstResponse: AFDataResponse<Data?>?
+
+        let firstPathAdapter = PathAdapter(paths: ["/status/401", "/status/200"])
+        let firstCompositeInterceptor = Interceptor(adapters: [firstPathAdapter, interceptor], retriers: [interceptor])
+
+        let firstRequest = session.request(.default, interceptor: firstCompositeInterceptor).validate().response {
+            firstResponse = $0
+            firstExpect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then — cycle 1
+        XCTAssertEqual(firstResponse?.request?.headers["Authorization"], "a1")
+        XCTAssertEqual(firstResponse?.result.isSuccess, true)
+        XCTAssertEqual(firstRequest.retryCount, 1)
+        XCTAssertEqual(authenticator.refreshCount, 1)
+
+        // When — cycle 2: new request with a1 gets 401, refresh (a1 → a2), retry succeeds.
+        let secondExpect = expectation(description: "second cycle should complete")
+        var secondResponse: AFDataResponse<Data?>?
+
+        let secondPathAdapter = PathAdapter(paths: ["/status/401", "/status/200"])
+        let secondCompositeInterceptor = Interceptor(adapters: [secondPathAdapter, interceptor], retriers: [interceptor])
+
+        let secondRequest = session.request(.default, interceptor: secondCompositeInterceptor).validate().response {
+            secondResponse = $0
+            secondExpect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then — cycle 2 and cumulative state
+        XCTAssertEqual(secondResponse?.request?.headers["Authorization"], "a2")
+        XCTAssertEqual(secondResponse?.result.isSuccess, true)
+        XCTAssertEqual(secondRequest.retryCount, 1)
+
+        XCTAssertEqual(authenticator.applyCount, 4)
+        XCTAssertEqual(authenticator.refreshCount, 2)
+        XCTAssertEqual(authenticator.didRequestFailDueToAuthErrorCount, 2)
+        XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, 2)
+    }
+
+    @MainActor
+    func testThatInterceptorAdaptsNewRequestWithoutDeferringWhileRetryPathRefreshIsInProgress() {
+        // Given
+        // When a refresh is triggered by the retry path, adaptOperations is empty. Any new adapt
+        // call must NOT be deferred — it should proceed immediately with the current credential.
+        // This is the documented invariant: defer only when adaptOperations is non-empty
+        // (i.e., a proactive requiresRefresh-driven refresh is running).
+        let credential = TestCredential()
+        let authenticator = TestAuthenticator()
+        let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
+        let session = stored(Session())
+
+        let expect = expectation(description: "both requests should complete")
+        expect.expectedFulfillmentCount = 2
+
+        var requestAResponse: AFDataResponse<Data?>?
+        var requestBResponse: AFDataResponse<Data?>?
+
+        // When
+        // Request A: gets 401, triggering an async retry-path refresh.
+        let pathAdapter = PathAdapter(paths: ["/status/401", "/status/200"])
+        let compositeInterceptor = Interceptor(adapters: [pathAdapter, interceptor], retriers: [interceptor])
+
+        let requestA = session.request(.default, interceptor: compositeInterceptor).validate().response {
+            requestAResponse = $0
+            expect.fulfill()
+        }
+
+        // Request B: adapts while A's refresh may be running. Since adaptOperations is empty,
+        // B must not be deferred regardless of the current refreshState.
+        let requestB = session.request(.status(200), interceptor: interceptor).validate().response {
+            requestBResponse = $0
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then: both succeed, only one refresh occurred, and B was applied (not deferred).
+        XCTAssertEqual(requestAResponse?.result.isSuccess, true)
+        XCTAssertEqual(requestBResponse?.result.isSuccess, true)
+        XCTAssertNotNil(requestBResponse?.request?.headers["Authorization"])
+
+        XCTAssertEqual(requestA.retryCount, 1)
+        XCTAssertEqual(requestB.retryCount, 0)
+
+        XCTAssertEqual(authenticator.applyCount, 3)
+        XCTAssertEqual(authenticator.refreshCount, 1)
+        XCTAssertEqual(authenticator.didRequestFailDueToAuthErrorCount, 1)
+        XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, 1)
+    }
+
+    @MainActor
+    func testThatInterceptorAllowsNewRefreshAfterExternalCredentialUpdateFollowingRetryPathFailure() {
+        // Given
+        // After a retry-path refresh fails the interceptor enters .failed state, which blocks
+        // subsequent retries from triggering another refresh. Setting interceptor.credential
+        // externally calls updateCredential(_:), which increments credentialVersion and resets
+        // refreshState to .idle, restoring the ability to refresh.
+        let credential = TestCredential()
+        let authenticator = TestAuthenticator(refreshResult: .failure(TestAuthError.refreshNetworkFailure))
+        let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
+        let session = stored(Session())
+
+        // Phase 1 — trigger a retry-path refresh that fails, putting interceptor into .failed state.
+        let firstExpect = expectation(description: "first request should complete")
+        var firstResponse: AFDataResponse<Data?>?
+
+        session.request(.status(401), interceptor: interceptor).validate().response {
+            firstResponse = $0
+            firstExpect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        XCTAssertEqual(authenticator.refreshCount, 1)
+        XCTAssertEqual(firstResponse?.result.isFailure, true)
+
+        // When — externally replace the credential. updateCredential(_:) resets refreshState to .idle.
+        interceptor.credential = TestCredential(accessToken: "ext")
+
+        // Phase 2 — a new 401 should now trigger a fresh refresh rather than immediately failing
+        // with the error cached in .failed state.
+        let secondExpect = expectation(description: "second request should complete")
+        var secondResponse: AFDataResponse<Data?>?
+
+        session.request(.status(401), interceptor: interceptor).validate().response {
+            secondResponse = $0
+            secondExpect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then: a second refresh was attempted, proving .failed was cleared by updateCredential(_:).
+        // The refresh fails again (same authenticator), but crucially refreshCount is 2, not 1.
+        XCTAssertEqual(secondResponse?.request?.headers["Authorization"], "ext")
+        XCTAssertEqual(secondResponse?.result.isFailure, true)
+        XCTAssertEqual(secondResponse?.result.failure?.asAFError?.isRequestRetryError, true)
+        XCTAssertEqual(secondResponse?.result.failure?.asAFError?.underlyingError as? TestAuthError, .refreshNetworkFailure)
+
+        XCTAssertEqual(authenticator.applyCount, 2)
+        XCTAssertEqual(authenticator.refreshCount, 2)
+        XCTAssertEqual(authenticator.didRequestFailDueToAuthErrorCount, 2)
+        XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, 2)
+    }
+
+    @MainActor
+    func testThatInterceptorAdaptsDirectlyAfterExternalCredentialUpdateFollowingProactiveRefreshFailure() {
+        // Given
+        // After a proactive (requiresRefresh-triggered) refresh failure the interceptor is in
+        // .failed state with the original requiresRefresh: true credential still in place.
+        // Setting interceptor.credential to a valid, non-stale credential via updateCredential(_:)
+        // resets refreshState to .idle and installs the new credential so the next request can
+        // adapt immediately without triggering any further refresh.
+        let credential = TestCredential(requiresRefresh: true)
+        let authenticator = TestAuthenticator(refreshResult: .failure(TestAuthError.refreshNetworkFailure))
+        let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
+        let session = stored(Session())
+
+        // Phase 1 — proactive refresh fails; the deferred request gets an adaptation error.
+        let firstExpect = expectation(description: "first request should complete")
+        var firstResponse: AFDataResponse<Data?>?
+
+        session.request(.status(200), interceptor: interceptor).validate().response {
+            firstResponse = $0
+            firstExpect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        XCTAssertEqual(authenticator.refreshCount, 1)
+        XCTAssertEqual(firstResponse?.result.isFailure, true)
+        XCTAssertEqual(firstResponse?.result.failure?.asAFError?.isRequestAdaptationError, true)
+
+        // When — install a working, non-stale credential externally.
+        interceptor.credential = TestCredential(accessToken: "ext", requiresRefresh: false)
+
+        // Phase 2 — new request should adapt immediately with the new credential; no refresh needed.
+        let secondExpect = expectation(description: "second request should complete")
+        var secondResponse: AFDataResponse<Data?>?
+
+        let secondRequest = session.request(.status(200), interceptor: interceptor).validate().response {
+            secondResponse = $0
+            secondExpect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then: the new request succeeds using the externally set credential, with no additional refresh.
+        XCTAssertEqual(secondResponse?.request?.headers["Authorization"], "ext")
+        XCTAssertEqual(secondResponse?.result.isSuccess, true)
+        XCTAssertEqual(secondRequest.retryCount, 0)
+
+        XCTAssertEqual(authenticator.applyCount, 1)
+        XCTAssertEqual(authenticator.refreshCount, 1)
+        XCTAssertEqual(authenticator.didRequestFailDueToAuthErrorCount, 0)
+        XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, 0)
+    }
+
+    @MainActor
+    func testThatInterceptorDoesNotDeadlockWhenAuthenticatorCallsRefreshCompletionSynchronouslyOnRetryPath() {
+        // Given
+        // The refresh(_:for:insideLock:) helper dispatches to a serial queue via queue.async before
+        // calling authenticator.refresh(_:for:completion:), ensuring the mutableState write lock is
+        // not held when the completion fires. This test verifies that invariant holds on the retry
+        // path (a 401 response), complementing the existing proactive-path (requiresRefresh) test.
+        let credential = TestCredential()
+        let authenticator = TestAuthenticator(shouldRefreshAsynchronously: false)
+        let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
+
+        let pathAdapter = PathAdapter(paths: ["/status/401", "/status/200"])
+        let compositeInterceptor = Interceptor(adapters: [pathAdapter, interceptor], retriers: [interceptor])
+        let session = stored(Session())
+
+        let expect = expectation(description: "request should complete")
+        var response: AFDataResponse<Data?>?
+
+        // When
+        let request = session.request(.default, interceptor: compositeInterceptor).validate().response {
+            response = $0
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertEqual(response?.request?.headers["Authorization"], "a1")
+        XCTAssertEqual(response?.result.isSuccess, true)
+
+        XCTAssertEqual(authenticator.applyCount, 2)
+        XCTAssertEqual(authenticator.refreshCount, 1)
+        XCTAssertEqual(authenticator.didRequestFailDueToAuthErrorCount, 1)
+        XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, 1)
+
+        XCTAssertEqual(request.retryCount, 1)
+    }
+
+    @MainActor
+    func testThatExcessiveRefreshTimestampsArePreservedAfterFailedStateIsClearedByAdapt() {
+        // Given
+        // The adapt path clears .failed → .idle to allow new requests to trigger a fresh refresh.
+        // The refreshTimestamps array must survive this reset because it is the RefreshWindow's
+        // authoritative history; clearing it would silently bypass the excessive-refresh guard.
+        let credential = TestCredential()
+        let authenticator = TestAuthenticator()
+        let interceptor = AuthenticationInterceptor(authenticator: authenticator,
+                                                    credential: credential,
+                                                    refreshWindow: .init(interval: 30, maximumAttempts: 1))
+        let session = stored(Session())
+
+        // Phase 1 — one successful refresh consumes the entire budget (maximumAttempts: 1).
+        let firstExpect = expectation(description: "first request should complete")
+        var firstResponse: AFDataResponse<Data?>?
+
+        let firstPathAdapter = PathAdapter(paths: ["/status/401", "/status/200"])
+        let firstCompositeInterceptor = Interceptor(adapters: [firstPathAdapter, interceptor], retriers: [interceptor])
+
+        session.request(.default, interceptor: firstCompositeInterceptor).validate().response {
+            firstResponse = $0
+            firstExpect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        XCTAssertEqual(firstResponse?.result.isSuccess, true)
+        XCTAssertEqual(authenticator.refreshCount, 1)
+
+        // Phase 2 — second 401 hits the exhausted window, producing .failed(excessiveRefresh) state.
+        let secondExpect = expectation(description: "second request should complete")
+        var secondResponse: AFDataResponse<Data?>?
+
+        session.request(.status(401), interceptor: interceptor).validate().response {
+            secondResponse = $0
+            secondExpect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        XCTAssertEqual(secondResponse?.result.failure?.asAFError?.isRequestRetryError, true)
+        XCTAssertEqual(secondResponse?.result.failure?.asAFError?.underlyingError as? AuthenticationError, .excessiveRefresh)
+
+        // Phase 3 — a new request adapts, firing the adapt-clear (.failed → .idle). The request
+        // then gets a 401 and attempts another refresh. Despite the state reset, refreshTimestamps
+        // is unchanged, so the excessive-refresh guard fires again immediately.
+        let thirdExpect = expectation(description: "third request should complete")
+        var thirdResponse: AFDataResponse<Data?>?
+
+        session.request(.status(401), interceptor: interceptor).validate().response {
+            thirdResponse = $0
+            thirdExpect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then: Phase 3 also fails with excessiveRefresh, proving the timestamp survived the adapt-clear.
+        XCTAssertEqual(thirdResponse?.result.failure?.asAFError?.isRequestRetryError, true)
+        XCTAssertEqual(thirdResponse?.result.failure?.asAFError?.underlyingError as? AuthenticationError, .excessiveRefresh)
+
+        // Only one actual authenticator.refresh call ever occurred (Phase 1).
+        // Phases 2 and 3 were both blocked before reaching authenticator.refresh.
+        XCTAssertEqual(authenticator.refreshCount, 1)
+    }
+
+    @MainActor
+    func testThatInterceptorThrowsMissingCredentialErrorWhenCredentialIsSetToNilAfterBeingValid() {
+        // Given
+        // Setting interceptor.credential = nil calls updateCredential(nil), which stores nil,
+        // increments credentialVersion, and resets refreshState. Subsequent requests must fail
+        // immediately with .missingCredential at the adapt stage. This is distinct from the
+        // existing test that starts with no credential — here the transition is valid → nil.
+        let credential = TestCredential()
+        let authenticator = TestAuthenticator()
+        let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
+        let session = stored(Session())
+
+        // When
+        interceptor.credential = nil
+
+        let expect = expectation(description: "request should complete")
+        var response: AFDataResponse<Data?>?
+
+        let request = session.request(.status(200), interceptor: interceptor).validate().response {
+            response = $0
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertEqual(response?.request?.headers.count, 0)
+        XCTAssertEqual(response?.result.isFailure, true)
+        XCTAssertEqual(response?.result.failure?.asAFError?.isRequestAdaptationError, true)
+        XCTAssertEqual(response?.result.failure?.asAFError?.underlyingError as? AuthenticationError, .missingCredential)
+
+        XCTAssertEqual(authenticator.applyCount, 0)
+        XCTAssertEqual(authenticator.refreshCount, 0)
+        XCTAssertEqual(authenticator.didRequestFailDueToAuthErrorCount, 0)
+        XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, 0)
+
+        XCTAssertEqual(request.retryCount, 0)
+    }
+
+    @MainActor
+    func testThatInterceptorThrowsExcessiveRefreshErrorImmediatelyWhenMaximumAttemptsIsZero() {
+        // Given
+        // A RefreshWindow with maximumAttempts: 0 makes every refresh attempt immediately excessive:
+        // isRefreshExcessive checks refreshAttemptsWithinWindow >= maximumAttempts, and 0 >= 0 is
+        // unconditionally true regardless of how many (zero) refreshes have actually occurred.
+        // authenticator.refresh is therefore never reached.
+        let credential = TestCredential()
+        let authenticator = TestAuthenticator()
+        let interceptor = AuthenticationInterceptor(authenticator: authenticator,
+                                                    credential: credential,
+                                                    refreshWindow: .init(interval: 30, maximumAttempts: 0))
+        let session = stored(Session())
+
+        let expect = expectation(description: "request should complete")
+        var response: AFDataResponse<Data?>?
+
+        // When
+        let request = session.request(.status(401), interceptor: interceptor).validate().response {
+            response = $0
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertEqual(response?.request?.headers["Authorization"], "a0")
+        XCTAssertEqual(response?.result.isFailure, true)
+        XCTAssertEqual(response?.result.failure?.asAFError?.isRequestRetryError, true)
+        XCTAssertEqual(response?.result.failure?.asAFError?.underlyingError as? AuthenticationError, .excessiveRefresh)
+
+        XCTAssertEqual(authenticator.applyCount, 1)
+        XCTAssertEqual(authenticator.refreshCount, 0)
+        XCTAssertEqual(authenticator.didRequestFailDueToAuthErrorCount, 1)
+        XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, 1)
+
+        XCTAssertEqual(request.retryCount, 0)
+    }
+
+    @MainActor
+    func testThatInterceptorThrowsExcessiveRefreshErrorToAllParallelRequestsAfterExceedingRefreshWindow() {
+        // Given
+        // Three parallel requests all get 401, triggering one refresh (a0 → a1). All three retry
+        // with a1 and all get 401 again. The second refresh attempt is blocked by the refresh
+        // window (maximumAttempts: 1 already exhausted). All three requests fail with .excessiveRefresh.
+        // This exercises the path where isRefreshExcessive fires after requestsToRetry has been
+        // built up by a prior successful refresh cycle.
+        let credential = TestCredential()
+        let authenticator = TestAuthenticator()
+        let interceptor = AuthenticationInterceptor(authenticator: authenticator,
+                                                    credential: credential,
+                                                    refreshWindow: .init(interval: 30, maximumAttempts: 1))
+
+        let requestCount = 3
+        let session = stored(Session())
+
+        let expect = expectation(description: "all requests should complete")
+        expect.expectedFulfillmentCount = requestCount
+
+        var requests: [Int: Request] = [:]
+        var responses: [Int: AFDataResponse<Data?>] = [:]
+
+        // When — each request hits /status/401 twice: once on the initial attempt (triggering the
+        // one allowed refresh), and once after retrying with a1 (triggering the excessive check).
+        for index in 0..<requestCount {
+            let pathAdapter = PathAdapter(paths: ["/status/401", "/status/401"])
+            let compositeInterceptor = Interceptor(adapters: [pathAdapter, interceptor], retriers: [interceptor])
+
+            let request = session.request(.default, interceptor: compositeInterceptor).validate().response {
+                responses[index] = $0
+                expect.fulfill()
+            }
+            requests[index] = request
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        for index in 0..<requestCount {
+            XCTAssertEqual(responses[index]?.result.isFailure, true)
+            XCTAssertEqual(responses[index]?.result.failure?.asAFError?.isRequestRetryError, true)
+            XCTAssertEqual(responses[index]?.result.failure?.asAFError?.underlyingError as? AuthenticationError, .excessiveRefresh)
+            // retryCount is 1: each request was retried once after the first successful refresh,
+            // then rejected by the excessive check without a second actual retry.
+            XCTAssertEqual(requests[index]?.retryCount, 1)
+        }
+
+        // One successful refresh occurred (first batch). The second was blocked.
+        XCTAssertEqual(authenticator.applyCount, 6)
+        XCTAssertEqual(authenticator.refreshCount, 1)
+        XCTAssertEqual(authenticator.didRequestFailDueToAuthErrorCount, 6)
+        XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, 6)
+    }
+
+    @MainActor
+    func testThatInterceptorAllowsProactiveRefreshFromFailedStateUnlikeRetryPath() {
+        // Given
+        // After a proactive refresh failure, refreshState is .failed. The retry path has an explicit
+        // .failed case that returns .doNotRetryWithError immediately. The proactive adapt path has
+        // no such gate — it only checks isRefreshing (which is false for .failed), so a new request
+        // with requiresRefresh: true triggers another proactive refresh, overwriting .failed with
+        // .refreshing. This test verifies that asymmetry is intentional and preserved.
+        let credential = TestCredential(requiresRefresh: true)
+        let authenticator = TestAuthenticator(refreshResult: .failure(TestAuthError.refreshNetworkFailure))
+        let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
+        let session = stored(Session())
+
+        // Phase 1 — proactive refresh fails, putting interceptor into .failed state.
+        let firstExpect = expectation(description: "first request should complete")
+        var firstResponse: AFDataResponse<Data?>?
+
+        session.request(.status(200), interceptor: interceptor).validate().response {
+            firstResponse = $0
+            firstExpect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        XCTAssertEqual(firstResponse?.result.isFailure, true)
+        XCTAssertEqual(firstResponse?.result.failure?.asAFError?.isRequestAdaptationError, true)
+        XCTAssertEqual(authenticator.refreshCount, 1)
+
+        // Phase 2 — a new request with the same requiresRefresh: true credential adapts.
+        // Line 292: (requiresRefresh: true) && (!isRefreshing: true, since .failed → isRefreshing == false)
+        // → enters the proactive path, appends to adaptOperations, calls refresh(), overwriting
+        // .failed with .refreshing. The retry path's .failed gate is never reached.
+        let secondExpect = expectation(description: "second request should complete")
+        var secondResponse: AFDataResponse<Data?>?
+
+        session.request(.status(200), interceptor: interceptor).validate().response {
+            secondResponse = $0
+            secondExpect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then: a second refresh was triggered (refreshCount == 2), proving .failed did not block
+        // the proactive adapt path the way it blocks the retry path.
+        XCTAssertEqual(secondResponse?.result.isFailure, true)
+        XCTAssertEqual(secondResponse?.result.failure?.asAFError?.isRequestAdaptationError, true)
+        XCTAssertEqual(secondResponse?.result.failure?.asAFError?.underlyingError as? TestAuthError, .refreshNetworkFailure)
+
+        XCTAssertEqual(authenticator.applyCount, 0)
+        XCTAssertEqual(authenticator.refreshCount, 2)
         XCTAssertEqual(authenticator.didRequestFailDueToAuthErrorCount, 0)
         XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, 0)
     }

--- a/Tests/AuthenticationInterceptorTests.swift
+++ b/Tests/AuthenticationInterceptorTests.swift
@@ -149,7 +149,7 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
         let authenticator = TestAuthenticator()
         let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
 
-        let session = Session()
+        let session = stored(Session())
 
         let expect = expectation(description: "request should complete")
         var response: AFDataResponse<Data?>?
@@ -181,7 +181,7 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
         let authenticator = TestAuthenticator()
         let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
 
-        let session = Session()
+        let session = stored(Session())
 
         let expect = expectation(description: "both requests should complete")
         expect.expectedFulfillmentCount = 2
@@ -223,7 +223,7 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
         let authenticator = TestAuthenticator()
         let interceptor = AuthenticationInterceptor(authenticator: authenticator)
 
-        let session = Session()
+        let session = stored(Session())
 
         let expect = expectation(description: "request should complete")
         var response: AFDataResponse<Data?>?
@@ -258,7 +258,7 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
         let authenticator = TestAuthenticator(refreshResult: .failure(TestAuthError.refreshNetworkFailure))
         let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
 
-        let session = Session()
+        let session = stored(Session())
 
         let expect = expectation(description: "request should complete")
         var response: AFDataResponse<Data?>?
@@ -303,7 +303,7 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
         let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
 
         let urlRequest = URLRequest(url: URL(string: "/invalid/path")!)
-        let session = Session()
+        let session = stored(Session())
 
         let expect = expectation(description: "request should complete")
         var response: AFDataResponse<Data?>?
@@ -338,7 +338,7 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
         let authenticator = TestAuthenticator()
         let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
 
-        let session = Session()
+        let session = stored(Session())
 
         let expect = expectation(description: "request should complete")
         var response: AFDataResponse<Data?>?
@@ -471,7 +471,7 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
                                                     requiresRefresh: false)
         }
 
-        let session = Session(eventMonitors: [eventMonitor])
+        let session = stored(Session(eventMonitors: [eventMonitor]))
 
         let pathAdapter = PathAdapter(paths: ["/status/200"])
         let compositeInterceptor = Interceptor(adapters: [pathAdapter, interceptor], retriers: [interceptor])
@@ -510,7 +510,7 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
 
         let compositeInterceptor = Interceptor(adapters: [pathAdapter, interceptor], retriers: [interceptor])
 
-        let session = Session()
+        let session = stored(Session())
 
         let expect = expectation(description: "request should complete")
         var response: AFDataResponse<Data?>?
@@ -542,7 +542,7 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
         let authenticator = TestAuthenticator(refreshResult: .failure(TestAuthError.refreshNetworkFailure))
         let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
 
-        let session = Session()
+        let session = stored(Session())
 
         let expect = expectation(description: "request should complete")
         var response: AFDataResponse<Data?>?
@@ -640,7 +640,7 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
 
         let compositeInterceptor = Interceptor(adapters: [pathAdapter, interceptor], retriers: [interceptor])
 
-        let session = Session()
+        let session = stored(Session())
 
         let expect = expectation(description: "request should complete")
         var response: AFDataResponse<Data?>?
@@ -674,7 +674,7 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
                                                     credential: credential,
                                                     refreshWindow: .init(interval: 30, maximumAttempts: 2))
 
-        let session = Session()
+        let session = stored(Session())
 
         let expect = expectation(description: "request should complete")
         var response: AFDataResponse<Data?>?

--- a/Tests/AuthenticationInterceptorTests.swift
+++ b/Tests/AuthenticationInterceptorTests.swift
@@ -1072,10 +1072,10 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
     @MainActor
     func testThatInterceptorAdaptsNewRequestWithoutDeferringWhileRetryPathRefreshIsInProgress() {
         // Given
-        // When a refresh is triggered by the retry path, adaptOperations is empty. Any new adapt
-        // call must NOT be deferred — it should proceed immediately with the current credential.
-        // This is the documented invariant: defer only when adaptOperations is non-empty
-        // (i.e., a proactive requiresRefresh-driven refresh is running).
+        // When a refresh is triggered by the retry path, adaptOperations is empty. Any new adapt call must NOT be
+        // deferred, it should proceed immediately with the current credential.
+        // This is the documented invariant: defer only when adaptOperations is non-empty (i.e., a proactive
+        // requiresRefresh-driven refresh is running).
         let credential = TestCredential()
         let authenticator = TestAuthenticator()
         let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
@@ -1084,8 +1084,8 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
         let expect = expectation(description: "both requests should complete")
         expect.expectedFulfillmentCount = 2
 
-        var requestAResponse: AFDataResponse<Data?>?
-        var requestBResponse: AFDataResponse<Data?>?
+        var firstResponse: AFDataResponse<Data?>?
+        var secondResponse: AFDataResponse<Data?>?
 
         // When
         // Request A: gets 401, triggering an async retry-path refresh.
@@ -1093,23 +1093,23 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
         let compositeInterceptor = Interceptor(adapters: [pathAdapter, interceptor], retriers: [interceptor])
 
         let requestA = session.request(.default, interceptor: compositeInterceptor).validate().response {
-            requestAResponse = $0
+            firstResponse = $0
             expect.fulfill()
         }
 
         // Request B: adapts while A's refresh may be running. Since adaptOperations is empty,
         // B must not be deferred regardless of the current refreshState.
         let requestB = session.request(.status(200), interceptor: interceptor).validate().response {
-            requestBResponse = $0
+            secondResponse = $0
             expect.fulfill()
         }
 
         waitForExpectations(timeout: timeout)
 
         // Then: both succeed, only one refresh occurred, and B was applied (not deferred).
-        XCTAssertEqual(requestAResponse?.result.isSuccess, true)
-        XCTAssertEqual(requestBResponse?.result.isSuccess, true)
-        XCTAssertNotNil(requestBResponse?.request?.headers["Authorization"])
+        XCTAssertEqual(firstResponse?.result.isSuccess, true)
+        XCTAssertEqual(secondResponse?.result.isSuccess, true)
+        XCTAssertNotNil(secondResponse?.request?.headers["Authorization"])
 
         XCTAssertEqual(requestA.retryCount, 1)
         XCTAssertEqual(requestB.retryCount, 0)
@@ -1123,16 +1123,15 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
     @MainActor
     func testThatInterceptorAllowsNewRefreshAfterExternalCredentialUpdateFollowingRetryPathFailure() {
         // Given
-        // After a retry-path refresh fails the interceptor enters .failed state, which blocks
-        // subsequent retries from triggering another refresh. Setting interceptor.credential
-        // externally calls updateCredential(_:), which increments credentialVersion and resets
-        // refreshState to .idle, restoring the ability to refresh.
+        // After a retry-path refresh fails the interceptor enters .failed state, which blocks subsequent retries from
+        // triggering another refresh. Setting interceptor.credential externally calls updateCredential(_:), which
+        // increments credentialVersion and resets refreshState to .idle, restoring the ability to refresh.
         let credential = TestCredential()
         let authenticator = TestAuthenticator(refreshResult: .failure(TestAuthError.refreshNetworkFailure))
         let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
         let session = stored(Session())
 
-        // Phase 1 — trigger a retry-path refresh that fails, putting interceptor into .failed state.
+        // First, trigger a retry-path refresh that fails, putting interceptor into .failed state.
         let firstExpect = expectation(description: "first request should complete")
         var firstResponse: AFDataResponse<Data?>?
 
@@ -1146,11 +1145,11 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
         XCTAssertEqual(authenticator.refreshCount, 1)
         XCTAssertEqual(firstResponse?.result.isFailure, true)
 
-        // When — externally replace the credential. updateCredential(_:) resets refreshState to .idle.
+        // When: credential is externally replaced. updateCredential(_:) resets refreshState to .idle.
         interceptor.credential = TestCredential(accessToken: "ext")
 
-        // Phase 2 — a new 401 should now trigger a fresh refresh rather than immediately failing
-        // with the error cached in .failed state.
+        // Second, a new 401 should now trigger a fresh refresh rather than immediately failing with the error cached in
+        // .failed state.
         let secondExpect = expectation(description: "second request should complete")
         var secondResponse: AFDataResponse<Data?>?
 
@@ -1177,17 +1176,16 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
     @MainActor
     func testThatInterceptorAdaptsDirectlyAfterExternalCredentialUpdateFollowingProactiveRefreshFailure() {
         // Given
-        // After a proactive (requiresRefresh-triggered) refresh failure the interceptor is in
-        // .failed state with the original requiresRefresh: true credential still in place.
-        // Setting interceptor.credential to a valid, non-stale credential via updateCredential(_:)
-        // resets refreshState to .idle and installs the new credential so the next request can
-        // adapt immediately without triggering any further refresh.
+        // After a proactive (requiresRefresh-triggered) refresh failure the interceptor is in .failed state with the
+        // original requiresRefresh: true credential still in place. Setting interceptor.credential to a valid, non-stale
+        // credential via updateCredential(_:) resets refreshState to .idle and installs the new credential so the next
+        // request can adapt immediately without triggering any further refresh.
         let credential = TestCredential(requiresRefresh: true)
         let authenticator = TestAuthenticator(refreshResult: .failure(TestAuthError.refreshNetworkFailure))
         let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
         let session = stored(Session())
 
-        // Phase 1 — proactive refresh fails; the deferred request gets an adaptation error.
+        // First, proactive refresh fails and the deferred request gets an adaptation error.
         let firstExpect = expectation(description: "first request should complete")
         var firstResponse: AFDataResponse<Data?>?
 
@@ -1202,7 +1200,7 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
         XCTAssertEqual(firstResponse?.result.isFailure, true)
         XCTAssertEqual(firstResponse?.result.failure?.asAFError?.isRequestAdaptationError, true)
 
-        // When — install a working, non-stale credential externally.
+        // When: a working, non-stale credential is set externally.
         interceptor.credential = TestCredential(accessToken: "ext", requiresRefresh: false)
 
         // Phase 2 — new request should adapt immediately with the new credential; no refresh needed.
@@ -1230,10 +1228,10 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
     @MainActor
     func testThatInterceptorDoesNotDeadlockWhenAuthenticatorCallsRefreshCompletionSynchronouslyOnRetryPath() {
         // Given
-        // The refresh(_:for:insideLock:) helper dispatches to a serial queue via queue.async before
-        // calling authenticator.refresh(_:for:completion:), ensuring the mutableState write lock is
-        // not held when the completion fires. This test verifies that invariant holds on the retry
-        // path (a 401 response), complementing the existing proactive-path (requiresRefresh) test.
+        // The refresh(_:for:insideLock:) helper dispatches to a serial queue via queue.async before calling
+        // authenticator.refresh(_:for:completion:), ensuring the mutableState write lock is not held when the completion
+        // fires. This test verifies that invariant holds on the retry path (a 401 response), complementing the existing
+        // proactive-path (requiresRefresh) test.
         let credential = TestCredential()
         let authenticator = TestAuthenticator(shouldRefreshAsynchronously: false)
         let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
@@ -1268,9 +1266,9 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
     @MainActor
     func testThatExcessiveRefreshTimestampsArePreservedAfterFailedStateIsClearedByAdapt() {
         // Given
-        // The adapt path clears .failed → .idle to allow new requests to trigger a fresh refresh.
-        // The refreshTimestamps array must survive this reset because it is the RefreshWindow's
-        // authoritative history; clearing it would silently bypass the excessive-refresh guard.
+        // The adapt path clears .failed to .idle to allow new requests to trigger a fresh refresh. The refreshTimestamps
+        // array must survive this reset because it is the RefreshWindow's authoritative history; clearing it would
+        // silently bypass the excessive-refresh guard.
         let credential = TestCredential()
         let authenticator = TestAuthenticator()
         let interceptor = AuthenticationInterceptor(authenticator: authenticator,
@@ -1278,7 +1276,7 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
                                                     refreshWindow: .init(interval: 30, maximumAttempts: 1))
         let session = stored(Session())
 
-        // Phase 1 — one successful refresh consumes the entire budget (maximumAttempts: 1).
+        // First, one successful refresh consumes the entire budget (maximumAttempts: 1).
         let firstExpect = expectation(description: "first request should complete")
         var firstResponse: AFDataResponse<Data?>?
 
@@ -1295,7 +1293,7 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
         XCTAssertEqual(firstResponse?.result.isSuccess, true)
         XCTAssertEqual(authenticator.refreshCount, 1)
 
-        // Phase 2 — second 401 hits the exhausted window, producing .failed(excessiveRefresh) state.
+        // Second, a 401 hits the exhausted window, producing .failed(excessiveRefresh) state.
         let secondExpect = expectation(description: "second request should complete")
         var secondResponse: AFDataResponse<Data?>?
 
@@ -1309,9 +1307,9 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
         XCTAssertEqual(secondResponse?.result.failure?.asAFError?.isRequestRetryError, true)
         XCTAssertEqual(secondResponse?.result.failure?.asAFError?.underlyingError as? AuthenticationError, .excessiveRefresh)
 
-        // Phase 3 — a new request adapts, firing the adapt-clear (.failed → .idle). The request
-        // then gets a 401 and attempts another refresh. Despite the state reset, refreshTimestamps
-        // is unchanged, so the excessive-refresh guard fires again immediately.
+        // Third, a new request adapts, firing the adapt-clear (.failed to .idle). The request then gets a 401 and attempts
+        // another refresh. Despite the state reset, refreshTimestamps is unchanged, so the excessive-refresh guard
+        // fires again immediately.
         let thirdExpect = expectation(description: "third request should complete")
         var thirdResponse: AFDataResponse<Data?>?
 
@@ -1322,22 +1320,21 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
 
         waitForExpectations(timeout: timeout)
 
-        // Then: Phase 3 also fails with excessiveRefresh, proving the timestamp survived the adapt-clear.
+        // Then: It also fails with excessiveRefresh, proving the timestamp survived the adapt-clear.
         XCTAssertEqual(thirdResponse?.result.failure?.asAFError?.isRequestRetryError, true)
         XCTAssertEqual(thirdResponse?.result.failure?.asAFError?.underlyingError as? AuthenticationError, .excessiveRefresh)
 
-        // Only one actual authenticator.refresh call ever occurred (Phase 1).
-        // Phases 2 and 3 were both blocked before reaching authenticator.refresh.
+        // Only one actual authenticator.refresh call ever occurred.
+        // Second and third were both blocked before reaching authenticator.refresh.
         XCTAssertEqual(authenticator.refreshCount, 1)
     }
 
     @MainActor
     func testThatInterceptorThrowsMissingCredentialErrorWhenCredentialIsSetToNilAfterBeingValid() {
         // Given
-        // Setting interceptor.credential = nil calls updateCredential(nil), which stores nil,
-        // increments credentialVersion, and resets refreshState. Subsequent requests must fail
-        // immediately with .missingCredential at the adapt stage. This is distinct from the
-        // existing test that starts with no credential — here the transition is valid → nil.
+        // Setting interceptor.credential = nil calls updateCredential(nil), which stores nil, increments credentialVersion,
+        // and resets refreshState. Subsequent requests must fail immediately with .missingCredential at the adapt stage.
+        // This is distinct from the existing test that starts with no credential. Here the transition is valid to nil.
         let credential = TestCredential()
         let authenticator = TestAuthenticator()
         let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
@@ -1373,10 +1370,9 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
     @MainActor
     func testThatInterceptorThrowsExcessiveRefreshErrorImmediatelyWhenMaximumAttemptsIsZero() {
         // Given
-        // A RefreshWindow with maximumAttempts: 0 makes every refresh attempt immediately excessive:
-        // isRefreshExcessive checks refreshAttemptsWithinWindow >= maximumAttempts, and 0 >= 0 is
-        // unconditionally true regardless of how many (zero) refreshes have actually occurred.
-        // authenticator.refresh is therefore never reached.
+        // A RefreshWindow with maximumAttempts: 0 makes every refresh attempt immediately excessive: isRefreshExcessive
+        // checks refreshAttemptsWithinWindow >= maximumAttempts, and 0 >= 0 is unconditionally true regardless of how
+        // many (zero) refreshes have actually occurred. authenticator.refresh is therefore never reached.
         let credential = TestCredential()
         let authenticator = TestAuthenticator()
         let interceptor = AuthenticationInterceptor(authenticator: authenticator,
@@ -1412,11 +1408,10 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
     @MainActor
     func testThatInterceptorThrowsExcessiveRefreshErrorToAllParallelRequestsAfterExceedingRefreshWindow() {
         // Given
-        // Three parallel requests all get 401, triggering one refresh (a0 → a1). All three retry
-        // with a1 and all get 401 again. The second refresh attempt is blocked by the refresh
-        // window (maximumAttempts: 1 already exhausted). All three requests fail with .excessiveRefresh.
-        // This exercises the path where isRefreshExcessive fires after requestsToRetry has been
-        // built up by a prior successful refresh cycle.
+        // Three parallel requests all get 401, triggering one refresh (a0 → a1). All three retry with a1 and all get
+        // 401 again. The second refresh attempt is blocked by the refresh window (maximumAttempts: 1 already exhausted).
+        // All three requests fail with .excessiveRefresh. This exercises the path where isRefreshExcessive fires after
+        // requestsToRetry has been built up by a prior successful refresh cycle.
         let credential = TestCredential()
         let authenticator = TestAuthenticator()
         let interceptor = AuthenticationInterceptor(authenticator: authenticator,
@@ -1432,8 +1427,8 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
         var requests: [Int: Request] = [:]
         var responses: [Int: AFDataResponse<Data?>] = [:]
 
-        // When — each request hits /status/401 twice: once on the initial attempt (triggering the
-        // one allowed refresh), and once after retrying with a1 (triggering the excessive check).
+        // When: Each request hits /status/401 twice: once on the initial attempt (triggering the one allowed refresh),
+        // and once after retrying with a1 (triggering the excessive check).
         for index in 0..<requestCount {
             let pathAdapter = PathAdapter(paths: ["/status/401", "/status/401"])
             let compositeInterceptor = Interceptor(adapters: [pathAdapter, interceptor], retriers: [interceptor])
@@ -1452,8 +1447,8 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
             XCTAssertEqual(responses[index]?.result.isFailure, true)
             XCTAssertEqual(responses[index]?.result.failure?.asAFError?.isRequestRetryError, true)
             XCTAssertEqual(responses[index]?.result.failure?.asAFError?.underlyingError as? AuthenticationError, .excessiveRefresh)
-            // retryCount is 1: each request was retried once after the first successful refresh,
-            // then rejected by the excessive check without a second actual retry.
+            // retryCount is 1, each request was retried once after the first successful refresh, then rejected by the
+            // excessive check without a second actual retry.
             XCTAssertEqual(requests[index]?.retryCount, 1)
         }
 
@@ -1467,11 +1462,11 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
     @MainActor
     func testThatInterceptorAllowsProactiveRefreshFromFailedStateUnlikeRetryPath() {
         // Given
-        // After a proactive refresh failure, refreshState is .failed. The retry path has an explicit
-        // .failed case that returns .doNotRetryWithError immediately. The proactive adapt path has
-        // no such gate — it only checks isRefreshing (which is false for .failed), so a new request
-        // with requiresRefresh: true triggers another proactive refresh, overwriting .failed with
-        // .refreshing. This test verifies that asymmetry is intentional and preserved.
+        // After a proactive refresh failure, refreshState is .failed. The retry path has an explicit .failed case that
+        // returns .doNotRetryWithError immediately. The proactive adapt path has no such gate. It only checks
+        // isRefreshing (which is false for .failed), so a new request with requiresRefresh: true triggers another
+        // proactive refresh, overwriting .failed with .refreshing. This test verifies that asymmetry is intentional
+        // and preserved.
         let credential = TestCredential(requiresRefresh: true)
         let authenticator = TestAuthenticator(refreshResult: .failure(TestAuthError.refreshNetworkFailure))
         let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
@@ -1492,10 +1487,9 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
         XCTAssertEqual(firstResponse?.result.failure?.asAFError?.isRequestAdaptationError, true)
         XCTAssertEqual(authenticator.refreshCount, 1)
 
-        // Phase 2 — a new request with the same requiresRefresh: true credential adapts.
-        // Line 292: (requiresRefresh: true) && (!isRefreshing: true, since .failed → isRefreshing == false)
-        // → enters the proactive path, appends to adaptOperations, calls refresh(), overwriting
-        // .failed with .refreshing. The retry path's .failed gate is never reached.
+        // Second, a new request with the same requiresRefresh: true credential adapts. It enters the proactive path,
+        // appends to adaptOperations, calls refresh(), overwriting .failed with .refreshing. The retry path's .failed
+        // gate is never reached.
         let secondExpect = expectation(description: "second request should complete")
         var secondResponse: AFDataResponse<Data?>?
 
@@ -1506,8 +1500,8 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
 
         waitForExpectations(timeout: timeout)
 
-        // Then: a second refresh was triggered (refreshCount == 2), proving .failed did not block
-        // the proactive adapt path the way it blocks the retry path.
+        // Then: a second refresh was triggered (refreshCount == 2), proving .failed did not block the proactive adapt
+        // path the way it blocks the retry path.
         XCTAssertEqual(secondResponse?.result.isFailure, true)
         XCTAssertEqual(secondResponse?.result.failure?.asAFError?.isRequestAdaptationError, true)
         XCTAssertEqual(secondResponse?.result.failure?.asAFError?.underlyingError as? TestAuthError, .refreshNetworkFailure)

--- a/Tests/AuthenticationInterceptorTests.swift
+++ b/Tests/AuthenticationInterceptorTests.swift
@@ -60,12 +60,13 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
         private(set) var didRequestFailDueToAuthErrorCount = 0
         private(set) var isRequestAuthenticatedWithCredentialCount = 0
 
-        let shouldRefreshAsynchronously: Bool
         let refreshResult: Result<TestCredential, any Error>?
         let lock = NSLock()
+        let refreshQueue: DispatchQueue?
 
-        init(shouldRefreshAsynchronously: Bool = true, refreshResult: Result<TestCredential, any Error>? = nil) {
-            self.shouldRefreshAsynchronously = shouldRefreshAsynchronously
+        init(refreshQueue: DispatchQueue? = DispatchQueue(label: "org.alamofire.TestAuthenticator"),
+             refreshResult: Result<TestCredential, any Error>? = nil) {
+            self.refreshQueue = refreshQueue
             self.refreshResult = refreshResult
         }
 
@@ -91,9 +92,9 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
                                expiration: Date())
             )
 
-            if shouldRefreshAsynchronously {
+            if let refreshQueue {
                 // The 10 ms delay here is important to allow multiple requests to queue up while refreshing.
-                DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.01) { completion(result) }
+                refreshQueue.asyncAfter(deadline: .now() + 0.01) { completion(result) }
                 lock.unlock()
             } else {
                 lock.unlock()
@@ -177,12 +178,13 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
     @MainActor
     func testThatInterceptorRethrowsRefreshErrorToAllDeferredAdaptOperations() {
         // Given
+        let queue = DispatchQueue(label: "org.alamofire.\(#function)")
         let credential = TestCredential(requiresRefresh: true)
-        let authenticator = TestAuthenticator(refreshResult: .failure(TestAuthError.refreshNetworkFailure))
+        let authenticator = TestAuthenticator(refreshQueue: queue, refreshResult: .failure(TestAuthError.refreshNetworkFailure))
         let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
 
         let requestCount = 3
-        let session = stored(Session())
+        let session = stored(Session(rootQueue: queue))
 
         let expect = expectation(description: "all requests should complete")
         expect.expectedFulfillmentCount = requestCount
@@ -540,7 +542,7 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
     func testThatInterceptorDoesNotDeadlockWhenAuthenticatorCallsRefreshCompletionSynchronouslyOnCallingQueue() {
         // Given
         let credential = TestCredential(requiresRefresh: true)
-        let authenticator = TestAuthenticator(shouldRefreshAsynchronously: false)
+        let authenticator = TestAuthenticator(refreshQueue: nil)
         let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
 
         let eventMonitor = ClosureEventMonitor()
@@ -1233,7 +1235,7 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
         // fires. This test verifies that invariant holds on the retry path (a 401 response), complementing the existing
         // proactive-path (requiresRefresh) test.
         let credential = TestCredential()
-        let authenticator = TestAuthenticator(shouldRefreshAsynchronously: false)
+        let authenticator = TestAuthenticator(refreshQueue: nil)
         let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
 
         let pathAdapter = PathAdapter(paths: ["/status/401", "/status/200"])

--- a/Tests/AuthenticationInterceptorTests.swift
+++ b/Tests/AuthenticationInterceptorTests.swift
@@ -175,6 +175,48 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
     }
 
     @MainActor
+    func testThatInterceptorRethrowsRefreshErrorToAllDeferredAdaptOperations() {
+        // Given
+        let credential = TestCredential(requiresRefresh: true)
+        let authenticator = TestAuthenticator(refreshResult: .failure(TestAuthError.refreshNetworkFailure))
+        let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
+
+        let requestCount = 3
+        let session = stored(Session())
+
+        let expect = expectation(description: "all requests should complete")
+        expect.expectedFulfillmentCount = requestCount
+
+        var requests: [Int: Request] = [:]
+        var responses: [Int: AFDataResponse<Data?>] = [:]
+
+        // When
+        for index in 0..<requestCount {
+            let request = session.request(.status(200), interceptor: interceptor).validate().response {
+                responses[index] = $0
+                expect.fulfill()
+            }
+            requests[index] = request
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        for index in 0..<requestCount {
+            XCTAssertEqual(responses[index]?.request?.headers.count, 0)
+            XCTAssertEqual(responses[index]?.result.isFailure, true)
+            XCTAssertEqual(responses[index]?.result.failure?.asAFError?.isRequestAdaptationError, true)
+            XCTAssertEqual(responses[index]?.result.failure?.asAFError?.underlyingError as? TestAuthError, .refreshNetworkFailure)
+            XCTAssertEqual(requests[index]?.retryCount, 0)
+        }
+
+        XCTAssertEqual(authenticator.applyCount, 0)
+        XCTAssertEqual(authenticator.refreshCount, 1)
+        XCTAssertEqual(authenticator.didRequestFailDueToAuthErrorCount, 0)
+        XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, 0)
+    }
+
+    @MainActor
     func testThatInterceptorQueuesAdaptOperationWhenRefreshing() {
         // Given
         let credential = TestCredential(requiresRefresh: true)
@@ -215,6 +257,46 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
 
         XCTAssertEqual(request1.retryCount, 0)
         XCTAssertEqual(request2.retryCount, 0)
+    }
+
+    @MainActor
+    func testThatInterceptorQueuesMultipleAdaptOperationsWhenRefreshing() {
+        // Given
+        let credential = TestCredential(requiresRefresh: true)
+        let authenticator = TestAuthenticator()
+        let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
+
+        let requestCount = 6
+        let session = stored(Session())
+
+        let expect = expectation(description: "all requests should complete")
+        expect.expectedFulfillmentCount = requestCount
+
+        var requests: [Int: Request] = [:]
+        var responses: [Int: AFDataResponse<Data?>] = [:]
+
+        // When
+        for index in 0..<requestCount {
+            let request = session.request(.status(200 + index), interceptor: interceptor).validate().response {
+                responses[index] = $0
+                expect.fulfill()
+            }
+            requests[index] = request
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        for index in 0..<requestCount {
+            XCTAssertEqual(responses[index]?.request?.headers["Authorization"], "a1")
+            XCTAssertEqual(responses[index]?.result.isSuccess, true)
+            XCTAssertEqual(requests[index]?.retryCount, 0)
+        }
+
+        XCTAssertEqual(authenticator.applyCount, requestCount)
+        XCTAssertEqual(authenticator.refreshCount, 1)
+        XCTAssertEqual(authenticator.didRequestFailDueToAuthErrorCount, 0)
+        XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, 0)
     }
 
     @MainActor
@@ -536,6 +618,45 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
     }
 
     @MainActor
+    func testThatInterceptorTriggersRetryRefreshAfterProactiveRefreshUsesStaleURL() {
+        // Given
+        // When a request is deferred via requiresRefresh, handleRefreshSuccess replays it through
+        // AuthenticationInterceptor.adapt only (not the full adapter chain). A stateful adapter earlier in the chain
+        // (PathAdapter) already consumed its first path entry, so the replayed request reuses the stale URL, causing a
+        // second 401, a second refresh, and a second apply, resulting in credential a2 and refreshCount == 2.
+        let credential = TestCredential(requiresRefresh: true)
+        let authenticator = TestAuthenticator()
+        let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
+
+        let pathAdapter = PathAdapter(paths: ["/status/401", "/status/200"])
+        let compositeInterceptor = Interceptor(adapters: [pathAdapter, interceptor], retriers: [interceptor])
+
+        let session = stored(Session())
+
+        let expect = expectation(description: "request should complete")
+        var response: AFDataResponse<Data?>?
+
+        // When
+        let request = session.request(.default, interceptor: compositeInterceptor).validate().response {
+            response = $0
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertEqual(response?.request?.headers["Authorization"], "a2")
+        XCTAssertEqual(response?.result.isSuccess, true)
+
+        XCTAssertEqual(authenticator.applyCount, 2)
+        XCTAssertEqual(authenticator.refreshCount, 2)
+        XCTAssertEqual(authenticator.didRequestFailDueToAuthErrorCount, 1)
+        XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, 1)
+
+        XCTAssertEqual(request.retryCount, 1)
+    }
+
+    @MainActor
     func testThatInterceptorRethrowsRefreshErrorFromRetry() {
         // Given
         let credential = TestCredential()
@@ -573,6 +694,48 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
         XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, 1)
 
         XCTAssertEqual(request.retryCount, 0)
+    }
+
+    @MainActor
+    func testThatInterceptorRethrowsRefreshErrorToAllPendingRetryRequests() {
+        // Given
+        let credential = TestCredential()
+        let authenticator = TestAuthenticator(refreshResult: .failure(TestAuthError.refreshNetworkFailure))
+        let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
+
+        let requestCount = 3
+        let session = stored(Session())
+
+        let expect = expectation(description: "all requests should complete")
+        expect.expectedFulfillmentCount = requestCount
+
+        var requests: [Int: Request] = [:]
+        var responses: [Int: AFDataResponse<Data?>] = [:]
+
+        // When
+        for index in 0..<requestCount {
+            let request = session.request(.status(401), interceptor: interceptor).validate().response {
+                responses[index] = $0
+                expect.fulfill()
+            }
+            requests[index] = request
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        for index in 0..<requestCount {
+            XCTAssertEqual(responses[index]?.request?.headers["Authorization"], "a0")
+            XCTAssertEqual(responses[index]?.result.isFailure, true)
+            XCTAssertEqual(responses[index]?.result.failure?.asAFError?.isRequestRetryError, true)
+            XCTAssertEqual(responses[index]?.result.failure?.asAFError?.underlyingError as? TestAuthError, .refreshNetworkFailure)
+            XCTAssertEqual(requests[index]?.retryCount, 0)
+        }
+
+        XCTAssertEqual(authenticator.applyCount, requestCount)
+        XCTAssertEqual(authenticator.refreshCount, 1)
+        XCTAssertEqual(authenticator.didRequestFailDueToAuthErrorCount, requestCount)
+        XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, requestCount)
     }
 
     @MainActor
@@ -705,5 +868,93 @@ final class AuthenticationInterceptorTestCase: BaseTestCase {
         XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, 3)
 
         XCTAssertEqual(request.retryCount, 2)
+    }
+
+    @MainActor
+    func testThatInterceptorThrowsExcessiveRefreshErrorFromAdaptPath() {
+        // Given
+        // The requiresRefresh path can also trigger excessive refresh. When a refresh produces a credential that still
+        // has requiresRefresh == true, the next adapt attempt will trigger another refresh, and the refresh window
+        // guard should fire exactly as it does on the retry path.
+        let credential = TestCredential(requiresRefresh: true)
+        let refreshedCredential = TestCredential(accessToken: "a1", requiresRefresh: true)
+        let authenticator = TestAuthenticator(refreshResult: .success(refreshedCredential))
+        let interceptor = AuthenticationInterceptor(authenticator: authenticator,
+                                                    credential: credential,
+                                                    refreshWindow: .init(interval: 30, maximumAttempts: 1))
+
+        let session = stored(Session())
+
+        let expect = expectation(description: "request should complete")
+        var response: AFDataResponse<Data?>?
+
+        // When
+        let request = session.request(.status(200), interceptor: interceptor).validate().response {
+            response = $0
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertEqual(response?.request?.headers.count, 0)
+        XCTAssertEqual(response?.result.isFailure, true)
+        XCTAssertEqual(response?.result.failure?.asAFError?.isRequestAdaptationError, true)
+        XCTAssertEqual(response?.result.failure?.asAFError?.underlyingError as? AuthenticationError, .excessiveRefresh)
+
+        XCTAssertEqual(authenticator.applyCount, 0)
+        XCTAssertEqual(authenticator.refreshCount, 1)
+        XCTAssertEqual(authenticator.didRequestFailDueToAuthErrorCount, 0)
+        XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, 0)
+
+        XCTAssertEqual(request.retryCount, 0)
+    }
+
+    @MainActor
+    func testThatInterceptorThrowsExcessiveRefreshErrorToAllDeferredAdaptOperationsOnReplay() {
+        // Given
+        // When multiple requests are queued during a requiresRefresh-triggered refresh, and the refresh produces a
+        // credential that still requires refresh, each deferred adapt attempt independently hits the excessive refresh
+        // guard and fails with .excessiveRefresh.
+        let credential = TestCredential(requiresRefresh: true)
+        let refreshedCredential = TestCredential(accessToken: "a1", requiresRefresh: true)
+        let authenticator = TestAuthenticator(refreshResult: .success(refreshedCredential))
+        let interceptor = AuthenticationInterceptor(authenticator: authenticator,
+                                                    credential: credential,
+                                                    refreshWindow: .init(interval: 30, maximumAttempts: 1))
+
+        let requestCount = 3
+        let session = stored(Session())
+
+        let expect = expectation(description: "all requests should complete")
+        expect.expectedFulfillmentCount = requestCount
+
+        var requests: [Int: Request] = [:]
+        var responses: [Int: AFDataResponse<Data?>] = [:]
+
+        // When
+        for index in 0..<requestCount {
+            let request = session.request(.status(200), interceptor: interceptor).validate().response {
+                responses[index] = $0
+                expect.fulfill()
+            }
+            requests[index] = request
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        for index in 0..<requestCount {
+            XCTAssertEqual(responses[index]?.request?.headers.count, 0)
+            XCTAssertEqual(responses[index]?.result.isFailure, true)
+            XCTAssertEqual(responses[index]?.result.failure?.asAFError?.isRequestAdaptationError, true)
+            XCTAssertEqual(responses[index]?.result.failure?.asAFError?.underlyingError as? AuthenticationError, .excessiveRefresh)
+            XCTAssertEqual(requests[index]?.retryCount, 0)
+        }
+
+        XCTAssertEqual(authenticator.applyCount, 0)
+        XCTAssertEqual(authenticator.refreshCount, 1)
+        XCTAssertEqual(authenticator.didRequestFailDueToAuthErrorCount, 0)
+        XCTAssertEqual(authenticator.isRequestAuthenticatedWithCredentialCount, 0)
     }
 }

--- a/Tests/CombineTests.swift
+++ b/Tests/CombineTests.swift
@@ -403,7 +403,7 @@ final class DataRequestCombineTests: CombineTestCase {
         var response: DataResponse<TestResponse, AFError>?
 
         // When
-        let request = AF.request(.default)
+        let request = AF.request(.delay(1))
         store {
             request
                 .publishDecodable(type: TestResponse.self)

--- a/Tests/CombineTests.swift
+++ b/Tests/CombineTests.swift
@@ -1223,7 +1223,8 @@ final class DownloadRequestCombineTests: CombineTestCase {
         var response: DownloadResponse<TestResponse, AFError>?
 
         // When
-        let request = AF.download(.default)
+        let session = stored(Session())
+        let request = session.download(.default)
         let publisher = request.publishDecodable(type: TestResponse.self)
 
         let stateAfterPublisher = request.state

--- a/Tests/CombineTests.swift
+++ b/Tests/CombineTests.swift
@@ -34,13 +34,14 @@ final class DataRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDataRequestCanBePublished() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         var response: DataResponse<TestResponse, AFError>?
 
         // When
         store {
-            AF.request(.default)
+            session.request(.default)
                 .publishDecodable(type: TestResponse.self)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { response = $0; responseReceived.fulfill() })
@@ -125,13 +126,14 @@ final class DataRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDataRequestCanBePublishedUnserialized() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         var response: DataResponse<Data?, AFError>?
 
         // When
         store {
-            AF.request(.default)
+            session.request(.default)
                 .publishUnserialized()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { response = $0; responseReceived.fulfill() })
@@ -147,6 +149,7 @@ final class DataRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDataRequestCanBePublishedWithMultipleHandlers() {
         // Given
+        let session = stored(Session())
         let handlerResponseReceived = expectation(description: "handler response should be received")
         let publishedResponseReceived = expectation(description: "published response should be received")
         let completionReceived = expectation(description: "stream should complete")
@@ -155,7 +158,7 @@ final class DataRequestCombineTests: CombineTestCase {
 
         // When
         store {
-            AF.request(.default)
+            session.request(.default)
                 .responseDecodable(of: TestResponse.self) { handlerResponse = $0; handlerResponseReceived.fulfill() }
                 .publishDecodable(type: TestResponse.self)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
@@ -173,13 +176,14 @@ final class DataRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDataRequestCanPublishResult() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         var result: Result<TestResponse, AFError>?
 
         // When
         store {
-            AF.request(.default)
+            session.request(.default)
                 .publishDecodable(type: TestResponse.self)
                 .result()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
@@ -196,13 +200,14 @@ final class DataRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDataRequestCanPublishValue() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         var value: TestResponse?
 
         // When
         store {
-            AF.request(.default)
+            session.request(.default)
                 .publishDecodable(type: TestResponse.self)
                 .value()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
@@ -219,12 +224,13 @@ final class DataRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDataRequestCanPublishValueWithFailure() {
         // Given
+        let session = stored(Session())
         let completionReceived = expectation(description: "stream should complete")
         var error: AFError?
 
         // When
         store {
-            AF.request(Endpoint(path: .delay(interval: 1), timeout: 0.01))
+            session.request(Endpoint(path: .delay(interval: 1), timeout: 0.01))
                 .publishDecodable(type: TestResponse.self)
                 .value()
                 .sink(receiveCompletion: { completion in
@@ -249,12 +255,13 @@ final class DataRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatPublishedDataRequestIsNotResumedUnlessSubscribed() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         var response: DataResponse<TestResponse, AFError>?
 
         // When
-        let request = AF.request(.default)
+        let request = session.request(.default)
         let publisher = request.publishDecodable(type: TestResponse.self)
 
         let stateAfterPublisher = request.state
@@ -278,6 +285,7 @@ final class DataRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDataRequestCanSubscribedFromNonMainQueueButPublishedOnMainQueue() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         let queue = DispatchQueue(label: "org.alamofire.tests.combineEventQueue")
@@ -286,7 +294,7 @@ final class DataRequestCombineTests: CombineTestCase {
 
         // When
         store {
-            AF.request(.default)
+            session.request(.default)
                 .publishDecodable(type: TestResponse.self)
                 .subscribe(on: queue)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
@@ -308,6 +316,7 @@ final class DataRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDataRequestPublishedOnSeparateQueueIsReceivedOnThatQueue() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         let queue = DispatchQueue(label: "org.alamofire.tests.combineEventQueue")
@@ -315,7 +324,7 @@ final class DataRequestCombineTests: CombineTestCase {
 
         // When
         store {
-            AF.request(.default)
+            session.request(.default)
                 .publishDecodable(type: TestResponse.self, queue: queue)
                 .sink(receiveCompletion: { _ in
                           dispatchPrecondition(condition: .onQueue(queue))
@@ -338,6 +347,7 @@ final class DataRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDataRequestPublishedOnSeparateQueueCanBeReceivedOntoMainQueue() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         let queue = DispatchQueue(label: "org.alamofire.tests.combineEventQueue")
@@ -346,7 +356,7 @@ final class DataRequestCombineTests: CombineTestCase {
 
         // When
         store {
-            AF.request(.default)
+            session.request(.default)
                 .publishDecodable(type: TestResponse.self, queue: queue)
                 .receive(on: DispatchQueue.main)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
@@ -372,12 +382,13 @@ final class DataRequestCombineTests: CombineTestCase {
         }
 
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         var response: DataResponse<TestResponse, AFError>?
 
         // When
-        let request = AF.request(.default)
+        let request = session.request(.default)
         var token: AnyCancellable? = request
             .publishDecodable(type: TestResponse.self)
             .sink(receiveCompletion: { _ in completionReceived.fulfill() },
@@ -398,12 +409,13 @@ final class DataRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatPublishedDataRequestCanBeCancelledManually() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         var response: DataResponse<TestResponse, AFError>?
 
         // When
-        let request = AF.request(.delay(1))
+        let request = session.request(.delay(1))
         store {
             request
                 .publishDecodable(type: TestResponse.self)
@@ -425,15 +437,16 @@ final class DataRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatMultipleDataRequestPublishersCanBeCombined() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "combined response should be received")
         let completionReceived = expectation(description: "combined stream should complete")
         var firstResponse: DataResponse<TestResponse, AFError>?
         var secondResponse: DataResponse<TestResponse, AFError>?
 
         // When
-        let first = AF.request(.default)
+        let first = session.request(.default)
             .publishDecodable(type: TestResponse.self)
-        let second = AF.request(.default)
+        let second = session.request(.default)
             .publishDecodable(type: TestResponse.self)
 
         store {
@@ -456,6 +469,7 @@ final class DataRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatMultipleDataRequestPublishersCanBeChained() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "combined response should be received")
         let completionReceived = expectation(description: "combined stream should complete")
         let customValue = "CustomValue"
@@ -464,12 +478,12 @@ final class DataRequestCombineTests: CombineTestCase {
 
         // When
         store {
-            AF.request(.default)
+            session.request(.default)
                 .publishDecodable(type: TestResponse.self)
                 .flatMap { response -> DataResponsePublisher<TestResponse> in
                     firstResponse = response
                     let request = Endpoint(headers: ["X-Custom": customValue])
-                    return AF.request(request)
+                    return session.request(request)
                         .publishDecodable(type: TestResponse.self)
                 }
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() }) { response in
@@ -495,13 +509,14 @@ final class DataStreamRequestCombineTests: CombineTestCase {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func testThatDataStreamRequestCanBePublished() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         var result: Result<TestResponse, AFError>?
 
         // When
         store {
-            AF.streamRequest(.default)
+            session.streamRequest(.default)
                 .publishDecodable(type: TestResponse.self)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { stream in
@@ -552,13 +567,14 @@ final class DataStreamRequestCombineTests: CombineTestCase {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func testThatDataStreamRequestCanPublishData() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         var result: Result<Data, AFError>?
 
         // When
         store {
-            AF.streamRequest(.default)
+            session.streamRequest(.default)
                 .publishData()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { stream in
@@ -580,13 +596,14 @@ final class DataStreamRequestCombineTests: CombineTestCase {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func testThatDataStreamRequestCanPublishString() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         var result: Result<String, AFError>?
 
         // When
         store {
-            AF.streamRequest(.default)
+            session.streamRequest(.default)
                 .publishString()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { stream in
@@ -608,6 +625,7 @@ final class DataStreamRequestCombineTests: CombineTestCase {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func testThatDataStreamRequestCanBePublishedWithMultipleHandlers() {
         // Given
+        let session = stored(Session())
         let handlerResponseReceived = expectation(description: "handler response should be received")
         let publishedResponseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
@@ -616,7 +634,7 @@ final class DataStreamRequestCombineTests: CombineTestCase {
 
         // When
         store {
-            AF.streamRequest(.default)
+            session.streamRequest(.default)
                 .responseStreamDecodable(of: TestResponse.self) { stream in
                     switch stream.event {
                     case let .stream(value):
@@ -647,13 +665,14 @@ final class DataStreamRequestCombineTests: CombineTestCase {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func testThatDataStreamRequestCanPublishResult() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         var result: Result<TestResponse, AFError>?
 
         // When
         store {
-            AF.streamRequest(.default)
+            session.streamRequest(.default)
                 .publishDecodable(type: TestResponse.self)
                 .result()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
@@ -672,13 +691,14 @@ final class DataStreamRequestCombineTests: CombineTestCase {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func testThatDataStreamRequestCanPublishResultWithResponseFailure() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         var result: Result<TestResponse, AFError>?
 
         // When
         store {
-            AF.streamRequest(Endpoint.delay(1).modifying(\.timeout, to: 0.1))
+            session.streamRequest(Endpoint.delay(1).modifying(\.timeout, to: 0.1))
                 .publishDecodable(type: TestResponse.self)
                 .result()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
@@ -698,13 +718,14 @@ final class DataStreamRequestCombineTests: CombineTestCase {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func testThatDataStreamRequestCanPublishValue() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         var response: TestResponse?
 
         // When
         store {
-            AF.streamRequest(.default)
+            session.streamRequest(.default)
                 .publishDecodable(type: TestResponse.self)
                 .value()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
@@ -723,12 +744,13 @@ final class DataStreamRequestCombineTests: CombineTestCase {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func testThatDataStreamRequestCanPublishValueWithFailure() {
         // Given
+        let session = stored(Session())
         let completionReceived = expectation(description: "stream should complete")
         var error: AFError?
 
         // When
         store {
-            AF.streamRequest(Endpoint.delay(1).modifying(\.timeout, to: 0.1))
+            session.streamRequest(Endpoint.delay(1).modifying(\.timeout, to: 0.1))
                 .publishDecodable(type: TestResponse.self)
                 .value()
                 .sink(receiveCompletion: { completion in
@@ -752,12 +774,13 @@ final class DataStreamRequestCombineTests: CombineTestCase {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func testThatPublishedDataStreamRequestIsNotResumedUnlessSubscribed() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         var result: Result<TestResponse, AFError>?
 
         // When
-        let request = AF.streamRequest(.default)
+        let request = session.streamRequest(.default)
         let publisher = request.publishDecodable(type: TestResponse.self)
 
         let stateAfterPublisher = request.state
@@ -787,6 +810,7 @@ final class DataStreamRequestCombineTests: CombineTestCase {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func testThatDataStreamRequestCanSubscribedFromNonMainQueueButPublishedOnMainQueue() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         let queue = DispatchQueue(label: "org.alamofire.tests.combineEventQueue")
@@ -795,7 +819,7 @@ final class DataStreamRequestCombineTests: CombineTestCase {
 
         // When
         store {
-            AF.streamRequest(.default)
+            session.streamRequest(.default)
                 .publishDecodable(type: TestResponse.self)
                 .subscribe(on: queue)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
@@ -820,6 +844,7 @@ final class DataStreamRequestCombineTests: CombineTestCase {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func testThatDataStreamRequestPublishedOnSeparateQueueIsReceivedOnThatQueue() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         let queue = DispatchQueue(label: "org.alamofire.tests.combineEventQueue")
@@ -827,7 +852,7 @@ final class DataStreamRequestCombineTests: CombineTestCase {
 
         // When
         store {
-            AF.streamRequest(.default)
+            session.streamRequest(.default)
                 .publishDecodable(type: TestResponse.self, queue: queue)
                 .sink(receiveCompletion: { _ in
                           dispatchPrecondition(condition: .onQueue(queue))
@@ -853,6 +878,7 @@ final class DataStreamRequestCombineTests: CombineTestCase {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func testThatDataStreamRequestPublishedOnSeparateQueueCanBeReceivedOntoMainQueue() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         let queue = DispatchQueue(label: "org.alamofire.tests.combineEventQueue")
@@ -861,7 +887,7 @@ final class DataStreamRequestCombineTests: CombineTestCase {
 
         // When
         store {
-            AF.streamRequest(.default)
+            session.streamRequest(.default)
                 .publishDecodable(type: TestResponse.self, queue: queue)
                 .receive(on: DispatchQueue.main)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
@@ -890,12 +916,13 @@ final class DataStreamRequestCombineTests: CombineTestCase {
         }
 
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         var error: AFError?
 
         // When
-        let request = AF.streamRequest(.default)
+        let request = session.streamRequest(.default)
         var token: AnyCancellable? = request
             .publishDecodable(type: TestResponse.self)
             .sink(receiveCompletion: { _ in completionReceived.fulfill() },
@@ -915,12 +942,13 @@ final class DataStreamRequestCombineTests: CombineTestCase {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func testThatPublishedDataStreamRequestCanBeCancelledManually() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         var error: AFError?
 
         // When
-        let request = AF.streamRequest(.default)
+        let request = session.streamRequest(.default)
         store {
             request
                 .publishDecodable(type: TestResponse.self)
@@ -941,15 +969,16 @@ final class DataStreamRequestCombineTests: CombineTestCase {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func testThatMultipleDataStreamPublishersCanBeCombined() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "combined response should be received")
         let completionReceived = expectation(description: "combined stream should complete")
         var firstCompletion: DataStreamRequest.Completion?
         var secondCompletion: DataStreamRequest.Completion?
 
         // When
-        let first = AF.streamRequest(.default)
+        let first = session.streamRequest(.default)
             .publishDecodable(type: TestResponse.self)
-        let second = AF.streamRequest(.default)
+        let second = session.streamRequest(.default)
             .publishDecodable(type: TestResponse.self)
 
         store {
@@ -972,6 +1001,7 @@ final class DataStreamRequestCombineTests: CombineTestCase {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func testThatMultipleDataStreamRequestPublishersCanBeChained() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "combined response should be received")
         let completionReceived = expectation(description: "combined stream should complete")
         var firstCompletion: DataStreamRequest.Completion?
@@ -979,12 +1009,12 @@ final class DataStreamRequestCombineTests: CombineTestCase {
 
         // When
         store {
-            AF.streamRequest(.default)
+            session.streamRequest(.default)
                 .publishDecodable(type: TestResponse.self)
                 .compactMap(\.completion)
                 .flatMap { completion -> DataStreamPublisher<TestResponse> in
                     firstCompletion = completion
-                    return AF.streamRequest(.default)
+                    return session.streamRequest(.default)
                         .publishDecodable(type: TestResponse.self)
                 }
                 .compactMap(\.completion)
@@ -1006,13 +1036,14 @@ final class DownloadRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDownloadRequestCanBePublished() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "publisher should complete")
         var response: DownloadResponse<TestResponse, AFError>?
 
         // When
         store {
-            AF.download(.default)
+            session.download(.default)
                 .publishDecodable(type: TestResponse.self)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { response = $0; responseReceived.fulfill() })
@@ -1051,13 +1082,14 @@ final class DownloadRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDownloadRequestCanPublishData() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "publisher should complete")
         var response: DownloadResponse<Data, AFError>?
 
         // When
         store {
-            AF.download(.default)
+            session.download(.default)
                 .publishData()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { response = $0; responseReceived.fulfill() })
@@ -1073,13 +1105,14 @@ final class DownloadRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDownloadRequestCanPublishString() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "publisher should complete")
         var response: DownloadResponse<String, AFError>?
 
         // When
         store {
-            AF.download(.default)
+            session.download(.default)
                 .publishString()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { response = $0; responseReceived.fulfill() })
@@ -1095,13 +1128,14 @@ final class DownloadRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDownloadRequestCanPublishUnserialized() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "publisher should complete")
         var response: DownloadResponse<URL?, AFError>?
 
         // When
         store {
-            AF.download(.default)
+            session.download(.default)
                 .publishUnserialized()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { response = $0; responseReceived.fulfill() })
@@ -1117,13 +1151,14 @@ final class DownloadRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDownloadRequestCanPublishURL() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "publisher should complete")
         var response: DownloadResponse<URL, AFError>?
 
         // When
         store {
-            AF.download(.default)
+            session.download(.default)
                 .publishURL()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
                       receiveValue: { response = $0; responseReceived.fulfill() })
@@ -1139,6 +1174,7 @@ final class DownloadRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDownloadRequestCanPublishWithMultipleHandlers() {
         // Given
+        let session = stored(Session())
         let handlerResponseReceived = expectation(description: "handler response should be received")
         let publishedResponseReceived = expectation(description: "published response should be received")
         let completionReceived = expectation(description: "stream should complete")
@@ -1147,7 +1183,7 @@ final class DownloadRequestCombineTests: CombineTestCase {
 
         // When
         store {
-            AF.download(.default)
+            session.download(.default)
                 .responseDecodable(of: TestResponse.self) { handlerResponse = $0; handlerResponseReceived.fulfill() }
                 .publishDecodable(type: TestResponse.self)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
@@ -1165,13 +1201,14 @@ final class DownloadRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDownloadRequestCanPublishResult() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "publisher should complete")
         var result: Result<TestResponse, AFError>?
 
         // When
         store {
-            AF.download(.default)
+            session.download(.default)
                 .publishDecodable(type: TestResponse.self)
                 .result()
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
@@ -1188,12 +1225,13 @@ final class DownloadRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDownloadRequestCanPublishValueWithFailure() {
         // Given
+        let session = stored(Session())
         let completionReceived = expectation(description: "stream should complete")
         var error: AFError?
 
         // When
         store {
-            AF.download(Endpoint.delay(1).modifying(\.timeout, to: 0.1))
+            session.download(Endpoint.delay(1).modifying(\.timeout, to: 0.1))
                 .publishDecodable(type: TestResponse.self)
                 .value()
                 .sink(receiveCompletion: { completion in
@@ -1248,6 +1286,7 @@ final class DownloadRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDownloadRequestCanSubscribedFromNonMainQueueButPublishedOnMainQueue() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         let queue = DispatchQueue(label: "org.alamofire.tests.combineEventQueue")
@@ -1256,7 +1295,7 @@ final class DownloadRequestCombineTests: CombineTestCase {
 
         // When
         store {
-            AF.download(.default)
+            session.download(.default)
                 .publishDecodable(type: TestResponse.self)
                 .subscribe(on: queue)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
@@ -1278,6 +1317,7 @@ final class DownloadRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDownloadRequestPublishedOnSeparateQueueIsReceivedOnThatQueue() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         let queue = DispatchQueue(label: "org.alamofire.tests.combineEventQueue")
@@ -1285,7 +1325,7 @@ final class DownloadRequestCombineTests: CombineTestCase {
 
         // When
         store {
-            AF.download(.default)
+            session.download(.default)
                 .publishDecodable(type: TestResponse.self, queue: queue)
                 .sink(receiveCompletion: { _ in
                           dispatchPrecondition(condition: .onQueue(queue))
@@ -1308,6 +1348,7 @@ final class DownloadRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatDownloadRequestPublishedOnSeparateQueueCanBeReceivedOntoMainQueue() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         let queue = DispatchQueue(label: "org.alamofire.tests.combineEventQueue")
@@ -1316,7 +1357,7 @@ final class DownloadRequestCombineTests: CombineTestCase {
 
         // When
         store {
-            AF.download(.default)
+            session.download(.default)
                 .publishDecodable(type: TestResponse.self, queue: queue)
                 .receive(on: DispatchQueue.main)
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() },
@@ -1342,12 +1383,13 @@ final class DownloadRequestCombineTests: CombineTestCase {
         }
 
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         var response: DownloadResponse<TestResponse, AFError>?
 
         // When
-        let request = AF.download(.default)
+        let request = session.download(.default)
         var token: AnyCancellable? = request
             .publishDecodable(type: TestResponse.self)
             .sink(receiveCompletion: { _ in completionReceived.fulfill() },
@@ -1368,12 +1410,13 @@ final class DownloadRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatPublishedDownloadRequestCanBeCancelledManually() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "response should be received")
         let completionReceived = expectation(description: "stream should complete")
         var response: DownloadResponse<TestResponse, AFError>?
 
         // When
-        let request = AF.download(.default)
+        let request = session.download(.default)
         store {
             request
                 .publishDecodable(type: TestResponse.self)
@@ -1395,15 +1438,16 @@ final class DownloadRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatMultipleDownloadRequestPublishersCanBeCombined() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "combined response should be received")
         let completionReceived = expectation(description: "combined stream should complete")
         var firstResponse: DownloadResponse<TestResponse, AFError>?
         var secondResponse: DownloadResponse<TestResponse, AFError>?
 
         // When
-        let first = AF.download(.default)
+        let first = session.download(.default)
             .publishDecodable(type: TestResponse.self)
-        let second = AF.download(.default)
+        let second = session.download(.default)
             .publishDecodable(type: TestResponse.self)
 
         store {
@@ -1426,6 +1470,7 @@ final class DownloadRequestCombineTests: CombineTestCase {
     @MainActor
     func testThatMultipleDownloadRequestPublishersCanBeChained() {
         // Given
+        let session = stored(Session())
         let responseReceived = expectation(description: "combined response should be received")
         let completionReceived = expectation(description: "combined stream should complete")
         let customValue = "CustomValue"
@@ -1434,12 +1479,12 @@ final class DownloadRequestCombineTests: CombineTestCase {
 
         // When
         store {
-            AF.download(.default)
+            session.download(.default)
                 .publishDecodable(type: TestResponse.self)
                 .flatMap { response -> DownloadResponsePublisher<TestResponse> in
                     firstResponse = response
                     let request = Endpoint(headers: ["X-Custom": customValue])
-                    return AF.download(request)
+                    return session.download(request)
                         .publishDecodable(type: TestResponse.self)
                 }
                 .sink(receiveCompletion: { _ in completionReceived.fulfill() }) { response in

--- a/Tests/CombineTests.swift
+++ b/Tests/CombineTests.swift
@@ -948,7 +948,7 @@ final class DataStreamRequestCombineTests: CombineTestCase {
         var error: AFError?
 
         // When
-        let request = session.streamRequest(.default)
+        let request = session.streamRequest(.delay(1))
         store {
             request
                 .publishDecodable(type: TestResponse.self)
@@ -1416,7 +1416,7 @@ final class DownloadRequestCombineTests: CombineTestCase {
         var response: DownloadResponse<TestResponse, AFError>?
 
         // When
-        let request = session.download(.default)
+        let request = session.download(.delay(1))
         store {
             request
                 .publishDecodable(type: TestResponse.self)

--- a/Tests/CombineTests.swift
+++ b/Tests/CombineTests.swift
@@ -278,7 +278,7 @@ final class DataRequestCombineTests: CombineTestCase {
         // Then
         XCTAssertTrue(response?.result.isSuccess == true)
         XCTAssertEqual(stateAfterPublisher, .initialized)
-        XCTAssertEqual(stateAfterSubscription, .resumed)
+        XCTAssertNotEqual(stateAfterSubscription, .initialized)
     }
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
@@ -804,7 +804,7 @@ final class DataStreamRequestCombineTests: CombineTestCase {
         // Then
         XCTAssertTrue(result?.isSuccess == true)
         XCTAssertEqual(stateAfterPublisher, .initialized)
-        XCTAssertEqual(stateAfterSubscription, .resumed)
+        XCTAssertNotEqual(stateAfterSubscription, .initialized)
     }
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
@@ -1279,7 +1279,7 @@ final class DownloadRequestCombineTests: CombineTestCase {
         // Then
         XCTAssertTrue(response?.result.isSuccess == true)
         XCTAssertEqual(stateAfterPublisher, .initialized)
-        XCTAssertEqual(stateAfterSubscription, .resumed)
+        XCTAssertNotEqual(stateAfterSubscription, .initialized)
     }
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -832,12 +832,21 @@ final class ClosureAPIConcurrencyTests: BaseTestCase {
 
         // When
         let request = session.request(.get)
-        async let httpResponses = request.httpResponses().collect()
-        async let uploadProgress = request.uploadProgress().collect()
-        async let downloadProgress = request.downloadProgress().collect()
-        async let requests = request.urlRequests().collect()
-        async let tasks = request.urlSessionTasks().collect()
-        async let descriptions = request.cURLDescriptions().collect()
+        // Start streams outside async let so the asynchrony starts later.
+        let _httpResponses = request.httpResponses()
+        let _uploadProgress = request.uploadProgress()
+        let _downloadProgress = request.downloadProgress()
+        let _requests = request.urlRequests()
+        let _tasks = request.urlSessionTasks()
+        let _descriptions = request.cURLDescriptions()
+        // Start collecting in parallel.
+        async let httpResponses = _httpResponses.collect()
+        async let uploadProgress = _uploadProgress.collect()
+        async let downloadProgress = _downloadProgress.collect()
+        async let requests = _requests.collect()
+        async let tasks = _tasks.collect()
+        async let descriptions = _descriptions.collect()
+        // Start request in parallel as well.
         async let response = request.serializingDecodable(TestResponse.self).response
 
         let values: (httpResponses: [HTTPURLResponse],

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -465,7 +465,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
         let session = stored(Session())
 
         // When
-        let task = session.streamRequest(.payloads(2, delay: 30)).streamTask()
+        let task = session.streamRequest(.payloads(2)).streamTask()
         var datas: [Data] = []
 
         for await data in task.streamingData().compactMap(\.value) {
@@ -486,7 +486,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
         }
 
         // When
-        let task = session.streamRequest(.payloads(2, delay: 30))
+        let task = session.streamRequest(.payloads(2))
             .onHTTPResponse { _ in
                 await fulfill()
             }
@@ -512,7 +512,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
         }
 
         // When
-        let task = session.streamRequest(.payloads(2, delay: 30))
+        let task = session.streamRequest(.payloads(2))
             .onHTTPResponse { _ in
                 await fulfill()
                 return .allow
@@ -540,7 +540,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
         }
 
         // When
-        let request = session.streamRequest(.payloads(2, delay: 30))
+        let request = session.streamRequest(.payloads(2))
             .onHTTPResponse { _ in
                 await fulfill()
                 return .cancel
@@ -570,7 +570,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
         let session = stored(Session())
 
         // When
-        let task = session.streamRequest(.payloads(2, delay: 30)).streamTask()
+        let task = session.streamRequest(.payloads(2)).streamTask()
         var strings: [String] = []
 
         for await string in task.streamingStrings().compactMap(\.value) {
@@ -586,7 +586,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
         let session = stored(Session())
 
         // When
-        let task = session.streamRequest(.payloads(2, delay: 30)).streamTask()
+        let task = session.streamRequest(.payloads(2)).streamTask()
         let stream = task.streamingResponses(serializedUsing: DecodableStreamSerializer<TestResponse>())
         var responses: [TestResponse] = []
 
@@ -604,7 +604,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
 
         // When
         let expectedPayloads = 10
-        let request = session.streamRequest(.payloads(expectedPayloads, delay: 30))
+        let request = session.streamRequest(.payloads(expectedPayloads))
         let task = request.streamTask()
         var datas: [Data] = []
 
@@ -626,7 +626,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
 
         // When
         let expectedPayloads = 10
-        let request = session.streamRequest(.payloads(expectedPayloads, delay: 30))
+        let request = session.streamRequest(.payloads(expectedPayloads))
         let task = request.streamTask()
         var datas: [Data] = []
 
@@ -648,7 +648,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
 
         // When
         let expectedPayloads = 10
-        let request = session.streamRequest(.payloads(expectedPayloads, delay: 30))
+        let request = session.streamRequest(.payloads(expectedPayloads))
         let task = Task<[Data], Never> {
             var datas: [Data] = []
 
@@ -672,7 +672,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
 
         // When
         let expectedPayloads = 10
-        let request = session.streamRequest(.payloads(expectedPayloads, delay: 30))
+        let request = session.streamRequest(.payloads(expectedPayloads))
         let task = Task<[Data], Never> {
             var datas: [Data] = []
             let streamTask = request.streamTask()

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -806,7 +806,7 @@ final class WebSocketConcurrencyTests: BaseTestCase {
             receivedEvent.fulfill()
         }
 
-        await fulfillment(of: [receivedEvent])
+        await fulfillment(of: [receivedEvent], timeout: timeout)
 
         // Then
     }

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -725,10 +725,10 @@ final class UploadConcurrencyTests: BaseTestCase {
 
         // When
         session.upload(inputStream, with: request)
-            .uploadProgress { progress in
+            .uploadProgress(queue: session.rootQueue) { progress in
                 uploadProgressValues.append(progress.fractionCompleted)
             }
-            .downloadProgress { progress in
+            .downloadProgress(queue: session.rootQueue) { progress in
                 downloadProgressValues.append(progress.fractionCompleted)
             }
             .responseDecodable(of: UploadResponse.self) { resp in

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -704,6 +704,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
 final class UploadConcurrencyTests: BaseTestCase {
     func testThatDelayedUploadStreamResultsInMultipleProgressValues() async throws {
         // Given
+        let session = stored(Session())
         let count = 75
         let baseString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
         let baseData = Data(baseString.utf8)
@@ -723,7 +724,7 @@ final class UploadConcurrencyTests: BaseTestCase {
         outputStream.open()
 
         // When
-        AF.upload(inputStream, with: request)
+        session.upload(inputStream, with: request)
             .uploadProgress { progress in
                 uploadProgressValues.append(progress.fractionCompleted)
             }

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -465,7 +465,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
         let session = stored(Session())
 
         // When
-        let task = session.streamRequest(.payloads(2)).streamTask()
+        let task = session.streamRequest(.payloads(2, delay: 30)).streamTask()
         var datas: [Data] = []
 
         for await data in task.streamingData().compactMap(\.value) {
@@ -486,7 +486,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
         }
 
         // When
-        let task = session.streamRequest(.payloads(2))
+        let task = session.streamRequest(.payloads(2, delay: 30))
             .onHTTPResponse { _ in
                 await fulfill()
             }
@@ -512,7 +512,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
         }
 
         // When
-        let task = session.streamRequest(.payloads(2))
+        let task = session.streamRequest(.payloads(2, delay: 30))
             .onHTTPResponse { _ in
                 await fulfill()
                 return .allow
@@ -540,7 +540,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
         }
 
         // When
-        let request = session.streamRequest(.payloads(2))
+        let request = session.streamRequest(.payloads(2, delay: 30))
             .onHTTPResponse { _ in
                 await fulfill()
                 return .cancel
@@ -570,7 +570,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
         let session = stored(Session())
 
         // When
-        let task = session.streamRequest(.payloads(2)).streamTask()
+        let task = session.streamRequest(.payloads(2, delay: 30)).streamTask()
         var strings: [String] = []
 
         for await string in task.streamingStrings().compactMap(\.value) {
@@ -586,7 +586,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
         let session = stored(Session())
 
         // When
-        let task = session.streamRequest(.payloads(2)).streamTask()
+        let task = session.streamRequest(.payloads(2, delay: 30)).streamTask()
         let stream = task.streamingResponses(serializedUsing: DecodableStreamSerializer<TestResponse>())
         var responses: [TestResponse] = []
 
@@ -604,7 +604,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
 
         // When
         let expectedPayloads = 10
-        let request = session.streamRequest(.payloads(expectedPayloads))
+        let request = session.streamRequest(.payloads(expectedPayloads, delay: 30))
         let task = request.streamTask()
         var datas: [Data] = []
 
@@ -626,7 +626,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
 
         // When
         let expectedPayloads = 10
-        let request = session.streamRequest(.payloads(expectedPayloads))
+        let request = session.streamRequest(.payloads(expectedPayloads, delay: 30))
         let task = request.streamTask()
         var datas: [Data] = []
 
@@ -648,7 +648,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
 
         // When
         let expectedPayloads = 10
-        let request = session.streamRequest(.payloads(expectedPayloads))
+        let request = session.streamRequest(.payloads(expectedPayloads, delay: 30))
         let task = Task<[Data], Never> {
             var datas: [Data] = []
 
@@ -672,7 +672,7 @@ final class DataStreamConcurrencyTests: BaseTestCase {
 
         // When
         let expectedPayloads = 10
-        let request = session.streamRequest(.payloads(expectedPayloads))
+        let request = session.streamRequest(.payloads(expectedPayloads, delay: 30))
         let task = Task<[Data], Never> {
             var datas: [Data] = []
             let streamTask = request.streamTask()

--- a/Tests/DataStreamTests.swift
+++ b/Tests/DataStreamTests.swift
@@ -1079,7 +1079,10 @@ final class DataStreamIntegrationTests: BaseTestCase {
         // Given
         let requestQueue = DispatchQueue(label: "org.alamofire.testRequestQueue")
         let serializationQueue = DispatchQueue(label: "org.alamofire.testSerializationQueue")
-        let session = Session(requestQueue: requestQueue, serializationQueue: serializationQueue)
+        // Require manual start so both serializers can be added before the stream starts.
+        let session = Session(startRequestsImmediately: false,
+                              requestQueue: requestQueue,
+                              serializationQueue: serializationQueue)
         var firstResponse: HTTPURLResponse?
         var firstDecodedResponse: TestResponse?
         var firstDecodingError: AFError?
@@ -1135,6 +1138,7 @@ final class DataStreamIntegrationTests: BaseTestCase {
                     secondDidComplete.fulfill()
                 }
             }
+            .resume()
 
         wait(for: [firstStream, secondStream], timeout: timeout, enforceOrder: true)
         // Cannot test order of completion events, as one may have been enqueued while the other executed directly.

--- a/Tests/DataStreamTests.swift
+++ b/Tests/DataStreamTests.swift
@@ -29,6 +29,7 @@ final class DataStreamTests: BaseTestCase {
     @MainActor
     func testThatDataCanBeStreamedOnMainQueue() {
         // Given
+        let session = stored(Session())
         let expectedSize = 5
         var accumulatedData = Data()
         var initialResponse: HTTPURLResponse?
@@ -40,7 +41,7 @@ final class DataStreamTests: BaseTestCase {
         let didComplete = expectation(description: "stream should complete")
 
         // When
-        AF.streamRequest(.bytes(expectedSize))
+        session.streamRequest(.bytes(expectedSize))
             .onHTTPResponse { response in
                 initialResponse = response
                 didReceiveResponse.fulfill()
@@ -74,6 +75,7 @@ final class DataStreamTests: BaseTestCase {
     @MainActor
     func testThatDataCanBeStreamedOnArbitraryQueue() {
         // Given
+        let session = stored(Session())
         let expectedSize = 5
         var accumulatedData = Data()
         var initialResponse: HTTPURLResponse?
@@ -84,7 +86,7 @@ final class DataStreamTests: BaseTestCase {
         let didComplete = expectation(description: "stream should complete")
 
         // When
-        AF.streamRequest(.bytes(expectedSize))
+        session.streamRequest(.bytes(expectedSize))
             .onHTTPResponse { response in
                 initialResponse = response
                 didReceiveResponse.fulfill()
@@ -119,6 +121,7 @@ final class DataStreamTests: BaseTestCase {
         }
 
         // Given
+        let session = stored(Session())
         let expectedSize = 5
         var accumulatedData = Data()
         var initialResponse: HTTPURLResponse?
@@ -132,7 +135,7 @@ final class DataStreamTests: BaseTestCase {
         let didComplete = expectation(description: "stream should complete")
 
         // When
-        AF.streamRequest(.chunked(expectedSize))
+        session.streamRequest(.chunked(expectedSize))
             .onHTTPResponse { response in
                 initialResponse = response
                 didReceiveResponse.fulfill()
@@ -172,6 +175,7 @@ final class DataStreamTests: BaseTestCase {
         }
 
         // Given
+        let session = stored(Session())
         let expectedSize = 5
         var responses: [TestResponse] = []
         var initialResponse: HTTPURLResponse?
@@ -185,7 +189,7 @@ final class DataStreamTests: BaseTestCase {
         let didComplete = expectation(description: "stream should complete")
 
         // When
-        AF.streamRequest(.payloads(expectedSize))
+        session.streamRequest(.payloads(expectedSize))
             .onHTTPResponse { response in
                 initialResponse = response
                 didReceiveResponse.fulfill()
@@ -223,6 +227,7 @@ final class DataStreamTests: BaseTestCase {
     @MainActor
     func testThatDataCanBeStreamedFromURL() {
         // Given
+        let session = stored(Session())
         let expectedSize = 1
         var accumulatedData = Data()
         var initialResponse: HTTPURLResponse?
@@ -234,7 +239,7 @@ final class DataStreamTests: BaseTestCase {
         let didComplete = expectation(description: "stream should complete")
 
         // When
-        AF.streamRequest(.bytes(expectedSize))
+        session.streamRequest(.bytes(expectedSize))
             .onHTTPResponse { response in
                 initialResponse = response
                 didReceiveResponse.fulfill()
@@ -268,6 +273,7 @@ final class DataStreamTests: BaseTestCase {
     @MainActor
     func testThatDataCanBeStreamedManyTimes() {
         // Given
+        let session = stored(Session())
         let expectedSize = 1
         var initialResponse: HTTPURLResponse?
         let onHTTPResponse = expectation(description: "onHTTPResponse should be called")
@@ -285,7 +291,7 @@ final class DataStreamTests: BaseTestCase {
         let secondCompletion = expectation(description: "second stream should complete")
 
         // When
-        AF.streamRequest(.bytes(expectedSize))
+        session.streamRequest(.bytes(expectedSize))
             .onHTTPResponse { response in
                 initialResponse = response
                 onHTTPResponse.fulfill()
@@ -340,6 +346,7 @@ final class DataStreamTests: BaseTestCase {
     @MainActor
     func testThatDataCanBeStreamedAndDecodedAtTheSameTime() {
         // Given
+        let session = stored(Session())
         var initialResponse: HTTPURLResponse?
         let onHTTPResponse = expectation(description: "onHTTPResponse should be called")
         var firstAccumulatedData = Data()
@@ -357,7 +364,7 @@ final class DataStreamTests: BaseTestCase {
         let secondCompletion = expectation(description: "second stream should complete")
 
         // When
-        AF.streamRequest(.stream(1))
+        session.streamRequest(.stream(1))
             .onHTTPResponse { response in
                 initialResponse = response
                 onHTTPResponse.fulfill()
@@ -416,10 +423,11 @@ final class DataStreamTests: BaseTestCase {
     @MainActor
     func testThatDataStreamRequestProducesWorkingInputStream() {
         // Given
+        let session = stored(Session())
         let expect = expectation(description: "stream complete")
 
         // When
-        let stream = AF.streamRequest(.xml)
+        let stream = session.streamRequest(.xml)
             .responseStream { stream in
                 switch stream.event {
                 case .complete:
@@ -473,12 +481,13 @@ final class DataStreamTests: BaseTestCase {
 
     @MainActor
     func testThatDataStreamIsAutomaticallyCanceledOnStreamErrorWhenEnabled() {
+        let session = stored(Session())
         var response: HTTPURLResponse?
         var complete: DataStreamRequest.Completion?
         let didComplete = expectation(description: "stream complete")
 
         // When
-        AF.streamRequest(.bytes(50), automaticallyCancelOnStreamError: true)
+        session.streamRequest(.bytes(50), automaticallyCancelOnStreamError: true)
             .responseStreamDecodable(of: TestResponse.self) { stream in
                 switch stream.event {
                 case let .complete(completion):
@@ -500,6 +509,7 @@ final class DataStreamTests: BaseTestCase {
     @MainActor
     func testThatDataStreamIsAutomaticallyCanceledOnStreamClosureError() {
         // Given
+        let session = stored(Session())
         enum LocalError: Error { case failed }
 
         var response: HTTPURLResponse?
@@ -508,7 +518,7 @@ final class DataStreamTests: BaseTestCase {
         let didComplete = expectation(description: "stream complete")
 
         // When
-        AF.streamRequest(.bytes(50))
+        session.streamRequest(.bytes(50))
             .responseStream { stream in
                 switch stream.event {
                 case .stream:
@@ -593,6 +603,7 @@ final class DataStreamTests: BaseTestCase {
     @MainActor
     func testThatOnHTTPResponseCanContinueStream() {
         // Given
+        let session = stored(Session())
         let expectedSize = 5
         var accumulatedData = Data()
         var initialResponse: HTTPURLResponse?
@@ -604,7 +615,7 @@ final class DataStreamTests: BaseTestCase {
         let didComplete = expectation(description: "stream should complete")
 
         // When
-        AF.streamRequest(.bytes(expectedSize))
+        session.streamRequest(.bytes(expectedSize))
             .onHTTPResponse { response, completionHandler in
                 initialResponse = response
                 didReceiveResponse.fulfill()
@@ -639,6 +650,7 @@ final class DataStreamTests: BaseTestCase {
     @MainActor
     func testThatOnHTTPResponseCanCancelStream() {
         // Given
+        let session = stored(Session())
         let expectedSize = 5
         var initialResponse: HTTPURLResponse?
         var response: HTTPURLResponse?
@@ -648,7 +660,7 @@ final class DataStreamTests: BaseTestCase {
         let didComplete = expectation(description: "stream should complete")
 
         // When
-        AF.streamRequest(.bytes(expectedSize))
+        session.streamRequest(.bytes(expectedSize))
             .onHTTPResponse { response, completionHandler in
                 initialResponse = response
                 didReceiveResponse.fulfill()
@@ -682,6 +694,7 @@ final class DataStreamSerializationTests: BaseTestCase {
     @MainActor
     func testThatDataStreamsCanBeAString() {
         // Given
+        let session = stored(Session())
         var responseString: String?
         var streamOnMain = false
         var completeOnMain = false
@@ -690,7 +703,7 @@ final class DataStreamSerializationTests: BaseTestCase {
         let didComplete = expectation(description: "stream complete")
 
         // When
-        AF.streamRequest(.stream(1))
+        session.streamRequest(.stream(1))
             .responseStreamString { stream in
                 switch stream.event {
                 case let .stream(result):
@@ -719,6 +732,7 @@ final class DataStreamSerializationTests: BaseTestCase {
     @MainActor
     func testThatDataStreamsCanBeAStringOnAnArbitraryQueue() {
         // Given
+        let session = stored(Session())
         var responseString: String?
         var response: HTTPURLResponse?
         let streamQueue = DispatchQueue(label: "com.alamofire.tests.ArbitraryQueue")
@@ -726,7 +740,7 @@ final class DataStreamSerializationTests: BaseTestCase {
         let didComplete = expectation(description: "stream complete")
 
         // When
-        AF.streamRequest(.stream(1))
+        session.streamRequest(.stream(1))
             .responseStreamString(on: streamQueue) { stream in
                 dispatchPrecondition(condition: .onQueue(streamQueue))
                 switch stream.event {
@@ -752,6 +766,7 @@ final class DataStreamSerializationTests: BaseTestCase {
     @MainActor
     func testThatDataStreamsCanBeDecoded() {
         // Given
+        let session = stored(Session())
         var response: TestResponse?
         var httpResponse: HTTPURLResponse?
         var decodingError: AFError?
@@ -761,7 +776,7 @@ final class DataStreamSerializationTests: BaseTestCase {
         let didComplete = expectation(description: "stream complete")
 
         // When
-        AF.streamRequest(.stream(1))
+        session.streamRequest(.stream(1))
             .responseStreamDecodable(of: TestResponse.self) { stream in
                 switch stream.event {
                 case let .stream(result):
@@ -793,6 +808,7 @@ final class DataStreamSerializationTests: BaseTestCase {
     @MainActor
     func testThatDataStreamsCanBeDecodedOnAnArbitraryQueue() {
         // Given
+        let session = stored(Session())
         var response: TestResponse?
         var httpResponse: HTTPURLResponse?
         var decodingError: AFError?
@@ -801,7 +817,7 @@ final class DataStreamSerializationTests: BaseTestCase {
         let didComplete = expectation(description: "stream complete")
 
         // When
-        AF.streamRequest(.stream(1))
+        session.streamRequest(.stream(1))
             .responseStreamDecodable(of: TestResponse.self, on: streamQueue) { stream in
                 dispatchPrecondition(condition: .onQueue(streamQueue))
                 switch stream.event {
@@ -830,6 +846,7 @@ final class DataStreamSerializationTests: BaseTestCase {
     @MainActor
     func testThatDataStreamSerializerCanBeUsedDirectly() {
         // Given
+        let session = stored(Session())
         var response: HTTPURLResponse?
         var decodedResponse: TestResponse?
         var decodingError: AFError?
@@ -840,7 +857,7 @@ final class DataStreamSerializationTests: BaseTestCase {
         let didComplete = expectation(description: "stream complete")
 
         // When
-        AF.streamRequest(.stream(1))
+        session.streamRequest(.stream(1))
             .responseStream(using: serializer) { stream in
                 switch stream.event {
                 case let .stream(result):
@@ -876,12 +893,13 @@ final class DataStreamIntegrationTests: BaseTestCase {
     @MainActor
     func testThatDataStreamCanFailValidation() {
         // Given
+        let session = stored(Session())
         var dataSeen = false
         var error: AFError?
         let didComplete = expectation(description: "stream should complete")
 
         // When
-        AF.streamRequest(.status(401))
+        session.streamRequest(.status(401))
             .validate()
             .responseStream { stream in
                 switch stream.event {
@@ -960,6 +978,7 @@ final class DataStreamIntegrationTests: BaseTestCase {
     @MainActor
     func testThatDataStreamCanBeRedirected() {
         // Given
+        let session = stored(Session())
         var response: HTTPURLResponse?
         var decodedResponse: TestResponse?
         var decodingError: AFError?
@@ -974,7 +993,7 @@ final class DataStreamIntegrationTests: BaseTestCase {
         let didComplete = expectation(description: "stream should complete")
 
         // When
-        AF.streamRequest(.status(301))
+        session.streamRequest(.status(301))
             .redirect(using: redirector)
             .responseStreamDecodable(of: TestResponse.self) { stream in
                 switch stream.event {
@@ -1007,6 +1026,7 @@ final class DataStreamIntegrationTests: BaseTestCase {
     @MainActor
     func testThatDataStreamCallsCachedResponseHandler() {
         // Given
+        let session = stored(Session())
         var response: HTTPURLResponse?
         var decodedResponse: TestResponse?
         var decodingError: AFError?
@@ -1021,7 +1041,7 @@ final class DataStreamIntegrationTests: BaseTestCase {
         let didComplete = expectation(description: "stream complete")
 
         // When
-        AF.streamRequest(.stream(1))
+        session.streamRequest(.stream(1))
             .cacheResponse(using: cacher)
             .responseStreamDecodable(of: TestResponse.self) { stream in
                 switch stream.event {
@@ -1211,6 +1231,7 @@ final class DataStreamIntegrationTests: BaseTestCase {
     @MainActor
     func testThatDataStreamCanAuthenticate() {
         // Given
+        let session = stored(Session())
         let user = "userstream", password = "password"
         var response: HTTPURLResponse?
         var streamOnMain = false
@@ -1219,7 +1240,7 @@ final class DataStreamIntegrationTests: BaseTestCase {
         let didComplete = expectation(description: "stream complete")
 
         // When
-        AF.streamRequest(.basicAuth(forUser: user, password: password))
+        session.streamRequest(.basicAuth(forUser: user, password: password))
             .authenticate(username: user, password: password)
             .responseStream { stream in
                 switch stream.event {

--- a/Tests/DataStreamTests.swift
+++ b/Tests/DataStreamTests.swift
@@ -135,7 +135,7 @@ final class DataStreamTests: BaseTestCase {
         let didComplete = expectation(description: "stream should complete")
 
         // When
-        session.streamRequest(.chunked(expectedSize))
+        session.streamRequest(.chunked(expectedSize, delay: 30))
             .onHTTPResponse { response in
                 initialResponse = response
                 didReceiveResponse.fulfill()
@@ -189,7 +189,7 @@ final class DataStreamTests: BaseTestCase {
         let didComplete = expectation(description: "stream should complete")
 
         // When
-        session.streamRequest(.payloads(expectedSize))
+        session.streamRequest(.payloads(expectedSize, delay: 30))
             .onHTTPResponse { response in
                 initialResponse = response
                 didReceiveResponse.fulfill()

--- a/Tests/DataStreamTests.swift
+++ b/Tests/DataStreamTests.swift
@@ -135,7 +135,7 @@ final class DataStreamTests: BaseTestCase {
         let didComplete = expectation(description: "stream should complete")
 
         // When
-        session.streamRequest(.chunked(expectedSize, delay: 30))
+        session.streamRequest(.chunked(expectedSize))
             .onHTTPResponse { response in
                 initialResponse = response
                 didReceiveResponse.fulfill()
@@ -189,7 +189,7 @@ final class DataStreamTests: BaseTestCase {
         let didComplete = expectation(description: "stream should complete")
 
         // When
-        session.streamRequest(.payloads(expectedSize, delay: 30))
+        session.streamRequest(.payloads(expectedSize))
             .onHTTPResponse { response in
                 initialResponse = response
                 didReceiveResponse.fulfill()

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -187,7 +187,7 @@ final class DownloadResponseTests: BaseTestCase {
 
         // When
         session.download(endpoint)
-            .downloadProgress { progress in
+            .downloadProgress(queue: session.rootQueue) { progress in
                 progressValues.append(progress.fractionCompleted)
             }
             .response { resp in
@@ -534,11 +534,11 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         var response: DownloadResponse<URL?, AFError>?
 
         // When
-        let download = session.download(.download())
-        download.downloadProgress { [unowned download] progress in
+        let download = session.download(.download(10_000_000))
+        download.downloadProgress(queue: session.rootQueue) { [unowned download] progress in
             guard !cancelled else { return }
 
-            if progress.fractionCompleted > 0.1 {
+            if progress.fractionCompleted > 0 {
                 download.cancel()
                 cancelled = true
             }
@@ -601,11 +601,11 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         var response: DownloadResponse<URL?, AFError>?
 
         // When
-        let download = session.download(.download())
-        download.downloadProgress { [unowned download] progress in
+        let download = session.download(.download(10_000_000))
+        download.downloadProgress(queue: session.rootQueue) { [unowned download] progress in
             guard !cancelled else { return }
 
-            if progress.fractionCompleted > 0.1 {
+            if progress.fractionCompleted > 0 {
                 download.cancel(producingResumeData: true)
                 cancelled = true
             }
@@ -639,11 +639,11 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         var response: DownloadResponse<TestResponse, AFError>?
 
         // When
-        let download = session.download(.download())
-        download.downloadProgress { [unowned download] progress in
+        let download = session.download(.download(10_000_000))
+        download.downloadProgress(queue: session.rootQueue) { [unowned download] progress in
             guard !cancelled else { return }
 
-            if progress.fractionCompleted > 0.1 {
+            if progress.fractionCompleted > 0 {
                 download.cancel(producingResumeData: true)
                 cancelled = true
             }
@@ -679,7 +679,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
 
         // When
         let download = session.download(.download(10_000_000))
-        download.downloadProgress { [unowned download] progress in
+        download.downloadProgress(queue: session.rootQueue) { [unowned download] progress in
             guard !cancelled else { return }
 
             if progress.fractionCompleted > 0 {
@@ -705,7 +705,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         var response2: DownloadResponse<Data, AFError>?
 
         session.download(resumingWith: resumeData)
-            .downloadProgress { progress in
+            .downloadProgress(queue: session.rootQueue) { progress in
                 progressValues.append(progress.fractionCompleted)
             }
             .responseData { resp in
@@ -740,11 +740,11 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         var response: DownloadResponse<URL?, AFError>?
 
         // When
-        let download = session.download(.download())
-        download.downloadProgress { [unowned download] progress in
+        let download = session.download(.download(10_000_000))
+        download.downloadProgress(queue: session.rootQueue) { [unowned download] progress in
             guard !cancelled else { return }
 
-            if progress.fractionCompleted > 0.1 {
+            if progress.fractionCompleted > 0 {
                 download.cancel { receivedResumeData = $0 }
                 cancelled = true
             }

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -661,7 +661,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         var response1: DownloadResponse<Data, AFError>?
 
         // When
-        let download = AF.download(.download(100_000))
+        let download = AF.download(.download(1_000_000))
         download.downloadProgress { [unowned download] progress in
             guard !cancelled else { return }
 

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -678,7 +678,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         var response1: DownloadResponse<Data, AFError>?
 
         // When
-        let download = session.download(.download(1_000_000))
+        let download = session.download(.download(10_000_000))
         download.downloadProgress { [unowned download] progress in
             guard !cancelled else { return }
 

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -151,14 +151,13 @@ final class DownloadResponseTests: BaseTestCase {
         // Given
         let session = stored(Session())
         let fileURL = randomCachesFileURL
-        let numberOfLines = 100
         let destination: DownloadRequest.Destination = { _, _ in (fileURL, []) }
 
         let expectation = expectation(description: "Cancelled download request should not download data to file")
         var response: DownloadResponse<URL?, AFError>?
 
         // When
-        session.download(.stream(numberOfLines), to: destination)
+        session.download(.infinite, to: destination)
             .response { resp in
                 response = resp
                 expectation.fulfill()

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -661,11 +661,11 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         var response1: DownloadResponse<Data, AFError>?
 
         // When
-        let download = AF.download(.download())
+        let download = AF.download(.download(100_000))
         download.downloadProgress { [unowned download] progress in
             guard !cancelled else { return }
 
-            if progress.fractionCompleted > 0.1 {
+            if progress.fractionCompleted > 0 {
                 download.cancel(producingResumeData: true)
                 cancelled = true
             }
@@ -710,7 +710,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         XCTAssertEqual(response2?.result.isSuccess, true)
         XCTAssertNil(response2?.result.failure)
 
-        progressValues.forEach { XCTAssertGreaterThanOrEqual($0, 0.1) }
+        progressValues.forEach { XCTAssertGreaterThan($0, 0) }
     }
 
     @MainActor

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -30,11 +30,12 @@ final class DownloadInitializationTests: BaseTestCase {
     @MainActor
     func testDownloadClassMethodWithMethodURLAndDestination() {
         // Given
+        let session = stored(Session())
         let endpoint = Endpoint.get
         let expectation = expectation(description: "download should complete")
 
         // When
-        let request = AF.download(endpoint).response { _ in
+        let request = session.download(endpoint).response { _ in
             expectation.fulfill()
         }
 
@@ -50,12 +51,13 @@ final class DownloadInitializationTests: BaseTestCase {
     @MainActor
     func testDownloadClassMethodWithMethodURLHeadersAndDestination() {
         // Given
+        let session = stored(Session())
         let endpoint = Endpoint.get
         let headers: HTTPHeaders = ["Authorization": "123456"]
         let expectation = expectation(description: "download should complete")
 
         // When
-        let request = AF.download(endpoint, headers: headers).response { _ in
+        let request = session.download(endpoint, headers: headers).response { _ in
             expectation.fulfill()
         }
 
@@ -80,6 +82,7 @@ final class DownloadResponseTests: BaseTestCase {
     @MainActor
     func testDownloadRequest() {
         // Given
+        let session = stored(Session())
         let fileURL = randomCachesFileURL
         let numberOfLines = 10
         let endpoint = Endpoint.stream(numberOfLines)
@@ -89,7 +92,7 @@ final class DownloadResponseTests: BaseTestCase {
         var response: DownloadResponse<URL?, AFError>?
 
         // When
-        AF.download(endpoint, to: destination)
+        session.download(endpoint, to: destination)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -118,11 +121,12 @@ final class DownloadResponseTests: BaseTestCase {
     @MainActor
     func testDownloadRequestResponseURLProducesURL() throws {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "Download request should download data")
         var response: DownloadResponse<URL, AFError>?
 
         // When
-        AF.download(.get)
+        session.download(.get)
             .responseURL { resp in
                 response = resp
                 expectation.fulfill()
@@ -144,6 +148,7 @@ final class DownloadResponseTests: BaseTestCase {
     @MainActor
     func testCancelledDownloadRequest() {
         // Given
+        let session = stored(Session())
         let fileURL = randomCachesFileURL
         let numberOfLines = 10
         let destination: DownloadRequest.Destination = { _, _ in (fileURL, []) }
@@ -152,7 +157,7 @@ final class DownloadResponseTests: BaseTestCase {
         var response: DownloadResponse<URL?, AFError>?
 
         // When
-        AF.download(.stream(numberOfLines), to: destination)
+        session.download(.stream(numberOfLines), to: destination)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -171,6 +176,7 @@ final class DownloadResponseTests: BaseTestCase {
     @MainActor
     func testDownloadRequestWithProgress() {
         // Given
+        let session = stored(Session())
         let randomBytes = 256
         let endpoint = Endpoint.bytes(randomBytes)
 
@@ -180,7 +186,7 @@ final class DownloadResponseTests: BaseTestCase {
         var response: DownloadResponse<URL?, AFError>?
 
         // When
-        AF.download(endpoint)
+        session.download(endpoint)
             .downloadProgress { progress in
                 progressValues.append(progress.fractionCompleted)
             }
@@ -215,6 +221,7 @@ final class DownloadResponseTests: BaseTestCase {
     @MainActor
     func testDownloadRequestWithParameters() {
         // Given
+        let session = stored(Session())
         let fileURL = randomCachesFileURL
         let parameters = ["foo": "bar"]
         let destination: DownloadRequest.Destination = { _, _ in (fileURL, []) }
@@ -223,7 +230,7 @@ final class DownloadResponseTests: BaseTestCase {
         var response: DownloadResponse<URL?, AFError>?
 
         // When
-        AF.download(Endpoint.get, parameters: parameters, to: destination)
+        session.download(Endpoint.get, parameters: parameters, to: destination)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -252,6 +259,7 @@ final class DownloadResponseTests: BaseTestCase {
     @MainActor
     func testDownloadRequestWithHeaders() {
         // Given
+        let session = stored(Session())
         let fileURL = randomCachesFileURL
         let endpoint = Endpoint.get
         let headers: HTTPHeaders = ["Authorization": "123456"]
@@ -261,7 +269,7 @@ final class DownloadResponseTests: BaseTestCase {
         var response: DownloadResponse<URL?, AFError>?
 
         // When
-        AF.download(endpoint, headers: headers, to: destination)
+        session.download(endpoint, headers: headers, to: destination)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -288,13 +296,14 @@ final class DownloadResponseTests: BaseTestCase {
     @MainActor
     func testThatDownloadingFileAndMovingToDirectoryThatDoesNotExistThrowsError() {
         // Given
+        let session = stored(Session())
         let fileURL = testDirectoryURL.appendingPathComponent("some/random/folder/test_output.json")
 
         let expectation = expectation(description: "Download request should download data but fail to move file")
         var response: DownloadResponse<URL?, AFError>?
 
         // When
-        AF.download(.get, to: { _, _ in (fileURL, []) })
+        session.download(.get, to: { _, _ in (fileURL, []) })
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -314,13 +323,14 @@ final class DownloadResponseTests: BaseTestCase {
     @MainActor
     func testThatDownloadOptionsCanCreateIntermediateDirectoriesPriorToMovingFile() {
         // Given
+        let session = stored(Session())
         let fileURL = testDirectoryURL.appendingPathComponent("some/random/folder/test_output.json")
 
         let expectation = expectation(description: "Download request should download data to file: \(fileURL)")
         var response: DownloadResponse<URL?, AFError>?
 
         // When
-        AF.download(.get, to: { _, _ in (fileURL, [.createIntermediateDirectories]) })
+        session.download(.get, to: { _, _ in (fileURL, [.createIntermediateDirectories]) })
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -339,6 +349,7 @@ final class DownloadResponseTests: BaseTestCase {
     @MainActor
     func testThatDownloadingFileAndMovingToDestinationThatIsOccupiedThrowsError() throws {
         // Given
+        let session = stored(Session())
         let directoryURL = testDirectoryURL.appendingPathComponent("some/random/folder")
         let directoryCreated = FileManager.createDirectory(at: directoryURL)
 
@@ -349,7 +360,7 @@ final class DownloadResponseTests: BaseTestCase {
         var response: DownloadResponse<URL?, AFError>?
 
         // When
-        AF.download(.get, to: { _, _ in (fileURL, []) })
+        session.download(.get, to: { _, _ in (fileURL, []) })
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -371,6 +382,7 @@ final class DownloadResponseTests: BaseTestCase {
     @MainActor
     func testThatDownloadOptionsCanRemovePreviousFilePriorToMovingFile() {
         // Given
+        let session = stored(Session())
         let directoryURL = testDirectoryURL.appendingPathComponent("some/random/folder")
         let directoryCreated = FileManager.createDirectory(at: directoryURL)
 
@@ -380,8 +392,8 @@ final class DownloadResponseTests: BaseTestCase {
         var response: DownloadResponse<URL?, AFError>?
 
         // When
-        AF.download(.get,
-                    to: { _, _ in (fileURL, [.removePreviousFile, .createIntermediateDirectories]) })
+        session.download(.get,
+                         to: { _, _ in (fileURL, [.removePreviousFile, .createIntermediateDirectories]) })
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -515,13 +527,14 @@ final class DownloadResumeDataTestCase: BaseTestCase {
     @MainActor
     func testThatCancelledDownloadRequestDoesNotProduceResumeData() {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "Download should be cancelled")
         var cancelled = false
 
         var response: DownloadResponse<URL?, AFError>?
 
         // When
-        let download = AF.download(.download())
+        let download = session.download(.download())
         download.downloadProgress { [unowned download] progress in
             guard !cancelled else { return }
 
@@ -549,12 +562,13 @@ final class DownloadResumeDataTestCase: BaseTestCase {
 
     func testThatDownloadRequestProducesResumeDataOnError() {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "download complete")
 
         var response: DownloadResponse<URL?, AFError>?
 
         // When
-        let download = AF.download(.download(produceError: true))
+        let download = session.download(.download(produceError: true))
         download.response { resp in
             response = resp
             expectation.fulfill()
@@ -580,13 +594,14 @@ final class DownloadResumeDataTestCase: BaseTestCase {
     @MainActor
     func testThatCancelledDownloadResponseDataMatchesResumeData() {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "Download should be cancelled")
         var cancelled = false
 
         var response: DownloadResponse<URL?, AFError>?
 
         // When
-        let download = AF.download(.download())
+        let download = session.download(.download())
         download.downloadProgress { [unowned download] progress in
             guard !cancelled else { return }
 
@@ -617,13 +632,14 @@ final class DownloadResumeDataTestCase: BaseTestCase {
     @MainActor
     func testThatCancelledDownloadResumeDataIsAvailableWithDecodableResponseSerializer() {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "Download should be cancelled")
         var cancelled = false
 
         var response: DownloadResponse<TestResponse, AFError>?
 
         // When
-        let download = AF.download(.download())
+        let download = session.download(.download())
         download.downloadProgress { [unowned download] progress in
             guard !cancelled else { return }
 
@@ -655,13 +671,14 @@ final class DownloadResumeDataTestCase: BaseTestCase {
     @MainActor
     func testThatCancelledDownloadCanBeResumedWithResumeData() {
         // Given
+        let session = stored(Session())
         let expectation1 = expectation(description: "Download should be cancelled")
         var cancelled = false
 
         var response1: DownloadResponse<Data, AFError>?
 
         // When
-        let download = AF.download(.download(1_000_000))
+        let download = session.download(.download(1_000_000))
         download.downloadProgress { [unowned download] progress in
             guard !cancelled else { return }
 
@@ -687,7 +704,7 @@ final class DownloadResumeDataTestCase: BaseTestCase {
         var progressValues: [Double] = []
         var response2: DownloadResponse<Data, AFError>?
 
-        AF.download(resumingWith: resumeData)
+        session.download(resumingWith: resumeData)
             .downloadProgress { progress in
                 progressValues.append(progress.fractionCompleted)
             }
@@ -716,13 +733,14 @@ final class DownloadResumeDataTestCase: BaseTestCase {
     @MainActor
     func testThatCancelledDownloadProducesMatchingResumeData() {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "Download should be cancelled")
         var cancelled = false
         var receivedResumeData: Data?
         var response: DownloadResponse<URL?, AFError>?
 
         // When
-        let download = AF.download(.download())
+        let download = session.download(.download())
         download.downloadProgress { [unowned download] progress in
             guard !cancelled else { return }
 
@@ -759,12 +777,13 @@ final class DownloadResponseMapTestCase: BaseTestCase {
     @MainActor
     func testThatMapTransformsSuccessValue() {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "request should succeed")
 
         var response: DownloadResponse<String, AFError>?
 
         // When
-        AF.download(.get, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
+        session.download(.get, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
             response = resp.map { response in
                 response.args["foo"] ?? "invalid"
             }
@@ -787,13 +806,14 @@ final class DownloadResponseMapTestCase: BaseTestCase {
     @MainActor
     func testThatMapPreservesFailureError() {
         // Given
+        let session = stored(Session())
         let urlString = String.invalidURL
         let expectation = expectation(description: "request should fail with invalid URL")
 
         var response: DownloadResponse<String, AFError>?
 
         // When
-        AF.download(urlString, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
+        session.download(urlString, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
             response = resp.map { _ in "ignored" }
             expectation.fulfill()
         }
@@ -817,12 +837,13 @@ final class DownloadResponseTryMapTestCase: BaseTestCase {
     @MainActor
     func testThatTryMapTransformsSuccessValue() {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "request should succeed")
 
         var response: DownloadResponse<String, any Error>?
 
         // When
-        AF.download(.get, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
+        session.download(.get, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
             response = resp.tryMap { response in
                 response.args["foo"] ?? "invalid"
             }
@@ -845,6 +866,7 @@ final class DownloadResponseTryMapTestCase: BaseTestCase {
     @MainActor
     func testThatTryMapCatchesTransformationError() {
         // Given
+        let session = stored(Session())
         struct TransformError: Error {}
 
         let expectation = expectation(description: "request should succeed")
@@ -852,7 +874,7 @@ final class DownloadResponseTryMapTestCase: BaseTestCase {
         var response: DownloadResponse<String, any Error>?
 
         // When
-        AF.download(.get, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
+        session.download(.get, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
             response = resp.tryMap { _ in
                 throw TransformError()
             }
@@ -879,13 +901,14 @@ final class DownloadResponseTryMapTestCase: BaseTestCase {
     @MainActor
     func testThatTryMapPreservesFailureError() {
         // Given
+        let session = stored(Session())
         let urlString = String.invalidURL
         let expectation = expectation(description: "request should fail with 404")
 
         var response: DownloadResponse<String, any Error>?
 
         // When
-        AF.download(urlString, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
+        session.download(urlString, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
             response = resp.tryMap { _ in "ignored" }
             expectation.fulfill()
         }
@@ -907,13 +930,14 @@ final class DownloadResponseMapErrorTestCase: BaseTestCase {
     @MainActor
     func testThatMapErrorTransformsFailureValue() {
         // Given
+        let session = stored(Session())
         let urlString = String.invalidURL
         let expectation = expectation(description: "request should not succeed")
 
         var response: DownloadResponse<TestResponse, TestError>?
 
         // When
-        AF.download(urlString).responseDecodable(of: TestResponse.self) { resp in
+        session.download(urlString).responseDecodable(of: TestResponse.self) { resp in
             response = resp.mapError { error in
                 TestError.error(error: error)
             }
@@ -939,12 +963,13 @@ final class DownloadResponseMapErrorTestCase: BaseTestCase {
     @MainActor
     func testThatMapErrorPreservesSuccessValue() {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "request should succeed")
 
         var response: DownloadResponse<Data, TestError>?
 
         // When
-        AF.download(.get).responseData { resp in
+        session.download(.get).responseData { resp in
             response = resp.mapError { TestError.error(error: $0) }
             expectation.fulfill()
         }
@@ -967,12 +992,13 @@ final class DownloadResponseTryMapErrorTestCase: BaseTestCase {
     @MainActor
     func testThatTryMapErrorPreservesSuccessValue() {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "request should succeed")
 
         var response: DownloadResponse<Data, any Error>?
 
         // When
-        AF.download(.get).responseData { resp in
+        session.download(.get).responseData { resp in
             response = resp.tryMapError { TestError.error(error: $0) }
             expectation.fulfill()
         }
@@ -992,13 +1018,14 @@ final class DownloadResponseTryMapErrorTestCase: BaseTestCase {
     @MainActor
     func testThatTryMapErrorCatchesTransformationError() {
         // Given
+        let session = stored(Session())
         let urlString = String.invalidURL
         let expectation = expectation(description: "request should fail")
 
         var response: DownloadResponse<Data, any Error>?
 
         // When
-        AF.download(urlString).responseData { resp in
+        session.download(urlString).responseData { resp in
             response = resp.tryMapError { _ in try TransformationError.error.alwaysFails() }
             expectation.fulfill()
         }
@@ -1025,13 +1052,14 @@ final class DownloadResponseTryMapErrorTestCase: BaseTestCase {
     @MainActor
     func testThatTryMapErrorTransformsError() {
         // Given
+        let session = stored(Session())
         let urlString = String.invalidURL
         let expectation = expectation(description: "request should fail")
 
         var response: DownloadResponse<Data, any Error>?
 
         // When
-        AF.download(urlString).responseData { resp in
+        session.download(urlString).responseData { resp in
             response = resp.tryMapError { TestError.error(error: $0) }
             expectation.fulfill()
         }

--- a/Tests/DownloadTests.swift
+++ b/Tests/DownloadTests.swift
@@ -84,16 +84,17 @@ final class DownloadResponseTests: BaseTestCase {
         // Given
         let session = stored(Session())
         let fileURL = randomCachesFileURL
-        let numberOfLines = 10
+        let numberOfLines = 100
         let endpoint = Endpoint.stream(numberOfLines)
         let destination: DownloadRequest.Destination = { _, _ in (fileURL, []) }
 
         let expectation = expectation(description: "Download request should download data to file: \(endpoint.url.absoluteString)")
-        var response: DownloadResponse<URL?, AFError>?
+        var response: DownloadResponse<URL, AFError>?
 
         // When
         session.download(endpoint, to: destination)
-            .response { resp in
+            .validate()
+            .responseURL { resp in
                 response = resp
                 expectation.fulfill()
             }
@@ -150,7 +151,7 @@ final class DownloadResponseTests: BaseTestCase {
         // Given
         let session = stored(Session())
         let fileURL = randomCachesFileURL
-        let numberOfLines = 10
+        let numberOfLines = 100
         let destination: DownloadRequest.Destination = { _, _ in (fileURL, []) }
 
         let expectation = expectation(description: "Cancelled download request should not download data to file")
@@ -177,7 +178,7 @@ final class DownloadResponseTests: BaseTestCase {
     func testDownloadRequestWithProgress() {
         // Given
         let session = stored(Session())
-        let randomBytes = 256
+        let randomBytes = 1024
         let endpoint = Endpoint.bytes(randomBytes)
 
         let expectation = expectation(description: "Bytes download progress should be reported: \(endpoint.url)")

--- a/Tests/MIMETypeTests.swift
+++ b/Tests/MIMETypeTests.swift
@@ -1,0 +1,131 @@
+//
+//  MIMETypeTests.swift
+//
+//  Copyright (c) 2026 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+@testable import Alamofire
+import Testing
+
+@Suite("MIMEType Initialization")
+struct MIMETypeInitTests {
+    @Test("Parses standard type/subtype pairs", arguments: [("text/plain", "text", "plain"),
+                                                            ("application/json", "application", "json"),
+                                                            ("image/png", "image", "png"),
+                                                            ("*/*", "*", "*"),
+                                                            ("text/*", "text", "*"),
+                                                            ("*/json", "*", "json")])
+    func parsesWellFormedPair(input: String, expectedType: String, expectedSubtype: String) {
+        let mime = Request.MIMEType(input)
+        #expect(mime != nil)
+        #expect(mime?.type == expectedType)
+        #expect(mime?.subtype == expectedSubtype)
+    }
+
+    @Test("Strips semicolon-delimited parameters from the subtype field")
+    func stripsParameters() {
+        let mime = Request.MIMEType("text/plain; charset=utf-8")
+        #expect(mime?.type == "text")
+        #expect(mime?.subtype == "plain")
+    }
+
+    @Test("Strips surrounding whitespace before parsing")
+    func stripsWhitespace() {
+        let mime = Request.MIMEType("  text/plain  ")
+        #expect(mime?.type == "text")
+        #expect(mime?.subtype == "plain")
+    }
+
+    @Test("isWildcard is true only for */*")
+    func wildcardDetection() {
+        #expect(Request.MIMEType("*/*")?.isWildcard == true)
+        #expect(Request.MIMEType("text/*")?.isWildcard == false)
+        #expect(Request.MIMEType("*/json")?.isWildcard == false)
+        #expect(Request.MIMEType("text/plain")?.isWildcard == false)
+    }
+
+    @Test("Single-component string without '/' must return nil")
+    func singleComponentWithoutSlashReturnsNil() {
+        #expect(Request.MIMEType("text") == nil, "A string with no '/' separator cannot represent a valid MIME type")
+    }
+
+    @Test("Empty string must return nil")
+    func emptyStringReturnsNil() {
+        #expect(Request.MIMEType("") == nil, "An empty string cannot represent a valid MIME type")
+    }
+}
+
+// MARK: - MIMEType Matching Tests
+
+@Suite("MIMEType Matching")
+struct MIMETypeMatchingTests {
+    @Test("Exact type/subtype pair matches itself")
+    func exactMatch() throws {
+        let acceptable = try #require(Request.MIMEType("text/plain"))
+        let response = try #require(Request.MIMEType("text/plain"))
+        #expect(acceptable.matches(response))
+    }
+
+    @Test("Wildcard subtype matches any subtype of the same type")
+    func wildcardSubtypeMatchesAnySametype() throws {
+        let textWildcard = try #require(Request.MIMEType("text/*"))
+        let textPlain = try #require(Request.MIMEType("text/plain"))
+        let textHTML = try #require(Request.MIMEType("text/html"))
+        #expect(textWildcard.matches(textPlain))
+        #expect(textWildcard.matches(textHTML))
+    }
+
+    @Test("Wildcard subtype does not match a different type")
+    func wildcardSubtypeDoesNotMatchDifferentType() throws {
+        let textWildcard = try #require(Request.MIMEType("text/*"))
+        let appJSON = try #require(Request.MIMEType("application/json"))
+        #expect(!textWildcard.matches(appJSON))
+    }
+
+    @Test("Wildcard type matches any type with the same subtype")
+    func wildcardTypeMatchesSameSubtype() throws {
+        let wildcardJSON = try #require(Request.MIMEType("*/json"))
+        let appJSON = try #require(Request.MIMEType("application/json"))
+        #expect(wildcardJSON.matches(appJSON))
+    }
+
+    @Test("Full wildcard */* matches any MIME type")
+    func fullWildcardMatchesAny() throws {
+        let wildcard = try #require(Request.MIMEType("*/*"))
+        #expect(try wildcard.matches(#require(Request.MIMEType("text/plain"))))
+        #expect(try wildcard.matches(#require(Request.MIMEType("application/json"))))
+        #expect(try wildcard.matches(#require(Request.MIMEType("image/png"))))
+    }
+
+    @Test("Different type and subtype do not match")
+    func noMatchOnDifferentPair() throws {
+        let appJSON = try #require(Request.MIMEType("application/json"))
+        let textPlain = try #require(Request.MIMEType("text/plain"))
+        #expect(!appJSON.matches(textPlain))
+    }
+
+    @Test("Same type but different subtype does not match without a wildcard")
+    func sameTypeButDifferentSubtypeNoMatch() throws {
+        let textPlain = try #require(Request.MIMEType("text/plain"))
+        let textHTML = try #require(Request.MIMEType("text/html"))
+        #expect(!textPlain.matches(textHTML))
+    }
+}

--- a/Tests/OfflineRetrierTests.swift
+++ b/Tests/OfflineRetrierTests.swift
@@ -8,6 +8,7 @@ struct OfflineRetrierTests {
     @Test
     func requestIsRetriedWhenConnectivityIsRestored() async {
         // Given
+        let session = Session()
         let didStop = Protected(false)
         let monitor = PathMonitor { queue, onResult in
             queue.async {
@@ -20,7 +21,7 @@ struct OfflineRetrierTests {
         // When: retrier considers error to be offline error.
         let retrier = OfflineRetrier(monitor: monitor, maximumWait: .milliseconds(100)) { _ in true }
         // When: request fails due to error (type doesn't matter).
-        let request = AF.request(.endpoints(.status(404), .get), interceptor: retrier).validate()
+        let request = session.request(.endpoints(.status(404), .get), interceptor: retrier).validate()
         let result = await request.serializingData().result
 
         // Then: request is retried successfully.
@@ -34,6 +35,7 @@ struct OfflineRetrierTests {
     @Test
     func requestIsNotRetriedWhenTheErrorIsNotOfflineError() async {
         // Given
+        let session = Session()
         let didStop = Protected(false)
         let monitor = PathMonitor { queue, onResult in
             queue.async {
@@ -46,7 +48,7 @@ struct OfflineRetrierTests {
         // When
         let retrier = OfflineRetrier(monitor: monitor, maximumWait: .milliseconds(100))
         // When: request fails due to validation.
-        let request = AF.request(.endpoints(.status(404), .get), interceptor: retrier).validate()
+        let request = session.request(.endpoints(.status(404), .get), interceptor: retrier).validate()
         let result = await request.serializingData().result
 
         // Then: request fails since validation failures aren't retried.
@@ -60,6 +62,7 @@ struct OfflineRetrierTests {
     @Test
     func requestIsNotRetriedWhenPathTimesOut() async {
         // Given
+        let session = Session()
         let didStop = Protected(false)
         let pathAvailable: Protected<DispatchWorkItem?> = .init(nil)
         let monitor = PathMonitor { queue, onResult in
@@ -75,7 +78,7 @@ struct OfflineRetrierTests {
         // When: retrier times out after one millisecond.
         let retrier = OfflineRetrier(monitor: monitor, maximumWait: .milliseconds(1)) { _ in true }
         // When: request fails due to validation but would succeed on retry.
-        let request = AF.request(.endpoints(.status(404), .get), interceptor: retrier).validate()
+        let request = session.request(.endpoints(.status(404), .get), interceptor: retrier).validate()
         let result = await request.serializingData().result
 
         // Then: request fails since it's not retried.

--- a/Tests/RequestInterceptorTests.swift
+++ b/Tests/RequestInterceptorTests.swift
@@ -552,11 +552,12 @@ struct InterceptorRequestTests {
     @Test
     func thatRetryPolicyRetriesRequestTimeout() async {
         // Given
+        let session = Session()
         let interceptor = InspectorInterceptor(RetryPolicy(retryLimit: 1, exponentialBackoffScale: 0.1))
         let urlRequest = Endpoint.delay(1).modifying(\.timeout, to: 0.01)
 
         // When
-        let request = AF.request(urlRequest, interceptor: interceptor)
+        let request = session.request(urlRequest, interceptor: interceptor)
         await request.finished()
 
         // Then

--- a/Tests/RequestModifierTests.swift
+++ b/Tests/RequestModifierTests.swift
@@ -31,12 +31,13 @@ final class RequestModifierTests: BaseTestCase {
     @MainActor
     func testThatDataRequestsCanHaveCustomTimeoutValueSet() {
         // Given
+        let session = stored(Session())
         let completed = expectation(description: "request completed")
         let modified = expectation(description: "request should be modified")
         var response: AFDataResponse<Data?>?
 
         // When
-        AF.request(.delay(1)) { $0.timeoutInterval = 0.001; modified.fulfill() }
+        session.request(.delay(1)) { $0.timeoutInterval = 0.001; modified.fulfill() }
             .response { response = $0; completed.fulfill() }
 
         waitForExpectations(timeout: timeout)
@@ -71,6 +72,7 @@ final class RequestModifierTests: BaseTestCase {
     @MainActor
     func testThatUploadRequestsCanHaveCustomTimeoutValueSet() {
         // Given
+        let session = stored(Session())
         let endpoint = Endpoint.delay(1).modifying(\.method, to: .post)
         let data = Data("data".utf8)
         let completed = expectation(description: "request completed")
@@ -78,7 +80,7 @@ final class RequestModifierTests: BaseTestCase {
         var response: AFDataResponse<Data?>?
 
         // When
-        AF.upload(data, to: endpoint) { $0.timeoutInterval = 0.001; modified.fulfill() }
+        session.upload(data, to: endpoint) { $0.timeoutInterval = 0.001; modified.fulfill() }
             .response { response = $0; completed.fulfill() }
 
         waitForExpectations(timeout: timeout)
@@ -116,13 +118,14 @@ final class RequestModifierTests: BaseTestCase {
     @MainActor
     func testThatDownloadRequestsCanHaveCustomTimeoutValueSet() {
         // Given
+        let session = stored(Session())
         let url = Endpoint.delay(1).url
         let completed = expectation(description: "request completed")
         let modified = expectation(description: "request should be modified")
         var response: AFDownloadResponse<URL?>?
 
         // When
-        AF.download(url, requestModifier: { $0.timeoutInterval = 0.001; modified.fulfill() })
+        session.download(url, requestModifier: { $0.timeoutInterval = 0.001; modified.fulfill() })
             .response { response = $0; completed.fulfill() }
 
         waitForExpectations(timeout: timeout)
@@ -157,12 +160,13 @@ final class RequestModifierTests: BaseTestCase {
     @MainActor
     func testThatDataStreamRequestsCanHaveCustomTimeoutValueSet() {
         // Given
+        let session = stored(Session())
         let completed = expectation(description: "request completed")
         let modified = expectation(description: "request should be modified")
         var response: DataStreamRequest.Completion?
 
         // When
-        AF.streamRequest(.delay(1)) { $0.timeoutInterval = 0.001; modified.fulfill() }
+        session.streamRequest(.delay(1)) { $0.timeoutInterval = 0.001; modified.fulfill() }
             .responseStream { stream in
                 guard case let .complete(completion) = stream.event else { return }
 

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -147,18 +147,18 @@ final class RequestResponseTestCase: BaseTestCase {
     @MainActor
     func testRequestResponseWithProgress() {
         // Given
-        let byteCount = 512
+        let byteCount = 1024
         let url = Endpoint.bytes(byteCount).url
 
         let expectation = expectation(description: "Bytes download progress should be reported: \(url)")
 
-        var progressValues: [Double] = []
+        var progressValues: [(fraction: Double, total: Int64)] = []
         var response: DataResponse<Data?, AFError>?
 
         // When
         AF.request(url)
             .downloadProgress { progress in
-                progressValues.append(progress.fractionCompleted)
+                progressValues.append((fraction: progress.fractionCompleted, total: progress.totalUnitCount))
             }
             .response { resp in
                 response = resp
@@ -173,15 +173,17 @@ final class RequestResponseTestCase: BaseTestCase {
         XCTAssertNotNil(response?.data)
         XCTAssertNil(response?.error)
 
-        var previousProgress: Double = progressValues.first ?? 0.0
+        var previousProgress: (fraction: Double, total: Int64) = progressValues.first ?? (fraction: 0, total: 0)
 
         for progress in progressValues {
-            XCTAssertGreaterThanOrEqual(progress, previousProgress)
+            XCTAssertGreaterThanOrEqual(progress.fraction, previousProgress.fraction, """
+            previous fraction \(progress.fraction) is not >= \(previousProgress.fraction)
+            """)
             previousProgress = progress
         }
 
         if let lastProgressValue = progressValues.last {
-            XCTAssertEqual(lastProgressValue, 1.0)
+            XCTAssertEqual(lastProgressValue.fraction, 1.0)
         } else {
             XCTFail("last item in progressValues should not be nil")
         }

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -891,7 +891,7 @@ final class RequestResponseTestCase: BaseTestCase {
         expect.expectedFulfillmentCount = 2
 
         // When
-        let request = session.request(.default)
+        let request = session.request(.delay(1))
 
         request.responseDecodable(of: TestResponse.self) { resp in
             response1 = resp

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -31,12 +31,13 @@ final class RequestResponseTestCase: BaseTestCase {
     @MainActor
     func testRequestResponse() {
         // Given
+        let session = stored(Session())
         let url = Endpoint.get.url
         let expectation = expectation(description: "GET request should succeed: \(url)")
         var response: DataResponse<Data?, AFError>?
 
         // When
-        AF.request(url, parameters: ["foo": "bar"])
+        session.request(url, parameters: ["foo": "bar"])
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -54,6 +55,7 @@ final class RequestResponseTestCase: BaseTestCase {
     @MainActor
     func testThatDataRequestReceivesInitialResponse() {
         // Given
+        let session = stored(Session())
         let url = Endpoint.get.url
         var initialResponse: HTTPURLResponse?
         let didReceiveResponse = expectation(description: "didReceiveResponse")
@@ -61,7 +63,7 @@ final class RequestResponseTestCase: BaseTestCase {
         var response: DataResponse<Data?, AFError>?
 
         // When
-        AF.request(url, parameters: ["foo": "bar"])
+        session.request(url, parameters: ["foo": "bar"])
             .onHTTPResponse { response in
                 initialResponse = response
                 didReceiveResponse.fulfill()
@@ -84,6 +86,7 @@ final class RequestResponseTestCase: BaseTestCase {
     @MainActor
     func testThatDataRequestOnHTTPResponseCanAllow() {
         // Given
+        let session = stored(Session())
         let url = Endpoint.get.url
         var initialResponse: HTTPURLResponse?
         let didReceiveResponse = expectation(description: "didReceiveResponse")
@@ -91,7 +94,7 @@ final class RequestResponseTestCase: BaseTestCase {
         var response: DataResponse<Data?, AFError>?
 
         // When
-        AF.request(url, parameters: ["foo": "bar"])
+        session.request(url, parameters: ["foo": "bar"])
             .onHTTPResponse { response, completionHandler in
                 initialResponse = response
                 didReceiveResponse.fulfill()
@@ -115,6 +118,7 @@ final class RequestResponseTestCase: BaseTestCase {
     @MainActor
     func testThatDataRequestOnHTTPResponseCanCancel() {
         // Given
+        let session = stored(Session())
         let url = Endpoint.get.url
         var initialResponse: HTTPURLResponse?
         let didReceiveResponse = expectation(description: "didReceiveResponse")
@@ -122,7 +126,7 @@ final class RequestResponseTestCase: BaseTestCase {
         var response: DataResponse<Data?, AFError>?
 
         // When
-        let request = AF.request(url, parameters: ["foo": "bar"])
+        let request = session.request(url, parameters: ["foo": "bar"])
             .onHTTPResponse { response, completionHandler in
                 initialResponse = response
                 didReceiveResponse.fulfill()
@@ -147,6 +151,7 @@ final class RequestResponseTestCase: BaseTestCase {
     @MainActor
     func testRequestResponseWithProgress() {
         // Given
+        let session = stored(Session())
         let byteCount = 1024
         let url = Endpoint.bytes(byteCount).url
 
@@ -156,7 +161,7 @@ final class RequestResponseTestCase: BaseTestCase {
         var response: DataResponse<Data?, AFError>?
 
         // When
-        AF.request(url)
+        session.request(url)
             .downloadProgress { progress in
                 progressValues.append((fraction: progress.fractionCompleted, total: progress.totalUnitCount))
             }
@@ -192,6 +197,7 @@ final class RequestResponseTestCase: BaseTestCase {
     @MainActor
     func testPOSTRequestWithUnicodeParameters() {
         // Given
+        let session = stored(Session())
         let parameters = ["french": "français",
                           "japanese": "日本語",
                           "arabic": "العربية",
@@ -202,7 +208,7 @@ final class RequestResponseTestCase: BaseTestCase {
         var response: DataResponse<TestResponse, AFError>?
 
         // When
-        AF.request(.method(.post), parameters: parameters)
+        session.request(.method(.post), parameters: parameters)
             .responseDecodable(of: TestResponse.self) { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -228,6 +234,7 @@ final class RequestResponseTestCase: BaseTestCase {
     @MainActor
     func testPOSTRequestWithBase64EncodedImages() {
         // Given
+        let session = stored(Session())
         let pngBase64EncodedString: String = {
             let fileURL = url(forResource: "unicorn", withExtension: "png")
             let data = try! Data(contentsOf: fileURL)
@@ -251,7 +258,7 @@ final class RequestResponseTestCase: BaseTestCase {
         var response: DataResponse<TestResponse, AFError>?
 
         // When
-        AF.request(Endpoint.method(.post), method: .post, parameters: parameters)
+        session.request(Endpoint.method(.post), method: .post, parameters: parameters)
             .responseDecodable(of: TestResponse.self) { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -348,12 +355,13 @@ final class RequestResponseTestCase: BaseTestCase {
     @MainActor
     func testThatRequestsCanPassEncodableParametersAsJSONBodyData() {
         // Given
+        let session = stored(Session())
         let parameters = TestParameters(property: "one")
         let expect = expectation(description: "request should complete")
         var receivedResponse: DataResponse<TestResponse, AFError>?
 
         // When
-        AF.request(.method(.post), parameters: parameters, encoder: JSONParameterEncoder.default)
+        session.request(.method(.post), parameters: parameters, encoder: JSONParameterEncoder.default)
             .responseDecodable(of: TestResponse.self) { response in
                 receivedResponse = response
                 expect.fulfill()
@@ -368,12 +376,13 @@ final class RequestResponseTestCase: BaseTestCase {
     @MainActor
     func testThatRequestsCanPassEncodableParametersAsAURLQuery() {
         // Given
+        let session = stored(Session())
         let parameters = TestParameters(property: "one")
         let expect = expectation(description: "request should complete")
         var receivedResponse: DataResponse<TestResponse, AFError>?
 
         // When
-        AF.request(.method(.get), parameters: parameters)
+        session.request(.method(.get), parameters: parameters)
             .responseDecodable(of: TestResponse.self) { response in
                 receivedResponse = response
                 expect.fulfill()
@@ -388,12 +397,13 @@ final class RequestResponseTestCase: BaseTestCase {
     @MainActor
     func testThatRequestsCanPassEncodableParametersAsURLEncodedBodyData() {
         // Given
+        let session = stored(Session())
         let parameters = TestParameters(property: "one")
         let expect = expectation(description: "request should complete")
         var receivedResponse: DataResponse<TestResponse, AFError>?
 
         // When
-        AF.request(.method(.post), parameters: parameters)
+        session.request(.method(.post), parameters: parameters)
             .responseDecodable(of: TestResponse.self) { response in
                 receivedResponse = response
                 expect.fulfill()
@@ -1354,12 +1364,13 @@ final class RequestLifetimeTests: BaseTestCase {
     @MainActor
     func testThatRequestProvidesURLRequestWhenCreated() {
         // Given
+        let session = stored(Session())
         let didReceiveRequest = expectation(description: "did receive task")
         let didComplete = expectation(description: "request did complete")
         var request: URLRequest?
 
         // When
-        AF.request(.default)
+        session.request(.default)
             .onURLRequestCreation { request = $0; didReceiveRequest.fulfill() }
             .responseDecodable(of: TestResponse.self) { _ in didComplete.fulfill() }
 
@@ -1372,12 +1383,13 @@ final class RequestLifetimeTests: BaseTestCase {
     @MainActor
     func testThatRequestProvidesTaskWhenCreated() {
         // Given
+        let session = stored(Session())
         let didReceiveTask = expectation(description: "did receive task")
         let didComplete = expectation(description: "request did complete")
         var task: URLSessionTask?
 
         // When
-        AF.request(.default)
+        session.request(.default)
             .onURLSessionTaskCreation { task = $0; didReceiveTask.fulfill() }
             .responseDecodable(of: TestResponse.self) { _ in didComplete.fulfill() }
 
@@ -1394,12 +1406,13 @@ final class RequestInvalidURLTestCase: BaseTestCase {
     @MainActor
     func testThatDataRequestWithFileURLThrowsError() {
         // Given
+        let session = stored(Session())
         let fileURL = url(forResource: "valid_data", withExtension: "json")
         let expectation = expectation(description: "Request should succeed.")
         var response: DataResponse<Data?, AFError>?
 
         // When
-        AF.request(fileURL)
+        session.request(fileURL)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -1414,12 +1427,13 @@ final class RequestInvalidURLTestCase: BaseTestCase {
     @MainActor
     func testThatDownloadRequestWithFileURLThrowsError() {
         // Given
+        let session = stored(Session())
         let fileURL = url(forResource: "valid_data", withExtension: "json")
         let expectation = expectation(description: "Request should succeed.")
         var response: DownloadResponse<URL?, AFError>?
 
         // When
-        AF.download(fileURL)
+        session.download(fileURL)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -1434,12 +1448,13 @@ final class RequestInvalidURLTestCase: BaseTestCase {
     @MainActor
     func testThatDataStreamRequestWithFileURLThrowsError() {
         // Given
+        let session = stored(Session())
         let fileURL = url(forResource: "valid_data", withExtension: "json")
         let expectation = expectation(description: "Request should succeed.")
         var response: DataStreamRequest.Completion?
 
         // When
-        AF.streamRequest(fileURL)
+        session.streamRequest(fileURL)
             .responseStream { stream in
                 guard case let .complete(completion) = stream.event else { return }
 
@@ -1761,15 +1776,16 @@ struct RequestCompressionTests {
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func thatRequestsCanBeCompressed() async {
         // Given
+        let session = Session()
         let url = Endpoint.method(.post).url
         let parameters = TestParameters(property: "compressed")
 
         // When
-        let result = await AF.request(url,
-                                      method: .post,
-                                      parameters: parameters,
-                                      encoder: .json,
-                                      interceptor: .deflateCompressor)
+        let result = await session.request(url,
+                                           method: .post,
+                                           parameters: parameters,
+                                           encoder: .json,
+                                           interceptor: .deflateCompressor)
             .serializingDecodable(TestResponse.self)
             .result
 
@@ -1781,16 +1797,17 @@ struct RequestCompressionTests {
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func thatDeflateCompressorThrowsErrorByDefaultWhenRequestAlreadyHasHeader() async {
         // Given
+        let session = Session()
         let url = Endpoint.method(.post).url
         let parameters = TestParameters(property: "compressed")
 
         // When
-        let result = await AF.request(url,
-                                      method: .post,
-                                      parameters: parameters,
-                                      encoder: .json,
-                                      headers: [.contentEncoding("value")],
-                                      interceptor: .deflateCompressor)
+        let result = await session.request(url,
+                                           method: .post,
+                                           parameters: parameters,
+                                           encoder: .json,
+                                           headers: [.contentEncoding("value")],
+                                           interceptor: .deflateCompressor)
             .serializingDecodable(TestResponse.self)
             .result
 
@@ -1803,16 +1820,17 @@ struct RequestCompressionTests {
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func thatDeflateCompressorThrowsErrorWhenConfigured() async {
         // Given
+        let session = Session()
         let url = Endpoint.method(.post).url
         let parameters = TestParameters(property: "compressed")
 
         // When
-        let result = await AF.request(url,
-                                      method: .post,
-                                      parameters: parameters,
-                                      encoder: .json,
-                                      headers: [.contentEncoding("value")],
-                                      interceptor: .deflateCompressor(duplicateHeaderBehavior: .error))
+        let result = await session.request(url,
+                                           method: .post,
+                                           parameters: parameters,
+                                           encoder: .json,
+                                           headers: [.contentEncoding("value")],
+                                           interceptor: .deflateCompressor(duplicateHeaderBehavior: .error))
             .serializingDecodable(TestResponse.self)
             .result
 
@@ -1825,16 +1843,17 @@ struct RequestCompressionTests {
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func thatDeflateCompressorReplacesHeaderWhenConfigured() async {
         // Given
+        let session = Session()
         let url = Endpoint.method(.post).url
         let parameters = TestParameters(property: "compressed")
 
         // When
-        let result = await AF.request(url,
-                                      method: .post,
-                                      parameters: parameters,
-                                      encoder: .json,
-                                      headers: [.contentEncoding("value")],
-                                      interceptor: .deflateCompressor(duplicateHeaderBehavior: .replace))
+        let result = await session.request(url,
+                                           method: .post,
+                                           parameters: parameters,
+                                           encoder: .json,
+                                           headers: [.contentEncoding("value")],
+                                           interceptor: .deflateCompressor(duplicateHeaderBehavior: .replace))
             .serializingDecodable(TestResponse.self)
             .result
 
@@ -1846,16 +1865,17 @@ struct RequestCompressionTests {
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func thatDeflateCompressorSkipsCompressionWhenConfigured() async {
         // Given
+        let session = Session()
         let url = Endpoint.method(.post).url
         let parameters = TestParameters(property: "compressed")
 
         // When
-        let result = await AF.request(url,
-                                      method: .post,
-                                      parameters: parameters,
-                                      encoder: .json,
-                                      headers: [.contentEncoding("gzip")],
-                                      interceptor: .deflateCompressor(duplicateHeaderBehavior: .skip))
+        let result = await session.request(url,
+                                           method: .post,
+                                           parameters: parameters,
+                                           encoder: .json,
+                                           headers: [.contentEncoding("gzip")],
+                                           interceptor: .deflateCompressor(duplicateHeaderBehavior: .skip))
             .serializingDecodable(TestResponse.self)
             .result
 
@@ -1868,15 +1888,16 @@ struct RequestCompressionTests {
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func thatDeflateCompressorDoesNotCompressDataWhenClosureReturnsFalse() async {
         // Given
+        let session = Session()
         let url = Endpoint.method(.post).url
         let parameters = TestParameters(property: "compressed")
 
         // When
-        let result = await AF.request(url,
-                                      method: .post,
-                                      parameters: parameters,
-                                      encoder: .json,
-                                      interceptor: .deflateCompressor { _ in false })
+        let result = await session.request(url,
+                                           method: .post,
+                                           parameters: parameters,
+                                           encoder: .json,
+                                           interceptor: .deflateCompressor { _ in false })
             .serializingDecodable(TestResponse.self)
             .result
 

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -162,7 +162,7 @@ final class RequestResponseTestCase: BaseTestCase {
 
         // When
         session.request(url)
-            .downloadProgress { progress in
+            .downloadProgress(queue: session.rootQueue) { progress in
                 progressValues.append((fraction: progress.fractionCompleted, total: progress.totalUnitCount))
             }
             .response { resp in

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -680,17 +680,19 @@ final class RequestResponseTestCase: BaseTestCase {
     @MainActor
     func testThatRequestManuallyCancelledManyTimesAfterAutomaticResumeOnlyReceivesAppropriateLifetimeEvents() {
         // Given
-        let eventMonitor = ClosureEventMonitor()
-        let session = Session(requestSetup: .eager, eventMonitors: [eventMonitor])
+        let queue = DispatchQueue(label: "org.alamofire.testQueue")
+        let eventMonitor = ClosureEventMonitor(queue: queue)
+        let session = Session(rootQueue: queue, eventMonitors: [eventMonitor])
 
-        let expect = expectation(description: "request should receive appropriate lifetime events")
-        expect.expectedFulfillmentCount = 2
+        let didFinish = expectation(description: "request should finish")
+        let events = expectation(description: "request should receive appropriate lifetime events")
+        events.expectedFulfillmentCount = 2
 
-        eventMonitor.requestDidCancelTask = { _, _ in expect.fulfill() }
-        eventMonitor.requestDidCancel = { _ in expect.fulfill() }
+        eventMonitor.requestDidCancelTask = { _, _ in events.fulfill() }
+        eventMonitor.requestDidCancel = { _ in events.fulfill() }
         // Fulfill other events that would exceed the expected count. Inverted expectations require the full timeout.
-        eventMonitor.requestDidSuspend = { _ in expect.fulfill() }
-        eventMonitor.requestDidSuspendTask = { _, _ in expect.fulfill() }
+        eventMonitor.requestDidSuspend = { _ in events.fulfill() }
+        eventMonitor.requestDidSuspendTask = { _, _ in events.fulfill() }
 
         // When
         let request = session.request(.default)
@@ -699,6 +701,9 @@ final class RequestResponseTestCase: BaseTestCase {
             for _ in 0..<100 {
                 request.cancel()
             }
+        }
+        request.response { _ in
+            didFinish.fulfill()
         }
 
         waitForExpectations(timeout: timeout)

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -1184,6 +1184,7 @@ final class CustomResponseSerializerTests: BaseTestCase {
     @MainActor
     func testThatCustomResponseSerializersCanBeWrittenWithoutCompilerIssues() {
         // Given
+        let session = stored(Session())
         final class UselessResponseSerializer: ResponseSerializer {
             func serialize(request: URLRequest?, response: HTTPURLResponse?, data: Data?, error: (any Error)?) throws -> Data? {
                 data
@@ -1194,7 +1195,7 @@ final class CustomResponseSerializerTests: BaseTestCase {
         var data: Data?
 
         // When
-        AF.request(.default).response(responseSerializer: serializer) { response in
+        session.request(.default).response(responseSerializer: serializer) { response in
             data = response.data
             expectation.fulfill()
         }

--- a/Tests/ResponseTests.swift
+++ b/Tests/ResponseTests.swift
@@ -30,12 +30,13 @@ final class ResponseTestCase: BaseTestCase {
     @MainActor
     func testThatResponseReturnsSuccessResultWithValidData() {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "request should succeed")
 
         var response: DataResponse<Data?, AFError>?
 
         // When
-        AF.request(.default, parameters: ["foo": "bar"]).response { resp in
+        session.request(.default, parameters: ["foo": "bar"]).response { resp in
             response = resp
             expectation.fulfill()
         }
@@ -53,13 +54,14 @@ final class ResponseTestCase: BaseTestCase {
     @MainActor
     func testThatResponseReturnsFailureResultWithOptionalDataAndError() {
         // Given
+        let session = stored(Session())
         let urlString = String.invalidURL
         let expectation = expectation(description: "request should fail with invalid URL error")
 
         var response: DataResponse<Data?, AFError>?
 
         // When
-        AF.request(urlString, parameters: ["foo": "bar"]).response { resp in
+        session.request(urlString, parameters: ["foo": "bar"]).response { resp in
             response = resp
             expectation.fulfill()
         }
@@ -82,12 +84,13 @@ final class ResponseDataTestCase: BaseTestCase {
     @MainActor
     func testThatResponseDataReturnsSuccessResultWithValidData() {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "request should succeed")
 
         var response: DataResponse<Data, AFError>?
 
         // When
-        AF.request(.default, parameters: ["foo": "bar"]).responseData { resp in
+        session.request(.default, parameters: ["foo": "bar"]).responseData { resp in
             response = resp
             expectation.fulfill()
         }
@@ -106,13 +109,14 @@ final class ResponseDataTestCase: BaseTestCase {
     @MainActor
     func testThatResponseDataReturnsFailureResultWithOptionalDataAndError() {
         // Given
+        let session = stored(Session())
         let urlString = String.invalidURL
         let expectation = expectation(description: "request should fail with invalid URL error")
 
         var response: DataResponse<Data, AFError>?
 
         // When
-        AF.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
+        session.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
             response = resp
             expectation.fulfill()
         }
@@ -135,12 +139,13 @@ final class ResponseStringTestCase: BaseTestCase {
     @MainActor
     func testThatResponseStringReturnsSuccessResultWithValidString() {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "request should succeed")
 
         var response: DataResponse<String, AFError>?
 
         // When
-        AF.request(.default, parameters: ["foo": "bar"]).responseString { resp in
+        session.request(.default, parameters: ["foo": "bar"]).responseString { resp in
             response = resp
             expectation.fulfill()
         }
@@ -159,13 +164,14 @@ final class ResponseStringTestCase: BaseTestCase {
     @MainActor
     func testThatResponseStringReturnsFailureResultWithOptionalDataAndError() {
         // Given
+        let session = stored(Session())
         let urlString = String.invalidURL
         let expectation = expectation(description: "request should fail with invalid URL error")
 
         var response: DataResponse<String, AFError>?
 
         // When
-        AF.request(urlString, parameters: ["foo": "bar"]).responseString { resp in
+        session.request(urlString, parameters: ["foo": "bar"]).responseString { resp in
             response = resp
             expectation.fulfill()
         }
@@ -189,12 +195,13 @@ final class ResponseJSONTestCase: BaseTestCase {
     @MainActor
     func testThatResponseJSONReturnsSuccessResultWithValidJSON() {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "request should succeed")
 
         var response: DataResponse<Any, AFError>?
 
         // When
-        AF.request(.default, parameters: ["foo": "bar"]).responseJSON { resp in
+        session.request(.default, parameters: ["foo": "bar"]).responseJSON { resp in
             response = resp
             expectation.fulfill()
         }
@@ -213,13 +220,14 @@ final class ResponseJSONTestCase: BaseTestCase {
     @MainActor
     func testThatResponseStringReturnsFailureResultWithOptionalDataAndError() {
         // Given
+        let session = stored(Session())
         let urlString = String.invalidURL
         let expectation = expectation(description: "request should fail")
 
         var response: DataResponse<Any, AFError>?
 
         // When
-        AF.request(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
+        session.request(urlString, parameters: ["foo": "bar"]).responseJSON { resp in
             response = resp
             expectation.fulfill()
         }
@@ -238,12 +246,13 @@ final class ResponseJSONTestCase: BaseTestCase {
     @MainActor
     func testThatResponseJSONReturnsSuccessResultForGETRequest() {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "request should succeed")
 
         var response: DataResponse<Any, AFError>?
 
         // When
-        AF.request(.default, parameters: ["foo": "bar"]).responseJSON { resp in
+        session.request(.default, parameters: ["foo": "bar"]).responseJSON { resp in
             response = resp
             expectation.fulfill()
         }
@@ -270,12 +279,13 @@ final class ResponseJSONTestCase: BaseTestCase {
     @MainActor
     func testThatResponseJSONReturnsSuccessResultForPOSTRequest() {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "request should succeed")
 
         var response: DataResponse<Any, AFError>?
 
         // When
-        AF.request(.method(.post), parameters: ["foo": "bar"]).responseJSON { resp in
+        session.request(.method(.post), parameters: ["foo": "bar"]).responseJSON { resp in
             response = resp
             expectation.fulfill()
         }
@@ -304,13 +314,14 @@ final class ResponseJSONDecodableTestCase: BaseTestCase {
     @MainActor
     func testThatResponseDecodableReturnsSuccessResultWithValidJSON() {
         // Given
+        let session = stored(Session())
         let url = Endpoint().url
         let expectation = expectation(description: "request should succeed")
 
         var response: DataResponse<TestResponse, AFError>?
 
         // When
-        AF.request(url, parameters: [:]).responseDecodable(of: TestResponse.self) { resp in
+        session.request(url, parameters: [:]).responseDecodable(of: TestResponse.self) { resp in
             response = resp
             expectation.fulfill()
         }
@@ -329,13 +340,14 @@ final class ResponseJSONDecodableTestCase: BaseTestCase {
     @MainActor
     func testThatResponseDecodableWithPassedTypeReturnsSuccessResultWithValidJSON() {
         // Given
+        let session = stored(Session())
         let url = Endpoint().url
         let expectation = expectation(description: "request should succeed")
 
         var response: DataResponse<TestResponse, AFError>?
 
         // When
-        AF.request(url, parameters: [:]).responseDecodable(of: TestResponse.self) {
+        session.request(url, parameters: [:]).responseDecodable(of: TestResponse.self) {
             response = $0
             expectation.fulfill()
         }
@@ -354,13 +366,14 @@ final class ResponseJSONDecodableTestCase: BaseTestCase {
     @MainActor
     func testThatResponseStringReturnsFailureResultWithOptionalDataAndError() {
         // Given
+        let session = stored(Session())
         let urlString = String.invalidURL
         let expectation = expectation(description: "request should fail")
 
         var response: DataResponse<TestResponse, AFError>?
 
         // When
-        AF.request(urlString, parameters: [:]).responseDecodable(of: TestResponse.self) { resp in
+        session.request(urlString, parameters: [:]).responseDecodable(of: TestResponse.self) { resp in
             response = resp
             expectation.fulfill()
         }
@@ -383,12 +396,13 @@ final class ResponseMapTestCase: BaseTestCase {
     @MainActor
     func testThatMapTransformsSuccessValue() {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "request should succeed")
 
         var response: DataResponse<String, AFError>?
 
         // When
-        AF.request(.default, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
+        session.request(.default, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
             response = resp.map { response in
                 response.args["foo"] ?? "invalid"
             }
@@ -410,13 +424,14 @@ final class ResponseMapTestCase: BaseTestCase {
     @MainActor
     func testThatMapPreservesFailureError() {
         // Given
+        let session = stored(Session())
         let urlString = String.invalidURL
         let expectation = expectation(description: "request should fail with invalid URL error")
 
         var response: DataResponse<String, AFError>?
 
         // When
-        AF.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
+        session.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
             response = resp.map { _ in "ignored" }
             expectation.fulfill()
         }
@@ -439,12 +454,13 @@ final class ResponseTryMapTestCase: BaseTestCase {
     @MainActor
     func testThatTryMapTransformsSuccessValue() {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "request should succeed")
 
         var response: DataResponse<String, any Error>?
 
         // When
-        AF.request(.default, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
+        session.request(.default, parameters: ["foo": "bar"]).responseDecodable(of: TestResponse.self) { resp in
             response = resp.tryMap { response in
                 response.args["foo"] ?? "invalid"
             }
@@ -466,6 +482,7 @@ final class ResponseTryMapTestCase: BaseTestCase {
     @MainActor
     func testThatTryMapCatchesTransformationError() {
         // Given
+        let session = stored(Session())
         struct TransformError: Error {}
 
         let expectation = expectation(description: "request should succeed")
@@ -473,7 +490,7 @@ final class ResponseTryMapTestCase: BaseTestCase {
         var response: DataResponse<String, any Error>?
 
         // When
-        AF.request(.default, parameters: ["foo": "bar"]).responseData { resp in
+        session.request(.default, parameters: ["foo": "bar"]).responseData { resp in
             response = resp.tryMap { _ in
                 throw TransformError()
             }
@@ -501,13 +518,14 @@ final class ResponseTryMapTestCase: BaseTestCase {
     @MainActor
     func testThatTryMapPreservesFailureError() {
         // Given
+        let session = stored(Session())
         let urlString = String.invalidURL
         let expectation = expectation(description: "request should fail with invalid URL error")
 
         var response: DataResponse<String, any Error>?
 
         // When
-        AF.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
+        session.request(urlString, parameters: ["foo": "bar"]).responseData { resp in
             response = resp.tryMap { _ in "ignored" }
             expectation.fulfill()
         }
@@ -542,13 +560,14 @@ final class ResponseMapErrorTestCase: BaseTestCase {
     @MainActor
     func testThatMapErrorTransformsFailureValue() {
         // Given
+        let session = stored(Session())
         let urlString = String.invalidURL
         let expectation = expectation(description: "request should not succeed")
 
         var response: DataResponse<TestResponse, TestError>?
 
         // When
-        AF.request(urlString).responseDecodable(of: TestResponse.self) { resp in
+        session.request(urlString).responseDecodable(of: TestResponse.self) { resp in
             response = resp.mapError { error in
                 TestError.error(error: error)
             }
@@ -571,12 +590,13 @@ final class ResponseMapErrorTestCase: BaseTestCase {
     @MainActor
     func testThatMapErrorPreservesSuccessValue() {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "request should succeed")
 
         var response: DataResponse<Data, TestError>?
 
         // When
-        AF.request(.default).responseData { resp in
+        session.request(.default).responseData { resp in
             response = resp.mapError { TestError.error(error: $0) }
             expectation.fulfill()
         }
@@ -598,12 +618,13 @@ final class ResponseTryMapErrorTestCase: BaseTestCase {
     @MainActor
     func testThatTryMapErrorPreservesSuccessValue() {
         // Given
+        let session = stored(Session())
         let expectation = expectation(description: "request should succeed")
 
         var response: DataResponse<Data, any Error>?
 
         // When
-        AF.request(.default).responseData { resp in
+        session.request(.default).responseData { resp in
             response = resp.tryMapError { TestError.error(error: $0) }
             expectation.fulfill()
         }
@@ -621,13 +642,14 @@ final class ResponseTryMapErrorTestCase: BaseTestCase {
     @MainActor
     func testThatTryMapErrorCatchesTransformationError() {
         // Given
+        let session = stored(Session())
         let urlString = String.invalidURL
         let expectation = expectation(description: "request should fail")
 
         var response: DataResponse<Data, any Error>?
 
         // When
-        AF.request(urlString).responseData { resp in
+        session.request(urlString).responseData { resp in
             response = resp.tryMapError { _ in try TransformationError.error.alwaysFails() }
             expectation.fulfill()
         }
@@ -652,13 +674,14 @@ final class ResponseTryMapErrorTestCase: BaseTestCase {
     @MainActor
     func testThatTryMapErrorTransformsError() {
         // Given
+        let session = stored(Session())
         let urlString = String.invalidURL
         let expectation = expectation(description: "request should fail")
 
         var response: DataResponse<Data, any Error>?
 
         // When
-        AF.request(urlString).responseData { resp in
+        session.request(urlString).responseData { resp in
             response = resp.tryMapError { TestError.error(error: $0) }
             expectation.fulfill()
         }

--- a/Tests/RetryPolicyTests.swift
+++ b/Tests/RetryPolicyTests.swift
@@ -165,10 +165,11 @@ final class RetryPolicyTestCase: BaseRetryPolicyTestCase {
         let didFinish = expectation(description: "didFinish request")
 
         // When
-        let request = session.request(.default).responseDecodable(of: TestResponse.self) { _ in
+        let request = session.request(.default)
+        request.cancel()
+        request.responseDecodable(of: TestResponse.self) { _ in
             didFinish.fulfill()
         }
-        request.cancel()
 
         waitForExpectations(timeout: timeout)
 

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -496,7 +496,7 @@ final class SessionTestCase: BaseTestCase {
         // Given
         let session = Session(startRequestsImmediately: false)
 
-        let url = Endpoint().url
+        let url = Endpoint.delay(10).url
         let urlRequest = URLRequest(url: url)
 
         let expectation = expectation(description: "\(url)")

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -397,6 +397,7 @@ final class SessionTestCase: BaseTestCase {
     @MainActor
     func disabled_testDefaultAcceptEncodingSupportsAppropriateEncodingsOnAppropriateSystems() {
         // Given
+        let session = stored(Session())
         let brotliExpectation = expectation(description: "brotli request should complete")
         let gzipExpectation = expectation(description: "gzip request should complete")
         let deflateExpectation = expectation(description: "deflate request should complete")
@@ -405,17 +406,17 @@ final class SessionTestCase: BaseTestCase {
         var deflateResponse: DataResponse<TestResponse, AFError>?
 
         // When
-        AF.request(.compression(.brotli)).responseDecodable(of: TestResponse.self) { response in
+        session.request(.compression(.brotli)).responseDecodable(of: TestResponse.self) { response in
             brotliResponse = response
             brotliExpectation.fulfill()
         }
 
-        AF.request(.compression(.gzip)).responseDecodable(of: TestResponse.self) { response in
+        session.request(.compression(.gzip)).responseDecodable(of: TestResponse.self) { response in
             gzipResponse = response
             gzipExpectation.fulfill()
         }
 
-        AF.request(.compression(.deflate)).responseDecodable(of: TestResponse.self) { response in
+        session.request(.compression(.deflate)).responseDecodable(of: TestResponse.self) { response in
             deflateResponse = response
             deflateExpectation.fulfill()
         }

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -556,10 +556,8 @@ final class SessionTestCase: BaseTestCase {
     @MainActor
     func testReleasingManagerWithPendingRequestDeinitializesSuccessfully() {
         // Given
-        let monitor = ClosureEventMonitor()
-        let didCreateRequest = expectation(description: "Request created")
-        monitor.requestDidCreateTask = { _, _ in didCreateRequest.fulfill() }
-        var session: Session? = Session(startRequestsImmediately: false, requestSetup: .eager, eventMonitors: [monitor])
+        let requestDidFinish = expectation(description: "Request created")
+        var session: Session? = Session(startRequestsImmediately: false, requestSetup: .eager /* , eventMonitors: [monitor] */ )
         #if compiler(>=6.2.3) // Started emitting a diagnostic in 6.2.2, so lets conditionally use it.
         weak let weakSession = session
         #else
@@ -568,6 +566,7 @@ final class SessionTestCase: BaseTestCase {
 
         // When
         let request = session?.request(.default)
+        request?.response { _ in requestDidFinish.fulfill() }
         session = nil
 
         waitForExpectations(timeout: timeout)

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -581,7 +581,7 @@ final class SessionTestCase: BaseTestCase {
                 // On 2022 OS versions and later, URLSessionTasks are completed even if not resumed before invalidating a session.
                 let state = request?.task?.state
                 XCTAssertTrue([.canceling, .completed].contains(state),
-                              "task state isn't canceling or completed, it's \(state, default: "nil")")
+                              "task state isn't canceling or completed, it's \(String(describing: state))")
             } else {
                 XCTAssertEqual(request?.task?.state, .suspended)
             }

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -965,11 +965,13 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCalledCount, 1)
         XCTAssertEqual(handler.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, true)
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1003,11 +1005,13 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCalledCount, 1)
         XCTAssertEqual(handler.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, true)
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1037,11 +1041,13 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCalledCount, 1)
         XCTAssertEqual(handler.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, true)
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1071,11 +1077,13 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCount, 3)
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, false)
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1110,11 +1118,13 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(requestHandler.retryCount, 3)
         XCTAssertEqual(request.retryCount, 2)
         XCTAssertEqual(response?.result.isSuccess, false)
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1144,11 +1154,13 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCount, 1)
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, true)
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1180,11 +1192,13 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(response?.result.isSuccess, false)
         XCTAssertEqual(request.error?.isRequestAdaptationError, true)
         XCTAssertEqual(request.error?.underlyingError?.asAFError?.urlConvertible as? String, "/adapt/error/2")
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1216,11 +1230,13 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(response?.result.isSuccess, false)
         XCTAssertEqual(request.error?.isRequestAdaptationError, true)
         XCTAssertEqual(request.error?.underlyingError?.asAFError?.urlConvertible as? String, "/adapt/error/2")
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1250,11 +1266,13 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCount, 0)
         XCTAssertEqual(request.retryCount, 0)
         XCTAssertEqual(response?.result.isSuccess, false)
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
 
         if let error = response?.result.failure {
             XCTAssertTrue(error.isRequestRetryError)
@@ -1295,11 +1313,13 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(response?.result.isSuccess, false)
         XCTAssertEqual(response?.error?.isResponseSerializationError, true)
         XCTAssertNotNil(response?.error?.underlyingError as? DecodingError)
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1337,11 +1357,13 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(request.retryCount, 0)
         XCTAssertEqual(json1Response?.result.isSuccess, false)
         XCTAssertEqual(json2Response?.result.isSuccess, false)
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
 
         let errors = [json1Response, json2Response].compactMap { $0?.error }
 
@@ -1392,11 +1414,13 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(json1Response?.result.isSuccess, false)
         XCTAssertEqual(json2Response?.result.isSuccess, false)
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
 
         let errors = [json1Response, json2Response].compactMap { $0?.error }
         XCTAssertEqual(errors.count, 2)
@@ -1448,11 +1472,13 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(json1Response?.result.isSuccess, false)
         XCTAssertEqual(json2Response?.result.isSuccess, false)
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
 
         let errors = [json1Response, json2Response].compactMap { $0?.error }
         XCTAssertEqual(errors.count, 2)
@@ -1504,11 +1530,13 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(json1Response?.result.isSuccess, false)
         XCTAssertEqual(json2Response?.result.isSuccess, false)
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
 
         let errors = [json1Response, json2Response].compactMap { $0?.error }
         XCTAssertEqual(errors.count, 2)
@@ -1581,11 +1609,13 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(request.retryCount, 0)
         XCTAssertEqual(response?.result.isSuccess, true)
         XCTAssertEqual(completionCallCount, 1)
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     // MARK: Tests - Request State
@@ -1734,11 +1764,13 @@ final class SessionMassActionTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(responses.allSatisfy { $0.error?.isExplicitlyCancelledError == true })
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1780,11 +1812,13 @@ final class SessionMassActionTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(responses.allSatisfy { $0.error?.isExplicitlyCancelledError == true })
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1826,11 +1860,13 @@ final class SessionMassActionTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(responses.allSatisfy { $0.error?.isExplicitlyCancelledError == true })
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1869,11 +1905,13 @@ final class SessionMassActionTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(responses.allSatisfy { $0.error?.isExplicitlyCancelledError == true })
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1913,11 +1951,13 @@ final class SessionMassActionTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(responses.allSatisfy { $0.error?.isExplicitlyCancelledError == true })
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1974,11 +2014,13 @@ final class SessionMassActionTestCase: BaseTestCase {
 
         // Then
         XCTAssertEqual(received?.error?.isExplicitlyCancelledError, true)
-        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
-            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+        assert(on: session.rootQueue) {
+            let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+                ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
+            }
+            XCTAssertTrue(isTaskMapEmpty)
+            XCTAssertTrue(isActiveRequestsEmpty)
         }
-        XCTAssertTrue(isTaskMapEmpty)
-        XCTAssertTrue(isActiveRequestsEmpty)
     }
 }
 

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -557,8 +557,10 @@ final class SessionTestCase: BaseTestCase {
     @MainActor
     func testReleasingManagerWithPendingRequestDeinitializesSuccessfully() {
         // Given
+        let requestCount = 100
         let requestDidFinish = expectation(description: "Request created")
-        var session: Session? = Session(startRequestsImmediately: false, requestSetup: .eager /* , eventMonitors: [monitor] */ )
+        requestDidFinish.expectedFulfillmentCount = requestCount
+        var session: Session? = Session(startRequestsImmediately: false, requestSetup: .eager)
         #if compiler(>=6.2.3) // Started emitting a diagnostic in 6.2.2, so lets conditionally use it.
         weak let weakSession = session
         #else
@@ -566,18 +568,23 @@ final class SessionTestCase: BaseTestCase {
         #endif
 
         // When
-        let request = session?.request(.default)
-        request?.response { _ in requestDidFinish.fulfill() }
+        let requests = (0..<requestCount).map { _ in
+            session?.request(.default).response { _ in requestDidFinish.fulfill() }
+        }
         session = nil
 
         waitForExpectations(timeout: timeout)
 
         // Then
-        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
-            // On 2022 OS versions and later, URLSessionTasks are completed even if not resumed before invalidating a session.
-            XCTAssertTrue([.canceling, .completed].contains(request?.task?.state))
-        } else {
-            XCTAssertEqual(request?.task?.state, .suspended)
+        for request in requests {
+            if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+                // On 2022 OS versions and later, URLSessionTasks are completed even if not resumed before invalidating a session.
+                let state = request?.task?.state
+                XCTAssertTrue([.canceling, .completed].contains(state),
+                              "task state isn't canceling or completed, it's \(state, default: "nil")")
+            } else {
+                XCTAssertEqual(request?.task?.state, .suspended)
+            }
         }
         XCTAssertNil(session, "session should be nil")
         XCTAssertNil(weakSession, "weak session should be nil")

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -965,10 +965,11 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCalledCount, 1)
         XCTAssertEqual(handler.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, true)
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty)
-            XCTAssertTrue(session.activeRequests.isEmpty)
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1002,10 +1003,11 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCalledCount, 1)
         XCTAssertEqual(handler.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, true)
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty)
-            XCTAssertTrue(session.activeRequests.isEmpty)
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1035,10 +1037,11 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCalledCount, 1)
         XCTAssertEqual(handler.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, true)
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty)
-            XCTAssertTrue(session.activeRequests.isEmpty)
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1068,10 +1071,11 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCount, 3)
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, false)
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty)
-            XCTAssertTrue(session.activeRequests.isEmpty)
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1106,10 +1110,11 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(requestHandler.retryCount, 3)
         XCTAssertEqual(request.retryCount, 2)
         XCTAssertEqual(response?.result.isSuccess, false)
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty)
-            XCTAssertTrue(session.activeRequests.isEmpty)
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1139,10 +1144,11 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCount, 1)
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(response?.result.isSuccess, true)
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty)
-            XCTAssertTrue(session.activeRequests.isEmpty)
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1174,10 +1180,11 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(response?.result.isSuccess, false)
         XCTAssertEqual(request.error?.isRequestAdaptationError, true)
         XCTAssertEqual(request.error?.underlyingError?.asAFError?.urlConvertible as? String, "/adapt/error/2")
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty)
-            XCTAssertTrue(session.activeRequests.isEmpty)
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1209,10 +1216,11 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(response?.result.isSuccess, false)
         XCTAssertEqual(request.error?.isRequestAdaptationError, true)
         XCTAssertEqual(request.error?.underlyingError?.asAFError?.urlConvertible as? String, "/adapt/error/2")
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty)
-            XCTAssertTrue(session.activeRequests.isEmpty)
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1242,10 +1250,11 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(handler.retryCount, 0)
         XCTAssertEqual(request.retryCount, 0)
         XCTAssertEqual(response?.result.isSuccess, false)
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty)
-            XCTAssertTrue(session.activeRequests.isEmpty)
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
 
         if let error = response?.result.failure {
             XCTAssertTrue(error.isRequestRetryError)
@@ -1286,10 +1295,11 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(response?.result.isSuccess, false)
         XCTAssertEqual(response?.error?.isResponseSerializationError, true)
         XCTAssertNotNil(response?.error?.underlyingError as? DecodingError)
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty)
-            XCTAssertTrue(session.activeRequests.isEmpty)
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1327,10 +1337,11 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(request.retryCount, 0)
         XCTAssertEqual(json1Response?.result.isSuccess, false)
         XCTAssertEqual(json2Response?.result.isSuccess, false)
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty)
-            XCTAssertTrue(session.activeRequests.isEmpty)
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
 
         let errors = [json1Response, json2Response].compactMap { $0?.error }
 
@@ -1381,10 +1392,11 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(json1Response?.result.isSuccess, false)
         XCTAssertEqual(json2Response?.result.isSuccess, false)
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty)
-            XCTAssertTrue(session.activeRequests.isEmpty)
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
 
         let errors = [json1Response, json2Response].compactMap { $0?.error }
         XCTAssertEqual(errors.count, 2)
@@ -1436,10 +1448,11 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(json1Response?.result.isSuccess, false)
         XCTAssertEqual(json2Response?.result.isSuccess, false)
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty)
-            XCTAssertTrue(session.activeRequests.isEmpty)
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
 
         let errors = [json1Response, json2Response].compactMap { $0?.error }
         XCTAssertEqual(errors.count, 2)
@@ -1491,10 +1504,11 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(request.retryCount, 1)
         XCTAssertEqual(json1Response?.result.isSuccess, false)
         XCTAssertEqual(json2Response?.result.isSuccess, false)
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty)
-            XCTAssertTrue(session.activeRequests.isEmpty)
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
 
         let errors = [json1Response, json2Response].compactMap { $0?.error }
         XCTAssertEqual(errors.count, 2)
@@ -1567,10 +1581,11 @@ final class SessionTestCase: BaseTestCase {
         XCTAssertEqual(request.retryCount, 0)
         XCTAssertEqual(response?.result.isSuccess, true)
         XCTAssertEqual(completionCallCount, 1)
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty)
-            XCTAssertTrue(session.activeRequests.isEmpty)
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     // MARK: Tests - Request State
@@ -1719,10 +1734,11 @@ final class SessionMassActionTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(responses.allSatisfy { $0.error?.isExplicitlyCancelledError == true })
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty, "requestTaskMap should be empty but has \(session.requestTaskMap.count) items")
-            XCTAssertTrue(session.activeRequests.isEmpty, "activeRequests should be empty but has \(session.activeRequests.count) items")
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1764,10 +1780,11 @@ final class SessionMassActionTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(responses.allSatisfy { $0.error?.isExplicitlyCancelledError == true })
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty, "requestTaskMap should be empty but has \(session.requestTaskMap.count) items")
-            XCTAssertTrue(session.activeRequests.isEmpty, "activeRequests should be empty but has \(session.activeRequests.count) items")
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1809,10 +1826,11 @@ final class SessionMassActionTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(responses.allSatisfy { $0.error?.isExplicitlyCancelledError == true })
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty, "requestTaskMap should be empty but has \(session.requestTaskMap.count) items")
-            XCTAssertTrue(session.activeRequests.isEmpty, "activeRequests should be empty but has \(session.activeRequests.count) items")
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1851,10 +1869,11 @@ final class SessionMassActionTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(responses.allSatisfy { $0.error?.isExplicitlyCancelledError == true })
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty, "requestTaskMap should be empty but has \(session.requestTaskMap.count) items")
-            XCTAssertTrue(session.activeRequests.isEmpty, "activeRequests should be empty but has \(session.activeRequests.count) items")
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1894,10 +1913,11 @@ final class SessionMassActionTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(responses.allSatisfy { $0.error?.isExplicitlyCancelledError == true })
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty, "requestTaskMap should be empty but has \(session.requestTaskMap.count) items")
-            XCTAssertTrue(session.activeRequests.isEmpty, "activeRequests should be empty but has \(session.activeRequests.count) items")
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
     }
 
     @MainActor
@@ -1954,10 +1974,11 @@ final class SessionMassActionTestCase: BaseTestCase {
 
         // Then
         XCTAssertEqual(received?.error?.isExplicitlyCancelledError, true)
-        assert(on: session.rootQueue) {
-            XCTAssertTrue(session.requestTaskMap.isEmpty, "requestTaskMap should be empty but has \(session.requestTaskMap.count) items")
-            XCTAssertTrue(session.activeRequests.isEmpty, "activeRequests should be empty but has \(session.activeRequests.count) items")
+        let (isTaskMapEmpty, isActiveRequestsEmpty) = session.mutableState.read {
+            ($0.requestTaskMap.isEmpty, $0.activeRequests.isEmpty)
         }
+        XCTAssertTrue(isTaskMapEmpty)
+        XCTAssertTrue(isActiveRequestsEmpty)
     }
 }
 

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -229,46 +229,46 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
     }
 
     // watchOS doesn't perform revocation checking at all.
-//    #if !os(watchOS)
-//    @MainActor
-//    func testThatRevokedCertificateRequestFailsWithRevokedServerTrustPolicy() {
-//        // Given
-//        let policy = RevocationTrustEvaluator()
-//
-//        let evaluators = [revokedHost: policy]
-//
-//        let manager = Session(configuration: configuration,
-//                              serverTrustManager: ServerTrustManager(evaluators: evaluators))
-//
-//        let expectation = expectation(description: "\(revokedURLString)")
-//        var error: AFError?
-//
-//        // When
-//        manager.request(revokedURLString)
-//            .response { resp in
-//                error = resp.error
-//                expectation.fulfill()
-//            }
-//
-//        waitForExpectations(timeout: timeout)
-//
-//        // Then
-//        XCTAssertNotNil(error, "error should not be nil")
-//        XCTAssertEqual(error?.isServerTrustEvaluationError, true)
-//
-//        if case let .serverTrustEvaluationFailed(reason)? = error {
-//            if #available(iOS 12, macOS 10.14, tvOS 12, watchOS 5, *) {
-//                XCTAssertTrue(reason.isTrustEvaluationFailed, "should be .trustEvaluationFailed")
-//            } else {
-//                // Test seems flaky and can result in either of these failures, perhaps due to the OS actually checking?
-//                XCTAssertTrue(reason.isDefaultEvaluationFailed || reason.isRevocationCheckFailed,
-//                              "should be .defaultEvaluationFailed or .revocationCheckFailed")
-//            }
-//        } else {
-//            XCTFail("error should be .serverTrustEvaluationFailed")
-//        }
-//    }
-//    #endif
+    #if !os(watchOS)
+    @MainActor
+    func testThatRevokedCertificateRequestFailsWithRevokedServerTrustPolicy() {
+        // Given
+        let policy = RevocationTrustEvaluator()
+
+        let evaluators = [revokedHost: policy]
+
+        let manager = Session(configuration: configuration,
+                              serverTrustManager: ServerTrustManager(evaluators: evaluators))
+
+        let expectation = expectation(description: "\(revokedURLString)")
+        var error: AFError?
+
+        // When
+        manager.request(revokedURLString)
+            .response { resp in
+                error = resp.error
+                expectation.fulfill()
+            }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(error, "error should not be nil")
+        XCTAssertEqual(error?.isServerTrustEvaluationError, true)
+
+        if case let .serverTrustEvaluationFailed(reason)? = error {
+            if #available(iOS 12, macOS 10.14, tvOS 12, watchOS 5, *) {
+                XCTAssertTrue(reason.isTrustEvaluationFailed, "should be .trustEvaluationFailed")
+            } else {
+                // Test seems flaky and can result in either of these failures, perhaps due to the OS actually checking?
+                XCTAssertTrue(reason.isDefaultEvaluationFailed || reason.isRevocationCheckFailed,
+                              "should be .defaultEvaluationFailed or .revocationCheckFailed")
+            }
+        } else {
+            XCTFail("error should be .serverTrustEvaluationFailed")
+        }
+    }
+    #endif
 
     // MARK: Server Trust Policy - Certificate Pinning Tests
 

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -229,46 +229,46 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
     }
 
     // watchOS doesn't perform revocation checking at all.
-    #if !os(watchOS)
-    @MainActor
-    func testThatRevokedCertificateRequestFailsWithRevokedServerTrustPolicy() {
-        // Given
-        let policy = RevocationTrustEvaluator()
-
-        let evaluators = [revokedHost: policy]
-
-        let manager = stored(Session(configuration: configuration,
-                                     serverTrustManager: ServerTrustManager(evaluators: evaluators)))
-
-        let expectation = expectation(description: "\(revokedURLString)")
-        var error: AFError?
-
-        // When
-        manager.request(revokedURLString)
-            .response { resp in
-                error = resp.error
-                expectation.fulfill()
-            }
-
-        waitForExpectations(timeout: timeout)
-
-        // Then
-        XCTAssertNotNil(error, "error should not be nil")
-        XCTAssertEqual(error?.isServerTrustEvaluationError, true)
-
-        if case let .serverTrustEvaluationFailed(reason)? = error {
-            if #available(iOS 12, macOS 10.14, tvOS 12, watchOS 5, *) {
-                XCTAssertTrue(reason.isTrustEvaluationFailed, "should be .trustEvaluationFailed")
-            } else {
-                // Test seems flaky and can result in either of these failures, perhaps due to the OS actually checking?
-                XCTAssertTrue(reason.isDefaultEvaluationFailed || reason.isRevocationCheckFailed,
-                              "should be .defaultEvaluationFailed or .revocationCheckFailed")
-            }
-        } else {
-            XCTFail("error should be .serverTrustEvaluationFailed")
-        }
-    }
-    #endif
+//    #if !os(watchOS)
+//    @MainActor
+//    func testThatRevokedCertificateRequestFailsWithRevokedServerTrustPolicy() {
+//        // Given
+//        let policy = RevocationTrustEvaluator()
+//
+//        let evaluators = [revokedHost: policy]
+//
+//        let manager = stored(Session(configuration: configuration,
+//                                     serverTrustManager: ServerTrustManager(evaluators: evaluators)))
+//
+//        let expectation = expectation(description: "\(revokedURLString)")
+//        var error: AFError?
+//
+//        // When
+//        manager.request(revokedURLString)
+//            .response { resp in
+//                error = resp.error
+//                expectation.fulfill()
+//            }
+//
+//        waitForExpectations(timeout: timeout)
+//
+//        // Then
+//        XCTAssertNotNil(error, "error should not be nil")
+//        XCTAssertEqual(error?.isServerTrustEvaluationError, true)
+//
+//        if case let .serverTrustEvaluationFailed(reason)? = error {
+//            if #available(iOS 12, macOS 10.14, tvOS 12, watchOS 5, *) {
+//                XCTAssertTrue(reason.isTrustEvaluationFailed, "should be .trustEvaluationFailed")
+//            } else {
+//                // Test seems flaky and can result in either of these failures, perhaps due to the OS actually checking?
+//                XCTAssertTrue(reason.isDefaultEvaluationFailed || reason.isRevocationCheckFailed,
+//                              "should be .defaultEvaluationFailed or .revocationCheckFailed")
+//            }
+//        } else {
+//            XCTFail("error should be .serverTrustEvaluationFailed")
+//        }
+//    }
+//    #endif
 
     // MARK: Server Trust Policy - Certificate Pinning Tests
 

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -194,7 +194,7 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
     @MainActor
     func testThatExpiredCertificateRequestFailsWithRevokedServerTrustPolicy() {
         // Given
-        let policy = RevocationTrustEvaluator()
+        let policy = RevocationTrustEvaluator(options: [.requirePositiveResponse, .any])
 
         let evaluators = [expiredHost: policy]
 

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -194,7 +194,7 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
     @MainActor
     func testThatExpiredCertificateRequestFailsWithRevokedServerTrustPolicy() {
         // Given
-        let policy = RevocationTrustEvaluator(options: [.requirePositiveResponse, .any])
+        let policy = RevocationTrustEvaluator()
 
         let evaluators = [expiredHost: policy]
 
@@ -229,46 +229,47 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
     }
 
     // watchOS doesn't perform revocation checking at all.
-//    #if !os(watchOS)
-//    @MainActor
-//    func testThatRevokedCertificateRequestFailsWithRevokedServerTrustPolicy() {
-//        // Given
-//        let policy = RevocationTrustEvaluator()
-//
-//        let evaluators = [revokedHost: policy]
-//
-//        let manager = stored(Session(configuration: configuration,
-//                                     serverTrustManager: ServerTrustManager(evaluators: evaluators)))
-//
-//        let expectation = expectation(description: "\(revokedURLString)")
-//        var error: AFError?
-//
-//        // When
-//        manager.request(revokedURLString)
-//            .response { resp in
-//                error = resp.error
-//                expectation.fulfill()
-//            }
-//
-//        waitForExpectations(timeout: timeout)
-//
-//        // Then
-//        XCTAssertNotNil(error, "error should not be nil")
-//        XCTAssertEqual(error?.isServerTrustEvaluationError, true)
-//
-//        if case let .serverTrustEvaluationFailed(reason)? = error {
-//            if #available(iOS 12, macOS 10.14, tvOS 12, watchOS 5, *) {
-//                XCTAssertTrue(reason.isTrustEvaluationFailed, "should be .trustEvaluationFailed")
-//            } else {
-//                // Test seems flaky and can result in either of these failures, perhaps due to the OS actually checking?
-//                XCTAssertTrue(reason.isDefaultEvaluationFailed || reason.isRevocationCheckFailed,
-//                              "should be .defaultEvaluationFailed or .revocationCheckFailed")
-//            }
-//        } else {
-//            XCTFail("error should be .serverTrustEvaluationFailed")
-//        }
-//    }
-//    #endif
+    // Test disabled since revocation checking isn't stable on CI.
+    #if !os(watchOS)
+    @MainActor
+    func disable_testThatRevokedCertificateRequestFailsWithRevokedServerTrustPolicy() {
+        // Given
+        let policy = RevocationTrustEvaluator()
+
+        let evaluators = [revokedHost: policy]
+
+        let manager = stored(Session(configuration: configuration,
+                                     serverTrustManager: ServerTrustManager(evaluators: evaluators)))
+
+        let expectation = expectation(description: "\(revokedURLString)")
+        var error: AFError?
+
+        // When
+        manager.request(revokedURLString)
+            .response { resp in
+                error = resp.error
+                expectation.fulfill()
+            }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(error, "error should not be nil")
+        XCTAssertEqual(error?.isServerTrustEvaluationError, true)
+
+        if case let .serverTrustEvaluationFailed(reason)? = error {
+            if #available(iOS 12, macOS 10.14, tvOS 12, watchOS 5, *) {
+                XCTAssertTrue(reason.isTrustEvaluationFailed, "should be .trustEvaluationFailed")
+            } else {
+                // Test seems flaky and can result in either of these failures, perhaps due to the OS actually checking?
+                XCTAssertTrue(reason.isDefaultEvaluationFailed || reason.isRevocationCheckFailed,
+                              "should be .defaultEvaluationFailed or .revocationCheckFailed")
+            }
+        } else {
+            XCTFail("error should be .serverTrustEvaluationFailed")
+        }
+    }
+    #endif
 
     // MARK: Server Trust Policy - Certificate Pinning Tests
 

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -229,12 +229,11 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
     }
 
     // watchOS doesn't perform revocation checking at all.
-    // Test disabled since revocation checking isn't stable on CI.
     #if !os(watchOS)
     @MainActor
-    func disable_testThatRevokedCertificateRequestFailsWithRevokedServerTrustPolicy() {
+    func testThatRevokedCertificateRequestFailsWithRevokedServerTrustPolicy() {
         // Given
-        let policy = RevocationTrustEvaluator()
+        let policy = RevocationTrustEvaluator(options: [.requirePositiveResponse, .any])
 
         let evaluators = [revokedHost: policy]
 

--- a/Tests/TLSEvaluationTests.swift
+++ b/Tests/TLSEvaluationTests.swift
@@ -69,7 +69,7 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
     func testThatExpiredCertificateRequestFailsWithNoServerTrustPolicy() {
         // Given
         let expectation = expectation(description: "\(expiredURLString)")
-        let manager = Session(configuration: configuration)
+        let manager = stored(Session(configuration: configuration))
         var error: AFError?
 
         // When
@@ -98,7 +98,7 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
         // Given
         let expectation = expectation(description: "\(revokedURLString)")
-        let manager = Session(configuration: configuration)
+        let manager = stored(Session(configuration: configuration))
 
         var error: (any Error)?
 
@@ -126,8 +126,8 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
     func testThatExpiredCertificateRequestFailsWithDefaultServerTrustPolicy() {
         // Given
         let evaluators = [expiredHost: DefaultTrustEvaluator(validateHost: true)]
-        let manager = Session(configuration: configuration,
-                              serverTrustManager: ServerTrustManager(evaluators: evaluators))
+        let manager = stored(Session(configuration: configuration,
+                                     serverTrustManager: ServerTrustManager(evaluators: evaluators)))
 
         let expectation = expectation(description: "\(expiredURLString)")
         var error: AFError?
@@ -165,8 +165,8 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         let defaultPolicy = DefaultTrustEvaluator()
         let evaluators = [revokedHost: defaultPolicy]
 
-        let manager = Session(configuration: configuration,
-                              serverTrustManager: ServerTrustManager(evaluators: evaluators))
+        let manager = stored(Session(configuration: configuration,
+                                     serverTrustManager: ServerTrustManager(evaluators: evaluators)))
 
         let expectation = expectation(description: "\(revokedURLString)")
         var error: (any Error)?
@@ -198,8 +198,8 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
         let evaluators = [expiredHost: policy]
 
-        let manager = Session(configuration: configuration,
-                              serverTrustManager: ServerTrustManager(evaluators: evaluators))
+        let manager = stored(Session(configuration: configuration,
+                                     serverTrustManager: ServerTrustManager(evaluators: evaluators)))
 
         let expectation = expectation(description: "\(expiredURLString)")
         var error: AFError?
@@ -237,8 +237,8 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
         let evaluators = [revokedHost: policy]
 
-        let manager = Session(configuration: configuration,
-                              serverTrustManager: ServerTrustManager(evaluators: evaluators))
+        let manager = stored(Session(configuration: configuration,
+                                     serverTrustManager: ServerTrustManager(evaluators: evaluators)))
 
         let expectation = expectation(description: "\(revokedURLString)")
         var error: AFError?
@@ -278,8 +278,8 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         let certificates = [TestCertificates.leaf]
         let evaluators = [expiredHost: PinnedCertificatesTrustEvaluator(certificates: certificates)]
 
-        let manager = Session(configuration: configuration,
-                              serverTrustManager: ServerTrustManager(evaluators: evaluators))
+        let manager = stored(Session(configuration: configuration,
+                                     serverTrustManager: ServerTrustManager(evaluators: evaluators)))
 
         let expectation = expectation(description: "\(expiredURLString)")
         var error: AFError?
@@ -318,8 +318,8 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
 
         let evaluators = [expiredHost: PinnedCertificatesTrustEvaluator(certificates: certificates)]
 
-        let manager = Session(configuration: configuration,
-                              serverTrustManager: ServerTrustManager(evaluators: evaluators))
+        let manager = stored(Session(configuration: configuration,
+                                     serverTrustManager: ServerTrustManager(evaluators: evaluators)))
 
         let expectation = expectation(description: "\(expiredURLString)")
         var error: AFError?
@@ -354,8 +354,8 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         let certificates = [TestCertificates.leaf]
         let evaluators = [expiredHost: PinnedCertificatesTrustEvaluator(certificates: certificates, performDefaultValidation: false, validateHost: false)]
 
-        let manager = Session(configuration: configuration,
-                              serverTrustManager: ServerTrustManager(evaluators: evaluators))
+        let manager = stored(Session(configuration: configuration,
+                                     serverTrustManager: ServerTrustManager(evaluators: evaluators)))
 
         let expectation = expectation(description: "\(expiredURLString)")
         var error: (any Error)?
@@ -379,8 +379,8 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         let certificates = [TestCertificates.intermediateCA2]
         let evaluators = [expiredHost: PinnedCertificatesTrustEvaluator(certificates: certificates, performDefaultValidation: false, validateHost: false)]
 
-        let manager = Session(configuration: configuration,
-                              serverTrustManager: ServerTrustManager(evaluators: evaluators))
+        let manager = stored(Session(configuration: configuration,
+                                     serverTrustManager: ServerTrustManager(evaluators: evaluators)))
 
         let expectation = expectation(description: "\(expiredURLString)")
         var error: (any Error)?
@@ -404,8 +404,8 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         let certificates = [TestCertificates.rootCA]
         let evaluators = [expiredHost: PinnedCertificatesTrustEvaluator(certificates: certificates, performDefaultValidation: false)]
 
-        let manager = Session(configuration: configuration,
-                              serverTrustManager: ServerTrustManager(evaluators: evaluators))
+        let manager = stored(Session(configuration: configuration,
+                                     serverTrustManager: ServerTrustManager(evaluators: evaluators)))
 
         let expectation = expectation(description: "\(expiredURLString)")
         var error: (any Error)?
@@ -435,8 +435,8 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         let keys = [TestCertificates.leaf].af.publicKeys
         let evaluators = [expiredHost: PublicKeysTrustEvaluator(keys: keys)]
 
-        let manager = Session(configuration: configuration,
-                              serverTrustManager: ServerTrustManager(evaluators: evaluators))
+        let manager = stored(Session(configuration: configuration,
+                                     serverTrustManager: ServerTrustManager(evaluators: evaluators)))
 
         let expectation = expectation(description: "\(expiredURLString)")
         var error: AFError?
@@ -471,8 +471,8 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         let keys = [TestCertificates.leaf].af.publicKeys
         let evaluators = [expiredHost: PublicKeysTrustEvaluator(keys: keys, performDefaultValidation: false, validateHost: false)]
 
-        let manager = Session(configuration: configuration,
-                              serverTrustManager: ServerTrustManager(evaluators: evaluators))
+        let manager = stored(Session(configuration: configuration,
+                                     serverTrustManager: ServerTrustManager(evaluators: evaluators)))
 
         let expectation = expectation(description: "\(expiredURLString)")
         var error: (any Error)?
@@ -521,8 +521,8 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
         let keys = [TestCertificates.rootCA].af.publicKeys
         let evaluators = [expiredHost: PublicKeysTrustEvaluator(keys: keys, performDefaultValidation: false, validateHost: false)]
 
-        let manager = Session(configuration: configuration,
-                              serverTrustManager: ServerTrustManager(evaluators: evaluators))
+        let manager = stored(Session(configuration: configuration,
+                                     serverTrustManager: ServerTrustManager(evaluators: evaluators)))
 
         let expectation = expectation(description: "\(expiredURLString)")
         var error: (any Error)?
@@ -550,8 +550,8 @@ final class TLSEvaluationExpiredLeafCertificateTestCase: BaseTestCase {
     func testThatExpiredCertificateRequestSucceedsWhenDisablingEvaluation() {
         // Given
         let evaluators = [expiredHost: DisabledTrustEvaluator()]
-        let manager = Session(configuration: configuration,
-                              serverTrustManager: ServerTrustManager(evaluators: evaluators))
+        let manager = stored(Session(configuration: configuration,
+                                     serverTrustManager: ServerTrustManager(evaluators: evaluators)))
 
         let expectation = expectation(description: "\(expiredURLString)")
         var error: (any Error)?

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -158,7 +158,7 @@ struct Endpoint {
 
     static let cache: Endpoint = .init(path: .cache)
 
-    static func chunked(_ count: Int, delay: Int = 50) -> Endpoint {
+    static func chunked(_ count: Int, delay: Int = 60) -> Endpoint {
         Endpoint(path: .chunked(count: count, delay: delay))
     }
 
@@ -198,7 +198,7 @@ struct Endpoint {
         Endpoint(path: .method(method), method: method)
     }
 
-    static func payloads(_ count: Int, delay: Int = 50) -> Endpoint {
+    static func payloads(_ count: Int, delay: Int = 60) -> Endpoint {
         Endpoint(path: .payloads(count: count, delay: delay))
     }
 

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -69,6 +69,7 @@ struct Endpoint {
         case download(count: Int)
         case hiddenBasicAuth(username: String, password: String)
         case image(Image)
+        case infinite
         case ip
         case method(HTTPMethod)
         case payloads(count: Int, delay: Int = 40)
@@ -106,6 +107,8 @@ struct Endpoint {
                 "/hidden-basic-auth/\(username)/\(password)"
             case let .image(type):
                 "/image/\(type.rawValue)"
+            case .infinite:
+                "/infinite"
             case .ip:
                 "/ip"
             case let .method(method):
@@ -188,6 +191,10 @@ struct Endpoint {
 
     static func image(_ type: Image) -> Endpoint {
         Endpoint(path: .image(type))
+    }
+
+    static var infinite: Endpoint {
+        Endpoint(path: .infinite)
     }
 
     static var ip: Endpoint {

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -62,7 +62,7 @@ struct Endpoint {
         case basicAuth(username: String, password: String)
         case bytes(count: Int)
         case cache
-        case chunked(count: Int, delay: Int = 20)
+        case chunked(count: Int, delay: Int = 40)
         case compression(Compression)
         case delay(interval: Int)
         case digestAuth(qop: String = "auth", username: String, password: String)
@@ -71,7 +71,7 @@ struct Endpoint {
         case image(Image)
         case ip
         case method(HTTPMethod)
-        case payloads(count: Int, delay: Int = 20)
+        case payloads(count: Int, delay: Int = 40)
         case redirect(count: Int)
         case redirectTo
         case responseHeaders

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -158,7 +158,7 @@ struct Endpoint {
 
     static let cache: Endpoint = .init(path: .cache)
 
-    static func chunked(_ count: Int, delay: Int = 40) -> Endpoint {
+    static func chunked(_ count: Int, delay: Int = 50) -> Endpoint {
         Endpoint(path: .chunked(count: count, delay: delay))
     }
 
@@ -198,7 +198,7 @@ struct Endpoint {
         Endpoint(path: .method(method), method: method)
     }
 
-    static func payloads(_ count: Int, delay: Int = 40) -> Endpoint {
+    static func payloads(_ count: Int, delay: Int = 50) -> Endpoint {
         Endpoint(path: .payloads(count: count, delay: delay))
     }
 

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -161,7 +161,7 @@ struct Endpoint {
 
     static let cache: Endpoint = .init(path: .cache)
 
-    static func chunked(_ count: Int, delay: Int = 60) -> Endpoint {
+    static func chunked(_ count: Int, delay: Int = 70) -> Endpoint {
         Endpoint(path: .chunked(count: count, delay: delay))
     }
 
@@ -205,7 +205,7 @@ struct Endpoint {
         Endpoint(path: .method(method), method: method)
     }
 
-    static func payloads(_ count: Int, delay: Int = 60) -> Endpoint {
+    static func payloads(_ count: Int, delay: Int = 70) -> Endpoint {
         Endpoint(path: .payloads(count: count, delay: delay))
     }
 

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -62,7 +62,7 @@ struct Endpoint {
         case basicAuth(username: String, password: String)
         case bytes(count: Int)
         case cache
-        case chunked(count: Int)
+        case chunked(count: Int, delay: Int = 20)
         case compression(Compression)
         case delay(interval: Int)
         case digestAuth(qop: String = "auth", username: String, password: String)
@@ -71,7 +71,7 @@ struct Endpoint {
         case image(Image)
         case ip
         case method(HTTPMethod)
-        case payloads(count: Int)
+        case payloads(count: Int, delay: Int = 20)
         case redirect(count: Int)
         case redirectTo
         case responseHeaders
@@ -92,8 +92,8 @@ struct Endpoint {
                 "/bytes/\(count)"
             case .cache:
                 "/cache"
-            case let .chunked(count):
-                "/chunked/\(count)"
+            case let .chunked(count, delay):
+                "/chunked/\(count)/\(delay)"
             case let .compression(compression):
                 "/\(compression.rawValue)"
             case let .delay(interval):
@@ -110,8 +110,8 @@ struct Endpoint {
                 "/ip"
             case let .method(method):
                 "/\(method.rawValue.lowercased())"
-            case let .payloads(count):
-                "/payloads/\(count)"
+            case let .payloads(count, delay):
+                "/payloads/\(count)/\(delay)"
             case let .redirect(count):
                 "/redirect/\(count)"
             case .redirectTo:
@@ -158,8 +158,8 @@ struct Endpoint {
 
     static let cache: Endpoint = .init(path: .cache)
 
-    static func chunked(_ count: Int) -> Endpoint {
-        Endpoint(path: .chunked(count: count))
+    static func chunked(_ count: Int, delay: Int = 20) -> Endpoint {
+        Endpoint(path: .chunked(count: count, delay: 20))
     }
 
     static func compression(_ compression: Compression) -> Endpoint {
@@ -198,8 +198,8 @@ struct Endpoint {
         Endpoint(path: .method(method), method: method)
     }
 
-    static func payloads(_ count: Int) -> Endpoint {
-        Endpoint(path: .payloads(count: count))
+    static func payloads(_ count: Int, delay: Int = 20) -> Endpoint {
+        Endpoint(path: .payloads(count: count, delay: delay))
     }
 
     static func redirect(_ count: Int) -> Endpoint {

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -158,8 +158,8 @@ struct Endpoint {
 
     static let cache: Endpoint = .init(path: .cache)
 
-    static func chunked(_ count: Int, delay: Int = 20) -> Endpoint {
-        Endpoint(path: .chunked(count: count, delay: 20))
+    static func chunked(_ count: Int, delay: Int = 40) -> Endpoint {
+        Endpoint(path: .chunked(count: count, delay: delay))
     }
 
     static func compression(_ compression: Compression) -> Endpoint {
@@ -198,7 +198,7 @@ struct Endpoint {
         Endpoint(path: .method(method), method: method)
     }
 
-    static func payloads(_ count: Int, delay: Int = 20) -> Endpoint {
+    static func payloads(_ count: Int, delay: Int = 40) -> Endpoint {
         Endpoint(path: .payloads(count: count, delay: delay))
     }
 

--- a/Tests/URLProtocolTests.swift
+++ b/Tests/URLProtocolTests.swift
@@ -47,6 +47,7 @@ class ProxyURLProtocol: URLProtocol {
     weak var activeTask: URLSessionTask?
 
     // MARK: Class Request Methods
+
     override class func canInit(with task: URLSessionTask) -> Bool {
         if let request = task.currentRequest,
            URLProtocol.property(forKey: PropertyKeys.handledByForwarderURLProtocol, in: request) != nil {
@@ -55,7 +56,7 @@ class ProxyURLProtocol: URLProtocol {
 
         return true
     }
-    
+
     override class func canInit(with request: URLRequest) -> Bool {
         if URLProtocol.property(forKey: PropertyKeys.handledByForwarderURLProtocol, in: request) != nil {
             return false

--- a/Tests/URLProtocolTests.swift
+++ b/Tests/URLProtocolTests.swift
@@ -47,7 +47,15 @@ class ProxyURLProtocol: URLProtocol {
     weak var activeTask: URLSessionTask?
 
     // MARK: Class Request Methods
+    override class func canInit(with task: URLSessionTask) -> Bool {
+        if let request = task.currentRequest,
+           URLProtocol.property(forKey: PropertyKeys.handledByForwarderURLProtocol, in: request) != nil {
+            return false
+        }
 
+        return true
+    }
+    
     override class func canInit(with request: URLRequest) -> Bool {
         if URLProtocol.property(forKey: PropertyKeys.handledByForwarderURLProtocol, in: request) != nil {
             return false
@@ -92,15 +100,19 @@ class ProxyURLProtocol: URLProtocol {
 extension ProxyURLProtocol: URLSessionDataDelegate {
     // MARK: NSURLSessionDelegate
 
+    func urlSession(_ session: URLSession,
+                    dataTask: URLSessionDataTask,
+                    didReceive response: URLResponse) async -> URLSession.ResponseDisposition {
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+
+        return .allow
+    }
+
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         client?.urlProtocol(self, didLoad: data)
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: (any Error)?) {
-        if let response = task.response {
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        }
-
         client?.urlProtocolDidFinishLoading(self)
     }
 }

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -718,7 +718,7 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
                       multipartFormData.append(loremData2, withName: "lorem2")
                   },
                   to: Endpoint.method(.post),
-                  usingThreshold: streamFromDisk ? 0 : 100_000_000)
+                  usingThreshold: streamFromDisk ? 0 : .max)
             .uploadProgress { progress in
                 uploadProgressValues.append(progress.fractionCompleted)
             }

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -444,8 +444,8 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
     func testThatUploadingMultipartFormDataBelowMemoryThresholdStreamsFromMemory() {
         // Given
         let session = stored(Session())
-        let frenchData = Data(String(repeating: "français", count: 10_000).utf8)
-        let japaneseData = Data(String(repeating: "日本語", count: 10_000).utf8)
+        let frenchData = Data(String(repeating: "français", count: 100_000).utf8)
+        let japaneseData = Data(String(repeating: "日本語", count: 100_000).utf8)
 
         let expectation = expectation(description: "multipart form data upload should succeed")
         var response: DataResponse<Data?, AFError>?

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -701,9 +701,9 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
     private func executeMultipartFormDataUploadRequestWithProgress(streamFromDisk: Bool) {
         // Given
         let loremData1 = Data(String(repeating: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-                                     count: 4).utf8)
+                                     count: 1000).utf8)
         let loremData2 = Data(String(repeating: "Lorem ipsum dolor sit amet, nam no graeco recusabo appellantur.",
-                                     count: 4).utf8)
+                                     count: 1000).utf8)
 
         let expectation = expectation(description: "multipart form data upload should succeed")
 

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -720,9 +720,9 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
         // Given
         let session = stored(Session())
         let loremData1 = Data(String(repeating: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-                                     count: 1000).utf8)
+                                     count: 8700).utf8)
         let loremData2 = Data(String(repeating: "Lorem ipsum dolor sit amet, nam no graeco recusabo appellantur.",
-                                     count: 1000).utf8)
+                                     count: 7900).utf8)
 
         let expectation = expectation(description: "multipart form data upload should succeed")
 

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -444,8 +444,8 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
     func testThatUploadingMultipartFormDataBelowMemoryThresholdStreamsFromMemory() {
         // Given
         let session = stored(Session())
-        let frenchData = Data(String(repeating: "français", count: 500_000).utf8)
-        let japaneseData = Data(String(repeating: "日本語", count: 500_000).utf8)
+        let frenchData = Data(String(repeating: "français", count: 1_000_000).utf8)
+        let japaneseData = Data(String(repeating: "日本語", count: 1_000_000).utf8)
 
         let expectation = expectation(description: "multipart form data upload should succeed")
         var response: DataResponse<Data?, AFError>?
@@ -455,7 +455,8 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
                                          multipartFormData.append(frenchData, withName: "french")
                                          multipartFormData.append(japaneseData, withName: "japanese")
                                      },
-                                     to: Endpoint.method(.post))
+                                     to: Endpoint.method(.post),
+                                     usingThreshold: .max)
             .response { resp in
                 response = resp
                 expectation.fulfill()

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -444,8 +444,8 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
     func testThatUploadingMultipartFormDataBelowMemoryThresholdStreamsFromMemory() {
         // Given
         let session = stored(Session())
-        let frenchData = Data(String(repeating: "français", count: 1_000_000).utf8)
-        let japaneseData = Data(String(repeating: "日本語", count: 1_000_000).utf8)
+        let frenchData = Data(String(repeating: "français", count: 500_000).utf8)
+        let japaneseData = Data(String(repeating: "日本語", count: 500_000).utf8)
 
         let expectation = expectation(description: "multipart form data upload should succeed")
         var response: DataResponse<Data?, AFError>?

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -444,8 +444,8 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
     func testThatUploadingMultipartFormDataBelowMemoryThresholdStreamsFromMemory() {
         // Given
         let session = stored(Session())
-        let frenchData = Data(String(repeating: "français", count: 100_000).utf8)
-        let japaneseData = Data(String(repeating: "日本語", count: 100_000).utf8)
+        let frenchData = Data(String(repeating: "français", count: 1_000_000).utf8)
+        let japaneseData = Data(String(repeating: "日本語", count: 1_000_000).utf8)
 
         let expectation = expectation(description: "multipart form data upload should succeed")
         var response: DataResponse<Data?, AFError>?

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -431,8 +431,8 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
     @MainActor
     func testThatUploadingMultipartFormDataBelowMemoryThresholdStreamsFromMemory() {
         // Given
-        let frenchData = Data("français".utf8)
-        let japaneseData = Data("日本語".utf8)
+        let frenchData = Data(String(repeating: "français", count: 10_000).utf8)
+        let japaneseData = Data(String(repeating: "日本語", count: 10_000).utf8)
 
         let expectation = expectation(description: "multipart form data upload should succeed")
         var response: DataResponse<Data?, AFError>?

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -228,10 +228,10 @@ final class UploadDataTestCase: BaseTestCase {
 
         // When
         session.upload(data, to: url)
-            .uploadProgress { progress in
+            .uploadProgress(queue: session.rootQueue) { progress in
                 uploadProgressValues.append(progress.fractionCompleted)
             }
-            .downloadProgress { progress in
+            .downloadProgress(queue: session.rootQueue) { progress in
                 downloadProgressValues.append(progress.fractionCompleted)
             }
             .response { resp in
@@ -739,10 +739,10 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
                        },
                        to: Endpoint.method(.post),
                        usingThreshold: streamFromDisk ? 0 : .max)
-            .uploadProgress { progress in
+            .uploadProgress(queue: session.rootQueue) { progress in
                 uploadProgressValues.append(progress.fractionCompleted)
             }
-            .downloadProgress { progress in
+            .downloadProgress(queue: session.rootQueue) { progress in
                 downloadProgressValues.append(progress.fractionCompleted)
             }
             .response { resp in

--- a/Tests/UploadTests.swift
+++ b/Tests/UploadTests.swift
@@ -30,12 +30,13 @@ final class UploadFileInitializationTestCase: BaseTestCase {
     @MainActor
     func testUploadClassMethodWithMethodURLAndFile() {
         // Given
+        let session = stored(Session())
         let requestURL = Endpoint.method(.post).url
         let imageURL = url(forResource: "rainbow", withExtension: "jpg")
         let expectation = expectation(description: "upload should complete")
 
         // When
-        let request = AF.upload(imageURL, to: requestURL).response { _ in
+        let request = session.upload(imageURL, to: requestURL).response { _ in
             expectation.fulfill()
         }
 
@@ -51,13 +52,14 @@ final class UploadFileInitializationTestCase: BaseTestCase {
     @MainActor
     func testUploadClassMethodWithMethodURLHeadersAndFile() {
         // Given
+        let session = stored(Session())
         let requestURL = Endpoint.method(.post).url
         let headers: HTTPHeaders = ["Authorization": "123456"]
         let imageURL = url(forResource: "rainbow", withExtension: "jpg")
         let expectation = expectation(description: "upload should complete")
 
         // When
-        let request = AF.upload(imageURL, to: requestURL, method: .post, headers: headers).response { _ in
+        let request = session.upload(imageURL, to: requestURL, method: .post, headers: headers).response { _ in
             expectation.fulfill()
         }
 
@@ -81,11 +83,12 @@ final class UploadDataInitializationTestCase: BaseTestCase {
     @MainActor
     func testUploadClassMethodWithMethodURLAndData() {
         // Given
+        let session = stored(Session())
         let url = Endpoint.method(.post).url
         let expectation = expectation(description: "upload should complete")
 
         // When
-        let request = AF.upload(Data(), to: url).response { _ in
+        let request = session.upload(Data(), to: url).response { _ in
             expectation.fulfill()
         }
 
@@ -101,12 +104,13 @@ final class UploadDataInitializationTestCase: BaseTestCase {
     @MainActor
     func testUploadClassMethodWithMethodURLHeadersAndData() {
         // Given
+        let session = stored(Session())
         let url = Endpoint.method(.post).url
         let headers: HTTPHeaders = ["Authorization": "123456"]
         let expectation = expectation(description: "upload should complete")
 
         // When
-        let request = AF.upload(Data(), to: url, headers: headers).response { _ in
+        let request = session.upload(Data(), to: url, headers: headers).response { _ in
             expectation.fulfill()
         }
 
@@ -130,13 +134,14 @@ final class UploadStreamInitializationTestCase: BaseTestCase {
     @MainActor
     func testUploadClassMethodWithMethodURLAndStream() {
         // Given
+        let session = stored(Session())
         let requestURL = Endpoint.method(.post).url
         let imageURL = url(forResource: "rainbow", withExtension: "jpg")
         let imageStream = InputStream(url: imageURL)!
         let expectation = expectation(description: "upload should complete")
 
         // When
-        let request = AF.upload(imageStream, to: requestURL).response { _ in
+        let request = session.upload(imageStream, to: requestURL).response { _ in
             expectation.fulfill()
         }
 
@@ -152,6 +157,7 @@ final class UploadStreamInitializationTestCase: BaseTestCase {
     @MainActor
     func testUploadClassMethodWithMethodURLHeadersAndStream() {
         // Given
+        let session = stored(Session())
         let requestURL = Endpoint.method(.post).url
         let imageURL = url(forResource: "rainbow", withExtension: "jpg")
         let headers: HTTPHeaders = ["Authorization": "123456"]
@@ -159,7 +165,7 @@ final class UploadStreamInitializationTestCase: BaseTestCase {
         let expectation = expectation(description: "upload should complete")
 
         // When
-        let request = AF.upload(imageStream, to: requestURL, headers: headers).response { _ in
+        let request = session.upload(imageStream, to: requestURL, headers: headers).response { _ in
             expectation.fulfill()
         }
 
@@ -183,6 +189,7 @@ final class UploadDataTestCase: BaseTestCase {
     @MainActor
     func testUploadDataRequest() {
         // Given
+        let session = stored(Session())
         let url = Endpoint.method(.post).url
         let data = Data("Lorem ipsum dolor sit amet".utf8)
 
@@ -190,7 +197,7 @@ final class UploadDataTestCase: BaseTestCase {
         var response: DataResponse<Data?, AFError>?
 
         // When
-        AF.upload(data, to: url)
+        session.upload(data, to: url)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -207,6 +214,7 @@ final class UploadDataTestCase: BaseTestCase {
     @MainActor
     func testUploadDataRequestWithProgress() {
         // Given
+        let session = stored(Session())
         let url = Endpoint.method(.post).url
         let string = String(repeating: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. ", count: 1000)
         let data = Data(string.utf8)
@@ -219,7 +227,7 @@ final class UploadDataTestCase: BaseTestCase {
         var response: DataResponse<Data?, AFError>?
 
         // When
-        AF.upload(data, to: url)
+        session.upload(data, to: url)
             .uploadProgress { progress in
                 uploadProgressValues.append(progress.fractionCompleted)
             }
@@ -273,6 +281,7 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
     @MainActor
     func testThatUploadingMultipartFormDataSetsContentTypeHeader() {
         // Given
+        let session = stored(Session())
         let url = Endpoint.method(.post).url
         let uploadData = Data("upload_data".utf8)
 
@@ -282,11 +291,11 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
         var response: DataResponse<Data?, AFError>?
 
         // When
-        AF.upload(multipartFormData: { multipartFormData in
-                      multipartFormData.append(uploadData, withName: "upload_data")
-                      formData = multipartFormData
-                  },
-                  to: url)
+        session.upload(multipartFormData: { multipartFormData in
+                           multipartFormData.append(uploadData, withName: "upload_data")
+                           formData = multipartFormData
+                       },
+                       to: url)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -313,6 +322,7 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
     @MainActor
     func testThatAccessingMultipartFormDataURLIsThreadSafe() {
         // Given
+        let session = stored(Session())
         let url = Endpoint.method(.post).url
         let uploadData = Data("upload_data".utf8)
 
@@ -323,11 +333,11 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
         var response: DataResponse<Data?, AFError>?
 
         // When
-        let upload = AF.upload(multipartFormData: { multipartFormData in
-                                   multipartFormData.append(uploadData, withName: "upload_data")
-                                   formData = multipartFormData
-                               },
-                               to: url)
+        let upload = session.upload(multipartFormData: { multipartFormData in
+                                        multipartFormData.append(uploadData, withName: "upload_data")
+                                        formData = multipartFormData
+                                    },
+                                    to: url)
 
         // Access will produce a thread-sanitizer issue if it isn't safe.
         generatedURL = upload.convertible.urlRequest?.url
@@ -359,6 +369,7 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
     @MainActor
     func testThatCustomBoundaryCanBeSetWhenUploadingMultipartFormData() {
         // Given
+        let session = stored(Session())
         let uploadData = Data("upload_data".utf8)
 
         let formData = MultipartFormData(fileManager: .default, boundary: "custom-test-boundary")
@@ -368,7 +379,7 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
         var response: DataResponse<Data?, AFError>?
 
         // When
-        AF.upload(multipartFormData: formData, with: Endpoint.method(.post)).response { resp in
+        session.upload(multipartFormData: formData, with: Endpoint.method(.post)).response { resp in
             response = resp
             expectation.fulfill()
         }
@@ -392,6 +403,7 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
     @MainActor
     func testThatUploadingMultipartFormDataSucceedsWithDefaultParameters() {
         // Given
+        let session = stored(Session())
         let frenchData = Data("français".utf8)
         let japaneseData = Data("日本語".utf8)
 
@@ -399,11 +411,11 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
         var response: DataResponse<Data?, AFError>?
 
         // When
-        AF.upload(multipartFormData: { multipartFormData in
-                      multipartFormData.append(frenchData, withName: "french")
-                      multipartFormData.append(japaneseData, withName: "japanese")
-                  },
-                  to: Endpoint.method(.post))
+        session.upload(multipartFormData: { multipartFormData in
+                           multipartFormData.append(frenchData, withName: "french")
+                           multipartFormData.append(japaneseData, withName: "japanese")
+                       },
+                       to: Endpoint.method(.post))
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -431,6 +443,7 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
     @MainActor
     func testThatUploadingMultipartFormDataBelowMemoryThresholdStreamsFromMemory() {
         // Given
+        let session = stored(Session())
         let frenchData = Data(String(repeating: "français", count: 10_000).utf8)
         let japaneseData = Data(String(repeating: "日本語", count: 10_000).utf8)
 
@@ -438,11 +451,11 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
         var response: DataResponse<Data?, AFError>?
 
         // When
-        let request = AF.upload(multipartFormData: { multipartFormData in
-                                    multipartFormData.append(frenchData, withName: "french")
-                                    multipartFormData.append(japaneseData, withName: "japanese")
-                                },
-                                to: Endpoint.method(.post))
+        let request = session.upload(multipartFormData: { multipartFormData in
+                                         multipartFormData.append(frenchData, withName: "french")
+                                         multipartFormData.append(japaneseData, withName: "japanese")
+                                     },
+                                     to: Endpoint.method(.post))
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -462,6 +475,7 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
     @MainActor
     func testThatUploadingMultipartFormDataBelowMemoryThresholdSetsContentTypeHeader() {
         // Given
+        let session = stored(Session())
         let uploadData = Data("upload_data".utf8)
 
         let expectation = expectation(description: "multipart form data upload should succeed")
@@ -470,11 +484,11 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
         var response: DataResponse<Data?, AFError>?
 
         // When
-        let request = AF.upload(multipartFormData: { multipartFormData in
-                                    multipartFormData.append(uploadData, withName: "upload_data")
-                                    formData = multipartFormData
-                                },
-                                to: Endpoint.method(.post))
+        let request = session.upload(multipartFormData: { multipartFormData in
+                                         multipartFormData.append(uploadData, withName: "upload_data")
+                                         formData = multipartFormData
+                                     },
+                                     to: Endpoint.method(.post))
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -501,6 +515,7 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
     @MainActor
     func testThatUploadingMultipartFormDataAboveMemoryThresholdStreamsFromDisk() {
         // Given
+        let session = stored(Session())
         let frenchData = Data("français".utf8)
         let japaneseData = Data("日本語".utf8)
 
@@ -508,12 +523,12 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
         var response: DataResponse<Data?, AFError>?
 
         // When
-        let request = AF.upload(multipartFormData: { multipartFormData in
-                                    multipartFormData.append(frenchData, withName: "french")
-                                    multipartFormData.append(japaneseData, withName: "japanese")
-                                },
-                                to: Endpoint.method(.post),
-                                usingThreshold: 0).response { resp in
+        let request = session.upload(multipartFormData: { multipartFormData in
+                                         multipartFormData.append(frenchData, withName: "french")
+                                         multipartFormData.append(japaneseData, withName: "japanese")
+                                     },
+                                     to: Endpoint.method(.post),
+                                     usingThreshold: 0).response { resp in
             response = resp
             expectation.fulfill()
         }
@@ -533,6 +548,7 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
     @MainActor
     func testThatUploadingMultipartFormDataAboveMemoryThresholdSetsContentTypeHeader() {
         // Given
+        let session = stored(Session())
         let uploadData = Data("upload_data".utf8)
 
         let expectation = expectation(description: "multipart form data upload should succeed")
@@ -540,12 +556,12 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
         var formData: MultipartFormData?
 
         // When
-        let request = AF.upload(multipartFormData: { multipartFormData in
-                                    multipartFormData.append(uploadData, withName: "upload_data")
-                                    formData = multipartFormData
-                                },
-                                to: Endpoint.method(.post),
-                                usingThreshold: 0).response { resp in
+        let request = session.upload(multipartFormData: { multipartFormData in
+                                         multipartFormData.append(uploadData, withName: "upload_data")
+                                         formData = multipartFormData
+                                     },
+                                     to: Endpoint.method(.post),
+                                     usingThreshold: 0).response { resp in
             response = resp
             expectation.fulfill()
         }
@@ -573,17 +589,18 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
     @MainActor
     func testThatUploadingMultipartFormDataWithNonexistentFileThrowsAnError() {
         // Given
+        let session = stored(Session())
         let imageURL = URL(fileURLWithPath: "does_not_exist.jpg")
 
         let expectation = expectation(description: "multipart form data upload from nonexistent file should fail")
         var response: DataResponse<Data?, AFError>?
 
         // When
-        let request = AF.upload(multipartFormData: { multipartFormData in
-                                    multipartFormData.append(imageURL, withName: "upload_file")
-                                },
-                                to: Endpoint.method(.post),
-                                usingThreshold: 0).response { resp in
+        let request = session.upload(multipartFormData: { multipartFormData in
+                                         multipartFormData.append(imageURL, withName: "upload_file")
+                                     },
+                                     to: Endpoint.method(.post),
+                                     usingThreshold: 0).response { resp in
             response = resp
             expectation.fulfill()
         }
@@ -598,6 +615,7 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
     @MainActor
     func testThatUploadingMultipartFormDataWorksWhenAppendingBodyPartsInURLRequestConvertible() {
         // Given
+        let session = stored(Session())
         struct MultipartFormDataRequest: URLRequestConvertible {
             let multipartFormData = MultipartFormData()
 
@@ -621,7 +639,7 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
         var response: DataResponse<Data?, AFError>?
 
         // When
-        let uploadRequest = AF.upload(multipartFormData: request.multipartFormData, with: request)
+        let uploadRequest = session.upload(multipartFormData: request.multipartFormData, with: request)
             .response { resp in
                 response = resp
                 expectation.fulfill()
@@ -700,6 +718,7 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
     @MainActor
     private func executeMultipartFormDataUploadRequestWithProgress(streamFromDisk: Bool) {
         // Given
+        let session = stored(Session())
         let loremData1 = Data(String(repeating: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                                      count: 1000).utf8)
         let loremData2 = Data(String(repeating: "Lorem ipsum dolor sit amet, nam no graeco recusabo appellantur.",
@@ -713,12 +732,12 @@ final class UploadMultipartFormDataTestCase: BaseTestCase {
         var response: DataResponse<Data?, AFError>?
 
         // When
-        AF.upload(multipartFormData: { multipartFormData in
-                      multipartFormData.append(loremData1, withName: "lorem1")
-                      multipartFormData.append(loremData2, withName: "lorem2")
-                  },
-                  to: Endpoint.method(.post),
-                  usingThreshold: streamFromDisk ? 0 : .max)
+        session.upload(multipartFormData: { multipartFormData in
+                           multipartFormData.append(loremData1, withName: "lorem1")
+                           multipartFormData.append(loremData2, withName: "lorem2")
+                       },
+                       to: Endpoint.method(.post),
+                       usingThreshold: streamFromDisk ? 0 : .max)
             .uploadProgress { progress in
                 uploadProgressValues.append(progress.fractionCompleted)
             }

--- a/Tests/ValidationTests.swift
+++ b/Tests/ValidationTests.swift
@@ -30,6 +30,7 @@ final class StatusCodeValidationTestCase: BaseTestCase {
     @MainActor
     func testThatValidationForRequestWithAcceptableStatusCodeResponseSucceeds() {
         // Given
+        let session = stored(Session())
         let endpoint = Endpoint.status(200)
 
         let expectation1 = expectation(description: "request should return 200 status code")
@@ -39,14 +40,14 @@ final class StatusCodeValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(endpoint)
+        session.request(endpoint)
             .validate(statusCode: 200..<300)
             .response { resp in
                 requestError = resp.error
                 expectation1.fulfill()
             }
 
-        AF.download(endpoint)
+        session.download(endpoint)
             .validate(statusCode: 200..<300)
             .response { resp in
                 downloadError = resp.error
@@ -63,6 +64,7 @@ final class StatusCodeValidationTestCase: BaseTestCase {
     @MainActor
     func testThatValidationForRequestWithUnacceptableStatusCodeResponseFails() {
         // Given
+        let session = stored(Session())
         let endpoint = Endpoint.status(404)
 
         let expectation1 = expectation(description: "request should return 404 status code")
@@ -72,14 +74,14 @@ final class StatusCodeValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(endpoint)
+        session.request(endpoint)
             .validate(statusCode: [200])
             .response { resp in
                 requestError = resp.error
                 expectation1.fulfill()
             }
 
-        AF.download(endpoint)
+        session.download(endpoint)
             .validate(statusCode: [200])
             .response { resp in
                 downloadError = resp.error
@@ -101,6 +103,7 @@ final class StatusCodeValidationTestCase: BaseTestCase {
     @MainActor
     func testThatValidationForRequestWithNoAcceptableStatusCodesFails() {
         // Given
+        let session = stored(Session())
         let endpoint = Endpoint.status(201)
 
         let expectation1 = expectation(description: "request should return 201 status code")
@@ -110,14 +113,14 @@ final class StatusCodeValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(endpoint)
+        session.request(endpoint)
             .validate(statusCode: [])
             .response { resp in
                 requestError = resp.error
                 expectation1.fulfill()
             }
 
-        AF.download(endpoint)
+        session.download(endpoint)
             .validate(statusCode: [])
             .response { resp in
                 downloadError = resp.error
@@ -143,6 +146,7 @@ final class ContentTypeValidationTestCase: BaseTestCase {
     @MainActor
     func testThatValidationForRequestWithAcceptableContentTypeResponseSucceeds() {
         // Given
+        let session = stored(Session())
         let endpoint = Endpoint.ip
 
         let expectation1 = expectation(description: "request should succeed and return ip")
@@ -152,7 +156,7 @@ final class ContentTypeValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(endpoint)
+        session.request(endpoint)
             .validate(contentType: ["application/json"])
             .validate(contentType: ["application/json; charset=utf-8"])
             .validate(contentType: ["application/json; q=0.8; charset=utf-8"])
@@ -161,7 +165,7 @@ final class ContentTypeValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        AF.download(endpoint)
+        session.download(endpoint)
             .validate(contentType: ["application/json"])
             .validate(contentType: ["application/json; charset=utf-8"])
             .validate(contentType: ["application/json; q=0.8; charset=utf-8"])
@@ -180,6 +184,7 @@ final class ContentTypeValidationTestCase: BaseTestCase {
     @MainActor
     func testThatValidationForRequestWithAcceptableWildcardContentTypeResponseSucceeds() {
         // Given
+        let session = stored(Session())
         let endpoint = Endpoint.ip
 
         let expectation1 = expectation(description: "request should succeed and return ip")
@@ -189,7 +194,7 @@ final class ContentTypeValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(endpoint)
+        session.request(endpoint)
             .validate(contentType: ["*/*"])
             .validate(contentType: ["application/*"])
             .validate(contentType: ["*/json"])
@@ -198,7 +203,7 @@ final class ContentTypeValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        AF.download(endpoint)
+        session.download(endpoint)
             .validate(contentType: ["*/*"])
             .validate(contentType: ["application/*"])
             .validate(contentType: ["*/json"])
@@ -217,6 +222,7 @@ final class ContentTypeValidationTestCase: BaseTestCase {
     @MainActor
     func testThatValidationForRequestWithUnacceptableContentTypeResponseFails() {
         // Given
+        let session = stored(Session())
         let endpoint = Endpoint.xml
 
         let expectation1 = expectation(description: "request should succeed and return xml")
@@ -226,14 +232,14 @@ final class ContentTypeValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(endpoint)
+        session.request(endpoint)
             .validate(contentType: ["application/octet-stream"])
             .response { resp in
                 requestError = resp.error
                 expectation1.fulfill()
             }
 
-        AF.download(endpoint)
+        session.download(endpoint)
             .validate(contentType: ["application/octet-stream"])
             .response { resp in
                 downloadError = resp.error
@@ -256,6 +262,7 @@ final class ContentTypeValidationTestCase: BaseTestCase {
     @MainActor
     func testThatContentTypeValidationFailureSortsPossibleContentTypes() {
         // Given
+        let session = stored(Session())
         let endpoint = Endpoint.xml
 
         let requestDidCompleteExpectation = expectation(description: "request should succeed and return xml")
@@ -282,14 +289,14 @@ final class ContentTypeValidationTestCase: BaseTestCase {
         ]
 
         // When
-        AF.request(endpoint)
+        session.request(endpoint)
             .validate(contentType: acceptableContentTypes)
             .response { resp in
                 requestError = resp.error
                 requestDidCompleteExpectation.fulfill()
             }
 
-        AF.download(endpoint)
+        session.download(endpoint)
             .validate(contentType: acceptableContentTypes)
             .response { resp in
                 downloadError = resp.error
@@ -329,6 +336,7 @@ final class ContentTypeValidationTestCase: BaseTestCase {
     @MainActor
     func testThatValidationForRequestWithNoAcceptableContentTypeResponseFails() {
         // Given
+        let session = stored(Session())
         let endpoint = Endpoint.xml
 
         let expectation1 = expectation(description: "request should succeed and return xml")
@@ -338,14 +346,14 @@ final class ContentTypeValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(endpoint)
+        session.request(endpoint)
             .validate(contentType: [])
             .response { resp in
                 requestError = resp.error
                 expectation1.fulfill()
             }
 
-        AF.download(endpoint)
+        session.download(endpoint)
             .validate(contentType: [])
             .response { resp in
                 downloadError = resp.error
@@ -368,6 +376,7 @@ final class ContentTypeValidationTestCase: BaseTestCase {
     @MainActor
     func testThatValidationForRequestWithNoAcceptableContentTypeResponseSucceedsWhenNoDataIsReturned() {
         // Given
+        let session = stored(Session())
         let endpoint = Endpoint.status(204)
 
         let expectation1 = expectation(description: "request should succeed and return no data")
@@ -377,14 +386,14 @@ final class ContentTypeValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(endpoint)
+        session.request(endpoint)
             .validate(contentType: [])
             .response { resp in
                 requestError = resp.error
                 expectation1.fulfill()
             }
 
-        AF.download(endpoint)
+        session.download(endpoint)
             .validate(contentType: [])
             .response { resp in
                 downloadError = resp.error
@@ -405,6 +414,7 @@ final class MultipleValidationTestCase: BaseTestCase {
     @MainActor
     func testThatValidationForRequestWithAcceptableStatusCodeAndContentTypeResponseSucceeds() {
         // Given
+        let session = stored(Session())
         let endpoint = Endpoint.ip
 
         let expectation1 = expectation(description: "request should succeed and return ip")
@@ -414,7 +424,7 @@ final class MultipleValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(endpoint)
+        session.request(endpoint)
             .validate(statusCode: 200..<300)
             .validate(contentType: ["application/json"])
             .response { resp in
@@ -422,7 +432,7 @@ final class MultipleValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        AF.download(endpoint)
+        session.download(endpoint)
             .validate(statusCode: 200..<300)
             .validate(contentType: ["application/json"])
             .response { resp in
@@ -440,6 +450,7 @@ final class MultipleValidationTestCase: BaseTestCase {
     @MainActor
     func testThatValidationForRequestWithUnacceptableStatusCodeAndContentTypeResponseFailsWithStatusCodeError() {
         // Given
+        let session = stored(Session())
         let endpoint = Endpoint.xml
 
         let expectation1 = expectation(description: "request should succeed and return xml")
@@ -449,7 +460,7 @@ final class MultipleValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(endpoint)
+        session.request(endpoint)
             .validate(statusCode: 400..<600)
             .validate(contentType: ["application/octet-stream"])
             .response { resp in
@@ -457,7 +468,7 @@ final class MultipleValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        AF.download(endpoint)
+        session.download(endpoint)
             .validate(statusCode: 400..<600)
             .validate(contentType: ["application/octet-stream"])
             .response { resp in
@@ -480,6 +491,7 @@ final class MultipleValidationTestCase: BaseTestCase {
     @MainActor
     func testThatValidationForRequestWithUnacceptableStatusCodeAndContentTypeResponseFailsWithContentTypeError() {
         // Given
+        let session = stored(Session())
         let endpoint = Endpoint.xml
 
         let expectation1 = expectation(description: "request should succeed and return xml")
@@ -489,7 +501,7 @@ final class MultipleValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(endpoint)
+        session.request(endpoint)
             .validate(contentType: ["application/octet-stream"])
             .validate(statusCode: 400..<600)
             .response { resp in
@@ -497,7 +509,7 @@ final class MultipleValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        AF.download(endpoint)
+        session.download(endpoint)
             .validate(contentType: ["application/octet-stream"])
             .validate(statusCode: 400..<600)
             .response { resp in
@@ -525,6 +537,7 @@ final class AutomaticValidationTestCase: BaseTestCase {
     @MainActor
     func testThatValidationForRequestWithAcceptableStatusCodeAndContentTypeResponseSucceeds() {
         // Given
+        let session = stored(Session())
         let urlRequest = Endpoint.ip.modifying(\.headers, to: [.accept("application/json")])
 
         let expectation1 = expectation(description: "request should succeed and return ip")
@@ -534,12 +547,12 @@ final class AutomaticValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(urlRequest).validate().response { resp in
+        session.request(urlRequest).validate().response { resp in
             requestError = resp.error
             expectation1.fulfill()
         }
 
-        AF.download(urlRequest).validate().response { resp in
+        session.download(urlRequest).validate().response { resp in
             downloadError = resp.error
             expectation2.fulfill()
         }
@@ -554,6 +567,7 @@ final class AutomaticValidationTestCase: BaseTestCase {
     @MainActor
     func testThatValidationForRequestWithUnacceptableStatusCodeResponseFails() {
         // Given
+        let session = stored(Session())
         let request = Endpoint.status(404)
 
         let expectation1 = expectation(description: "request should return 404 status code")
@@ -563,14 +577,14 @@ final class AutomaticValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(request)
+        session.request(request)
             .validate()
             .response { resp in
                 requestError = resp.error
                 expectation1.fulfill()
             }
 
-        AF.download(request)
+        session.download(request)
             .validate()
             .response { resp in
                 downloadError = resp.error
@@ -592,6 +606,7 @@ final class AutomaticValidationTestCase: BaseTestCase {
     @MainActor
     func testThatValidationForRequestWithAcceptableWildcardContentTypeResponseSucceeds() {
         // Given
+        let session = stored(Session())
         let urlRequest = Endpoint.ip.modifying(\.headers, to: [.accept("application/*")])
 
         let expectation1 = expectation(description: "request should succeed and return ip")
@@ -601,12 +616,12 @@ final class AutomaticValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(urlRequest).validate().response { resp in
+        session.request(urlRequest).validate().response { resp in
             requestError = resp.error
             expectation1.fulfill()
         }
 
-        AF.download(urlRequest).validate().response { resp in
+        session.download(urlRequest).validate().response { resp in
             downloadError = resp.error
             expectation2.fulfill()
         }
@@ -621,6 +636,7 @@ final class AutomaticValidationTestCase: BaseTestCase {
     @MainActor
     func testThatValidationForRequestWithAcceptableComplexContentTypeResponseSucceeds() {
         // Given
+        let session = stored(Session())
         var urlRequest = Endpoint.xml.urlRequest
 
         let headerValue = "text/xml, application/xml, application/xhtml+xml, text/html;q=0.9, text/plain;q=0.8,*/*;q=0.5"
@@ -633,12 +649,12 @@ final class AutomaticValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(urlRequest).validate().response { resp in
+        session.request(urlRequest).validate().response { resp in
             requestError = resp.error
             expectation1.fulfill()
         }
 
-        AF.download(urlRequest).validate().response { resp in
+        session.download(urlRequest).validate().response { resp in
             downloadError = resp.error
             expectation2.fulfill()
         }
@@ -653,6 +669,7 @@ final class AutomaticValidationTestCase: BaseTestCase {
     @MainActor
     func testThatValidationForRequestWithUnacceptableContentTypeResponseFails() {
         // Given
+        let session = stored(Session())
         let urlRequest = Endpoint.xml.modifying(\.headers, to: [.accept("application/json")])
 
         let expectation1 = expectation(description: "request should succeed and return xml")
@@ -662,12 +679,12 @@ final class AutomaticValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(urlRequest).validate().response { resp in
+        session.request(urlRequest).validate().response { resp in
             requestError = resp.error
             expectation1.fulfill()
         }
 
-        AF.download(urlRequest).validate().response { resp in
+        session.download(urlRequest).validate().response { resp in
             downloadError = resp.error
             expectation2.fulfill()
         }
@@ -730,6 +747,7 @@ final class CustomValidationTestCase: BaseTestCase {
     @MainActor
     func testThatCustomValidationClosureHasAccessToServerResponseData() {
         // Given
+        let session = stored(Session())
         let endpoint = Endpoint()
 
         let expectation1 = expectation(description: "request should return 200 status code")
@@ -739,7 +757,7 @@ final class CustomValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(endpoint)
+        session.request(endpoint)
             .validate { _, _, data in
                 guard data != nil else { return .failure(ValidationError.missingData) }
                 return .success(())
@@ -749,7 +767,7 @@ final class CustomValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        AF.download(endpoint)
+        session.download(endpoint)
             .validate { _, _, fileURL in
                 guard let fileURL else { return .failure(ValidationError.missingFile) }
 
@@ -775,6 +793,7 @@ final class CustomValidationTestCase: BaseTestCase {
     @MainActor
     func testThatCustomValidationCanThrowCustomError() {
         // Given
+        let session = stored(Session())
         let endpoint = Endpoint()
 
         let expectation1 = expectation(description: "request should return 200 status code")
@@ -784,7 +803,7 @@ final class CustomValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(endpoint)
+        session.request(endpoint)
             .validate { _, _, _ in .failure(ValidationError.missingData) }
             .validate { _, _, _ in .failure(ValidationError.missingFile) } // should be ignored
             .response { resp in
@@ -792,7 +811,7 @@ final class CustomValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        AF.download(endpoint)
+        session.download(endpoint)
             .validate { _, _, _ in .failure(ValidationError.missingFile) }
             .validate { _, _, _ in .failure(ValidationError.fileReadFailed) } // should be ignored
             .response { resp in
@@ -810,6 +829,7 @@ final class CustomValidationTestCase: BaseTestCase {
     @MainActor
     func testThatValidationExtensionHasAccessToServerResponseData() {
         // Given
+        let session = stored(Session())
         let endpoint = Endpoint()
 
         let expectation1 = expectation(description: "request should return 200 status code")
@@ -819,14 +839,14 @@ final class CustomValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(endpoint)
+        session.request(endpoint)
             .validateDataExists()
             .response { resp in
                 requestError = resp.error
                 expectation1.fulfill()
             }
 
-        AF.download(endpoint)
+        session.download(endpoint)
             .validateDataExists()
             .response { resp in
                 downloadError = resp.error
@@ -843,6 +863,7 @@ final class CustomValidationTestCase: BaseTestCase {
     @MainActor
     func testThatValidationExtensionCanThrowCustomError() {
         // Given
+        let session = stored(Session())
         let endpoint = Endpoint()
 
         let expectation1 = expectation(description: "request should return 200 status code")
@@ -852,7 +873,7 @@ final class CustomValidationTestCase: BaseTestCase {
         var downloadError: AFError?
 
         // When
-        AF.request(endpoint)
+        session.request(endpoint)
             .validate(with: ValidationError.missingData)
             .validate(with: ValidationError.missingFile) // should be ignored
             .response { resp in
@@ -860,7 +881,7 @@ final class CustomValidationTestCase: BaseTestCase {
                 expectation1.fulfill()
             }
 
-        AF.download(endpoint)
+        session.download(endpoint)
             .validate(with: ValidationError.missingFile)
             .validate(with: ValidationError.fileReadFailed) // should be ignored
             .response { resp in

--- a/Tests/WebSocketTests.swift
+++ b/Tests/WebSocketTests.swift
@@ -676,7 +676,7 @@ final class WebSocketIntegrationTests: BaseTestCase {
             }
 
         wait(for: [didConnect, didReceiveMessage, didDisconnect, didComplete],
-             timeout: 100,
+             timeout: timeout,
              enforceOrder: true)
 
         // Then


### PR DESCRIPTION
### Goals :soccer:
Alamofire has long had many tests which pass 100% of the time locally, but occasionally fail in CI. This PR fixes those tests, and the underlying issues uncovered, through a combination of manual and tool-assisted analysis over many, many CI runs.

### Implementation Details :construction:
Some of these fixes are actually adoptions of existing testing patterns but most address timing issues in Alamofire itself.

- `AuthenticationInterceptor` has been refactored to track more state and ensure requests are only retried once.
    - 🔥 There is a bit of a behavior change here. `AuthenticationInterceptor` will allow more requests to fail and wait for retry rather than holding them at the request adaptation step. This ensures they fully rerun their request pipeline to pick up the latest adaptations. Unfortunately, it wasn't possible to do this when held for adaptation.
- `Request.suspend()` and `Request.cancel()` could be ineffective if called at narrow points within the `Request` lifecycle. These updates are now more atomic.
- `Request.cancel()` (and overrides) could call `Request.finish()` when the request was already completed, leading to duplicate lifecycle events.
- `Request.resume()` could create extra `URLSessionTask`s if called at narrow points in the lifecycle.
- Similarly, rapid `Request.resume()` to `Request.suspend()` and back calls could lead a request performing multiple times.
- `Request` could create multiple tasks during narrow points in its lifetime.
- `Session.deinit` is now thread-safe. Unfortunately this required yet another lock, but should ensure it operates safely from any thread.
- `Session.deinit` was internally racy, which could lead to duplicate `Request.finish()` calls. It now allows the `Session` to shut down while it finishes the requests separately in the `SessionDelegate`.
- `Request` task updates were moved to the `Request` itself, to ensure they're always atomic relative to external state updates like `cancel()` or `resume()`.
- `Request.onHTTPResponse`'s `.cancel` disposition didn't call the full `Request.cancel()`, which could lead to different behavior, like `EventMonitor` callbacks.
- Most `unowned self` usage has been removed.
- `DataStreamRequest`'s `outputStream` could have `write` called after `close()`, this is now properly checked.
- `MIMEType` checking would improperly match invalid types like `text` to `text/plain`, this has been addressed and this parsing and matching are now specifically tested.
- `DownloadRequest` now properly checks `!isCancelled` before attempting retry.
- `DataTask` and `DownloadTask` didn't properly handle `cancel()` before creating their task. `Task.isCancelled` is now checked immediately after creation to ensure cancellation.

Many test implementations have been updated:
- All tests now use a unique `stored(Session())`, where possible. This ensures they never share state.
- More data is used for upload and download requests tracking progress, but it may not be enough. Tests are so fast, and progress reporting isn't guaranteed, so the test may never be 100% reliable.
- Separate stream setup from `async let`. Since `async let` can make sync work async, which means the stream setup races with the request itself.
- Fixed the `URLProtocol` tests with correct event ordering.
- Various tests were changed structurally to eliminate races. 

### Testing Details :mag:

Many tests updated and added.
