### PR TITLE
Fix cURL description credential and cookie handling

### DIFF
--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -1174,11 +1174,11 @@ extension Request {
                     guard let user = credential.user, let password = credential.password else { continue }
                     components.append("-u \(user):\(password)")
                 }
-            } else {
-                if let credential, let user = credential.user, let password = credential.password {
-                    components.append("-u \(user):\(password)")
-                }
+            } else if let credential, let user = credential.user, let password = credential.password {
+                components.append("-u \(user):\(password)")
             }
+        } else if let credential, let user = credential.user, let password = credential.password {
+            components.append("-u \(user):\(password)")
         }
 
         if let configuration = delegate?.sessionConfiguration, configuration.httpShouldSetCookies {
@@ -1193,13 +1193,15 @@ extension Request {
 
         var headers = HTTPHeaders()
 
+        let shouldFilterCookieHeader = delegate?.sessionConfiguration.httpShouldSetCookies ?? true
+
         if let sessionHeaders = delegate?.sessionConfiguration.headers {
-            for header in sessionHeaders where header.name != "Cookie" {
+            for header in sessionHeaders where !shouldFilterCookieHeader || header.name != "Cookie" {
                 headers[header.name] = header.value
             }
         }
 
-        for header in request.headers where header.name != "Cookie" {
+        for header in request.headers where !shouldFilterCookieHeader || header.name != "Cookie" {
             headers[header.name] = header.value
         }
 

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -1291,6 +1291,52 @@ final class RequestCURLDescriptionTestCase: BaseTestCase {
     }
 
     @MainActor
+    func testPOSTRequestWithCookiesDisabledHasCookieHeaderInCURLDescription() {
+        // Given
+        let url = Endpoint.method(.post).url
+        let cookieHeaders = HTTPCookie.requestHeaderFields(with: [
+            HTTPCookie(properties: [.domain: url.host as Any,
+                                    .path: url.path,
+                                    .name: "foo",
+                                    .value: "bar"])!,
+        ])
+        let expectation = expectation(description: "request should complete")
+        var cURLDescription: String?
+
+        // When
+        sessionDisallowingCookies.request(url, method: .post, headers: HTTPHeaders(cookieHeaders)).cURLDescription {
+            cURLDescription = $0
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertNotNil(cURLDescription?.range(of: "-H \"Cookie: foo=bar\""))
+    }
+
+    @MainActor
+    func testRequestWithCredentialInCURLDescription() {
+        // Given
+        let url = Endpoint().url
+        let expectation = expectation(description: "request should complete")
+        var components: [String]?
+
+        // When
+        session.request(url).authenticate(username: "user", password: "password").cURLDescription {
+            components = self.cURLCommandComponents(from: $0)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        // Then
+        XCTAssertEqual(components?[0..<3], ["$", "curl", "-v"])
+        XCTAssertTrue(components?.contains("-u") == true)
+        XCTAssertNotNil(components?.first(where: { $0.contains("user:password") }))
+    }
+
+    @MainActor
     func testMultipartFormDataRequestWithDuplicateHeadersCURLDescriptionHasOneContentTypeHeader() {
         // Given
         let url = Endpoint.method(.post).url


### PR DESCRIPTION
## Summary

Fixes two bugs in `cURLDescription()` where credential and cookie information was silently omitted from the cURL output under certain session configurations.

Fixes #2435, References #2252

## Changes

### 1. Per-request credential now shown without `URLCredentialStorage`

Previously, `self.credential` (set via `.authenticate(username:password:)` or `.authenticate(with:)`) was only included in the cURL output when the session had a `URLCredentialStorage` configured. The credential fallback was nested inside the `if let credentialStorage` block, so sessions without credential storage would silently omit the `-u` flag.

**Fix:** Moved the per-request credential fallback outside the `credentialStorage` check so it's always included when present.

### 2. `Cookie` header now shown when `httpShouldSetCookies` is `false`

When `httpShouldSetCookies = false` and cookies are manually set via request headers (e.g., using `HTTPCookie.requestHeaderFields(with:)`), the `Cookie` header was filtered out from the cURL output. This meant cookies appeared neither as `-b` (gated by `httpShouldSetCookies`) nor as `-H "Cookie: ..."` (explicitly filtered).

**Fix:** The `Cookie` header is now included in the `-H` output when `httpShouldSetCookies` is `false`, reflecting what is actually sent over the wire.

### Files changed
- `Source/Core/Request.swift`: Fixed credential and cookie logic in `cURLDescription()`
- `Tests/RequestTests.swift`: Added two new tests

## Test Plan

- [x] Added `testRequestWithCredentialInCURLDescription` — verifies `-u user:password` appears for per-request credentials
- [x] Added `testPOSTRequestWithCookiesDisabledHasCookieHeaderInCURLDescription` — verifies `-H "Cookie: foo=bar"` appears when cookies are manually set with `httpShouldSetCookies=false`
- [x] All 14 existing `RequestCURLDescriptionTestCase` tests pass
- [x] Build succeeds with no new warnings