### PR TITLE
Add flattened async streams and convenience APIs for DataStreamTask

### DIFF
--- a/Source/Features/Concurrency.swift
+++ b/Source/Features/Concurrency.swift
@@ -600,6 +600,55 @@ public struct DataStreamTask: Sendable {
         }
     }
 
+    /// Creates a flattened `AsyncThrowingStream` of `Data` values from the underlying `DataStreamRequest`.
+    ///
+    /// - Parameters:
+    ///   - shouldAutomaticallyCancel: `Bool` indicating whether the underlying `DataStreamRequest` should be canceled
+    ///                                when observation of the stream stops. `true` by default.
+    ///   - bufferingPolicy:           `BufferingPolicy` that determines the stream's buffering behavior.
+    ///                                `.unbounded` by default.
+    ///
+    /// - Returns: The `AsyncThrowingStream`.
+    public func streamingDataValues(
+        automaticallyCancelling shouldAutomaticallyCancel: Bool = true,
+        bufferingPolicy: AsyncThrowingStream<Data, any Error>.Continuation.BufferingPolicy = .unbounded
+    ) -> AsyncThrowingStream<Data, any Error> {
+        createThrowingStream(automaticallyCancelling: shouldAutomaticallyCancel, bufferingPolicy: bufferingPolicy) { onStream in
+            request.responseStream(on: .streamCompletionQueue(forRequestID: request.id), stream: onStream)
+        } transform: { stream in
+            switch stream.event {
+            case let .stream(.success(data)):
+                return data
+            case .stream(.failure):
+                return nil
+            case .complete:
+                return nil
+            }
+        }
+    }
+
+    /// Creates a flattened `AsyncThrowingStream` of `(Data, HTTPURLResponse)` tuples from the underlying
+    /// `DataStreamRequest`.
+    ///
+    /// - Parameters:
+    ///   - shouldAutomaticallyCancel: `Bool` indicating whether the underlying `DataStreamRequest` should be canceled
+    ///                                when observation of the stream stops. `true` by default.
+    ///   - bufferingPolicy:           `BufferingPolicy` that determines the stream's buffering behavior.
+    ///                                `.unbounded` by default.
+    ///
+    /// - Returns: The `AsyncThrowingStream`.
+    public func streamingDataValuesWithResponses(
+        automaticallyCancelling shouldAutomaticallyCancel: Bool = true,
+        bufferingPolicy: AsyncThrowingStream<(Data, HTTPURLResponse), any Error>.Continuation.BufferingPolicy = .unbounded
+    ) -> AsyncThrowingStream<(Data, HTTPURLResponse), any Error> {
+        createThrowingStream(automaticallyCancelling: shouldAutomaticallyCancel, bufferingPolicy: bufferingPolicy) { onStream in
+            request.responseStream(on: .streamCompletionQueue(forRequestID: request.id), stream: onStream)
+        } transform: { [request] stream in
+            guard case let .stream(.success(data)) = stream.event, let response = request.response else { return nil }
+            return (data, response)
+        }
+    }
+
     /// Creates a `Stream` of `UTF-8` `String`s from the underlying `DataStreamRequest`.
     ///
     /// - Parameters:
@@ -665,6 +714,34 @@ public struct DataStreamTask: Sendable {
                 continuation.yield(stream)
                 if case .complete = stream.event {
                     continuation.finish()
+                }
+            }
+        }
+    }
+
+    private func createThrowingStream<Success>(
+        automaticallyCancelling shouldAutomaticallyCancel: Bool = true,
+        bufferingPolicy: AsyncThrowingStream<Success, any Error>.Continuation.BufferingPolicy = .unbounded,
+        forResponse onResponse: @Sendable @escaping (@escaping @Sendable (DataStreamRequest.Stream<Data, AFError>) -> Void) -> Void,
+        transform: @Sendable @escaping (DataStreamRequest.Stream<Data, AFError>) -> Success?
+    ) -> AsyncThrowingStream<Success, any Error> {
+        AsyncThrowingStream(bufferingPolicy: bufferingPolicy) { continuation in
+            if shouldAutomaticallyCancel, request.isInitialized || request.isResumed || request.isSuspended {
+                continuation.onTermination = { _ in
+                    cancel()
+                }
+            }
+
+            onResponse { stream in
+                if let value = transform(stream) {
+                    continuation.yield(value)
+                }
+
+                switch stream.event {
+                case .stream:
+                    break
+                case let .complete(completion):
+                    continuation.finish(throwing: completion.error)
                 }
             }
         }

--- a/Tests/ConcurrencyTests.swift
+++ b/Tests/ConcurrencyTests.swift
@@ -476,6 +476,38 @@ final class DataStreamConcurrencyTests: BaseTestCase {
         XCTAssertEqual(datas.count, 2)
     }
 
+    func testThatDataStreamTaskCanStreamDataValues() async throws {
+        // Given
+        let session = stored(Session())
+        let task = session.streamRequest(.payloads(2)).streamTask()
+        var datas: [Data] = []
+
+        // When
+        for try await data in task.streamingDataValues() {
+            datas.append(data)
+        }
+
+        // Then
+        XCTAssertEqual(datas.count, 2)
+    }
+
+    func testThatDataStreamTaskCanStreamDataValuesWithResponses() async throws {
+        // Given
+        let session = stored(Session())
+        let task = session.streamRequest(.payloads(2)).streamTask()
+        var payloads: [(Data, HTTPURLResponse)] = []
+
+        // When
+        for try await payload in task.streamingDataValuesWithResponses() {
+            payloads.append(payload)
+        }
+
+        // Then
+        XCTAssertEqual(payloads.count, 2)
+        XCTAssertTrue(payloads.allSatisfy { !$0.0.isEmpty })
+        XCTAssertTrue(payloads.allSatisfy { $0.1.statusCode == 200 })
+    }
+
     #if canImport(Darwin)
     func testThatDataStreamHasAsyncOnHTTPResponse() async {
         // Given


### PR DESCRIPTION
## Issue Link
Closes #3998

## Summary
This PR adds flattened async sequence conveniences on `DataStreamTask` to improve streaming ergonomics and reduce manual event/result unwrapping.

## What changed
Added two new APIs:

- `streamingDataValues(...) -> AsyncThrowingStream<Data, any Error>`
- `streamingDataValuesWithResponses(...) -> AsyncThrowingStream<(Data, HTTPURLResponse), any Error>`

Both APIs:
- flatten stream output for `for try await` usage,
- propagate stream failures by throwing,
- support automatic cancellation and configurable buffering policies.

## Why
Current `streamTask` iteration requires handling nested `Event` / `Result` values in each loop. These new APIs provide a data-centric path that is easier to adopt for common streaming scenarios while keeping existing streaming APIs unchanged.

## Tests
Added coverage in `ConcurrencyTests` for both new APIs:

- `testThatDataStreamTaskCanStreamDataValues`
- `testThatDataStreamTaskCanStreamDataValuesWithResponses`

These verify successful streaming behavior and response/status access in the tuple variant.