### PR TITLE
Fix for DataPreprocessor doesn't have it's own failure reason #3073

### DIFF
--- a/Source/Core/AFError.swift
+++ b/Source/Core/AFError.swift
@@ -131,6 +131,8 @@ public enum AFError: Error, Sendable {
         case customSerializationFailed(error: any Error)
         /// Generic serialization failed for an empty response that wasn't type `Empty` but instead the associated type.
         case invalidEmptyResponse(type: String)
+        /// A `DataPreprocessor` failed to preprocess the response data due to the associated `Error`.
+        case dataPreprocessingFailed(error: any Error)
     }
 
     #if canImport(Security)
@@ -593,6 +595,7 @@ extension AFError.ResponseSerializationFailureReason {
              .jsonSerializationFailed(_),
              .decodingFailed(_),
              .customSerializationFailed(_),
+             .dataPreprocessingFailed(_),
              .invalidEmptyResponse:
             nil
         }
@@ -602,7 +605,8 @@ extension AFError.ResponseSerializationFailureReason {
         switch self {
         case let .jsonSerializationFailed(error),
              let .decodingFailed(error),
-             let .customSerializationFailed(error):
+             let .customSerializationFailed(error),
+             let .dataPreprocessingFailed(error):
             error
         case .inputDataNilOrZeroLength,
              .inputFileNil,
@@ -797,6 +801,8 @@ extension AFError.ResponseSerializationFailureReason {
             "Response could not be decoded because of error:\n\(error.localizedDescription)"
         case let .customSerializationFailed(error):
             "Custom response serializer failed with error:\n\(error.localizedDescription)"
+        case let .dataPreprocessingFailed(error):
+            "Data preprocessing failed with error:\n\(error.localizedDescription)"
         }
     }
 }

--- a/Source/Core/DataStreamRequest.swift
+++ b/Source/Core/DataStreamRequest.swift
@@ -545,7 +545,12 @@ public struct DecodableStreamSerializer<T: Decodable>: DataStreamSerializer wher
     }
 
     public func serialize(_ data: Data) throws -> T {
-        let processedData = try dataPreprocessor.preprocess(data)
+        let processedData: Data
+        do {
+            processedData = try dataPreprocessor.preprocess(data)
+        } catch {
+            throw AFError.responseSerializationFailed(reason: .dataPreprocessingFailed(error: error))
+        }
         do {
             return try decoder.decode(T.self, from: processedData)
         } catch {

--- a/Source/Features/ResponseSerialization.swift
+++ b/Source/Features/ResponseSerialization.swift
@@ -237,7 +237,11 @@ public final class DataResponseSerializer: ResponseSerializer {
             return Data()
         }
 
-        data = try dataPreprocessor.preprocess(data)
+        do {
+            data = try dataPreprocessor.preprocess(data)
+        } catch {
+            throw AFError.responseSerializationFailed(reason: .dataPreprocessingFailed(error: error))
+        }
 
         return data
     }
@@ -305,7 +309,11 @@ public final class StringResponseSerializer: ResponseSerializer {
             return ""
         }
 
-        data = try dataPreprocessor.preprocess(data)
+        do {
+            data = try dataPreprocessor.preprocess(data)
+        } catch {
+            throw AFError.responseSerializationFailed(reason: .dataPreprocessingFailed(error: error))
+        }
 
         var convertedEncoding = encoding
 
@@ -392,7 +400,11 @@ public final class JSONResponseSerializer: ResponseSerializer {
             return NSNull()
         }
 
-        data = try dataPreprocessor.preprocess(data)
+        do {
+            data = try dataPreprocessor.preprocess(data)
+        } catch {
+            throw AFError.responseSerializationFailed(reason: .dataPreprocessingFailed(error: error))
+        }
 
         do {
             return try JSONSerialization.jsonObject(with: data, options: options)
@@ -498,7 +510,11 @@ public final class DecodableResponseSerializer<T: Decodable>: ResponseSerializer
             return emptyValue
         }
 
-        data = try dataPreprocessor.preprocess(data)
+        do {
+            data = try dataPreprocessor.preprocess(data)
+        } catch {
+            throw AFError.responseSerializationFailed(reason: .dataPreprocessingFailed(error: error))
+        }
 
         do {
             return try decoder.decode(T.self, from: data)

--- a/Tests/ResponseSerializationTests.swift
+++ b/Tests/ResponseSerializationTests.swift
@@ -1250,6 +1250,13 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
         XCTAssertTrue(result.isFailure)
         XCTAssertNil(result.success)
         XCTAssertNotNil(result.failure)
+        XCTAssertTrue(result.failure?.asAFError?.isResponseSerializationError == true)
+        if case .responseSerializationFailed(let reason) = result.failure?.asAFError,
+           case .dataPreprocessingFailed = reason {
+            // Expected
+        } else {
+            XCTFail("Error should be AFError.responseSerializationFailed(.dataPreprocessingFailed), got: \(String(describing: result.failure))")
+        }
     }
 
     func testThatStringResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
@@ -1280,6 +1287,13 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
         XCTAssertTrue(result.isFailure)
         XCTAssertNil(result.success)
         XCTAssertNotNil(result.failure)
+        XCTAssertTrue(result.failure?.asAFError?.isResponseSerializationError == true)
+        if case .responseSerializationFailed(let reason) = result.failure?.asAFError,
+           case .dataPreprocessingFailed = reason {
+            // Expected
+        } else {
+            XCTFail("Error should be AFError.responseSerializationFailed(.dataPreprocessingFailed), got: \(String(describing: result.failure))")
+        }
     }
 
     @available(*, deprecated)
@@ -1312,6 +1326,20 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
         XCTAssertTrue(result.isFailure)
         XCTAssertNil(result.success)
         XCTAssertNotNil(result.failure)
+        XCTAssertTrue(result.failure?.asAFError?.isResponseSerializationError == true)
+        if case .responseSerializationFailed(let reason) = result.failure?.asAFError,
+           case .dataPreprocessingFailed = reason {
+            // Expected
+        } else {
+            XCTFail("Error should be AFError.responseSerializationFailed(.dataPreprocessingFailed), got: \(String(describing: result.failure))")
+        }
+        XCTAssertTrue(result.failure?.asAFError?.isResponseSerializationError == true)
+        if case .responseSerializationFailed(let reason) = result.failure?.asAFError,
+           case .dataPreprocessingFailed = reason {
+            // Expected
+        } else {
+            XCTFail("Error should be AFError.responseSerializationFailed(.dataPreprocessingFailed), got: \(String(describing: result.failure))")
+        }
     }
 
     func testThatDecodableResponseSerializerProperlyCallsSuccessfulDataPreprocessor() {
@@ -1342,6 +1370,13 @@ final class DataPreprocessorSerializationTests: BaseTestCase {
         XCTAssertTrue(result.isFailure)
         XCTAssertNil(result.success)
         XCTAssertNotNil(result.failure)
+        XCTAssertTrue(result.failure?.asAFError?.isResponseSerializationError == true)
+        if case .responseSerializationFailed(let reason) = result.failure?.asAFError,
+           case .dataPreprocessingFailed = reason {
+            // Expected
+        } else {
+            XCTFail("Error should be AFError.responseSerializationFailed(.dataPreprocessingFailed), got: \(String(describing: result.failure))")
+        }
     }
 }
 


### PR DESCRIPTION
### Issue Link :link:
https://github.com/Alamofire/Alamofire/issues/3073

### Goals :soccer:
1. Add a dedicated AFError.ResponseSerializationFailureReason case for DataPreprocessor failures so they are no longer incorrectly surfaced as .customSerializationFailed.
2. Ensure all built-in serializers and stream serializers wrap preprocessing errors in the new specific error case.
3. Improve debuggability for consumers who implement custom DataPreprocessor types that can throw.

### Implementation Details :construction:
1. Added a new case dataPreprocessingFailed(error: any Error) to AFError.ResponseSerializationFailureReason in AFError.swift, along with updates to underlyingError, failedStringEncoding, and localizedDescription to handle it exhaustively.
2. In ResponseSerialization.swift, wrapped the dataPreprocessor.preprocess(data) call in a do-catch block inside all four built-in serializers (DataResponseSerializer, StringResponseSerializer, JSONResponseSerializer, DecodableResponseSerializer) so any thrown error is re-thrown as AFError.responseSerializationFailed(reason: .dataPreprocessingFailed(error: error)).
3. Applied the same fix to DecodableStreamSerializer.serialize(_:) in DataStreamRequest.swift, which had the same unguarded call.

### Testing Details :mag:
Updated all four existing "failing data preprocessor" tests in DataPreprocessorSerializationTests (Tests/ResponseSerializationTests.swift) to assert the error is specifically AFError.responseSerializationFailed(.dataPreprocessingFailed(...)) rather than just any non-nil failure. This covers DataResponseSerializer, StringResponseSerializer, JSONResponseSerializer, and DecodableResponseSerializer.