### PR TITLE
Surface the associated URL for more AFError cases

### DIFF
--- a/Source/Core/AFError.swift
+++ b/Source/Core/AFError.swift
@@ -372,10 +372,25 @@ extension AFError {
         return url
     }
 
-    /// The `URL` associated with the error.
+    /// The `URL` associated with the error, if any.
+    ///
+    /// For `.multipartEncodingFailed` errors, this is the body part `URL` that triggered the failure. For errors that
+    /// wrap an underlying error, such as `.sessionTaskFailed`, this is the `URL` extracted from that error, like the
+    /// `failingURL` of an underlying `URLError`. For `.requestRetryFailed`, only the `retryError` is consulted.
+    ///
+    /// - Note: Cases that carry no associated `URL`, such as `.explicitlyCancelled` and `.invalidURL`, return `nil`.
+    ///         Use `urlConvertible` to recover the value of an `.invalidURL` error.
     public var url: URL? {
-        guard case let .multipartEncodingFailed(reason) = self else { return nil }
-        return reason.url
+        switch self {
+        case let .multipartEncodingFailed(reason):
+            reason.url
+        case let .responseValidationFailed(reason):
+            reason.url
+        case let .responseSerializationFailed(reason):
+            reason.url
+        default:
+            underlyingError?.url
+        }
     }
 
     /// The underlying `Error` responsible for generating the failure associated with `.sessionInvalidated`,
@@ -461,6 +476,23 @@ extension AFError {
         (underlyingError as? URLError)?.userInfo[NSURLSessionDownloadTaskResumeData] as? Data
     }
     #endif
+}
+
+extension Error {
+    /// The `URL` associated with the error, extracted from well-known Foundation error types.
+    ///
+    /// Returns the `failingURL` of a `URLError`, the `NSURLErrorKey` value of any other bridged `NSError`, or, when the
+    /// error is an `AFError`, that error's own `url`, so nested errors resolve transparently.
+    var url: URL? {
+        switch self {
+        case let afError as AFError:
+            afError.url
+        case let urlError as URLError:
+            urlError.failingURL
+        default:
+            (self as NSError).userInfo[NSURLErrorKey] as? URL
+        }
+    }
 }
 
 extension AFError.ParameterEncodingFailureReason {
@@ -580,6 +612,20 @@ extension AFError.ResponseValidationFailureReason {
             nil
         }
     }
+
+    var url: URL? {
+        switch self {
+        case let .dataFileReadFailed(url):
+            url
+        case let .customValidationFailed(error):
+            error.url
+        case .dataFileNil,
+             .missingContentType,
+             .unacceptableContentType,
+             .unacceptableStatusCode:
+            nil
+        }
+    }
 }
 
 extension AFError.ResponseSerializationFailureReason {
@@ -607,6 +653,22 @@ extension AFError.ResponseSerializationFailureReason {
         case .inputDataNilOrZeroLength,
              .inputFileNil,
              .inputFileReadFailed,
+             .stringSerializationFailed,
+             .invalidEmptyResponse:
+            nil
+        }
+    }
+
+    var url: URL? {
+        switch self {
+        case let .inputFileReadFailed(url):
+            url
+        case let .jsonSerializationFailed(error),
+             let .decodingFailed(error),
+             let .customSerializationFailed(error):
+            error.url
+        case .inputDataNilOrZeroLength,
+             .inputFileNil,
              .stringSerializationFailed,
              .invalidEmptyResponse:
             nil

--- a/Tests/AFError+AlamofireTests.swift
+++ b/Tests/AFError+AlamofireTests.swift
@@ -24,6 +24,7 @@
 
 import Alamofire
 import Foundation
+import XCTest
 
 extension AFError {
     // ParameterEncodingFailureReason
@@ -398,5 +399,175 @@ extension AFError.URLRequestValidationFailureReason {
     var isBodyDataInGETRequest: Bool {
         if case .bodyDataInGETRequest = self { return true }
         return false
+    }
+}
+
+// MARK: -
+
+final class AFErrorURLTests: BaseTestCase {
+    private let url = URL(string: "https://example.com/path")!
+    private let otherURL = URL(string: "https://example.com/other")!
+
+    // MARK: Underlying Network Errors
+
+    func testThatURLIsExtractedFromSessionTaskFailedURLError() {
+        // Given
+        let error = AFError.sessionTaskFailed(error: urlError(failingURL: url))
+
+        // When, Then
+        XCTAssertEqual(error.url, url)
+    }
+
+    func testThatSessionTaskFailedReturnsNilURLWhenUnderlyingErrorHasNoURL() {
+        // Given
+        let error = AFError.sessionTaskFailed(error: URLError(.timedOut))
+
+        // When, Then
+        XCTAssertNil(error.url)
+    }
+
+    func testThatURLIsExtractedFromSessionInvalidatedURLError() {
+        // Given
+        let error = AFError.sessionInvalidated(error: urlError(failingURL: url))
+
+        // When, Then
+        XCTAssertEqual(error.url, url)
+    }
+
+    func testThatSessionInvalidatedWithNilErrorReturnsNilURL() {
+        // Given
+        let error = AFError.sessionInvalidated(error: nil)
+
+        // When, Then
+        XCTAssertNil(error.url)
+    }
+
+    func testThatURLIsExtractedFromRequestAdaptationFailed() {
+        // Given
+        let error = AFError.requestAdaptationFailed(error: urlError(failingURL: url))
+
+        // When, Then
+        XCTAssertEqual(error.url, url)
+    }
+
+    func testThatURLIsExtractedFromCreateUploadableFailed() {
+        // Given
+        let error = AFError.createUploadableFailed(error: urlError(failingURL: url))
+
+        // When, Then
+        XCTAssertEqual(error.url, url)
+    }
+
+    func testThatURLIsExtractedFromCreateURLRequestFailed() {
+        // Given
+        let error = AFError.createURLRequestFailed(error: urlError(failingURL: url))
+
+        // When, Then
+        XCTAssertEqual(error.url, url)
+    }
+
+    // MARK: Retry Failures
+
+    func testThatRequestRetryFailedReturnsURLFromRetryErrorOnly() {
+        // Given
+        let error = AFError.requestRetryFailed(retryError: urlError(failingURL: url),
+                                               originalError: urlError(failingURL: otherURL))
+
+        // When, Then
+        XCTAssertEqual(error.url, url, "url should come from the retryError, never the originalError")
+    }
+
+    func testThatRequestRetryFailedReturnsNilURLWhenRetryErrorHasNoURL() {
+        // Given
+        let error = AFError.requestRetryFailed(retryError: URLError(.cancelled),
+                                               originalError: urlError(failingURL: otherURL))
+
+        // When, Then
+        XCTAssertNil(error.url, "url should not fall back to the originalError")
+    }
+
+    // MARK: Foundation Error Bridging
+
+    func testThatURLIsExtractedFromNSErrorURLErrorKey() {
+        // Given
+        let underlying = NSError(domain: NSCocoaErrorDomain,
+                                 code: NSFileReadNoSuchFileError,
+                                 userInfo: [NSURLErrorKey: url])
+        let error = AFError.createURLRequestFailed(error: underlying)
+
+        // When, Then
+        XCTAssertEqual(error.url, url)
+    }
+
+    func testThatURLIsExtractedFromNestedAFError() {
+        // Given
+        let nested = AFError.sessionTaskFailed(error: urlError(failingURL: url))
+        let error = AFError.requestRetryFailed(retryError: nested, originalError: URLError(.cancelled))
+
+        // When, Then
+        XCTAssertEqual(error.url, url, "url should resolve through nested AFErrors")
+    }
+
+    // MARK: Response Validation & Serialization
+
+    func testThatURLIsReturnedForResponseValidationDataFileReadFailed() {
+        // Given
+        let error = AFError.responseValidationFailed(reason: .dataFileReadFailed(at: url))
+
+        // When, Then
+        XCTAssertEqual(error.url, url)
+    }
+
+    func testThatURLIsExtractedFromResponseValidationCustomValidationFailed() {
+        // Given
+        let error = AFError.responseValidationFailed(reason: .customValidationFailed(error: urlError(failingURL: url)))
+
+        // When, Then
+        XCTAssertEqual(error.url, url)
+    }
+
+    func testThatURLIsReturnedForResponseSerializationInputFileReadFailed() {
+        // Given
+        let error = AFError.responseSerializationFailed(reason: .inputFileReadFailed(at: url))
+
+        // When, Then
+        XCTAssertEqual(error.url, url)
+    }
+
+    func testThatURLIsExtractedFromResponseSerializationDecodingFailed() {
+        // Given
+        let error = AFError.responseSerializationFailed(reason: .decodingFailed(error: urlError(failingURL: url)))
+
+        // When, Then
+        XCTAssertEqual(error.url, url)
+    }
+
+    // MARK: Preserved & Absent URLs
+
+    func testThatURLIsReturnedForMultipartEncodingFailed() {
+        // Given
+        let error = AFError.multipartEncodingFailed(reason: .bodyPartFileNotReachable(at: url))
+
+        // When, Then
+        XCTAssertEqual(error.url, url)
+    }
+
+    func testThatURLIsNilForErrorsWithoutAssociatedURL() {
+        // Given
+        let errors: [AFError] = [.explicitlyCancelled,
+                                 .invalidURL(url: "https://example.com"),
+                                 .sessionDeinitialized,
+                                 .urlRequestValidationFailed(reason: .bodyDataInGETRequest(Data()))]
+
+        // When, Then
+        for error in errors {
+            XCTAssertNil(error.url, "\(error) should not produce a URL")
+        }
+    }
+
+    // MARK: Helpers
+
+    private func urlError(failingURL: URL) -> URLError {
+        URLError(.timedOut, userInfo: [NSURLErrorFailingURLErrorKey: failingURL])
     }
 }


### PR DESCRIPTION
### Issue Link :link:

Resolves #3965.
Supersedes the stalled #3976 by implementing the review direction left there.

### Goals :soccer:

`AFError.url` only returned a value for `.multipartEncodingFailed`. When a request fails with `.sessionTaskFailed`, the failing URL lives on the underlying `URLError.failingURL`, so callers had to unwrap the error by hand just to log it or branch on it. The goal is for `AFError.url` to return the associated `URL` for every case that actually has one, with no behavior change for `.multipartEncodingFailed`.

### Implementation Details :construction:

- Added an internal `Error.url` that extracts a `URL` from the Foundation error types that carry one: `URLError.failingURL`, the `NSURLErrorKey` of any other bridged `NSError` (e.g. `CocoaError` file operations), and nested `AFError`s, which resolve transparently.
- `AFError.url` now routes its error-wrapping cases through `underlyingError`, so `.sessionTaskFailed`, `.sessionInvalidated`, `.requestAdaptationFailed`, `.createUploadableFailed`, and `.createURLRequestFailed` resolve their URL. Because `underlyingError` already returns the `retryError` for `.requestRetryFailed`, a retry failure's URL comes from the `retryError` only, never the `originalError`.
- The file URLs stored on `.responseValidationFailed` (`.dataFileReadFailed`) and `.responseSerializationFailed` (`.inputFileReadFailed`) are surfaced too, with their `customValidationFailed` / `decodingFailed` cases delegating to the wrapped error.
- This follows the review feedback on #3976: the logic is an extension on `Error`, the retry URL comes from `retryError` only, the docs use a `Note` section with no bold, and there is no `Usage.md` change. `Error.url` is kept `internal` so the public surface stays `AFError.url`; happy to make it `public` if preferred.

### Testing Details :mag:

- Added `AFErrorURLTests` with 17 unit tests covering each resolving case, the retry-error-only semantics (including that it does not fall back to `originalError`), `NSURLErrorKey`/nested-`AFError` extraction, the preserved `.multipartEncodingFailed` behavior, and the cases that must remain `nil` (`.explicitlyCancelled`, `.invalidURL`, `.sessionDeinitialized`, `.urlRequestValidationFailed`).
- The existing multipart `.url` assertions in `MultipartFormDataFailureTestCase` still pass, confirming no regression.

---

_AI usage disclosure: implemented with AI assistance (Claude Code) under my direction and review; this description is human-written._
