### PR TITLE
Align async serializingDecodable sendable constraints

### DIFF
--- a/Source/Features/Concurrency.swift
+++ b/Source/Features/Concurrency.swift
@@ -255,7 +255,7 @@ extension DataRequest {
     /// Creates a `DataTask` to `await` serialization of a `Decodable` value.
     ///
     /// - Parameters:
-    ///   - type:                      `Decodable` type to decode from response data.
+    ///   - type:                      `Decodable & Sendable` type to decode from response data.
     ///   - shouldAutomaticallyCancel: `Bool` determining whether or not the request should be cancelled when the
     ///                                enclosing async context is cancelled. Only applies to `DataTask`'s async
     ///                                properties. `true` by default.
@@ -266,12 +266,12 @@ extension DataRequest {
     ///   - emptyRequestMethods:       `HTTPMethod`s for which empty responses are always valid. `[.head]` by default.
     ///
     /// - Returns: The `DataTask`.
-    public func serializingDecodable<Value: Decodable>(_ type: Value.Type = Value.self,
-                                                       automaticallyCancelling shouldAutomaticallyCancel: Bool = true,
-                                                       dataPreprocessor: any DataPreprocessor = DecodableResponseSerializer<Value>.defaultDataPreprocessor,
-                                                       decoder: any DataDecoder = JSONDecoder(),
-                                                       emptyResponseCodes: Set<Int> = DecodableResponseSerializer<Value>.defaultEmptyResponseCodes,
-                                                       emptyRequestMethods: Set<HTTPMethod> = DecodableResponseSerializer<Value>.defaultEmptyRequestMethods) -> DataTask<Value> {
+    public func serializingDecodable<Value: Decodable & Sendable>(_ type: Value.Type = Value.self,
+                                                                  automaticallyCancelling shouldAutomaticallyCancel: Bool = true,
+                                                                  dataPreprocessor: any DataPreprocessor = DecodableResponseSerializer<Value>.defaultDataPreprocessor,
+                                                                  decoder: any DataDecoder = JSONDecoder(),
+                                                                  emptyResponseCodes: Set<Int> = DecodableResponseSerializer<Value>.defaultEmptyResponseCodes,
+                                                                  emptyRequestMethods: Set<HTTPMethod> = DecodableResponseSerializer<Value>.defaultEmptyRequestMethods) -> DataTask<Value> {
         serializingResponse(using: DecodableResponseSerializer<Value>(dataPreprocessor: dataPreprocessor,
                                                                       decoder: decoder,
                                                                       emptyResponseCodes: emptyResponseCodes,
@@ -450,7 +450,7 @@ extension DownloadRequest {
     /// - Note: This serializer reads the entire response into memory before parsing.
     ///
     /// - Parameters:
-    ///   - type:                      `Decodable` type to decode from response data.
+    ///   - type:                      `Decodable & Sendable` type to decode from response data.
     ///   - shouldAutomaticallyCancel: `Bool` determining whether or not the request should be cancelled when the
     ///                                enclosing async context is cancelled. Only applies to `DownloadTask`'s async
     ///                                properties. `true` by default.
@@ -461,12 +461,12 @@ extension DownloadRequest {
     ///   - emptyRequestMethods:       `HTTPMethod`s for which empty responses are always valid. `[.head]` by default.
     ///
     /// - Returns:                   The `DownloadTask`.
-    public func serializingDecodable<Value: Decodable>(_ type: Value.Type = Value.self,
-                                                       automaticallyCancelling shouldAutomaticallyCancel: Bool = true,
-                                                       dataPreprocessor: any DataPreprocessor = DecodableResponseSerializer<Value>.defaultDataPreprocessor,
-                                                       decoder: any DataDecoder = JSONDecoder(),
-                                                       emptyResponseCodes: Set<Int> = DecodableResponseSerializer<Value>.defaultEmptyResponseCodes,
-                                                       emptyRequestMethods: Set<HTTPMethod> = DecodableResponseSerializer<Value>.defaultEmptyRequestMethods) -> DownloadTask<Value> {
+    public func serializingDecodable<Value: Decodable & Sendable>(_ type: Value.Type = Value.self,
+                                                                  automaticallyCancelling shouldAutomaticallyCancel: Bool = true,
+                                                                  dataPreprocessor: any DataPreprocessor = DecodableResponseSerializer<Value>.defaultDataPreprocessor,
+                                                                  decoder: any DataDecoder = JSONDecoder(),
+                                                                  emptyResponseCodes: Set<Int> = DecodableResponseSerializer<Value>.defaultEmptyResponseCodes,
+                                                                  emptyRequestMethods: Set<HTTPMethod> = DecodableResponseSerializer<Value>.defaultEmptyRequestMethods) -> DownloadTask<Value> {
         serializingDownload(using: DecodableResponseSerializer<Value>(dataPreprocessor: dataPreprocessor,
                                                                       decoder: decoder,
                                                                       emptyResponseCodes: emptyResponseCodes,


### PR DESCRIPTION
## Issue Link
Closes #4031

## Summary
This change makes the async `serializingDecodable` APIs explicitly require `Decodable & Sendable` for both `DataRequest` and `DownloadRequest`.

## Motivation
The async decodable path already relies on `DecodableResponseSerializer`, which requires `Sendable`. Declaring the same requirement on these public async APIs makes the type contract explicit and consistent, especially for Swift 6 concurrency checks.

## Changes
- Updated `DataRequest.serializingDecodable` generic constraint to `Value: Decodable & Sendable`.
- Updated `DownloadRequest.serializingDecodable` generic constraint to `Value: Decodable & Sendable`.
- Updated method parameter docs to reflect the same constraint.

## Impact
- No runtime behavior changes.
- No request/response pipeline changes.
- This is an API-surface alignment so compile-time constraints match serializer requirements already in effect.

## Validation
- Confirmed changes are scoped to `Source/Features/Concurrency.swift`.
- Verified no unrelated modifications are included in this branch.