### PR TITLE
chore: rename package/product/target to PfAlamofire for module disamb…

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,16 +25,16 @@
 
 import PackageDescription
 
-let package = Package(name: "Alamofire",
+let package = Package(name: "PfAlamofire",
                       platforms: [.macOS(.v10_13),
                                   .iOS(.v12),
                                   .tvOS(.v12),
                                   .watchOS(.v4)],
                       products: [
-                          .library(name: "Alamofire", targets: ["Alamofire"]),
-                          .library(name: "AlamofireDynamic", type: .dynamic, targets: ["Alamofire"])
+                          .library(name: "PfAlamofire", targets: ["PfAlamofire"]),
+                          .library(name: "PfAlamofireDynamic", type: .dynamic, targets: ["PfAlamofire"])
                       ],
-                      targets: [.target(name: "Alamofire",
+                      targets: [.target(name: "PfAlamofire",
                                         path: "Source",
                                         exclude: ["Info.plist"],
                                         resources: [.process("PrivacyInfo.xcprivacy")],
@@ -44,8 +44,8 @@ let package = Package(name: "Alamofire",
                                                                                             .macOS,
                                                                                             .tvOS,
                                                                                             .watchOS]))]),
-                                .testTarget(name: "AlamofireTests",
-                                            dependencies: ["Alamofire"],
+                                .testTarget(name: "PfAlamofireTests",
+                                            dependencies: ["PfAlamofire"],
                                             path: "Tests",
                                             exclude: ["Info.plist", "Test Plans"],
                                             resources: [.process("Resources")])],

--- a/Package@swift-5.10.swift
+++ b/Package@swift-5.10.swift
@@ -25,16 +25,16 @@
 
 import PackageDescription
 
-let package = Package(name: "Alamofire",
+let package = Package(name: "PfAlamofire",
                       platforms: [.macOS(.v10_13),
                                   .iOS(.v12),
                                   .tvOS(.v12),
                                   .watchOS(.v4)],
                       products: [
-                          .library(name: "Alamofire", targets: ["Alamofire"]),
-                          .library(name: "AlamofireDynamic", type: .dynamic, targets: ["Alamofire"])
+                          .library(name: "PfAlamofire", targets: ["PfAlamofire"]),
+                          .library(name: "PfAlamofireDynamic", type: .dynamic, targets: ["PfAlamofire"])
                       ],
-                      targets: [.target(name: "Alamofire",
+                      targets: [.target(name: "PfAlamofire",
                                         path: "Source",
                                         exclude: ["Info.plist"],
                                         resources: [.process("PrivacyInfo.xcprivacy")],
@@ -43,8 +43,8 @@ let package = Package(name: "Alamofire",
                                                                                             .macOS,
                                                                                             .tvOS,
                                                                                             .watchOS]))]),
-                                .testTarget(name: "AlamofireTests",
-                                            dependencies: ["Alamofire"],
+                                .testTarget(name: "PfAlamofireTests",
+                                            dependencies: ["PfAlamofire"],
                                             path: "Tests",
                                             exclude: ["Info.plist", "Test Plans"],
                                             resources: [.process("Resources")])],

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -25,16 +25,16 @@
 
 import PackageDescription
 
-let package = Package(name: "Alamofire",
+let package = Package(name: "PfAlamofire",
                       platforms: [.macOS(.v10_13),
                                   .iOS(.v12),
                                   .tvOS(.v12),
                                   .watchOS(.v4)],
                       products: [
-                          .library(name: "Alamofire", targets: ["Alamofire"]),
-                          .library(name: "AlamofireDynamic", type: .dynamic, targets: ["Alamofire"])
+                          .library(name: "PfAlamofire", targets: ["PfAlamofire"]),
+                          .library(name: "PfAlamofireDynamic", type: .dynamic, targets: ["PfAlamofire"])
                       ],
-                      targets: [.target(name: "Alamofire",
+                      targets: [.target(name: "PfAlamofire",
                                         path: "Source",
                                         exclude: ["Info.plist"],
                                         resources: [.process("PrivacyInfo.xcprivacy")],
@@ -43,8 +43,8 @@ let package = Package(name: "Alamofire",
                                                                                             .macOS,
                                                                                             .tvOS,
                                                                                             .watchOS]))]),
-                                .testTarget(name: "AlamofireTests",
-                                            dependencies: ["Alamofire"],
+                                .testTarget(name: "PfAlamofireTests",
+                                            dependencies: ["PfAlamofire"],
                                             path: "Tests",
                                             exclude: ["Info.plist", "Test Plans"],
                                             resources: [.process("Resources")])],


### PR DESCRIPTION
…iguation

Renames Alamofire -> PfAlamofire across all three Package.swift manifests (Package.swift, Package@swift-5.9.swift, Package@swift-5.10.swift).

Changes: package name, product names (Alamofire, AlamofireDynamic), and target name. The target name is the critical change — Swift uses it to mangle ObjC class names, so the SDK binary will emit _TtC11PfAlamofire... instead of _TtC9Alamofire..., eliminating duplicate-class collisions when customers bundle their own Alamofire.

### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
