### PR TITLE
fix: the httpheaders update and append methods in so... in...

### DIFF
--- a/Source/Core/HTTPHeaders.swift
+++ b/Source/Core/HTTPHeaders.swift
@@ -198,8 +198,8 @@ public struct HTTPHeader: Equatable, Hashable, Sendable {
     ///   - name:  The name of the header.
     ///   - value: The value of the header.
     public init(name: String, value: String) {
-        self.name = name
-        self.value = value
+        self.name = name.filter { $0 != "\r" && $0 != "\n" }
+        self.value = value.filter { $0 != "\r" && $0 != "\n" }
     }
 }
 


### PR DESCRIPTION
## Summary
Fix high severity security issue in `Source/Core/HTTPHeaders.swift`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `Source/Core/HTTPHeaders.swift:46` |

**Description**: The HTTPHeaders update and append methods in Source/Core/HTTPHeaders.swift accept arbitrary string values for header names and values without stripping or rejecting CRLF sequences (\r\n). If application code passes user-controlled input directly into these methods, an attacker can inject additional HTTP headers by embedding newline characters in the header value, a technique known as HTTP header injection or HTTP response splitting.

## Changes
- `Source/Core/HTTPHeaders.swift`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
